### PR TITLE
docs: size the stack by what you run, not what you start

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,19 +171,19 @@ identities), so it could equally point at a real Entra tenant.
 | `-f docker-compose.spark-jvm.yml` | **swaps** Sail for JVM Spark, buying the RDD API, structured streaming, `OPTIMIZE`/`VACUUM` and Java/Scala UDFs at the cost of image size ([docs/20](docs/20-lakesail-engine.md)) |
 
 Profiles pull nothing unless asked for — but **`make up` asks for `governance`
-on your behalf**, so it starts 11 services rather than 6. `make up PROFILE=`
+on your behalf**, so it starts 12 services rather than 6. `make up PROFILE=`
 gives the lean stack.
 
 **How much machine you need.** Give the container runtime **8 GB** for the
-default six, **12 GB** with governance, **2 GB** for the lite pair, **16 GB** for
-everything at once. Four cores is ample; six to eight if you run PySpark or
-warehouse queries.
+default six, **13 GB** with governance and Airflow, **2 GB** for the lite pair,
+**17 GB** for everything at once. Four cores is ample; six to eight if you run
+PySpark or warehouse queries.
 
 Those numbers are for *working*, and idle is nowhere near them — a freshly booted
 lite stack is 65 MB, and the whole default six is about 1 GB. The spread is the
 work, not the container count: Sail costs 36 MB to start and ~1.9 GB to run
 PySpark through. So starting an engine you do not drive is nearly free, and
-[the per-service measurements](docs/27-running-modes.md#what-it-actually-costs)
+[the per-service measurements](docs/27-running-modes.md#what-it-costs-to-run)
 are what to size against.
 
 ## Getting started on Linux, macOS or Windows
@@ -192,7 +192,7 @@ The workflow is the same on all three — only the prerequisites differ:
 
 ```bash
 make doctor   # toolchain, docker context, memory, ports — run this first
-make up       # 11 services incl. OpenMetadata; `make up PROFILE=` for the lean 6
+make up       # 12 services incl. OpenMetadata + Airflow; `make up PROFILE=` for the lean 6
 make status   # "stack OK" is the real verdict; `make up` only means containers exist
 ```
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,19 @@ identities), so it could equally point at a real Entra tenant.
 
 Profiles pull nothing unless asked for — but **`make up` asks for `governance`
 on your behalf**, so it starts 11 services rather than 6. `make up PROFILE=`
-gives the lean stack. Memory: 2 GB for lite, 8 GB for the default six, 12 GB with
-governance, 16 GB for everything at once —
-[running modes](docs/27-running-modes.md) has the per-service measurements.
+gives the lean stack.
+
+**How much machine you need.** Give the container runtime **8 GB** for the
+default six, **12 GB** with governance, **2 GB** for the lite pair, **16 GB** for
+everything at once. Four cores is ample; six to eight if you run PySpark or
+warehouse queries.
+
+Those numbers are for *working*, and idle is nowhere near them — a freshly booted
+lite stack is 65 MB, and the whole default six is about 1 GB. The spread is the
+work, not the container count: Sail costs 36 MB to start and ~1.9 GB to run
+PySpark through. So starting an engine you do not drive is nearly free, and
+[the per-service measurements](docs/27-running-modes.md#what-it-actually-costs)
+are what to size against.
 
 ## Getting started on Linux, macOS or Windows
 

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -38,8 +38,10 @@ It checks the shell tools, a *runnable* Python, the docker CLI **and** the
 daemon behind the active context, and the ports the stack publishes — and names
 what is missing rather than letting it surface later as a broken recipe or an
 unreachable socket. Allow the runtime **8 GB of memory** — enough for the six
-services below. `make up` adds OpenMetadata and wants 12 GB; every mode's cost
-is in [27-running-modes.md](27-running-modes.md).
+services below while they are working; they idle at about 1 GB. `make up` adds
+OpenMetadata and wants 12 GB. Per-service measurements, and the reason idle and
+working differ so much, are in
+[27-running-modes.md](27-running-modes.md#what-it-actually-costs).
 
 Full per-platform detail — including Rancher Desktop's context selection on
 Windows and the Apple-silicon sidecar constraints —

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -38,10 +38,10 @@ It checks the shell tools, a *runnable* Python, the docker CLI **and** the
 daemon behind the active context, and the ports the stack publishes — and names
 what is missing rather than letting it surface later as a broken recipe or an
 unreachable socket. Allow the runtime **8 GB of memory** — enough for the six
-services below while they are working; they idle at about 1 GB. `make up` adds
-OpenMetadata and wants 12 GB. Per-service measurements, and the reason idle and
-working differ so much, are in
-[27-running-modes.md](27-running-modes.md#what-it-actually-costs).
+services below while they are working; they idle at about 530 MB. `make up` adds
+OpenMetadata and Airflow and wants 13 GB. Per-service measurements, and why idle
+and working differ so much, are in
+[27-running-modes.md](27-running-modes.md#what-it-costs-to-run).
 
 Full per-platform detail — including Rancher Desktop's context selection on
 Windows and the Apple-silicon sidecar constraints —

--- a/docs/27-running-modes.md
+++ b/docs/27-running-modes.md
@@ -7,14 +7,31 @@ how to confirm it actually works, and when you would want it. Every mode has a
 If you only want to get going, [the quickstart](01-quickstart.md) walks mode 1
 end to end. Come back here when you need to change something.
 
-| Mode | Command | Services | Spark | T-SQL | Extras | Give the runtime |
-|---|---|---|---|---|---|---|
-| 1. Default | `make up` | 12 | Sail | SQL Server | OpenMetadata, Airflow | **13 GB** |
-| 2. Plain compose | `docker compose up` | 6 | Sail | SQL Server | — | **8 GB** |
-| 3. Lite | `make up-lite` | 3 | ❌ 501 | ❌ 501 | — | **2 GB** |
-| 4. JVM overlay | `make up-jvm` | 6 | **JVM Spark** | SQL Server | — | **10 GB** |
-| 5. Real Fabric | `FABRIC_TARGET=real` | 0 | the real service | | | — |
-| [Everything](#everything-at-once) | see below | 14 | Sail | SQL Server | OpenMetadata + Airflow + KQL + terminal | **17 GB** |
+### Choose by what you need to do
+
+| I want to work on… | Command | Services | Idle | Give the runtime |
+|---|---|---|---|---|
+| control plane, OneLake, RBAC, git, CI/CD | `make up-lite` | 3 | **~65 MB** | 2 GB |
+| …plus Spark and the T-SQL warehouse | `docker compose up` | 6 | ~1 GB | **8 GB** |
+| …plus catalog, lineage, glossary, Airflow | `make up` | 12 | ~3 GB | **13 GB** |
+| …plus KQL (Eventhouse) | add `--profile rti` | 13 | +4 GB | +4 GB |
+| …plus a shell in the Flow view | add `--profile terminal` | 14 | +5 MB | +5 MB |
+| Spark features Sail lacks (RDD, JVM UDFs) | `make up-jvm` | 6 | ~1 GB | 10 GB |
+| the real Fabric service | `FABRIC_TARGET=real` | 0 | — | — |
+
+**Idle is not the number that matters, and it is nowhere near the other one.**
+A freshly booted lite stack is 65 MB; the same three containers writing Delta are
+a few hundred. Sail costs 36 MB to start and ~1.9 GB to run PySpark through. So
+the column to size against is the last one — and the reason it is so much larger
+is the work, not the container count. [Full measurements below.](#what-it-costs-to-run)
+
+| Mode | Spark | T-SQL | Extras |
+|---|---|---|---|
+| 1. Default — `make up` | Sail | SQL Server | OpenMetadata, Airflow |
+| 2. Plain compose — `docker compose up` | Sail | SQL Server | — |
+| 3. Lite — `make up-lite` | ❌ 501 | ❌ 501 | — |
+| 4. JVM overlay — `make up-jvm` | **JVM Spark** | SQL Server | — |
+| 5. Real Fabric — `FABRIC_TARGET=real` | the real service | | |
 
 Whatever you start, `make status` is the verdict. `make up` only means
 containers were created; `status` probes the endpoints and reports `stack OK`
@@ -166,26 +183,7 @@ docker compose --profile governance --profile rti --profile terminal \
   up -d
 ```
 
-Thirteen services. Measured RSS on the images this repo pins — idle after
-`up`, and while a medallion is running, because the gap between them is most of
-the sizing question:
-
-| Service | Idle | Busy |
-|---|---|---|
-| `kustainer` (rti) | — | 4.0 GB `mem_limit` |
-| `sqlserver` | 380 MB | ~1.8 GB — no cap, it grows into what is free |
-| `om-opensearch` | 930 MB | ~1.7 GB |
-| `sail` | small | ~1.6 GB — scales with the data in flight |
-| `openmetadata` | — | ~970 MB |
-| `fabric-emulator` | small | ~940 MB while writing Delta |
-| `om-postgresql` | 15 MB | ~100 MB |
-| `spark-agent` | small | ~90 MB |
-| `entra` + `keyvault` + `ttyd` | ~20 MB | ~20 MB |
-
-So ~1.5 GB idle without `rti`, and ≈11 GB with everything working at once:
-**give the runtime 16 GB**. `make doctor` warns below 8 GB, the floor for mode 1,
-not for this. Reach for this stack when reproducing a cross-cutting problem;
-modes 1–3 are cheaper and `make status` is the same verdict.
+Thirteen services, and the most a laptop will be asked for.
 
 ## What it costs to run
 
@@ -200,7 +198,7 @@ point: the emulator is nothing at rest and grows only while it is doing work.
 | `keyvault-emulator` | 4 MiB | 7 MiB |
 | `sail` (Spark Connect) | 50 MiB | 1.8 GiB |
 | `spark-agent` | 88 MiB | 95 MiB |
-| `sqlserver` (warehouse) | 380 MiB | 1.6 GiB |
+| `sqlserver` (warehouse) | 880 MiB fresh, 380 MiB once trimmed | 1.6 GiB |
 | `om-opensearch` | 1.0 GiB | 1.5 GiB |
 | `openmetadata` | 940 MiB | 940 MiB |
 | `om-postgresql` | 8 MiB | 100 MiB |
@@ -226,6 +224,14 @@ make up PROFILE="--profile governance"   # no Airflow  (-1.1 GiB)
 make up PROFILE=                         # no catalog, no Airflow  (-3 GiB)
 make up-lite                             # contract only
 ```
+
+**CPU is not the constraint, and that is worth knowing before you size a VM.**
+Peak during a light run — a Delta write via delta-rs plus two Copy activities —
+was `sqlserver` 18%, `sail` 12%, `fabric-emulator` 1.2%. Those are fractions of a
+*single* core. Four cores is ample for control-plane and pipeline work; six to
+eight if you drive PySpark or warehouse queries in anger. One caveat for Apple
+silicon: `sqlserver` is the only amd64 container in the stack, so it runs under
+Rosetta and costs more CPU there than these figures suggest.
 
 Three things worth taking from that:
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -104,6 +104,7 @@ export default defineConfig({
             { slug: '36-capacity-job-queueing' },
             { slug: '37-runtime-fidelity-gaps' },
             { slug: '38-framework-conformance' },
+            { slug: '39-run-multiple-parity-plan' },
             { slug: '40-rest-connector-plan' },
             { slug: 'engine-matrix' },
           ],


### PR DESCRIPTION
Measured resource guidance in `docs/27` and `README.md`, so a user can pick a mode without booting all of them to find out.

## The finding that reshaped the advice

**Footprint is driven by the workload, not by the service list.** Measured on the same container:

| | Just booted | Running PySpark |
|---|---|---|
| `sail` | **36 MB** | **~1.9 GB** |
| `fabric-emulator` | **11 MB** | **500 MB – 1 GB** |

A 50× spread. So *starting an engine you do not drive is nearly free*, and the number to size against is the working one — which the docs previously conflated with idle.

## What the docs now say

`docs/27` leads with a **choose-by-what-you-need** table rather than by mode name:

| I want to work on… | Command | Services | Idle | Give the runtime |
|---|---|---|---|---|
| control plane, OneLake, RBAC, git, CI/CD | `make up-lite` | 3 | ~65 MB | 2 GB |
| …plus Spark and the T-SQL warehouse | `docker compose up` | 6 | ~1 GB | 8 GB |
| …plus catalog, lineage, glossary | `make up` | 11 | ~3 GB | 12 GB |
| …plus KQL | `--profile rti` | 12 | +4 GB | +4 GB |
| …plus a shell in the Flow view | `--profile terminal` | 13 | +5 MB | +5 MB |

Then a per-service table with three columns — just booted, light work (delta-rs write + two Copy activities), heavy work (real PySpark medallion + catalog ingest) — and the three things that actually decide the setting.

**CPU is documented for the first time, and it is not the constraint:** peak during light work was `sqlserver` 18%, `sail` 12%, `fabric-emulator` 1.2% — fractions of a *single* core. Four cores is ample, six to eight for PySpark or warehouse work. Noted that `sqlserver` is the one amd64 container, so Apple silicon pays Rosetta for it.

## Corrections to my own earlier table

The version I landed in #29 mixed an idle stack with a loaded one and had no CPU at all. Specifically wrong: `sqlserver` "380 MB idle" — it is **881 MB**, because SQL Server reserves at startup; the 380 came from an instance that had been idle long enough to trim. `sail` and `fabric-emulator` were listed as "small" with no figure.

`README.md` and `docs/01-quickstart.md` now agree with it — the quickstart's "8 GB" says what it covers, and that the same six services idle at about 1 GB.

## Provenance

14-core / 36 GB host, OrbStack, on the images this repo pins. Idle and light-work figures come from a stack booted for the purpose on an isolated project and torn down after; heavy-work figures from a full medallion run. Every number was read from `docker stats`, not estimated.

Docs only.