### PR TITLE
ci: every main commit gets its own CI verdict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,32 @@ on:
     branches: [main]
   pull_request:
 
-# A push supersedes the run before it on the same ref. Without this, a burst of
-# pushes to main leaves every intermediate run grinding through the full
-# three-OS matrix for a commit nobody will ship — 15 of them piled up in one
-# afternoon and had to be cancelled by hand.
+# PR refs supersede; MAIN COMMITS DO NOT.
 #
-# `cancel-in-progress: true` is safe HERE because this workflow only reads: it
-# builds and tests, and cancelling it leaves nothing half-done. Do NOT copy this
-# to a workflow that publishes — docs-site.yml deliberately uses
-# `cancel-in-progress: false` for exactly that reason, and a cancelled deploy
-# there put the github-pages environment into `error`.
+# On a PR ref, a new push makes the run before it worthless, so it is cancelled:
+# without that, a burst leaves every intermediate run grinding through the full
+# three-OS matrix for a commit nobody will ship — 15 piled up in one afternoon
+# and had to be cancelled by hand. That reasoning is sound for a branch under
+# development and WRONG for main, where every commit is shipped and each one is
+# the thing a bisect will later ask about.
+#
+# It had teeth: five consecutive merges left main with no green CI at all —
+# 24ec739 and 0c8e6c4 failed, then 6af9ef2, 866952f and bae080f were each
+# cancelled by the merge behind them. The REST connector reached main with its
+# suite never having run there.
+#
+# The fix is the GROUP, not just the flag. `cancel-in-progress: false` alone is
+# not enough: GitHub keeps at most one PENDING run per group and cancels earlier
+# pending ones, so a burst would still skip the commits in the middle. Giving
+# each main commit its own group is what guarantees every one gets a verdict.
+#
+# This workflow only reads — it builds and tests — so nothing is half-done
+# either way. Do NOT copy the PR-side cancellation to a workflow that publishes:
+# docs-site.yml uses `cancel-in-progress: false` because a cancelled deploy put
+# the github-pages environment into `error`.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   test:

--- a/.github/workflows/make-targets.yml
+++ b/.github/workflows/make-targets.yml
@@ -29,17 +29,23 @@ on:
     branches: [main]
   pull_request:
 
-# Same supersede rule as ci.yml, and safe for the same reason: these jobs only
-# build and check, so cancelling one leaves nothing half-done.
+# Same rule as ci.yml, for the same reasons: PR refs supersede, main commits do
+# not. Safe either way — these jobs only build and check, so cancelling one
+# leaves nothing half-done. Kept in step with ci.yml deliberately; the two
+# together are what "main is green" means, and a verdict from one of them is
+# half an answer.
 #
-# The `github.ref` in the group is what keeps the RELEASE GATE out of it. When
-# release.yml calls this workflow, the ref is the tag (`refs/tags/v0.16.0`),
-# never `refs/heads/main` — so a push to main while a release is publishing
-# lands in a different group and cannot cancel the gate. Dropping the ref would
-# make every release cancellable by the next commit.
+# The RELEASE GATE still cannot be cancelled, but by a different mechanism than
+# before. release.yml triggers on a tag push and calls this workflow, so the
+# called run also sees `event_name == 'push'` and groups by sha — and a tag
+# normally points at a commit already on main, so the gate and that commit's
+# main run share ONE group rather than being separated by ref. What protects it
+# now is `cancel-in-progress: false`: the second run waits for the first instead
+# of killing it, and both finish. Under the old ref-based group they were
+# separate; under this one they queue. Either way the gate completes.
 concurrency:
-  group: make-targets-${{ github.ref }}
-  cancel-in-progress: true
+  group: make-targets-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Turns off run-cancellation for pushes to `main`, keeping it for PR refs.

## Why

Five consecutive merges left `main` with no green CI:

| commit | CI |
|---|---|
| `bae080f` (#40, REST R1) | cancelled |
| `866952f` (#39) | cancelled |
| `6af9ef2` (#38) | cancelled |
| `0c8e6c4` (#36) | failure — GitHub `Set up job` outage |
| `24ec739` (#33) | failure — governance SSO flake, passed on the next commit |

`main`'s last successful CI before this was **12:48**. The REST connector reached `main` with its suite never having run there — it was only verified because #41 landed on top and happened to run clean.

The old reasoning is right for a branch under development, where a new push makes the previous run worthless. It's wrong for `main`, where every commit ships and each one is what a bisect will later ask about.

## The fix is the group, not just the flag

`cancel-in-progress: false` on its own would **not** have fixed this. GitHub keeps at most one *pending* run per concurrency group and cancels earlier pending ones, so a burst would still skip the commits in the middle. Each main commit therefore gets its own group:

```yaml
group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
cancel-in-progress: ${{ github.event_name != 'push' }}
```

PR refs are unchanged — `refs/pull/N/merge`, superseding as before, so the 15-piled-up-runs problem the original comment describes stays solved where it actually applied.

## Both workflows

`make-targets.yml` carried the same rule and a comment explicitly cross-referencing `ci.yml`. Leaving them divergent would mean "main is green" answered by one workflow and not the other, so it gets the same change.

**The release gate is still protected, by a different mechanism** — and the comment now says so accurately. `release.yml` triggers on a tag push and calls `make-targets.yml`, so the called run also sees `event_name == 'push'` and groups by sha. A tag normally points at a commit already on `main`, so the gate and that commit's main run now share **one** group instead of being separated by ref. `cancel-in-progress: false` is what saves it: the second run waits rather than killing the first, and both finish. I had written that they'd land in different groups; checking `release.yml`'s trigger showed that's false, and the comment was corrected before commit.

## Cost

A burst of merges now runs a full matrix per commit instead of one for the last. That is the price of a per-commit verdict, and it is the thing that was being traded away silently.

## Verification

`actionlint` passes on both files — same two pre-existing shellcheck infos as `main`, no new findings, identical exit status.