### PR TITLE
config: say what the portal's unauthenticated premise now covers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,34 +70,20 @@ type Config struct {
 	// its own bearer (TerminalToken) rather than inheriting the portal's
 	// premise, and the other routes are untouched.
 	//
-	// WHAT THAT PREMISE NOW COVERS — read this before assuming the portal is
-	// inert. It was 11 GET routes over local state; it is now 11 GETs plus
-	// `POST /_emulator/portal/models/{id}/query`, which evaluates caller-supplied
-	// DAX against an import model through the same evaluator as executeQueries
-	// (internal/server/portal.go, internal/api/executequeries.go). That is the
-	// right implementation — the box and the wire cannot diverge by
-	// construction — and it is still a read of local state. But three things
-	// follow that "11 read-only GETs" did not imply, and they are written down
-	// here rather than rediscovered:
+	// THAT PREMISE IS NARROWER THAN IT LOOKS. The portal is 11 GETs plus
+	// `POST /_emulator/portal/models/{id}/query`, which runs caller-supplied DAX
+	// through the same evaluator as executeQueries (internal/server/portal.go).
+	// Three consequences the read-only GETs did not carry:
 	//
-	//  1. An unauthenticated caller who can reach the port can execute arbitrary
-	//     DAX against any import model. The earlier surface was fixed GET
-	//     routes; this one takes caller input into an evaluator.
-	//  2. It has an effect beyond answering. publishQuery fires for a portal
-	//     query exactly as for a REST one — correctly, because the model WAS
-	//     queried and the flow view reports what happened — so an
-	//     unauthenticated request now puts a visible event in every other
-	//     viewer's log. "Read-only over local state" no longer quite describes
-	//     it.
-	//  3. Arbitrary DAX is arbitrary compute, unbounded and unauthenticated. A
-	//     pathological query costs whatever the evaluator costs. Almost
-	//     certainly fine for something bound to localhost, and cheap to bound
-	//     now; awkward to retrofit if the portal is ever exposed further.
+	//  1. Anyone who reaches the port can evaluate arbitrary DAX against any
+	//     import model — caller input into an evaluator, not a fixed route.
+	//  2. It is not only a read: publishQuery fires, so the request puts a
+	//     visible event in every other viewer's flow log.
+	//  3. Arbitrary DAX is unbounded compute. Cheap to limit now, awkward to
+	//     retrofit if the portal is ever reachable beyond localhost.
 	//
-	// None of these is a defect for a local emulator, and none is a reason to
-	// remove the runner. They are the reason the next feature on this surface
-	// should be weighed rather than waved through: the premise that made 11 GETs
-	// safe is not the premise this route runs under.
+	// Fine for a local emulator, and not an argument against the runner. Written
+	// down so the next feature here is weighed rather than waved through.
 	TerminalURL string
 
 	// TerminalToken authorises the terminal proxy. Generated at startup when

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,11 +65,39 @@ type Config struct {
 	// terminal pane proxied through the portal's origin. Empty = the feature
 	// does not exist: no route is mounted and the pane never appears.
 	//
-	// THE PORTAL IS OTHERWISE UNAUTHENTICATED, and deliberately so — it is 11
-	// GET routes over local state (internal/server/portal.go). A terminal is
-	// not another read; it is arbitrary execution. So the proxy route carries
+	// THE PORTAL IS OTHERWISE UNAUTHENTICATED, and deliberately so. A terminal
+	// is not another read; it is arbitrary execution. So the proxy route carries
 	// its own bearer (TerminalToken) rather than inheriting the portal's
 	// premise, and the other routes are untouched.
+	//
+	// WHAT THAT PREMISE NOW COVERS — read this before assuming the portal is
+	// inert. It was 11 GET routes over local state; it is now 11 GETs plus
+	// `POST /_emulator/portal/models/{id}/query`, which evaluates caller-supplied
+	// DAX against an import model through the same evaluator as executeQueries
+	// (internal/server/portal.go, internal/api/executequeries.go). That is the
+	// right implementation — the box and the wire cannot diverge by
+	// construction — and it is still a read of local state. But three things
+	// follow that "11 read-only GETs" did not imply, and they are written down
+	// here rather than rediscovered:
+	//
+	//  1. An unauthenticated caller who can reach the port can execute arbitrary
+	//     DAX against any import model. The earlier surface was fixed GET
+	//     routes; this one takes caller input into an evaluator.
+	//  2. It has an effect beyond answering. publishQuery fires for a portal
+	//     query exactly as for a REST one — correctly, because the model WAS
+	//     queried and the flow view reports what happened — so an
+	//     unauthenticated request now puts a visible event in every other
+	//     viewer's log. "Read-only over local state" no longer quite describes
+	//     it.
+	//  3. Arbitrary DAX is arbitrary compute, unbounded and unauthenticated. A
+	//     pathological query costs whatever the evaluator costs. Almost
+	//     certainly fine for something bound to localhost, and cheap to bound
+	//     now; awkward to retrofit if the portal is ever exposed further.
+	//
+	// None of these is a defect for a local emulator, and none is a reason to
+	// remove the runner. They are the reason the next feature on this surface
+	// should be weighed rather than waved through: the premise that made 11 GETs
+	// safe is not the premise this route runs under.
 	TerminalURL string
 
 	// TerminalToken authorises the terminal proxy. Generated at startup when


### PR DESCRIPTION
The comment on `Config.TerminalURL` justified the terminal carrying its own bearer by contrast:

> THE PORTAL IS OTHERWISE UNAUTHENTICATED, and deliberately so — it is 11 GET routes over local state.

**That sentence stopped being true** when `42052d2` added `POST /_emulator/portal/models/{id}/query`. It is now 11 GETs plus a route that evaluates caller-supplied DAX. Nothing warned anyone, because the comment lives in `config/` and the route was added in `server/`.

So this corrects it, and writes down the three consequences that "11 read-only GETs" did not imply — raised by the session that wrote the DAX runner, and its own design decisions rather than mine:

1. **An unauthenticated caller who can reach the port can execute arbitrary DAX** against any import model. The earlier surface was fixed GET routes; this one takes caller input into an evaluator.
2. **It has an effect beyond answering.** `publishQuery` fires for a portal query exactly as for a REST one — correctly, because the model *was* queried and the flow view reports what happened — so an unauthenticated request now puts a visible event in every other viewer's log. "Read-only over local state" no longer quite describes it.
3. **Arbitrary DAX is arbitrary compute**, unbounded and unauthenticated. Cheap to bound now, awkward to retrofit if the portal is ever exposed beyond localhost.

None of these is a defect for a local emulator and none is a reason to remove the runner — the shared-evaluator implementation is the right one, since the box and the wire cannot diverge by construction. The point is the last line of the comment: the premise that made 11 GETs safe is not the premise this route runs under, so the next feature on this surface should be weighed rather than waved through.

Comment-only change. `gofmt` clean, `go build ./...`, `go vet`, `internal/config` tests and `make check` all pass.