### PR TITLE
docs: fix parity-version deploy on release, dedupe the tag==HEAD case

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -3,9 +3,6 @@ name: Docs site
 on:
   push:
     branches: [main]
-    # Release tags also rebuild the docs so the parity map re-stamps with the
-    # clean vX.Y.Z version and a new per-release snapshot appears.
-    tags: ['v*']
     paths:
       - 'docs/**'
       - 'website/**'
@@ -13,6 +10,15 @@ on:
       - 'pnpm-workspace.yaml'
       - 'package.json'
       - '.github/workflows/docs-site.yml'
+  # NOTE: we do NOT trigger on `v*` tags. The `github-pages` environment only
+  # permits deployments from `main`, so a tag build would pass but its deploy
+  # would be rejected ("Tag … is not allowed to deploy … environment protection
+  # rules"). Instead the parity map re-stamps to the clean vX.Y.Z on the next
+  # push to main after a release (the checkout below fetches tags, so
+  # `git describe` sees the new tag). To publish immediately after tagging, run
+  # this workflow via workflow_dispatch on main. (To restore automatic tag
+  # deploys, allow the `v*` tag pattern in the github-pages environment's
+  # deployment branch/tag rules, then re-add `tags: ['v*']` here.)
   workflow_dispatch:
 
 # Allow the deploy job to publish to GitHub Pages.

--- a/website/scripts/parity-versions.mjs
+++ b/website/scripts/parity-versions.mjs
@@ -113,10 +113,25 @@ const BASE = '/fabric-emulator/';
 export function collectParity(repo) {
   const version = gitVersion(repo);
   const tags = releaseTags(repo);
+  let headSha = '';
+  try {
+    headSha = git(repo, 'rev-parse HEAD').trim();
+  } catch {
+    /* not a git checkout */
+  }
   const points = [];
   for (const tag of tags) {
     const p = parityPathAt(repo, tag);
-    if (p) points.push({ label: tag, released: true, md: git(repo, `show ${tag}:${p}`) });
+    if (!p) continue;
+    // Skip a tag that IS the current commit: the live map already represents
+    // it, so avoid a redundant "Current vX" + "vX snapshot" pair right at the
+    // release. The snapshot appears once main advances past the tag.
+    try {
+      if (git(repo, `rev-parse ${tag}^{commit}`).trim() === headSha) continue;
+    } catch {
+      /* ignore an unreadable tag */
+    }
+    points.push({ label: tag, released: true, md: git(repo, `show ${tag}:${p}`) });
   }
   const livePath = parityPathAt(repo, 'HEAD');
   const liveMd = livePath ? git(repo, `show HEAD:${livePath}`) : '';


### PR DESCRIPTION
Two issues surfaced while cutting **v0.2.0**. The release itself succeeded (binaries, GHCR, GitHub Release); these are docs-tooling fixes.

## 1. Docs deploy was rejected on the release tag
The `github-pages` environment only permits deployments from `main`, so the `tags: ['v*']` trigger built the docs on the `v0.2.0` tag but its deploy was rejected:

> Tag "v0.2.0" is not allowed to deploy to github-pages due to environment protection rules.

**Fix:** `docs-site.yml` no longer triggers on `v*` tags. The parity map re-stamps to the clean `vX.Y.Z` on the next push to `main` after a release (the checkout fetches tags, so `git describe` sees it). To publish immediately after tagging, run the workflow via `workflow_dispatch` on `main`.

> To restore automatic tag deploys instead, allow the `v*` tag pattern in **Settings → Environments → github-pages → Deployment branches and tags**, then re-add `tags: ['v*']`.

## 2. Redundant snapshot right at the release commit
At the exact tag commit, `git describe` = `v0.2.0` and the generator emitted both a "Current v0.2.0" live map *and* a "v0.2.0" snapshot (plus a two-entry picker for the same version).

**Fix:** `collectParity` skips a tag whose commit **is** HEAD — the live map already represents it. The snapshot appears once `main` advances past the tag (so merging this PR produces the clean post-release state: `Current — v0.2.0-N (unreleased)` + a `v0.2.0` snapshot).

Verified with a full Astro build at the tag commit (clean, picker hidden, no duplicate snapshot).