### PR TITLE
Force the govern-types stub path so coverage stops depending on the venv

### DIFF
--- a/docs/10-testing.md
+++ b/docs/10-testing.md
@@ -256,6 +256,18 @@ harnesses run inside containers that have pytest but not pytest-cov — where th
 flags are unrecognised arguments and the suite dies with exit 4 for a reason
 that has nothing to do with what it was testing.
 
+**Measure the floor in a clean venv.** `--frozen --group test` is what CI runs,
+so it is the only environment whose number is authoritative. A venv that has
+drifted — anything installed with an extra group or `uv run --with` persists —
+can read a point lower, because code that only runs when a dependency is
+*absent* stops running once something installs it. `scripts/check_govern_types.py`
+did exactly that: 98% clean, 85% with `urllib3` present, one point on the total
+against a 70% floor. The lesson generalises past that file — if a test's coverage
+depends on what happens to be installed, force the branch instead of inheriting
+it, or the gate fails on whoever pushes next rather than on whoever spent the
+margin. That drift happened to read low, which is the safe direction; the same
+mechanism reading high would hide a real regression under a floor that passes.
+
 `FABRIC_COVERAGE=1` makes the harness layer `e2e/docker-compose.coverage.yml`,
 which builds the emulator with `COVER=1` and mounts one repository-level
 `covdata/`. Every wired suite writes into that same directory, so the merge sees

--- a/python/tests/test_check_govern_types.py
+++ b/python/tests/test_check_govern_types.py
@@ -10,8 +10,10 @@ type-map change nobody connected to it.
 Two things are worth pinning: that the guard's import shim does not mask a real
 dependency, and that the guard actually fails on the column it exists to catch.
 """
+import importlib
 import importlib.util
 import sys
+import types
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -45,6 +47,57 @@ def test_stub_is_installed_when_the_module_is_missing():
         assert name in sys.modules
     finally:
         sys.modules.pop(name, None)
+
+
+def test_stub_builders_run_when_the_dependency_group_is_absent(monkeypatch):
+    """Force every stubbed dependency absent, so the BUILDERS run here too.
+
+    This exists for the measurement as much as the behaviour. `_stub_missing`
+    builds a stand-in only when the import fails, so on a machine that happens
+    to have `requests` installed — it arrives with the `sessions` extra, or in
+    any venv that has drifted — the builder bodies never execute and coverage
+    reports them missing. That made this file's number a function of the ambient
+    environment: 98% in a clean venv, 85% with urllib3 present, a full point on
+    the repo total against a 70% floor. A gate that reads differently depending
+    on which machine measured it fails on whoever pushes next.
+
+    So the builders are exercised deterministically. `urllib3`'s is the one that
+    matters: it is the only multi-line builder, and it has to supply exactly the
+    names govern_ingest touches at import time.
+    """
+    absent = {"requests", "yaml", "urllib3"}
+    saved = {n: sys.modules.get(n) for n in absent | {"urllib3.exceptions"}}
+    real_import = importlib.import_module
+
+    def missing_on_demand(name, *args, **kwargs):
+        if name in absent:
+            raise ImportError(f"forced absent for this test: {name}")
+        return real_import(name, *args, **kwargs)
+
+    for name in saved:
+        sys.modules.pop(name, None)
+    monkeypatch.setattr(importlib, "import_module", missing_on_demand)
+    try:
+        gi = cg.load_ingest()
+
+        u = sys.modules["urllib3"]
+        # The stub must carry what govern_ingest uses at import time, and no
+        # more: asserting the module merely exists would pass on an empty
+        # ModuleType and leave the real import to fail in CI instead.
+        assert issubclass(u.exceptions.InsecureRequestWarning, Warning)
+        assert u.disable_warnings() is None
+        assert sys.modules["urllib3.exceptions"] is u.exceptions
+        assert isinstance(sys.modules["requests"], types.ModuleType)
+        assert isinstance(sys.modules["yaml"], types.ModuleType)
+
+        # And the point of the stubbing: the mapping module still loads.
+        assert hasattr(gi, "TYPE_MAP") and hasattr(gi, "om_column")
+    finally:
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
 
 
 def test_load_ingest_returns_the_real_mapping_module():


### PR DESCRIPTION
Found while reconciling a one-point coverage disagreement between two machines measuring the same commit.

## The defect

`scripts/check_govern_types.py` builds stand-ins for `requests`, `yaml` and `urllib3` **only when the import fails**, so those builder bodies never execute on a machine where the real package is installed — and coverage reports them missing. `requests` arrives with `fabric-target`'s `sessions` extra, and any `uv run --with` leaves packages behind in a venv that a later `--group test` run happily reuses.

Same commit, same worktree, one variable:

```
uv run --frozen --group test ...                          check_govern_types  54  1  98%   TOTAL 1545 439 72%
... --with urllib3 --with requests --with pyyaml ...      check_govern_types  54  8  85%   TOTAL 1545 446 71%
                                                          missing: 64-70
```

Lines 64-70 are `_urllib3()`'s body. That is a full point on the repo total against `--cov-fail-under=70`, on identical code. A gate that reads differently depending on which machine measured it fails on whoever pushes next rather than on whoever spent the margin.

CI is on the clean side (`.github/workflows/ci.yml:1147` — no extras, no `--with`), so 72% was always the authoritative figure. The drift read *low*, which is the safe direction; the same mechanism reading high would hide a real regression under a floor that passes.

## The fix

One test that forces every stubbed dependency absent — `importlib.import_module` monkeypatched to raise `ImportError` for those three names, `sys.modules` entries removed and restored — so the builders run regardless of what is installed. It asserts the stub carries exactly what `govern_ingest` touches at import time (`exceptions.InsecureRequestWarning` subclassing `Warning`, a callable `disable_warnings`, the `urllib3.exceptions` entry), because asserting the module merely exists would pass on an empty `ModuleType` and leave the real import to fail in CI instead.

After:

```
clean venv                                  check_govern_types  54  1  98%   TOTAL 1545 439 72%
with urllib3 + requests + pyyaml present    check_govern_types  54  1  98%   TOTAL 1545 439 72%
```

Identical. The measurement no longer depends on the environment.

## Non-vacuous

Two mutations of the source, each reverted after:

- delete `mod.disable_warnings = ...` → **7 failed** (govern_ingest calls it at import, so it takes the file's other tests with it)
- delete `sys.modules["urllib3.exceptions"] = exc` → **1 failed**, and it is the new test

The second is the isolated kill: nothing but this test notices that line going missing.

## Also

`docs/10-testing.md` gains a note under the Python floor: measure in a clean venv, and if a test's coverage depends on what happens to be installed, force the branch rather than inheriting it.

248 passed, `--cov-fail-under=70` satisfied at 72%, `go build`/`go vet`/`go test ./...` and `make check` green.

Credit for finding it: the one-pass per-file table diff came from a parallel session working on `contoso-data-platform`, which also identified `_stub_missing` as the cause. My initial suspect was the wrong file.