### PR TITLE
perf: cap the warehouse sidecar's memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,12 @@ jobs:
       - name: SQL Server (Linux, native)
         if: matrix.os == 'ubuntu-latest'
         run: |
+          # Same memory cap the compose files ship, so the warehouse tests run
+          # against the configuration developers actually get. Without it CI
+          # would validate an uncapped engine nobody runs.
           docker run -d --name mssql -e ACCEPT_EULA=Y \
             -e MSSQL_SA_PASSWORD='Str0ng!Passw0rd' \
+            -e MSSQL_MEMORY_LIMIT_MB=2048 \
             -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
 
       # A started container is not a ready one. `services:` would have waited on

--- a/docker-compose.compute.yml
+++ b/docker-compose.compute.yml
@@ -66,6 +66,19 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "Str0ng!Passw0rd"
+      # Bound the engine's memory. UNCAPPED, SQL Server sizes its buffer pool from
+      # what it can see — 12.8 GB of a 16 GB host — and grew to ~1.8 GB RSS under a
+      # medallion run; on a bigger dev box it takes proportionally more. This caps
+      # what it believes it has, which is the knob that matters:
+      #
+      #   uncapped   physical 12832 MB, committed target 1490 MB, ~1.8 GB busy
+      #   2048       physical  2048 MB, committed target ~1.2 GB, ~0.9 GB busy
+      #
+      # 2048 and not lower because the engine FLOORS it there: MSSQL_MEMORY_LIMIT_MB=1024
+      # still reports 2000 MB, so a smaller number would only mislead the next reader.
+      # Note this does NOT move `max server memory` in sys.configurations, which stays
+      # at its 2147483647 sentinel — checking that setting makes the cap look inert.
+      MSSQL_MEMORY_LIMIT_MB: "2048"
     healthcheck:
       test:
         - CMD

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -112,6 +112,19 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "Str0ng!Passw0rd"
+      # Bound the engine's memory. UNCAPPED, SQL Server sizes its buffer pool from
+      # what it can see — 12.8 GB of a 16 GB host — and grew to ~1.8 GB RSS under a
+      # medallion run; on a bigger dev box it takes proportionally more. This caps
+      # what it believes it has, which is the knob that matters:
+      #
+      #   uncapped   physical 12832 MB, committed target 1490 MB, ~1.8 GB busy
+      #   2048       physical  2048 MB, committed target ~1.2 GB, ~0.9 GB busy
+      #
+      # 2048 and not lower because the engine FLOORS it there: MSSQL_MEMORY_LIMIT_MB=1024
+      # still reports 2000 MB, so a smaller number would only mislead the next reader.
+      # Note this does NOT move `max server memory` in sys.configurations, which stays
+      # at its 2147483647 sentinel — checking that setting makes the cap look inert.
+      MSSQL_MEMORY_LIMIT_MB: "2048"
     healthcheck:
       test:
         - CMD

--- a/e2e/dbt-fabric/docker-compose.yml
+++ b/e2e/dbt-fabric/docker-compose.yml
@@ -31,6 +31,10 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "Str0ng!Passw0rd"
+      # Same cap as docker-compose.override.yml — 2048 is the engine's floor.
+      # Capping only the dev stack would leave CI exercising a configuration
+      # nobody runs, which is the wrong way round for a memory limit.
+      MSSQL_MEMORY_LIMIT_MB: "2048"
     healthcheck:
       test:
         - CMD

--- a/e2e/medallion/docker-compose.yml
+++ b/e2e/medallion/docker-compose.yml
@@ -62,6 +62,10 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "Str0ng!Passw0rd"
+      # Same cap as docker-compose.override.yml — 2048 is the engine's floor.
+      # Capping only the dev stack would leave CI exercising a configuration
+      # nobody runs, which is the wrong way round for a memory limit.
+      MSSQL_MEMORY_LIMIT_MB: "2048"
     healthcheck:
       test:
         - CMD


### PR DESCRIPTION
SQL Server was the only service in the stack with **no memory bound at all**:

```
$ SELECT value_in_use FROM sys.configurations WHERE name='max server memory (MB)'
2147483647
```

It sizes its buffer pool from what it can see — 12.8 GB of a 16 GB host — and grew to **~1.8 GB RSS** under a medallion run. The cost scales with the host, so a 64 GB dev box gives it proportionally more.

## What the knob actually does

`MSSQL_MEMORY_LIMIT_MB` does **not** move `max server memory` — that stays at its sentinel, which makes the cap look inert if that is what you check. It bounds what the engine believes it has:

| | visible physical | committed target | busy RSS |
|---|---|---|---|
| uncapped | 12832 MB | 1490 MB | ~1.8 GB |
| **2048** | 2048 MB | ~1233 MB | **~0.9 GB** |

**2048, not lower, because the engine floors it there.** `MSSQL_MEMORY_LIMIT_MB=1024` still reports 2000 MB visible — I checked 1024 and 3072 to find the mapping (3072 maps directly, so 1024 is clamped). Writing `1024` would have been a number that silently becomes something else.

Both facts are in the compose comment, since both are traps for whoever looks next.

## Applied in all four places, plus CI

The sidecar is defined in `docker-compose.override.yml`, `docker-compose.compute.yml`, `e2e/dbt-fabric/` and `e2e/medallion/`, and CI's `test` job runs its own `docker run`. Capping only the dev stack would leave CI validating a configuration nobody runs — the wrong way round for a memory limit.

## Validated against real workloads

| Check | Result |
|---|---|
| `internal/warehouse` | ok |
| `internal/tds` | ok |
| `internal/server` | ok |
| **`e2e/dbt-fabric`** — Microsoft's real dbt-fabric 1.10 adapter over ODBC Driver 18 | **PASS=3, all stages passed** |

After those suites the container sat at 970 MiB with 274 MB committed against a 1233 MB target — comfortably inside the cap rather than pressed against it, which is what says 2048 is not too tight.

Every changed compose file re-parses; `ci.yml` parses; `make check` and `go build` clean.

## Not done

`make up` keeps `governance` as its default, per your call. The other candidates — OpenMetadata's JVM heap, `GOMEMLIMIT` on the emulator, `om-opensearch` 1 GB → 512 MB — are each worth their own change with their own validation; `om-opensearch` was already cut from upstream's 4 GB, so that one is partly picked already.