### PR TITLE
docs: add a version dropdown to the parity map

### DIFF
--- a/website/scripts/parity-versions.mjs
+++ b/website/scripts/parity-versions.mjs
@@ -105,21 +105,16 @@ function diffParity(prev, cur) {
 
 // versionSlug("v0.1.0-69-g1935665") -> "v0-1-0-69-g1935665" (route-safe).
 const versionSlug = (v) => v.replace(/[.+]/g, '-');
+const BASE = '/fabric-emulator/';
 
-/**
- * Emit parity-history/ pages. `helpers` provides { convertBody, editUrlFor }
- * from sync-docs so snapshots share the same H1-stripping + link-rewriting.
- * Returns the resolved version string so the caller can stamp the live map.
- */
-export function writeParityHistory(OUT, repo, helpers) {
+// Collect the ordered version points once — each release tag that carries a
+// parity file (oldest first), then the working-tree "latest" (maybe unreleased)
+// — with the parity markdown at each. Shared by the writer and the picker.
+export function collectParity(repo) {
   const version = gitVersion(repo);
-  const outDir = join(OUT, 'parity-history');
-  mkdirSync(outDir, { recursive: true });
-
-  // Ordered points, oldest -> newest: each release tag that carries a parity
-  // file, then the working-tree "latest" (which may be unreleased).
+  const tags = releaseTags(repo);
   const points = [];
-  for (const tag of releaseTags(repo)) {
+  for (const tag of tags) {
     const p = parityPathAt(repo, tag);
     if (p) points.push({ label: tag, released: true, md: git(repo, `show ${tag}:${p}`) });
   }
@@ -127,17 +122,67 @@ export function writeParityHistory(OUT, repo, helpers) {
   const liveMd = livePath ? git(repo, `show HEAD:${livePath}`) : '';
   const liveSlug = livePath ? livePath.replace(/^docs\//, '').replace(/\.md$/, '') : null;
   points.push({ label: version, released: isRelease(version), latest: true, md: liveMd });
+  return { version, liveSlug, points, firstTag: tags[0] ?? null };
+}
+
+// The site URL of a version's parity view: the live map for "latest", a
+// snapshot route for a tag.
+export function pointUrl(parity, pt) {
+  return pt.latest ? `${BASE}${parity.liveSlug}/` : `${BASE}parity-history/${versionSlug(pt.label)}/`;
+}
+
+const optionLabel = (pt) =>
+  pt.latest ? `Current — ${pt.label}${pt.released ? '' : ' (unreleased)'}` : pt.label;
+
+// A build-time <select> (newest first) that navigates to the chosen version's
+// parity page. Inline styles use Starlight CSS vars so it themes in light/dark;
+// the inline onchange keeps it a single self-contained block (no client script
+// to bundle). `currentUrl` marks which option is pre-selected.
+export function versionPicker(parity, currentUrl) {
+  if (parity.points.length < 2) return ''; // only "latest" exists — nothing to pick
+  const opts = parity.points
+    .slice()
+    .reverse()
+    .map((pt) => {
+      const url = pointUrl(parity, pt);
+      return `    <option value="${url}"${url === currentUrl ? ' selected' : ''}>${optionLabel(pt)}</option>`;
+    })
+    .join('\n');
+  return (
+    `<div class="parity-version-picker" style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin:0 0 1.5rem">\n` +
+    `  <label for="parity-version"><strong>Capabilities as of version:</strong></label>\n` +
+    `  <select id="parity-version" aria-label="Choose a released version of the parity map"` +
+    ` onchange="if(this.value)location.assign(this.value)"` +
+    ` style="font:inherit;padding:.35rem .55rem;border-radius:.375rem;border:1px solid var(--sl-color-gray-5);background:var(--sl-color-bg);color:var(--sl-color-text)">\n` +
+    `${opts}\n` +
+    `  </select>\n` +
+    `</div>\n\n`
+  );
+}
+
+/**
+ * Emit parity-history/ pages from a `collectParity` result. `helpers` provides
+ * { convertBody } from sync-docs so snapshots share the same H1-stripping +
+ * link-rewriting. Returns { version, snapshots, liveSlug }.
+ */
+export function writeParityHistory(OUT, parity, helpers) {
+  const { version, liveSlug, points } = parity;
+  const outDir = join(OUT, 'parity-history');
+  mkdirSync(outDir, { recursive: true });
 
   // Snapshot page per released tag (the "latest" point links to the live map
-  // instead of duplicating it).
+  // instead of duplicating it). Each opens with the version picker.
   for (const pt of points) {
     if (pt.latest) continue;
     const slug = versionSlug(pt.label);
     const body = helpers.convertBody(pt.md);
     const fm = `---\ntitle: ${JSON.stringify(`Parity — ${pt.label}`)}\neditUrl: false\nprev: false\nnext: false\n---\n\n`;
+    const picker = versionPicker(parity, pointUrl(parity, pt));
     const banner = `:::note[Historical snapshot]\nThe feature-parity map as of release **${pt.label}**. The current map is on the [Parity page](/fabric-emulator/${liveSlug}/).\n:::\n\n`;
-    writeFileSync(join(outDir, `${slug}.md`), fm + banner + body);
+    writeFileSync(join(outDir, `${slug}.md`), fm + picker + banner + body);
   }
+
+  const liveMd = points.find((p) => p.latest)?.md ?? '';
 
   // Changelog: diff consecutive points.
   const cl = [];
@@ -167,7 +212,7 @@ export function writeParityHistory(OUT, repo, helpers) {
     (liveTally ? `**Current (${version}):** ${liveTally}.\n\n` : '') +
     (cl.length
       ? cl.join('\n')
-      : `_No tagged release includes the parity map yet — the map was introduced after ${releaseTags(repo)[0] ?? 'the first tag'}. ` +
+      : `_No tagged release includes the parity map yet — the map was introduced after ${parity.firstTag ?? 'the first tag'}. ` +
         `The first entry here appears when a release ships that carries it._\n`);
   writeFileSync(join(outDir, 'changelog.md'), clFm + clBody);
 
@@ -187,7 +232,7 @@ export function writeParityHistory(OUT, repo, helpers) {
     '\n\n' +
     (releasedPoints.length
       ? ''
-      : `:::note\nOnly the unreleased tip carries a parity map so far (it was added after \`${releaseTags(repo)[0] ?? 'v0.1.0'}\`). ` +
+      : `:::note\nOnly the unreleased tip carries a parity map so far (it was added after \`${parity.firstTag ?? 'v0.1.0'}\`). ` +
         `Each future \`vX.Y.Z\` release will appear above automatically.\n:::\n`);
   writeFileSync(join(outDir, 'index.md'), idxFm + idxBody);
 

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -8,7 +8,7 @@
 import { readdirSync, readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { writeParityHistory, gitVersion } from './parity-versions.mjs';
+import { collectParity, writeParityHistory, versionPicker, pointUrl } from './parity-versions.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const REPO = join(here, '..', '..');
@@ -16,10 +16,10 @@ const DOCS_SRC = join(REPO, 'docs');
 const OUT = join(here, '..', 'src', 'content', 'docs');
 export const BASE = '/fabric-emulator/';
 
-// The release version this build reflects (e.g. "v0.2.0" on a tag, or
-// "v0.1.0-69-g1935665" between releases). Used to stamp the parity map.
-const VERSION = gitVersion(REPO);
-const IS_RELEASE = /^v\d+\.\d+\.\d+$/.test(VERSION);
+// Parity version data (release tags + the live map), collected once. `version`
+// is e.g. "v0.2.0" on a tag or "v0.1.0-69-g1935665" between releases.
+const PARITY = collectParity(REPO);
+const IS_RELEASE = /^v\d+\.\d+\.\d+$/.test(PARITY.version);
 const PARITY_RE = /-parity\.md$/;
 
 // Rewrite `](./|docs/ NN-slug.md#anchor)` → `](/fabric-emulator/NN-slug/#anchor)`.
@@ -49,12 +49,17 @@ function convertBody(raw) {
   return rewriteLinks(lines.join('\n').replace(/^\n+/, ''));
 }
 
-// The version banner injected at the top of the live parity map.
+// The version picker + context line injected at the top of the live parity
+// map. The picker's selected option is the live map itself; choosing a release
+// navigates to that version's snapshot. When no releases carry a parity map
+// yet, versionPicker() returns "" and only the context line shows.
 function parityStamp() {
   const unreleased = IS_RELEASE ? '' : ' (unreleased)';
+  const picker = versionPicker(PARITY, pointUrl(PARITY, { latest: true }));
   return (
-    `:::note[Version]\nParity map as of **${VERSION}**${unreleased} — tracked by git release tags. ` +
-    `See the [version history](${BASE}parity-history/) and [parity changelog](${BASE}parity-history/changelog/).\n:::\n\n`
+    picker +
+    `_Parity map as of **${PARITY.version}**${unreleased} — tracked by git release tags. ` +
+    `See the [version history](${BASE}parity-history/) and [parity changelog](${BASE}parity-history/changelog/)._\n\n`
   );
 }
 
@@ -105,8 +110,8 @@ for (const name of names) {
   writeFileSync(join(OUT, name), convert(name));
 }
 writeIndex();
-const parity = writeParityHistory(OUT, REPO, { convertBody });
+const info = writeParityHistory(OUT, PARITY, { convertBody });
 console.log(
   `sync-docs: wrote ${names.length} docs + index to src/content/docs/ ` +
-    `(parity ${parity.version}; ${parity.snapshots.length} tagged snapshot(s))`,
+    `(parity ${info.version}; ${info.snapshots.length} tagged snapshot(s))`,
 );


### PR DESCRIPTION
The parity map and each snapshot now open with a "Capabilities as of version" <select>: choosing a release navigates to that version's parity page (the current page's version is pre-selected). Build-time generated from the same git-tag data — inline onchange + Starlight CSS vars, so no client bundle and it themes in light/dark. Hidden until at least one release carries a parity map (nothing to pick with only the live tip).

Refactor: split collectParity() (the version/point data) from writeParityHistory() (page emission) so the picker, live-map stamp, and snapshots all share one collection. Verified with a full Astro build and by driving the dropdown in a browser (select v9.9.8 → snapshot page).

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes/no
| BC Break      | yes/no
| New Feature   | yes/no
| RFC           | yes/no
| QA            | yes/no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
