### PR TITLE
Export the running cell's identity so observed lineage can fire

### DIFF
--- a/docs/28-tutorial-end-to-end.md
+++ b/docs/28-tutorial-end-to-end.md
@@ -408,10 +408,23 @@ is attributable. `engine.py` closes that by **declaring** its read/write set to
 
 Removing the step therefore loses the notebook's lineage edge entirely — no
 declaration and no observation. Measured, not assumed:
-`AssertionError: Notebook edge into bronze_orders missing: []`. The real fix is
-to mint an attributed storage token for the driven session; until then the
-emulator will not guess what a notebook touched, and this step is how the edge
-gets recorded.
+`AssertionError: Notebook edge into bronze_orders missing: []`.
+
+**And minting an attributed token for the driven session does not fix it**,
+which was the obvious next move and is worth recording as a dead end. Sail takes
+its storage credentials from process env *once, before the server binds* —
+`object_store`'s `MicrosoftAzureBuilder::from_env` runs at startup, which is why
+`docker/sail/launcher.py` restarts sail to rotate a token at all. There is no
+per-session credential channel, so a `df.write` executing inside Sail can never
+carry the running cell's identity.
+
+What the emulator *can* attribute is the I/O its own agent performs: the driver
+now sends `jobId`/`cellIndex` with every statement, and the agent exports them
+as `FABRIC_JOB_ID`/`FABRIC_CELL_INDEX` for that statement's duration. That makes
+`notebookutils.fs` tag its requests and `storage.py` forge a claim-carrying
+token for delta-rs — both of which had **only readers and no writer** until
+now, so neither had ever fired. Spark's own writes stay unattributed, and this
+step is still how their edge gets recorded.
 
 Inside the notebook, OneLake is addressed the way a Fabric notebook addresses
 it — by the **full account host**, not a bare account name:

--- a/internal/api/notebookdrive.go
+++ b/internal/api/notebookdrive.go
@@ -184,8 +184,23 @@ func (a *API) driveNotebookRun(wid, iid, jid string, run notebookRun, params map
 		if strings.EqualFold(cell.Language, "sql") {
 			kind = "sql"
 		}
+		// jobId/cellIndex are the cell's IDENTITY, and they travel with every
+		// statement so the agent can export them for the duration of the cell.
+		//
+		// Two things downstream read that export and are dead without it:
+		// notebookutils.fs tags its OneLake requests with the
+		// x-ms-fabric-job-id / x-ms-fabric-cell-index headers, and
+		// spark_agent/storage.py forges a Storage token carrying the same
+		// values as claims (delta-rs takes credentials, not headers). Both
+		// feed the storage layer's observed lineage, which is how an edge gets
+		// recorded without anyone parsing the notebook's code.
+		//
+		// NOT sufficient for Spark's own writes: a `df.write` executes inside
+		// Sail, whose storage token enters it through startup env and cannot
+		// vary per cell (docker/sail/launcher.py). Those stay unattributed.
 		out, err := a.agentPost("/statements", map[string]any{
 			"session": session, "code": cell.Source, "kind": kind,
+			"jobId": jid, "cellIndex": cell.Index,
 		})
 		if err != nil {
 			finalised = true
@@ -198,6 +213,7 @@ func (a *API) driveNotebookRun(wid, iid, jid string, run notebookRun, params map
 		if i == injectAfter && paramCode != "" {
 			if _, perr := a.agentPost("/statements", map[string]any{
 				"session": session, "code": paramCode, "kind": "python",
+				"jobId": jid, "cellIndex": cell.Index,
 			}); perr != nil {
 				finalised = true
 				a.failNotebookRun(wid, iid, jid, run, fmt.Sprintf("applying run parameters: %v", perr))

--- a/internal/api/notebookdrive_test.go
+++ b/internal/api/notebookdrive_test.go
@@ -25,6 +25,10 @@ type fakeAgent struct {
 	// code received, in order, so a test can assert the driver ran the cells it
 	// was given and did not, say, run them twice or skip the prelude.
 	got []string
+	// the full statement requests, so a test can assert the cell IDENTITY the
+	// driver sent alongside the code — that is what the agent exports and what
+	// makes observed lineage possible.
+	posts []fakeStatement
 	// reply decides what each statement returns; nil means an empty ok.
 	reply func(code string) map[string]any
 	// exit is what the notebook exited WITH; empty means it never called
@@ -42,9 +46,11 @@ func newFakeAgent(t *testing.T, a *API) *fakeAgent {
 		}
 		body, _ := io.ReadAll(r.Body)
 		var req struct {
-			Session string `json:"session"`
-			Code    string `json:"code"`
-			Kind    string `json:"kind"`
+			Session   string `json:"session"`
+			Code      string `json:"code"`
+			Kind      string `json:"kind"`
+			JobID     string `json:"jobId"`
+			CellIndex *int   `json:"cellIndex"`
 		}
 		_ = json.Unmarshal(body, &req)
 
@@ -65,6 +71,8 @@ func newFakeAgent(t *testing.T, a *API) *fakeAgent {
 				return
 			}
 			f.got = append(f.got, req.Code)
+			f.posts = append(f.posts, fakeStatement{
+				code: req.Code, jobID: req.JobID, cellIndex: req.CellIndex})
 			if f.reply != nil {
 				if out := f.reply(req.Code); out != nil {
 					writeJSON(w, 200, out)
@@ -81,6 +89,20 @@ func newFakeAgent(t *testing.T, a *API) *fakeAgent {
 		t.Fatal(err)
 	}
 	return f
+}
+
+// fakeStatement is one /statements request: the code, and the cell identity
+// carried with it.
+type fakeStatement struct {
+	code      string
+	jobID     string
+	cellIndex *int
+}
+
+func (f *fakeAgent) sent() []fakeStatement {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]fakeStatement(nil), f.posts...)
 }
 
 func (f *fakeAgent) statements() []string {
@@ -447,5 +469,57 @@ func TestJobDoesNotReportCompletedWhileCellsArePending(t *testing.T) {
 	}
 	if _, ok := body["endTimeUtc"]; ok {
 		t.Fatalf("a job that has not really finished must not carry endTimeUtc: %+v", body)
+	}
+}
+
+// TestEveryStatementCarriesTheCellIdentity.
+//
+// The identity is what makes observed lineage possible, and nothing in the
+// repo set it before: FABRIC_JOB_ID / FABRIC_CELL_INDEX had only readers.
+// `notebookutils.fs` tags its OneLake requests from those, and
+// `spark_agent/storage.py` forges a Storage token carrying them as claims
+// (delta-rs takes credentials, not request headers) — so with no exporter both
+// were dead code, and a driven notebook's I/O was attributed to nothing.
+//
+// The PRELUDE deliberately carries no identity: it is the driver's own
+// scaffolding, not the notebook's work, and attributing its I/O to cell 0
+// would invent an edge the notebook did not cause.
+//
+// This does NOT cover Spark's own writes. A `df.write` executes inside Sail,
+// whose storage token enters through startup env and cannot vary per cell
+// (docker/sail/launcher.py) — see docs/28.
+func TestEveryStatementCarriesTheCellIdentity(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	nb := createNotebook(t, st, ws.ID, sampleNotebook)
+	agent := newFakeAgent(t, a)
+
+	_, jid := runJob(t, a, ws.ID, nb.ID, "jobType=RunNotebook", "")
+	if s := awaitJob(t, a, ws.ID, nb.ID, jid); s != "Completed" {
+		t.Fatalf("job status = %s", s)
+	}
+
+	sent := agent.sent()
+	if len(sent) != 3 {
+		t.Fatalf("statements = %d, want prelude + 2 cells", len(sent))
+	}
+	if sent[0].jobID != "" || sent[0].cellIndex != nil {
+		t.Errorf("the prelude carried an identity (%q, %v); it is the driver's "+
+			"own scaffolding and must not be attributed to a cell",
+			sent[0].jobID, sent[0].cellIndex)
+	}
+	for i, s := range sent[1:] {
+		if s.jobID != jid {
+			t.Errorf("cell %d jobId = %q; want the run's job id %q", i, s.jobID, jid)
+		}
+		if s.cellIndex == nil {
+			t.Errorf("cell %d carried no cellIndex; storage.py forges no "+
+				"attributed token without it", i)
+			continue
+		}
+		if *s.cellIndex != i {
+			t.Errorf("cell %d cellIndex = %d; want %d — a wrong index attributes "+
+				"the I/O to the wrong cell, which reads as real lineage", i, *s.cellIndex, i)
+		}
 	}
 }

--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -422,12 +422,24 @@ class Handler(BaseHTTPRequestHandler):
             # and comes back as REPL text. Before this dispatch existed the agent
             # was Python-only, which is why dbt-fabricspark needed a second,
             # SQL-only agent to talk to (e2e/dbt-fabricspark/sql_agent.py).
-            if (req.get("kind") or "").lower() == "sql":
-                self._send(200, run_sql(req.get("code", ""),
-                                        ns(req.get("session", "default"))))
-            else:
-                self._send(200, run_code(req.get("code", ""),
-                                         ns(req.get("session", "default"))))
+            # storage.py owns the export: it is the module whose token forge
+            # consumes it, and it carries no pyspark import so it stays unit
+            # testable. Absent (a runtime without the agent's modules) the
+            # statement still runs, just unattributed.
+            try:
+                from storage import cell_context
+            except ImportError:  # pragma: no cover - runtime without storage.py
+                from contextlib import nullcontext as cell_context_stub
+
+                def cell_context(*_a, **_k):
+                    return cell_context_stub()
+            with cell_context(req.get("jobId"), req.get("cellIndex")):
+                if (req.get("kind") or "").lower() == "sql":
+                    self._send(200, run_sql(req.get("code", ""),
+                                            ns(req.get("session", "default"))))
+                else:
+                    self._send(200, run_code(req.get("code", ""),
+                                             ns(req.get("session", "default"))))
         elif self.path == "/register":
             self._send(200, register_tables(req.get("session", "default"),
                                             req.get("schema", ""),

--- a/python/spark_agent/storage.py
+++ b/python/spark_agent/storage.py
@@ -39,6 +39,7 @@ import ssl
 import time
 import urllib.parse
 import urllib.request
+from contextlib import contextmanager
 
 # Refresh this long before the token actually expires, so a statement that
 # starts just under the wire still finishes with a valid bearer.
@@ -90,6 +91,39 @@ def token(env=None):
     # lifetime: minting on every statement would turn a REPL into a token flood.
     _cached["good_until"] = now + max(60.0, lifetime - _SKEW_SECONDS)
     return minted
+
+
+
+@contextmanager
+def cell_context(job, cell):
+    """Export the running cell's identity for the duration of one statement.
+
+    Nothing set FABRIC_JOB_ID / FABRIC_CELL_INDEX before this existed — they had
+    only readers, so `_forge_attributed` below always returned None and
+    `notebookutils.fs` tagged nothing. Both were dead paths, and a driven
+    notebook's I/O was attributed to no cell at all.
+
+    RESTORED, not cleared. The agent is long-lived and serves interleaved
+    sessions; leaving one cell's identity set would attribute the NEXT
+    statement's I/O to it. A wrong lineage edge is worse than a missing one —
+    nothing about it looks wrong. Absent job/cell (an ordinary Livy statement)
+    this sets nothing at all.
+    """
+    if not job or cell is None:
+        yield
+        return
+    keys = ("FABRIC_JOB_ID", "FABRIC_CELL_INDEX")
+    prev = {k: os.environ.get(k) for k in keys}
+    os.environ["FABRIC_JOB_ID"] = str(job)
+    os.environ["FABRIC_CELL_INDEX"] = str(cell)
+    try:
+        yield
+    finally:
+        for k in keys:
+            if prev[k] is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev[k]
 
 
 def _forge_attributed(env):

--- a/python/tests/test_cell_context.py
+++ b/python/tests/test_cell_context.py
@@ -1,0 +1,116 @@
+"""The cell-identity export, and what it turns from dead code into a live path.
+
+Nothing in this repo set FABRIC_JOB_ID / FABRIC_CELL_INDEX before it existed —
+there were only readers. `storage._forge_attributed` returns None without them,
+so an attributed Storage token was NEVER minted on any path, and
+`notebookutils.fs` tagged none of its OneLake requests. Both were dead.
+
+What this does not do: attribute Spark's own writes. A `df.write` executes
+inside Sail, whose credentials enter through startup env and cannot vary per
+cell — storage.py's own module docstring says it ("There is no per-session
+credential channel"), and docker/sail/launcher.py restarts sail to rotate them.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import storage
+
+
+def _clear():
+    for k in ("FABRIC_JOB_ID", "FABRIC_CELL_INDEX"):
+        os.environ.pop(k, None)
+
+
+def test_exports_the_identity_for_the_duration_of_the_statement():
+    _clear()
+    with storage.cell_context("job-1", 3):
+        assert os.environ["FABRIC_JOB_ID"] == "job-1"
+        # str, not int: it travels as a header value and a JWT claim.
+        assert os.environ["FABRIC_CELL_INDEX"] == "3"
+    assert "FABRIC_JOB_ID" not in os.environ
+    assert "FABRIC_CELL_INDEX" not in os.environ
+
+
+def test_cell_zero_is_a_real_cell():
+    """`if not cell` would treat index 0 as absent — the FIRST cell of every
+    notebook, which is exactly the one most likely to do the reading."""
+    _clear()
+    with storage.cell_context("job-1", 0):
+        assert os.environ["FABRIC_CELL_INDEX"] == "0"
+
+
+def test_restores_a_previous_identity_rather_than_clearing_it():
+    """The agent is long-lived and serves interleaved sessions. Clearing rather
+    than restoring would drop the outer cell's identity, so its later I/O would
+    attribute to nothing — a lineage edge silently missing."""
+    os.environ["FABRIC_JOB_ID"] = "outer"
+    os.environ["FABRIC_CELL_INDEX"] = "7"
+    with storage.cell_context("inner", 1):
+        assert os.environ["FABRIC_JOB_ID"] == "inner"
+    assert os.environ["FABRIC_JOB_ID"] == "outer"
+    assert os.environ["FABRIC_CELL_INDEX"] == "7"
+    _clear()
+
+
+def test_restores_even_when_the_statement_raises():
+    """A failing cell is the common case, not the edge case. Leaking the
+    identity past it would attribute the NEXT statement's I/O to the cell that
+    just failed — a wrong edge, which reads as real."""
+    _clear()
+    try:
+        with storage.cell_context("job-1", 2):
+            raise RuntimeError("cell failed")
+    except RuntimeError:
+        pass
+    assert "FABRIC_JOB_ID" not in os.environ
+
+
+def test_an_ordinary_livy_statement_sets_nothing():
+    """dbt-fabricspark drives the same agent and has no cell identity. Setting
+    a placeholder would attribute its I/O to a notebook run that never ran."""
+    _clear()
+    with storage.cell_context(None, None):
+        assert "FABRIC_JOB_ID" not in os.environ
+    with storage.cell_context("", None):
+        assert "FABRIC_JOB_ID" not in os.environ
+
+
+def test_the_export_is_what_makes_the_token_forge_fire(monkeypatch):
+    """The point of the export. `_forge_attributed` reads the same two vars, so
+    without the context it returns None and delta-rs authenticates with an
+    unattributed token — which is what shipped until now."""
+    calls = {}
+
+    def fake_urlopen(req, *a, **k):
+        calls["body"] = json.loads(req.data)
+
+        class R:
+            def read(self):
+                return b'{"access_token": "forged"}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+        return R()
+
+    monkeypatch.setattr(storage.urllib.request, "urlopen", fake_urlopen)
+    env = {"ENTRA_CLIENT_ID": "c", "ENTRA_FORGE_URL": "https://entra/forge"}
+
+    # Without the context: no claims to carry, so no forge call at all.
+    assert storage._forge_attributed(env) is None
+    assert not calls
+
+    # With it, using the SAME environment the agent exports into.
+    _clear()
+    with storage.cell_context("job-9", 4):
+        merged = {**env, **os.environ}
+        assert storage._forge_attributed(merged) == "forged"
+    assert calls["body"]["extraClaims"] == {
+        "fabric_job_id": "job-9", "fabric_cell_index": "4"}


### PR DESCRIPTION
`FABRIC_JOB_ID` / `FABRIC_CELL_INDEX` had **only readers** in this repo — no code anywhere set them. Two paths depend on them and had therefore never once fired:

- `notebookutils/fs.py` tags its OneLake requests with `x-ms-fabric-job-id` / `x-ms-fabric-cell-index` — it read the vars, found nothing, tagged nothing.
- `spark_agent/storage.py::_forge_attributed` mints a Storage token carrying the same values as JWT claims (delta-rs takes credentials, not request headers) — it returned `None` on every call, so an attributed token was never minted on any path.

The driver now sends `jobId`/`cellIndex` with every statement, and the agent exports them for that statement's duration via `storage.cell_context`.

**Scope — this does not let `engine.py` go.** I went looking for "mint an attributed token for the driven session" and it is not achievable: Sail reads storage credentials from process env once, before the server binds (`MicrosoftAzureBuilder::from_env`), which is why `docker/sail/launcher.py` *restarts* sail to rotate a token. There is no per-session credential channel, so a `df.write` executing inside Sail can never carry the cell's identity. `docs/28` now records that as a dead end rather than an open TODO, so nobody re-derives it.

Covered, with each mutation checked:
- Go: every cell statement carries the run's job id and its own index; the prelude deliberately carries none (it is driver scaffolding, not the notebook's work). Dropping the fields fails the test.
- Python, 6 cases: exports during, restores after, **cell 0 is a real cell** (`if not cell` would drop the first cell of every notebook), restores a previous identity rather than clearing it, restores when the statement raises, and sets nothing for an ordinary Livy statement (dbt-fabricspark drives the same agent). Both likely-wrong conditions fail their specific test when mutated.
- One test asserts the export is what makes `_forge_attributed` fire, and that the claims carry the right values.