### PR TITLE
Cover the SQL connection resolvers and two escaping helpers

### DIFF
--- a/internal/server/warehouse_internal_test.go
+++ b/internal/server/warehouse_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/calvinchengx/fabric-emulator/internal/testsupport"
+	"strings"
 	"testing"
 
 	"github.com/calvinchengx/fabric-emulator/internal/clock"
@@ -241,4 +242,120 @@ func TestMirrorItem(t *testing.T) {
 	if err := mirrorItem(&fakeWH{db: sqldb}, st)(ctx, db.ID); err == nil {
 		t.Error("expected Mirror to surface an error against a non-SQL-Server backend")
 	}
+}
+
+// TestResolveSQLItem covers how a TDS connection's `database=` and server name
+// become an ITEM — the decision that settles which workspace's data a session
+// reads. It was reachable only through TestWarehouseRouter, which gates on a
+// real SQL Server and so skips on any machine without one; these lookups need
+// no engine at all.
+//
+// The precedence matters and is easy to get backwards. A workspace can hold a
+// Warehouse and a Lakehouse of the SAME name, and they are not
+// interchangeable: the Warehouse is read-write and owns its data, the
+// Lakehouse endpoint is a read-only reflection. Resolving to the wrong one
+// turns a client's writes into errors, or worse, points a reader at a stale
+// mirror while it believes it is on the warehouse.
+func TestResolveSQLItem(t *testing.T) {
+	st, err := store.Open("", clock.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ws := &store.Workspace{DisplayName: "analytics"}
+	if err := st.CreateWorkspace(ws, store.Principal{ID: "u", Type: "User"}); err != nil {
+		t.Fatal(err)
+	}
+	other := &store.Workspace{DisplayName: "other"}
+	if err := st.CreateWorkspace(other, store.Principal{ID: "u", Type: "User"}); err != nil {
+		t.Fatal(err)
+	}
+	// "sales" exists as BOTH kinds in the same workspace — the ambiguity the
+	// precedence rule exists to settle.
+	lake := &store.Item{WorkspaceID: ws.ID, Type: "Lakehouse", DisplayName: "sales"}
+	wh := &store.Item{WorkspaceID: ws.ID, Type: "Warehouse", DisplayName: "sales"}
+	lakeOnly := &store.Item{WorkspaceID: ws.ID, Type: "Lakehouse", DisplayName: "raw"}
+	for _, it := range []*store.Item{lake, wh, lakeOnly} {
+		if err := st.CreateItem(it, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("by item id, workspace-agnostic", func(t *testing.T) {
+		// No workspace in the server name at all: an id is globally unique, so
+		// it must resolve without one. This is how the emulator's own tooling
+		// connects.
+		got, err := resolveSQLItem(st, "localhost", lakeOnly.ID)
+		if err != nil || got.ID != lakeOnly.ID {
+			t.Fatalf("by id = %v, %v; want %s", got, err, lakeOnly.ID)
+		}
+	})
+
+	t.Run("by name, workspace from the server label", func(t *testing.T) {
+		got, err := resolveSQLItem(st, "analytics.datawarehouse.fabric.microsoft.com", "raw")
+		if err != nil || got.ID != lakeOnly.ID {
+			t.Fatalf("by name = %v, %v; want %s", got, err, lakeOnly.ID)
+		}
+	})
+
+	t.Run("workspace addressable by id as well as name", func(t *testing.T) {
+		got, err := resolveSQLItem(st, ws.ID+".datawarehouse.fabric.microsoft.com", "raw")
+		if err != nil || got.ID != lakeOnly.ID {
+			t.Fatalf("workspace by id = %v, %v", got, err)
+		}
+	})
+
+	t.Run("a Warehouse wins over a Lakehouse of the same name", func(t *testing.T) {
+		got, err := resolveSQLItem(st, "analytics", "sales")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.ID != wh.ID {
+			t.Errorf("resolved %q (%s); want the Warehouse %s — the Lakehouse "+
+				"endpoint is a read-only reflection and cannot serve a writer",
+				got.DisplayName, got.Type, wh.ID)
+		}
+	})
+
+	t.Run("no workspace in the server name says so", func(t *testing.T) {
+		// An IPv4 host has no workspace label, so a NAME cannot be resolved.
+		// The message has to explain that, or the user retries the same string.
+		_, err := resolveSQLItem(st, "127.0.0.1", "raw")
+		if err == nil {
+			t.Fatal("want an error when the name has no workspace to resolve in")
+		}
+		if !strings.Contains(err.Error(), "workspace in the server name") {
+			t.Errorf("error = %q; it must name the missing piece", err)
+		}
+	})
+
+	t.Run("unknown workspace, and unknown item, are different errors", func(t *testing.T) {
+		_, err := resolveSQLItem(st, "nosuchws", "raw")
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Errorf("unknown workspace error = %v", err)
+		}
+		// "raw" exists, but not in THIS workspace — a cross-workspace read
+		// must not resolve.
+		_, err = resolveSQLItem(st, "other", "raw")
+		if err == nil {
+			t.Fatal("an item in another workspace must not resolve")
+		}
+		if !strings.Contains(err.Error(), "no warehouse or lakehouse") {
+			t.Errorf("error = %q; want the item-not-in-workspace message", err)
+		}
+	})
+
+	t.Run("resolveWorkspace takes an id or a display name", func(t *testing.T) {
+		byID, err := resolveWorkspace(st, ws.ID)
+		if err != nil || byID.ID != ws.ID {
+			t.Fatalf("by id = %v, %v", byID, err)
+		}
+		byName, err := resolveWorkspace(st, "analytics")
+		if err != nil || byName.ID != ws.ID {
+			t.Fatalf("by name = %v, %v", byName, err)
+		}
+		if _, err := resolveWorkspace(st, "nope"); err == nil {
+			t.Error("want an error for an unknown workspace")
+		}
+	})
 }

--- a/internal/warehouse/types_test.go
+++ b/internal/warehouse/types_test.go
@@ -951,3 +951,50 @@ func TestDecimalWithMoreScaleThanItsColumnTruncates(t *testing.T) {
 		t.Errorf("a Decimal at scale 4 into a scale-2 column = %v; want 123", got)
 	}
 }
+
+// TestTimestampAndIdentifierRendering covers two small functions that only the
+// SQL-Server-gated tests reached, so they were unexecuted on any machine
+// without a sidecar — including every laptop.
+//
+// Both render a value INTO a SQL statement, which is why they earn a test of
+// their own rather than being left to an integration path.
+func TestTimestampAndIdentifierRendering(t *testing.T) {
+	// A Timestamp renders in UTC, and to microseconds. Fabric maps Delta
+	// TIMESTAMP to datetime2, whose documented precision is 6 fractional
+	// digits — rendering local time would shift every instant by the host's
+	// offset, which is invisible on a UTC CI runner and wrong everywhere else.
+	tokyo := time.FixedZone("JST", 9*3600)
+	ts := Timestamp{T: time.Date(2026, 7, 15, 20, 0, 0, 123456000, tokyo)}
+	if got := ts.String(); got != "2026-07-15 11:00:00.123456" {
+		t.Errorf("Timestamp.String() = %q; want the UTC instant to microseconds "+
+			"— a local-time render is off by the host's offset", got)
+	}
+	// Trailing zeros are dropped by the format, which is fine for a literal.
+	if got := (Timestamp{T: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}).String(); got != "2026-01-02 03:04:05" {
+		t.Errorf("whole-second Timestamp = %q", got)
+	}
+
+	// quoteIdent is the only thing standing between a table name and the
+	// statement it is spliced into. A name containing `]` closes the bracket
+	// early unless it is doubled, so this is an escaping test, not a
+	// formatting one.
+	for _, c := range []struct{ in, want string }{
+		{"plain", "[plain]"},
+		{"with space", "[with space]"},
+		{"bracket]inside", "[bracket]]inside]"},
+		{"]", "[]]]"},
+		{"a]]b", "[a]]]]b]"},
+		{"", "[]"},
+	} {
+		if got := quoteIdent(c.in); got != c.want {
+			t.Errorf("quoteIdent(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+	// The property that matters: after escaping, every `]` in the body is
+	// doubled, so nothing can terminate the identifier early.
+	body := quoteIdent("evil]; DROP TABLE t; --")
+	if strings.Count(body, "]")%2 == 0 {
+		t.Errorf("quoteIdent produced %q — the closing bracket must be the only "+
+			"unpaired one, or the identifier can be escaped from", body)
+	}
+}


### PR DESCRIPTION
Three functions that were reachable **only** through `WAREHOUSE_MSSQL_DSN`-gated tests, so they never executed on a machine without a SQL Server sidecar — including every laptop. None of them needs an engine.

**`resolveSQLItem` / `resolveWorkspace`** (`internal/server`) decide which item a TDS connection lands on — the same surface the empty-database RBAC bypass lived on. Seven cases: by item id (workspace-agnostic), by name via the server's workspace label, workspace addressable by id or name, the Warehouse-beats-Lakehouse precedence, the no-workspace-in-server-name error, and cross-workspace isolation.

The precedence is the one worth having. A workspace can hold a Warehouse and a Lakehouse of the *same name*, and they are not interchangeable: one is read-write and owns its data, the other is a read-only reflection. Resolving to the wrong one either fails a writer or points a reader at a stale mirror while it believes it is on the warehouse.

**`quoteIdent`** (`internal/warehouse`) is the only thing between a table name and the statement it is spliced into. A name containing `]` terminates the identifier early unless doubled — so this is an escaping test, with a property assertion that the closing bracket stays the only unpaired one.

**`Timestamp.String`** renders in UTC to microseconds. A local-time render is off by the host's offset — invisible on a UTC CI runner, wrong everywhere else.

Every assertion mutation-checked; each mutation fails its own specific test. One mutation I tried (dropping the workspace scope from the item lookup) turns out to be unwritable — Go rejects it as `declared and not used` — so the compiler already guarantees that one.

Coverage 90.04% → 90.18% deduplicated, but the number is incidental: these are branches where being wrong is silent.