### PR TITLE
e2e: one governance stack, so the pull retry cannot go missing

### DIFF
--- a/e2e/governance/run.py
+++ b/e2e/governance/run.py
@@ -13,7 +13,6 @@ past our Postgres pins, and schema drift in scripts/govern_ingest.py.
 import base64
 import json
 import os
-import subprocess
 import sys
 import time
 import urllib.parse
@@ -22,48 +21,16 @@ from decimal import Decimal
 
 DIR = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(DIR))
+sys.path.insert(0, DIR)
+
+from stack import Stack, log  # noqa: E402 — after the path insert above
 
 FABRIC_PORT = os.environ.get("GOV_FABRIC_PORT", "9443")
 ENTRA_PORT = os.environ.get("GOV_ENTRA_PORT", "8443")
 OM_PORT = os.environ.get("GOV_OM_PORT", "8585")
 TENANT = "11111111-1111-1111-1111-111111111111"
 
-COMPOSE = ["docker", "compose", "-p", "fabricgov-e2e",
-           "-f", os.path.join(REPO, "docker-compose.yml"),
-           "-f", os.path.join(DIR, "build-override.yml"),
-           "--profile", "governance"]
-
-
-def log(msg):
-    print(f"==> {msg}", flush=True)
-
-
-def compose(*args, check=True):
-    return subprocess.run(COMPOSE + list(args), check=check,
-                          env={**os.environ, "GOV_BUILD_CONTEXT": REPO})
-
-
-def compose_pulling(*args, attempts=3, base_delay=15):
-    """Run a compose command whose failure mode is usually a registry hiccup.
-
-    OpenMetadata ships from docker.getcollate.io — a third-party registry with
-    no mirror — so a reset connection mid-pull reds an otherwise-green run.
-    (Seen in CI: `read tcp ...:443: read: connection reset by peer`.)
-
-    Retries are bounded and each one is logged, so a real outage still fails
-    the suite rather than being silently absorbed or hanging.
-    """
-    for attempt in range(1, attempts + 1):
-        result = compose(*args, check=False)
-        if result.returncode == 0:
-            return result
-        if attempt == attempts:
-            log(f"compose {args[0]} failed {attempts}x — giving up")
-            raise subprocess.CalledProcessError(result.returncode, COMPOSE + list(args))
-        delay = base_delay * attempt
-        log(f"compose {args[0]} exited {result.returncode}; "
-            f"retrying in {delay}s ({attempt}/{attempts - 1}) — likely a registry hiccup")
-        time.sleep(delay)
+stack = Stack("fabricgov-e2e", "build-override.yml")
 
 
 def main():
@@ -75,27 +42,18 @@ def main():
     # Two phases: `up --wait` chokes on om-migrate (a one-shot that exits 0
     # is counted as failed on some compose versions), so wait only on the
     # long-running services, then start the OM chain and poll its API.
-    compose_pulling("up", "-d", "--build", "--wait", "--wait-timeout", "600",
-                    "entra-emulator", "keyvault-emulator", "fabric-emulator",
-                    "om-postgresql", "om-opensearch")
+    stack.pulling("up", "-d", "--build", "--wait", "--wait-timeout", "600",
+                  "entra-emulator", "keyvault-emulator", "fabric-emulator",
+                  "om-postgresql", "om-opensearch")
 
     log("starting OpenMetadata (first-boot migration takes a few minutes)")
-    compose_pulling("up", "-d", "--no-recreate", "openmetadata")
+    stack.pulling("up", "-d", "--no-recreate", "openmetadata")
 
     entra = f"https://localhost:{ENTRA_PORT}"
     fabric = f"https://localhost:{FABRIC_PORT}"
     om = f"http://localhost:{OM_PORT}"
 
-    end = time.time() + 900
-    while time.time() < end:
-        try:
-            if requests.get(f"{om}/api/v1/system/version", timeout=3).status_code == 200:
-                break
-        except requests.RequestException:
-            pass
-        time.sleep(5)
-    else:
-        raise RuntimeError("OpenMetadata never became healthy")
+    stack.wait_for_om(om)
 
     def token(scope):
         r = requests.post(
@@ -207,7 +165,7 @@ def main():
     # --no-deps: everything is already up; letting compose re-evaluate the
     # dependency chain here re-runs one-shots and can recreate fabric,
     # wiping its in-memory state between seed and ingest (seen on CI).
-    compose("run", "--rm", "--no-deps", "govern-ingest")
+    stack.compose("run", "--rm", "--no-deps", "govern-ingest")
 
     log("asserting through OpenMetadata's API")
     r = requests.post(f"{om}/api/v1/users/login",
@@ -331,7 +289,7 @@ def main():
 
     # Idempotency: a second ingest must succeed and not duplicate.
     log("re-running govern-ingest (idempotency)")
-    compose("run", "--rm", "--no-deps", "govern-ingest")
+    stack.compose("run", "--rm", "--no-deps", "govern-ingest")
     t2 = requests.get(f"{om}/api/v1/tables/name/fabric-emulator.govws.lake.orders",
                       headers=h, timeout=30)
     assert t2.status_code == 200
@@ -348,7 +306,7 @@ def main():
     r = s.post(f"{fabric}/v1/admin/items/bulkRemoveLabels",
                json={"items": [{"id": by_name["lake"]}]}, timeout=15)
     assert r.status_code == 200 and not r.json()["failedItems"], (r.status_code, r.text)
-    compose("run", "--rm", "--no-deps", "govern-ingest")
+    stack.compose("run", "--rm", "--no-deps", "govern-ingest")
     assert schema_label_tags("fabric-emulator.govws.lake") == set(), \
         f"label removed in Fabric but still tagged in OM: {schema_label_tags('fabric-emulator.govws.lake')}"
     # …and the removal was targeted: the other lakehouse and the hand-applied
@@ -370,9 +328,7 @@ if __name__ == "__main__":
     try:
         main()
     except Exception:
-        for svc in ("om-migrate", "openmetadata", "govern-ingest", "fabric-emulator"):
-            sys.stderr.write(f"\n==== {svc} log tail ====\n")
-            compose("logs", "--tail", "40", svc, check=False)
+        stack.dump_logs("om-migrate", "openmetadata", "govern-ingest", "fabric-emulator")
         raise
     finally:
-        compose("down", "-v", "--remove-orphans", check=False)
+        stack.down()

--- a/e2e/governance/sso.py
+++ b/e2e/governance/sso.py
@@ -12,12 +12,13 @@ The browser login flow (OIDC_* confidential client) rides the same trust edge
 but needs a real browser, so it is deliberately not asserted here.
 """
 import os
-import subprocess
 import sys
-import time
 
 DIR = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(DIR))
+sys.path.insert(0, DIR)
+
+from stack import Stack, log  # noqa: E402 — after the path insert above
 
 FABRIC_PORT = os.environ.get("GOV_FABRIC_PORT", "9443")
 ENTRA_PORT = os.environ.get("GOV_ENTRA_PORT", "8443")
@@ -30,20 +31,7 @@ CLIENT_ID = "cccccccc-0000-0000-0000-000000000002"
 ALICE_OID = "aaaaaaaa-0000-0000-0000-000000000001"
 ALICE_UPN = "alice@entraemulator.dev"
 
-COMPOSE = ["docker", "compose", "-p", "fabricgov-sso",
-           "-f", os.path.join(REPO, "docker-compose.yml"),
-           "-f", os.path.join(DIR, "build-override.yml"),
-           "-f", os.path.join(DIR, "sso-override.yml"),
-           "--profile", "governance"]
-
-
-def log(msg):
-    print(f"==> {msg}", flush=True)
-
-
-def compose(*args, check=True):
-    return subprocess.run(COMPOSE + list(args), check=check,
-                          env={**os.environ, "GOV_BUILD_CONTEXT": REPO})
+stack = Stack("fabricgov-sso", "build-override.yml", "sso-override.yml")
 
 
 def main():
@@ -52,26 +40,17 @@ def main():
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     log("starting family + OM backing stores (SSO overlay)")
-    compose("up", "-d", "--build", "--wait", "--wait-timeout", "600",
-            "entra-emulator", "keyvault-emulator", "fabric-emulator",
-            "om-postgresql", "om-opensearch")
+    stack.pulling("up", "-d", "--build", "--wait", "--wait-timeout", "600",
+                  "entra-emulator", "keyvault-emulator", "fabric-emulator",
+                  "om-postgresql", "om-opensearch")
     log("starting OpenMetadata with entra as its authenticator")
-    compose("up", "-d", "--no-recreate", "openmetadata")
+    stack.pulling("up", "-d", "--no-recreate", "openmetadata")
 
     # The SSO overlay runs the issuer over plain HTTP (see sso-override.yml).
     entra = f"http://localhost:{ENTRA_PORT}"
     om = f"http://localhost:{OM_PORT}"
 
-    end = time.time() + 900
-    while time.time() < end:
-        try:
-            if requests.get(f"{om}/api/v1/system/version", timeout=3).status_code == 200:
-                break
-        except requests.RequestException:
-            pass
-        time.sleep(5)
-    else:
-        raise RuntimeError("OpenMetadata never became healthy")
+    stack.wait_for_om(om)
 
     def forge(**over):
         # A real Entra delegated token carries the user's identity claims; the
@@ -120,9 +99,7 @@ if __name__ == "__main__":
     try:
         main()
     except Exception:
-        for svc in ("openmetadata", "om-migrate"):
-            sys.stderr.write(f"\n==== {svc} log tail ====\n")
-            compose("logs", "--tail", "40", svc, check=False)
+        stack.dump_logs("openmetadata", "om-migrate")
         raise
     finally:
-        compose("down", "-v", "--remove-orphans", check=False)
+        stack.down()

--- a/e2e/governance/stack.py
+++ b/e2e/governance/stack.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""The governance stack, shared by the two witnesses that boot it.
+
+`run.py` catalogs a Delta table; `sso.py` checks OpenMetadata's trust chain.
+Both bring up the same family + OpenMetadata, and each carried its own copy of
+*how* — which is exactly how one of them ended up without the pull retry.
+
+OpenMetadata ships from docker.getcollate.io, a third-party registry with no
+mirror, so a reset connection or a TLS handshake timeout mid-pull reds an
+otherwise-green run. `run.py` learned that and grew a bounded retry; `sso.py`
+held the same twenty lines minus the retry, and failed on precisely that pull.
+Two copies of a boot sequence is one copy that will not get the next fix.
+
+Sibling module rather than a package: every e2e suite here is a directory of
+scripts run as `python e2e/<suite>/run.py`, and this follows that.
+"""
+import os
+import subprocess
+import sys
+import time
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(DIR))
+
+
+def log(msg):
+    print(f"==> {msg}", flush=True)
+
+
+class Stack:
+    """One `docker compose` project, with the retry the registry needs.
+
+    The overlay list is given per-witness and must stay exactly what each one
+    used before: compose hashes the configuration it is HANDED, so booting with
+    a different `-f` list recreates containers that were already up.
+    """
+
+    def __init__(self, project, *overlays, profile="governance"):
+        self.argv = ["docker", "compose", "-p", project,
+                     "-f", os.path.join(REPO, "docker-compose.yml")]
+        for overlay in overlays:
+            self.argv += ["-f", os.path.join(DIR, overlay)]
+        # One `--profile` per profile: the flag is repeatable, and a
+        # comma-joined value is read as a single profile name that matches
+        # nothing (COMPOSE_PROFILES, the env var, is the comma-separated one).
+        self.argv += ["--profile", profile]
+
+    def compose(self, *args, check=True):
+        return subprocess.run(self.argv + list(args), check=check,
+                              env={**os.environ, "GOV_BUILD_CONTEXT": REPO})
+
+    def pulling(self, *args, attempts=3, base_delay=15):
+        """Run a compose command whose failure mode is usually a registry hiccup.
+
+        Seen in CI, both from docker.getcollate.io:
+        `read tcp ...:443: read: connection reset by peer`, and a TLS handshake
+        timeout.
+
+        Retries are bounded and each one is logged, so a real outage still fails
+        the suite rather than being silently absorbed or hanging.
+        """
+        for attempt in range(1, attempts + 1):
+            result = self.compose(*args, check=False)
+            if result.returncode == 0:
+                return result
+            if attempt == attempts:
+                log(f"compose {args[0]} failed {attempts}x — giving up")
+                raise subprocess.CalledProcessError(result.returncode,
+                                                    self.argv + list(args))
+            delay = base_delay * attempt
+            log(f"compose {args[0]} exited {result.returncode}; "
+                f"retrying in {delay}s ({attempt}/{attempts - 1}) — "
+                f"likely a registry hiccup")
+            time.sleep(delay)
+
+    def wait_for_om(self, om, timeout=900):
+        """Block until OpenMetadata answers, or say plainly that it never did.
+
+        First boot runs a schema migration that takes minutes, so this is a poll
+        and not a healthcheck wait: `up --wait` counts om-migrate — a one-shot
+        that exits 0 — as failed on some compose versions.
+        """
+        import requests  # a governance-group dependency; not imported at module load
+
+        end = time.time() + timeout
+        while time.time() < end:
+            try:
+                if requests.get(f"{om}/api/v1/system/version",
+                                timeout=3).status_code == 200:
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(5)
+        raise RuntimeError(f"OpenMetadata never became healthy within {timeout}s")
+
+    def dump_logs(self, *services):
+        """Tail the containers that explain a failure, for the CI log."""
+        for svc in services:
+            sys.stderr.write(f"\n==== {svc} log tail ====\n")
+            self.compose("logs", "--tail", "40", svc, check=False)
+
+    def down(self):
+        self.compose("down", "-v", "--remove-orphans", check=False)


### PR DESCRIPTION
`e2e/governance/run.py` and `e2e/governance/sso.py` boot the same family + OpenMetadata and each carried its own copy of *how*. `run.py` learned that docker.getcollate.io — a third-party registry with no mirror — drops connections mid-pull, and grew a bounded retry. `sso.py` held the same twenty lines **minus the retry**, and failed on exactly that: a TLS handshake timeout pulling the OM image.

Two copies of a boot sequence is one copy that will not get the next fix.

### What changes

New sibling module `e2e/governance/stack.py` with a `Stack` class holding what both need:

- `compose()` / `pulling()` — the bounded, logged retry, so a real outage still fails the suite rather than being absorbed or hanging;
- `wait_for_om()` — the 900s readiness poll both had byte-identical (a poll and not `up --wait`, because om-migrate is a one-shot that some compose versions count as failed when it exits 0);
- `dump_logs()` / `down()` — the teardown both had.

Sibling module with an explicit `sys.path.insert(0, DIR)`, matching how `e2e/medallion-advanced/run.py` already imports across suites.

### The thing that had to not change

Compose hashes the configuration it is *handed*, so a different `-f` list recreates containers that were already up. The overlay list is therefore per-witness, and I asserted the resulting argv is byte-identical to what each script built before:

```
run: docker compose -p fabricgov-e2e -f docker-compose.yml -f e2e/governance/build-override.yml --profile governance
sso: docker compose -p fabricgov-sso -f docker-compose.yml -f e2e/governance/build-override.yml -f e2e/governance/sso-override.yml --profile governance
```

Same project names, same order, same single `--profile` (the flag is repeatable; only `COMPOSE_PROFILES` is comma-separated).

`ruff check` clean. The suites themselves need a Linux runner with the OM images, so CI's `governance` and `governance-sso` jobs are the real proof.