### PR TITLE
Sail: refresh the Storage token against the emulator's clock

### DIFF
--- a/docker/sail/launcher.py
+++ b/docker/sail/launcher.py
@@ -131,7 +131,7 @@ def mint():
     return body["access_token"], int(body.get("expires_in", 3600))
 
 
-def main():
+def main():  # pragma: no cover - the supervisor loop; witnessed by e2e/sail
     if not os.environ.get("ENTRA_TOKEN_URL") or os.environ.get("AZURE_STORAGE_TOKEN"):
         os.execvp("sail", ["sail"] + sys.argv[1:])
 
@@ -205,5 +205,5 @@ def main():
             time.sleep(2)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/docker/sail/launcher.py
+++ b/docker/sail/launcher.py
@@ -38,6 +38,78 @@ import urllib.request
 # token's life is actually used.
 REFRESH_MARGIN = int(os.environ.get("SAIL_TOKEN_REFRESH_MARGIN_SECONDS", "300"))
 
+# How often to re-read the emulator's clock while waiting. Cheap (a local GET)
+# and it only has to be faster than a person can notice a stalled pipeline.
+CLOCK_POLL_SECONDS = int(os.environ.get("SAIL_CLOCK_POLL_SECONDS", "10"))
+
+
+def emulator_base():
+    """The emulator's origin, or None when it is not one.
+
+    Derived from the storage endpoint the container already has rather than a
+    new variable: OneLake IS the emulator, so anything configured to read
+    OneLake already knows where to ask. An explicit override exists for
+    deployments where those differ.
+    """
+    explicit = os.environ.get("FABRIC_EMULATOR_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    endpoint = os.environ.get("AZURE_STORAGE_ENDPOINT", "")
+    parts = urllib.parse.urlsplit(endpoint)
+    if not parts.scheme or not parts.netloc:
+        return None
+    return f"{parts.scheme}://{parts.netloc}"
+
+
+def clock_offset():
+    """Seconds the emulator's clock runs AHEAD of real time; 0 if unknown.
+
+    WHY THE LAUNCHER CARES ABOUT SOMEBODY ELSE'S CLOCK. The token's expiry is
+    set by the issuer in real time, but it is *judged* by the emulator, and the
+    emulator's clock can be advanced — that is a feature, and it is the only
+    way to test a schedule without waiting for a real occurrence. Once it is
+    advanced, a token the issuer considers fresh is read as expired, and every
+    OneLake call 401s from inside a notebook cell with nothing to point at.
+
+    Unreachable, unconfigured or unparseable all mean 0: this must never be the
+    reason the launcher fails to start sail.
+    """
+    base = emulator_base()
+    if not base:
+        return 0
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        req = urllib.request.Request(f"{base}/_emulator/clock")
+        with urllib.request.urlopen(req, timeout=5, context=ctx) as r:
+            return max(0, int(json.loads(r.read()).get("offset", 0)))
+    except Exception:  # noqa: BLE001 - a clock we cannot read is a clock at zero
+        return 0
+
+
+def refresh_deadline(minted_at, expires_in, offset, margin=REFRESH_MARGIN):
+    """Wall-clock instant to re-mint by, given how far the judge's clock leads.
+
+    The emulator marks the token dead at `minted_at + expires_in - offset` in
+    real time, so the whole schedule shifts earlier by the offset. Floored a
+    minute out so a large advance cannot spin this into a restart loop.
+    """
+    return minted_at + max(60, expires_in - margin - max(0, offset))
+
+
+def hopeless(expires_in, offset):
+    """True when no mintable token can satisfy the emulator.
+
+    The line is the token's LIFETIME, not lifetime-minus-margin. Between those
+    two a refresh still buys real time — a 3600s token under a 1200s advance is
+    accepted for 2400s, which is most of a working session — and warning there
+    would cry wolf on the ordinary case this fix exists to handle. Past the
+    lifetime the fresh token is born expired and restarting sail only costs a
+    session.
+    """
+    return max(0, offset) >= expires_in
+
 
 def mint():
     """Return (token, expires_in_seconds) from the configured issuer."""
@@ -73,17 +145,27 @@ def main():
     signal.signal(signal.SIGINT, forward)
 
     while True:
-        token, expires_in = mint()
-        os.environ["AZURE_STORAGE_TOKEN"] = token
         # Wall clock, NOT time.monotonic(): the token's expiry is a wall-clock
         # fact set by the issuer, and inside a VM (docker on macOS) the
         # monotonic clock pauses and warps against it — observed as a launcher
         # that sat through a refresh deadline while the token expired under it.
-        refresh_at = time.time() + max(60, expires_in - REFRESH_MARGIN)
+        minted_at = time.time()
+        token, expires_in = mint()
+        os.environ["AZURE_STORAGE_TOKEN"] = token
+        offset = clock_offset()
+        refresh_at = refresh_deadline(minted_at, expires_in, offset)
         verb = "restarting with fresh" if child else "minted"
+        skew = f", emulator clock +{offset}s" if offset else ""
         print(f"launcher: {verb} Storage token from {os.environ['ENTRA_TOKEN_URL']} "
-              f"(expires_in={expires_in}s, refresh in {int(refresh_at - time.time())}s)",
+              f"(expires_in={expires_in}s{skew}, refresh in {int(refresh_at - time.time())}s)",
               flush=True)
+        if hopeless(expires_in, offset):
+            # No refresh can help: the fresh token is already born expired from
+            # the emulator's point of view. Say so plainly rather than
+            # restarting sail every minute while every call 401s anyway.
+            print(f"launcher: WARNING the emulator's clock is {offset}s ahead, which "
+                  f"outruns the {expires_in}s token lifetime — every OneLake call will "
+                  f"401 until the clock is reset or the issuer follows it", flush=True)
 
         if child and child.poll() is None:
             child.terminate()
@@ -97,11 +179,29 @@ def main():
         # Wait for whichever comes first: the refresh deadline, or sail dying
         # on its own (in which case exit with ITS code so the container's
         # restart policy and healthcheck see the truth).
+        #
+        # THE DEADLINE IS RECOMPUTED, not fixed at mint time. A clock advance
+        # that lands mid-wait moves the token's effective expiry earlier by the
+        # amount of the jump, and a launcher holding a deadline it decided
+        # minutes ago sleeps straight through it — which is exactly how a
+        # scheduled notebook run 401s while the launcher reports a healthy
+        # token with 40 minutes left on it.
+        next_clock_check = 0.0
         while time.time() < refresh_at:
             code = child.poll()
             if code is not None:
                 print(f"launcher: sail exited with {code}", flush=True)
                 sys.exit(code)
+            now = time.time()
+            if now >= next_clock_check:
+                next_clock_check = now + CLOCK_POLL_SECONDS
+                moved = clock_offset()
+                if moved != offset:
+                    offset = moved
+                    refresh_at = refresh_deadline(minted_at, expires_in, offset)
+                    print(f"launcher: emulator clock moved to +{offset}s — token now "
+                          f"effectively expires {int(refresh_at - now)}s from here",
+                          flush=True)
             time.sleep(2)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ markers = [
 # surface in the repo contributed nothing to the gate. Its low-coverage members
 # (fs, _http) are witnessed by e2e rather than unit tests, the same way the
 # omitted spark_agent files are.
-source = ["scripts", "python/spark_agent", "python/notebookutils"]
+source = ["scripts", "python/spark_agent", "python/notebookutils", "docker/sail"]
 omit = [
     # Run inside the Spark image, witnessed by e2e/notebook-run and e2e/sail.
     "python/spark_agent/agent.py",

--- a/python/tests/test_sail_launcher.py
+++ b/python/tests/test_sail_launcher.py
@@ -1,0 +1,140 @@
+"""The Sail launcher's token-refresh arithmetic.
+
+The launcher had no tests, and it grew a real calculation the day a scheduled
+notebook run started failing with `401 Unauthorized` raised inside a cell: the
+emulator's clock had been advanced (the only way to test a schedule without
+waiting for a real occurrence), so a token the issuer considered fresh was
+judged expired by the service reading it, while the launcher slept on a
+deadline it had computed before the jump.
+
+What matters here is that the deadline moves EARLIER by the offset, that a
+clock nobody can read is treated as no offset at all, and that an advance
+larger than a token's life cannot spin the supervisor into a restart loop.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+LAUNCHER = (
+    pathlib.Path(__file__).resolve().parents[2] / "docker" / "sail" / "launcher.py"
+)
+
+
+def load():
+    """Import launcher.py by path — it ships as a script, not a package."""
+    spec = importlib.util.spec_from_file_location("sail_launcher", LAUNCHER)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sail_launcher"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def launcher():
+    return load()
+
+
+def test_without_skew_the_deadline_is_lifetime_minus_margin(launcher):
+    at = 1_000_000.0
+    assert launcher.refresh_deadline(at, 3600, 0, margin=300) == at + 3300
+
+
+def test_an_advanced_clock_pulls_the_deadline_earlier_by_the_offset(launcher):
+    # The failure this file exists for: 3600s token, 300s margin, and an
+    # emulator advanced 1200s. Refreshing at 3300s leaves an 1100s window in
+    # which the launcher believes the token is good and every call 401s.
+    at = 1_000_000.0
+    assert launcher.refresh_deadline(at, 3600, 1200, margin=300) == at + 2100
+
+
+def test_a_negative_offset_is_ignored_rather_than_extending_the_token(launcher):
+    # A clock BEHIND real time cannot make a token live longer than the issuer
+    # said; treating it as extra life would be the same bug pointing backwards.
+    at = 1_000_000.0
+    assert launcher.refresh_deadline(at, 3600, -600, margin=300) == at + 3300
+
+
+def test_an_advance_past_the_token_lifetime_floors_instead_of_looping(launcher):
+    # Nothing can be minted that survives this, so the deadline must not go to
+    # now-or-earlier: that would restart sail continuously while every call
+    # failed anyway.
+    at = 1_000_000.0
+    assert launcher.refresh_deadline(at, 3600, 9999, margin=300) == at + 60
+
+
+def test_an_ordinary_advance_is_not_reported_as_hopeless(launcher):
+    # The case this whole fix exists for. A 3600s token under the 1200s advance
+    # a schedule test makes is still accepted for 2400s — most of a working
+    # session — so warning here would cry wolf on the normal path. Caught by
+    # running it: the first version keyed off lifetime-minus-margin and
+    # announced that 1200s "outruns the 3600s token lifetime", which is false.
+    assert not launcher.hopeless(3600, 1200)
+    assert not launcher.hopeless(3600, 3599)
+
+
+def test_an_advance_past_the_lifetime_is_hopeless(launcher):
+    assert launcher.hopeless(3600, 3600)
+    assert launcher.hopeless(3600, 9999)
+
+
+def test_no_skew_is_never_hopeless(launcher):
+    assert not launcher.hopeless(3600, 0)
+    assert not launcher.hopeless(3600, -50)
+
+
+def test_the_emulator_origin_comes_from_the_storage_endpoint(launcher, monkeypatch):
+    monkeypatch.delenv("FABRIC_EMULATOR_URL", raising=False)
+    monkeypatch.setenv("AZURE_STORAGE_ENDPOINT", "https://fabric-emulator:9443/onelake")
+    assert launcher.emulator_base() == "https://fabric-emulator:9443"
+
+
+def test_an_explicit_url_wins_over_the_storage_endpoint(launcher, monkeypatch):
+    monkeypatch.setenv("FABRIC_EMULATOR_URL", "https://elsewhere:1234/")
+    monkeypatch.setenv("AZURE_STORAGE_ENDPOINT", "https://fabric-emulator:9443/onelake")
+    assert launcher.emulator_base() == "https://elsewhere:1234"
+
+
+def test_no_endpoint_means_no_origin(launcher, monkeypatch):
+    monkeypatch.delenv("FABRIC_EMULATOR_URL", raising=False)
+    monkeypatch.setenv("AZURE_STORAGE_ENDPOINT", "")
+    assert launcher.emulator_base() is None
+
+
+def test_an_unreachable_clock_reads_as_no_skew(launcher, monkeypatch):
+    # Degrading to today's behaviour is the requirement: a clock endpoint that
+    # is missing, slow or serving nonsense must never stop sail from starting.
+    monkeypatch.setenv("FABRIC_EMULATOR_URL", "https://127.0.0.1:9/nope")
+    assert launcher.clock_offset() == 0
+
+
+def test_an_unconfigured_endpoint_reads_as_no_skew(launcher, monkeypatch):
+    monkeypatch.delenv("FABRIC_EMULATOR_URL", raising=False)
+    monkeypatch.setenv("AZURE_STORAGE_ENDPOINT", "")
+    assert launcher.clock_offset() == 0
+
+
+def test_the_offset_is_read_from_the_clock_endpoint(launcher, monkeypatch):
+    import http.server
+    import threading
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler's interface
+            body = b'{"frozen":false,"now":1786066201,"offset":1200}'
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_):
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        monkeypatch.setenv("FABRIC_EMULATOR_URL", f"http://127.0.0.1:{srv.server_port}")
+        assert launcher.clock_offset() == 1200
+    finally:
+        srv.shutdown()

--- a/python/tests/test_sail_launcher.py
+++ b/python/tests/test_sail_launcher.py
@@ -138,3 +138,60 @@ def test_the_offset_is_read_from_the_clock_endpoint(launcher, monkeypatch):
         assert launcher.clock_offset() == 1200
     finally:
         srv.shutdown()
+
+
+def test_mint_reads_the_token_and_its_lifetime(launcher, monkeypatch):
+    # `mint` was untested, and it is where the token's declared lifetime enters
+    # the arithmetic everything above depends on — a mint that ignored
+    # `expires_in` would leave every deadline computed off a default.
+    import http.server
+    import threading
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler's interface
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            body = b'{"access_token":"tok-123","expires_in":900}'
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_):
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        monkeypatch.setenv("ENTRA_TOKEN_URL", f"http://127.0.0.1:{srv.server_port}/token")
+        monkeypatch.setenv("ENTRA_CLIENT_ID", "id")
+        monkeypatch.setenv("ENTRA_CLIENT_SECRET", "secret")
+        assert launcher.mint() == ("tok-123", 900)
+    finally:
+        srv.shutdown()
+
+
+def test_mint_defaults_the_lifetime_when_the_issuer_omits_it(launcher, monkeypatch):
+    import http.server
+    import threading
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler's interface
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            body = b'{"access_token":"tok-456"}'
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_):
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        monkeypatch.setenv("ENTRA_TOKEN_URL", f"http://127.0.0.1:{srv.server_port}/token")
+        monkeypatch.setenv("ENTRA_CLIENT_ID", "id")
+        monkeypatch.setenv("ENTRA_CLIENT_SECRET", "secret")
+        assert launcher.mint() == ("tok-456", 3600)
+    finally:
+        srv.shutdown()

--- a/python/tests/test_sail_launcher.py
+++ b/python/tests/test_sail_launcher.py
@@ -26,6 +26,11 @@ LAUNCHER = (
 def load():
     """Import launcher.py by path — it ships as a script, not a package."""
     spec = importlib.util.spec_from_file_location("sail_launcher", LAUNCHER)
+    # Asserted rather than assumed: `spec_from_file_location` returns None for
+    # a path it cannot load, and a moved or renamed launcher would otherwise
+    # surface as an AttributeError on None several lines later, pointing at the
+    # wrong thing entirely.
+    assert spec and spec.loader, f"cannot load {LAUNCHER}"
     mod = importlib.util.module_from_spec(spec)
     sys.modules["sail_launcher"] = mod
     spec.loader.exec_module(mod)


### PR DESCRIPTION
Fixes #48.

## What was wrong

The emulator's clock is deliberately controllable — advancing it is the only way to test a schedule without waiting for a real occurrence. The Sail launcher's refresh timer ran on **real** time. So once the clock moved, a token the issuer considered fresh was judged expired by the service reading it, and every OneLake call 401d from inside a notebook cell with nothing to point at.

With the stock 3600s token, 300s margin and the 1200s advance a schedule test makes, the token was rejected from real age 2400s while the launcher refreshed at 3299s — an **899-second window per token cycle** in which a scheduled run fails. Invisible on a fresh stack, because a young token survives the skew, which is why no CI run has ever seen it.

## What changed

The launcher reads `offset` from `/_emulator/clock` and computes the deadline as `expires_in - margin - offset`.

- **The origin needs no new configuration.** It is derived from `AZURE_STORAGE_ENDPOINT`, which already points at the emulator, since OneLake *is* the emulator. `FABRIC_EMULATOR_URL` overrides it where they differ.
- **The deadline is recomputed while waiting**, not fixed at mint time. A jump landing mid-wait must move a deadline decided minutes earlier — sleeping through it is the actual defect.
- **Unreachable, unconfigured or unparseable all read as offset 0**, so this degrades to exactly today's behaviour and can never be the reason sail fails to start.

## Why not refresh-on-401-and-retry

That is what I recommended in the issue, and it is not implementable here: the 401 is raised inside Sail's `object_store` client and surfaces to the notebook, never to the launcher, which only supervises the process. It would have to live in Sail itself — upstream Rust. The clock is the one relevant thing the launcher can observe.

## Verified

Live, with stock settings:

```
launcher: minted Storage token ... (expires_in=3600s, refresh in 3299s)
launcher: emulator clock moved to +1200s — token now effectively expires 2089s from here
```

3299 → 2089, inside the 2400s rejection point. Window closed.

**Running it caught a bug in the fix.** The first version warned when `offset >= expires_in - margin`, and announced that a 1200s advance "outruns the 3600s token lifetime" — false, and it fired on the ordinary path this change exists to support. The line is the lifetime itself: between the two a refresh still buys 2400 useful seconds. Now `hopeless()`, with its own tests, and the default-margin run logs no warning.

## Tests

13 tests on a file that had none. Mutation-checked: reverting the offset subtraction fails exactly the two offset tests and leaves the other eleven green.