### PR TITLE
docs: describe Key Vault in the architecture, and assert the roster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,11 @@ jobs:
       # yet; the flag arms in the same change that lands the matrix, so it can
       # never afterwards go missing without failing here.
       - run: uv run --frozen --no-sync python scripts/check_conformance.py
+      # docs/03's diagram described a two-system model for as long as
+      # keyvault-emulator had been a default compose service — the topology was
+      # right, the cast of services had drifted. Nothing about adding a service
+      # reminds anyone to redraw, so the roster is asserted instead.
+      - run: uv run --frozen --no-sync python scripts/check_arch_services.py
       # The portal's event-kind list is GENERATED from internal/store/bus.go.
       # The stream names each SSE frame and EventSource has no wildcard
       # listener, so a kind missing from the client is invisible — no error,

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ check: ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_govern_types.py
 	@$(PY) scripts/check_example_parity.py
 	@$(PY) scripts/check_conformance.py
+	@$(PY) scripts/check_arch_services.py
 	@$(PY) scripts/gen_event_kinds.py --check
 
 # Not part of `check`: these need Node and an installed portal, and `check` is

--- a/docs/03-architecture.md
+++ b/docs/03-architecture.md
@@ -24,23 +24,33 @@ When re-auditing, diff the grounding files against this SHA
 docs/cicd/git-integration/git-automation.md docs/security/workspace-identity.md
 docs/security/permission-model.md`) and bump the pin.
 
-## The two-system model
+## The three-system model
 
-A Fabric environment is two independent products with two protocols:
+A Fabric environment is three independent Azure products with three protocols.
+Each stays a separate emulator, reached only over HTTP, because that is what the
+real boundary is — and it is what lets any one of them be swapped for the live
+service unchanged (see [21-real-fabric-toggle.md](21-real-fabric-toggle.md)):
 
 1. **Entra ID** — issues tokens (service-principal client credentials for the
    Fabric audience; **workspace identities** = auto-managed app registrations +
    service principals). Emulated by **entra-emulator**.
-2. **The Fabric control plane** — `https://api.fabric.microsoft.com/v1/…`:
+2. **Azure Key Vault** — the secrets data plane. Fabric never holds the secret
+   behind an **Azure Key Vault reference** connection: it stores a pointer and
+   resolves it at use with a vault-audience token. Same for
+   `notebookutils.credentials.getSecret()` inside a notebook. Emulated by
+   **azure-keyvault-emulator**; fabric-emulator is a *client* of it
+   ([internal/akv](../internal/akv/)).
+3. **The Fabric control plane** — `https://api.fabric.microsoft.com/v1/…`:
    workspace RBAC, item CRUD, item **definitions** (the CI/CD source format),
    git integration, deployment pipelines, long-running operations, and the
    workspace-identity *lifecycle orchestration*. Plus **OneLake**
    (`https://onelake.dfs.fabric.microsoft.com`), an ADLS-Gen2-shaped data plane.
    Emulated by **fabric-emulator**.
 
-Keeping these as two composable emulators preserves single responsibility:
-**fabric-emulator validates bearer tokens against entra-emulator's JWKS, exactly
-as real Fabric validates against Entra.**
+Keeping these as three composable emulators preserves single responsibility, and
+the token flow is one-way: **entra ISSUES; fabric and keyvault only VALIDATE**,
+each against entra-emulator's JWKS, exactly as the real products validate
+against Entra. Neither validator can mint a token.
 
 ```mermaid
 flowchart LR
@@ -57,6 +67,10 @@ flowchart LR
         JWKS["/{tenant}/discovery/v2.0/keys"]
         Forge["token forge / MSI endpoint"]
     end
+    subgraph kv["azure-keyvault-emulator"]
+        direction TB
+        Secrets["/secrets/{name} — data plane 7.4"]
+    end
     subgraph engines["opt-in engine sidecars"]
         direction TB
         Spark["Spark agent (Livy)"]
@@ -67,9 +81,17 @@ flowchart LR
     Client -->|"FedAuth (aud = database.windows.net)"| WH
     API -->|"verify (iss + aud + sig)"| JWKS
     Ident -->|"mint SP / identity tokens"| Forge
+    API -->|"resolve AKV reference (aud = vault)"| Secrets
+    Secrets -->|"verify (iss + aud + sig)"| JWKS
     API -.->|"native execution"| Spark
     WH -.->|"session splice"| SQL
 ```
+
+Every core service in [`docker-compose.yml`](../docker-compose.yml) appears in
+that diagram, and `scripts/check_arch_services.py` fails the build if one stops
+appearing. The check exists because this document described a *two*-system model
+for as long as Key Vault had been a default service — the shape was a decision
+and stayed true, but the **cast of services is a list**, and lists drift.
 
 ## Design principle: mirror entra-emulator
 
@@ -158,10 +180,19 @@ engine can be attached, the surface returns an honest **501** rather than faking
 a result. The principle is *never fake compute*, not *no compute*. See
 [14-real-compute.md](14-real-compute.md).
 
-## Decoupling from entra-emulator
+## Decoupling from the sibling emulators
 
 - Depends on entra-emulator **only over HTTP** (JWKS + issuer; plus a token-mint
   call for workspace identities — the shipped identity handshake). No shared process.
+- Depends on azure-keyvault-emulator **only over HTTP** too, and only as an
+  outbound client: `internal/akv` GETs `{vaultURI}/secrets/{name}` with a
+  vault-audience bearer when an `AzureKeyVaultReference` connection is used. The
+  secret value is returned to the caller and **never persisted** in the
+  emulator's database — only the `{vaultUri, secretName}` pointer is — which is
+  the property that makes credential-by-reference worth having.
+- There is no global vault setting to point elsewhere: **each connection carries
+  its own `vaultUri`**, as in real Fabric, so a connection naming a real vault
+  works alongside one naming the emulator with no reconfiguration.
 - For Go integration tests, it *may* import entra-emulator's public `emulator`
   package to run both in one process with no network — an ergonomics option, not
   a coupling requirement.

--- a/scripts/check_arch_services.py
+++ b/scripts/check_arch_services.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Every always-on service must appear in the architecture diagram.
+
+WHY THIS EXISTS. docs/03-architecture.md opened with "The two-system model" and
+a mermaid diagram showing entra-emulator and fabric-emulator — for as long as
+`keyvault-emulator` had been a default service in docker-compose.yml. Key Vault
+appeared *zero* times in the file, while `internal/akv` existed to call it and
+docs/parity.md carried a correct row for it. Nothing failed. The document was
+simply describing a system with one fewer component than the one that ships, and
+an architecture audit built by reading it inherited the gap wholesale.
+
+The general shape of the bug: a diagram's TOPOLOGY is a design decision and
+stays true for years, but its CAST OF SERVICES is a list, and lists drift
+silently. Hand-drawing the topology is right. Leaving the roster unasserted is
+not — nothing about adding a service to compose reminds anyone to redraw.
+
+SCOPE, deliberately narrow. Only services in docker-compose.yml with no
+`profiles:` key: the set that starts unconditionally, for everyone, with no flag.
+Profiled services (governance, rti, terminal) are opt-in and documented in their
+own files. The engine sidecars in docker-compose.override.yml are excluded too —
+they appear in the diagram under their ROLES ("Spark agent (Livy)", "SQL Server")
+rather than their compose names, and a check that demanded literal service names
+there would fail on correct prose. A narrow check that always passes honestly
+beats a broad one that gets disabled the first time it is wrong.
+
+Usage:
+    check_arch_services.py           exit non-zero naming any missing service
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+COMPOSE = ROOT / "docker-compose.yml"
+ARCH = ROOT / "docs" / "03-architecture.md"
+
+
+def core_services(compose_text):
+    """Service names under `services:` that carry no `profiles:` key.
+
+    Parsed rather than yaml-loaded so this runs in any CI job without pulling a
+    dependency in for eight lines of structure. Compose files are 2-space
+    indented by convention and this one is; a service is a 2-space key inside
+    the top-level `services:` block.
+    """
+    services, current, in_services = {}, None, False
+    for line in compose_text.splitlines():
+        if re.match(r"^[a-zA-Z]", line):  # a top-level key: services:, volumes:, …
+            in_services = line.startswith("services:")
+            current = None
+            continue
+        if not in_services:
+            continue
+        m = re.match(r"^  ([a-zA-Z0-9._-]+):\s*$", line)
+        if m:
+            current = m.group(1)
+            services[current] = False
+            continue
+        if current and re.match(r"^\s+profiles:", line):
+            services[current] = True
+    return [name for name, profiled in services.items() if not profiled]
+
+
+def main():
+    compose = COMPOSE.read_text()
+    arch = ARCH.read_text()
+
+    mermaid = "\n".join(re.findall(r"```mermaid\n(.*?)```", arch, re.S))
+    if not mermaid:
+        print("check_arch_services: docs/03-architecture.md has no mermaid block")
+        return 1
+
+    services = core_services(compose)
+    if not services:
+        # A parse that finds nothing must fail rather than vacuously pass —
+        # otherwise a compose reformat silently disarms this check.
+        print("check_arch_services: parsed no core services from docker-compose.yml")
+        return 1
+
+    missing = []
+    for name in services:
+        # Substring, so the doc may name it more fully than compose does
+        # (`keyvault-emulator` → `azure-keyvault-emulator`). Both the prose and
+        # the diagram must carry it: prose alone leaves the picture wrong, which
+        # is the failure this was written for.
+        where = []
+        if name not in arch:
+            where.append("the document")
+        if name not in mermaid:
+            where.append("the mermaid diagram")
+        if where:
+            missing.append((name, " and ".join(where)))
+
+    if missing:
+        print("check_arch_services: docker-compose.yml starts services that")
+        print("docs/03-architecture.md does not describe.\n")
+        for name, where in missing:
+            print(f"  {name:24s} missing from {where}")
+        print(
+            "\nAdd it to the three-system model and to the diagram, or give it a\n"
+            "`profiles:` key if it is genuinely opt-in."
+        )
+        return 1
+
+    print(f"check_arch_services: {len(services)} core services, all described "
+          f"({', '.join(sorted(services))})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/website/plugins/remark-mermaid.mjs
+++ b/website/plugins/remark-mermaid.mjs
@@ -14,7 +14,10 @@ export function remarkMermaid() {
       if (node.lang !== 'mermaid' || !parent || index === null) return;
       parent.children[index] = {
         type: 'html',
-        value: `<pre class="mermaid" role="img" aria-label="diagram">${escapeHtml(node.value)}</pre>`,
+        // tabindex="0": the diagram now scrolls horizontally (see the
+        // pre.mermaid rule in src/components/Head.astro), and a scrollable
+        // region a keyboard cannot reach is unreachable content.
+        value: `<pre class="mermaid" role="img" aria-label="diagram" tabindex="0">${escapeHtml(node.value)}</pre>`,
       };
     });
   };

--- a/website/src/components/Head.astro
+++ b/website/src/components/Head.astro
@@ -31,7 +31,13 @@ import Default from '@astrojs/starlight/components/Head.astro';
     mermaid.initialize({
       startOnLoad: false,
       theme: themeFor(),
-      flowchart: { htmlLabels: false, useMaxWidth: true },
+      // useMaxWidth: false — the diagram renders at its NATURAL size and the
+      // container scrolls, instead of being scaled down to the prose column.
+      // The architecture diagram is 2620px wide against a 45rem (720px)
+      // content width: scaled to fit, its 16px labels land at ~4px and the
+      // whole thing is unreadable. A reader can scroll a wide diagram; nobody
+      // can zoom a raster-thin one.
+      flowchart: { htmlLabels: false, useMaxWidth: false },
     });
     mermaid.run({ nodes });
   }
@@ -44,3 +50,19 @@ import Default from '@astrojs/starlight/components/Head.astro';
     if (muts.some((m) => m.attributeName === 'data-theme')) render();
   }).observe(document.documentElement, { attributes: true });
 </script>
+
+<style is:global>
+  /* The scroll container that makes useMaxWidth:false safe. Without it a
+     natural-size diagram simply overflows and the PAGE scrolls sideways. */
+  pre.mermaid {
+    overflow-x: auto;
+    max-width: 100%;
+  }
+  /* Defensive, not load-bearing: Starlight ships no `svg { max-width }` reset
+     today (checked — other svgs on the page compute `none`), and mermaid's own
+     inline style would outrank this anyway. It is here so that adding a global
+     image reset later cannot silently re-squash every diagram. */
+  pre.mermaid svg {
+    max-width: none;
+  }
+</style>


### PR DESCRIPTION
`docs/03-architecture.md` opened with **"The two-system model"** and a mermaid diagram showing entra-emulator and fabric-emulator — for as long as `keyvault-emulator` had been a default service in `docker-compose.yml`. Key Vault appeared **zero times** in the file, while `internal/akv` existed to call it and `docs/parity.md` carried a correct row for it.

Nothing failed. The document simply described a system with one fewer component than the one that ships, and an architecture audit built by reading it inherited the gap wholesale.

## The doc

- Two-system model → **three**, with Azure Key Vault as its own product boundary: Fabric stores a `{vaultUri, secretName}` pointer and resolves it at use with a vault-audience token, never holding the secret. Same path backs `notebookutils.credentials.getSecret()`.
- The diagram gains `azure-keyvault-emulator`, and the token flow is now stated as one-way: **entra issues; fabric and keyvault only validate**, each against entra's JWKS. Neither validator can mint.
- Decoupling section notes there is no global vault setting — each connection carries its own `vaultUri`, as in real Fabric.

## The check

`scripts/check_arch_services.py` — every service in `docker-compose.yml` with no `profiles:` key must appear in both the prose and the mermaid block.

Scope is deliberately narrow. Profiled services are opt-in and documented elsewhere; the override-file engine sidecars are excluded because the diagram names them by role ("Spark agent (Livy)") rather than compose name, and demanding literal names there would fail on correct prose. A narrow check that always passes honestly beats a broad one that gets disabled the first time it is wrong.

Mutation-tested twice:

| Mutation | Result |
|---|---|
| Run against the pre-fix doc | fails — `keyvault-emulator missing from the document and the mermaid diagram` |
| Keep the prose, strip it from the diagram only | fails — `missing from the mermaid diagram` |

So both assertions bite independently, and it catches the exact historical bug. A parse that finds zero services also fails rather than vacuously passing, so a compose reformat can't silently disarm it.

Wired into `make check` and the `docs` CI job. `make check`, `ruff check`, `ty check` all clean.

## Why this shape

A diagram's **topology** is a design decision and stays true for years. Its **cast of services** is a list, and lists drift silently — nothing about adding a compose service reminds anyone to redraw. Hand-drawing the topology is right; leaving the roster unasserted was not.