### PR TITLE
deps: close all six Dependabot advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss: '>=8.5.18'
+  js-yaml: '>=4.3.1 <5'
 
 importers:
 
@@ -2163,8 +2164,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -3449,7 +3450,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.5
       retext-smartypants: 6.2.0
       shiki: 4.3.1
@@ -3542,7 +3543,7 @@ snapshots:
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 26.3.6(typescript@7.0.2)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       klona: 2.0.6
       magic-string: 0.30.21
       mdast-util-directive: 3.1.0
@@ -4624,7 +4625,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
@@ -5494,7 +5495,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: 7.1.1
         version: 7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.3)(jiti@2.7.0)
       mermaid:
-        specifier: ^11.16.0
-        version: 11.16.0
+        specifier: ^11.16.1
+        version: 11.16.1
       sharp:
         specifier: 0.35.3
         version: 0.35.3(@types/node@24.13.3)
@@ -2443,8 +2443,8 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -5853,7 +5853,7 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,15 @@ onlyBuiltDependencies:
   - esbuild
   - sharp
 
-# Security floor for transitive deps (Dependabot): postcss < 8.5.18 has a
-# parsing vulnerability; nothing we use needs the old behavior.
+# Security floors for transitive deps (Dependabot). Each of these arrives through
+# something else — Astro, Starlight, their remark/rehype chains — so there is no
+# manifest to bump; the override is the only lever.
+#
+#   postcss  < 8.5.18  parsing vulnerability
+#   js-yaml  < 4.3.1   CVE-2026-59870, quadratic CPU in `!!omap` resolution.
+#                      Bounded `<5` deliberately: a bare `>=4.3.1` resolves to
+#                      5.2.3 and hands Astro's remark chain a different major.
+#                      The fix is a patch, so stay in the major that shipped it.
 overrides:
   postcss: ">=8.5.18"
+  js-yaml: ">=4.3.1 <5"

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/starlight": "0.41.3",
     "astro": "7.1.1",
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "sharp": "0.35.3",
     "unist-util-visit": "^5.1.0"
   }


### PR DESCRIPTION
All six open alerts, fixed at their patch versions.

| # | Severity | Package | | Advisory |
|---|---|---|---|---|
| 15 | **high** | `js-yaml` | 4.3.0 → **4.3.1** | CVE-2026-59870 — quadratic CPU in `!!omap` resolution |
| 14 | medium | `mermaid` | 11.16.0 → **11.16.1** | radar diagrams vulnerable to DoS |
| 13 | low | `mermaid` | ″ | configuration APIs allow prototype pollution |
| 12 | medium | `mermaid` | ″ | CSS injection into sibling elements |
| 11 | medium | `mermaid` | ″ | architecture diagrams — prototype pollution |
| 10 | medium | `mermaid` | ″ | XY charts — infinite-loop DoS |

Two different fixes, because they arrive two different ways.

**`mermaid` is a direct dependency** of `website/`, and 11.16.1 already satisfied the declared `^11.16.0` — so the lockfile alone was stale. Bumped the range to `^11.16.1` as well, so the security floor is stated rather than merely resolved.

**`js-yaml` is transitive** — Astro and `zwitch` pull it, there is no manifest to edit — so it needs an override, the same lever the repo already uses for `postcss`.

### The override needed bounding, and I only found that by checking

A bare `js-yaml: ">=4.3.1"` resolves to **5.2.3** — a major jump that hands Astro's remark chain a different API. The advisory is a patch-level fix, so the override is `">=4.3.1 <5"` and the comment says why. Verified 4.3.1 is what actually resolves.

Also checked before applying it: no `js-yaml@3.x` anywhere in the tree, so forcing the floor cannot drag a 3.x consumer across a major either.

### Verified

- `pnpm install --frozen-lockfile` — the lockfile is consistent
- **docs site builds**: 69 pages, and Astro is the main consumer of both packages
- **portal suite**: 232 tests, 100% statements/functions/lines — it shares the workspace override
- `portal/dist` byte-identical after a rebuild, so the committed bundle is unaffected
- `make check` clean

No source changes; two manifests and the lockfile.