### PR TITLE
v0.17.0 notes: credit the right cause for the 404 banner

### DIFF
--- a/docs/release-notes/v0.17.0.md
+++ b/docs/release-notes/v0.17.0.md
@@ -163,7 +163,28 @@ of worked around:
 - The flow view gains a terminal pane beside the graph: a profiled ttyd
   proxied through the portal, behind its own token, so watching a run and
   poking at the stack no longer means leaving the page.
-- A transient graph error no longer sticks for the rest of the session.
+- **That pane shipped with a defect worth describing, because the symptom was
+  nowhere near the cause.** The proxy hijacked *every* request under its
+  prefix, not only the WebSocket upgrade — a comment asserted the request was
+  an upgrade and nothing checked it. So the pane's plain requests (its HTML,
+  its JS) spliced the browser's whole keep-alive connection to ttyd, and the
+  next same-origin request the browser sent on it — `GET
+  /_emulator/portal/lineage` — arrived at ttyd and came back as ttyd's HTML
+  404. That painted an `HTTP 404` banner beside a healthy run, for viewers with
+  the pane open, until the browser happened to rotate connections.
+
+  It was invisible to every obvious check: nothing in `curl`, nothing in a
+  plain browser without the pane, and **nothing server-side** — the emulator
+  never saw the request, having given the socket away. Five instrumented runs
+  of theorising found nothing; logging the 404's first 120 bytes ended it in
+  one line, because the body was ttyd's index page rather than this server's
+  JSON. Only a genuine `Upgrade: websocket` is spliced now; plain requests go
+  through a per-request reverse proxy with the same header and query hygiene.
+- The flow view also recovers from a failed graph load on its own: the error
+  clears on the next success, and a failure now schedules its own retry rather
+  than waiting for a lineage event that an idle stack never emits. Both were
+  written while the banner above was still thought to be a transient — they are
+  worth having regardless, but the banner's cause was the proxy.
 
 ## Tooling, CI, security
 


### PR DESCRIPTION
`e6e0548` filed the notes while the `HTTP 404` banner was still believed to be a transient graph load failure. The story has moved twice since: `4e4c456` cleared the error on the next success, `07f288c` added a retry when it still stuck, and `9bfda55` found that **neither was the cause** — the terminal proxy was hijacking plain requests as well as WebSocket upgrades and giving away the browser's keep-alive connection.

The old text was not false — a transient error genuinely no longer sticks — but it told the wrong story and **omitted `9bfda55` entirely**, which is the most significant portal fix of the three and a defect in a feature shipping in this same release.

That is the shape this repo has already paid for once: `v0.16.0`'s notes asserted nested columns were omitted when the binary served them as `varchar` NULL. A notes file describing behaviour the code does not deliver — or crediting a fix to the wrong mechanism — is the same mistake with a different subject.

Now the notes: describe the hijack and why it was invisible to , to a plain browser, and server-side; record that the body's first 120 bytes ended five runs of theorising; and say plainly that the resilience fixes are worth having but were not the cause.

Raised by the session that found it, flagged as worth reconciling **before** the tag is cut. There is still no `v0.17.0` tag — latest is `v0.16.1`.

`make check` 0. Docs only.