### PR TITLE
govern: validate ingest columns against OpenMetadata's own vendored schema

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,15 @@ Dockerfile text eol=lf
 *.bat   text eol=crlf
 *.cmd   text eol=crlf
 *.ps1   text eol=crlf
+
+# Vendored golden references are hashed BYTE-FOR-BYTE in their PROVENANCE.md,
+# which is the tamper check third_party/README.md requires. Line-ending
+# normalisation would rewrite them on checkout — on Windows, where
+# core.autocrlf=true is the Git-for-Windows default, `basic.json` gains 320
+# bytes and its sha256 no longer matches the one recorded on the machine that
+# vendored it. `-text` disables the conversion in both directions, so a
+# vendored artifact is identical to upstream on every platform.
+#
+# Applies to the whole tree rather than to `*.json`: whatever a future
+# reference happens to be (a licence, a .proto, a .csv), it is still hashed.
+third_party/** -text

--- a/docs/22-openmetadata.md
+++ b/docs/22-openmetadata.md
@@ -184,6 +184,18 @@ edge but needs a real browser, so it is not asserted.
 - **CI witness**: `e2e/governance/run.py` (CI job `governance`) boots the
   profile, seeds a real Delta table, runs the ingest, and asserts the
   cataloged columns through OM's API on every push.
+- **Payloads are checked before any of that runs.** The columns
+  `govern_ingest` builds are validated against **OpenMetadata's own schema**,
+  vendored at the release the compose file pins
+  ([`third_party/openmetadata-schema/`](../third_party/openmetadata-schema/)).
+  A `dataType` outside its 86-value enum, a missing `name`, a `dataLength` of
+  the wrong type or a malformed nested column now fails in
+  `python/tests/test_govern_column_schema.py` — no postgres, no OpenSearch, no
+  Java server. Three layers, each catching what the others cannot: the schema
+  cannot see the `dataLength`-is-required rule (it lives in prose and is
+  enforced in OM's Java layer, which is what `scripts/check_govern_types.py`
+  exists for), and neither can see whether OM actually accepted the payload,
+  which is the e2e above.
 - **Weight warning:** this is a real Java server + OpenSearch (~1 GB heap)
   + Postgres. Expect ~2–3 GB RAM on top of the family, and a couple of
   minutes of first-boot migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ test = [
     # dropped; the python side had 28 tests and no number at all, so a checker
     # could lose its tests without anything saying so.
     "pytest-cov>=5,<8",
+    # test_govern_column_schema.py validates the payloads govern_ingest builds
+    # against OpenMetadata's OWN vendored schema (third_party/openmetadata-schema).
+    # Draft-07, so `referencing` comes with it for the local $ref registry.
+    "jsonschema>=4.21,<5",
     # test_spark_agent_packaging.py reads the compose files to prove the agent
     # ships INSIDE its image rather than over a bind mount. Declared here
     # because a developer machine usually has pyyaml lying around and CI does

--- a/python/tests/test_govern_column_schema.py
+++ b/python/tests/test_govern_column_schema.py
@@ -1,0 +1,170 @@
+"""The payloads `govern_ingest` sends are checked against OpenMetadata's OWN schema.
+
+Nothing validated them before. `scripts/check_govern_types.py` checks one rule,
+hand-transcribed from a 400 this repo already paid for; everything else about a
+column — the `dataType` enum, required fields, field types, `children` nesting —
+was unchecked until the containerized `ci:governance` e2e ran, and that suite
+needs postgres, opensearch and the OpenMetadata server to start at all. A typo
+in `TYPE_MAP` cost a full container run to discover.
+
+THE VALIDATED NODE IS `column`, NOT `table`. That is the whole reason this is
+cheap. `table.json#/definitions/column` reaches three external schemas whose
+closure is eight files; validating `table.json` itself would pull 146 files and
+451 KB, because it references `databaseService.json` and therefore every
+connector configuration OpenMetadata supports. See
+third_party/openmetadata-schema/PROVENANCE.md.
+
+WHAT THIS CANNOT CATCH, stated here so the next reader does not delete
+check_govern_types.py in favour of it: `dataLength` is required for
+char/varchar/binary/varbinary, and that rule is NOT in the schema. `column`
+declares only `required: ["name", "dataType"]`; the constraint lives in prose in
+a description and is enforced in OpenMetadata's Java layer. A validator passes
+the exact payload that costs the whole table.
+"""
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+from check_govern_types import load_ingest  # noqa: E402
+
+jsonschema = pytest.importorskip("jsonschema")
+from referencing import Registry, Resource  # noqa: E402
+from referencing.jsonschema import DRAFT7  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+VENDOR = ROOT / "third_party" / "openmetadata-schema"
+SCHEMA_DIR = VENDOR / "schema"
+COLUMN = "file:///entity/data/table.json#/definitions/column"
+
+
+@pytest.fixture(scope="module")
+def validator():
+    """A Draft-07 validator for one column, resolving $refs from the vendored copy.
+
+    Every vendored file is registered under a `file:///` URI mirroring its path,
+    so the relative `$ref`s upstream writes (`../../type/basic.json`) resolve
+    without rewriting a byte of the schema — the sha256 in PROVENANCE.md is only
+    evidence if what we load is what we recorded.
+    """
+    resources = {}
+    for p in SCHEMA_DIR.rglob("*.json"):
+        uri = "file:///" + p.relative_to(SCHEMA_DIR).as_posix()
+        resources[uri] = Resource(contents=json.loads(p.read_text()), specification=DRAFT7)
+    registry = Registry().with_resources(resources.items())
+    return jsonschema.Draft7Validator({"$ref": COLUMN}, registry=registry)
+
+
+@pytest.fixture(scope="module")
+def gi():
+    return load_ingest()
+
+
+def errors(validator, column):
+    return [e.message for e in validator.iter_errors(column)]
+
+
+# --- every column the mapper can produce --------------------------------------
+
+def test_every_type_map_entry_produces_a_valid_column(validator, gi):
+    # The whole map, not a sample: a target that OpenMetadata does not know is a
+    # 400 on the entire table, and the map is where a wrong name would live.
+    for delta_type in gi.TYPE_MAP:
+        col = gi.om_column(f"c_{delta_type}", delta_type)
+        assert not errors(validator, col), f"{delta_type} -> {col}"
+
+
+def test_parameterised_decimal_is_valid(validator, gi):
+    # delta-rs renders these as "decimal(10,2)"; precision and scale are the
+    # detail a catalog is judged on, so they must survive schema validation.
+    col = gi.om_column("amount", "decimal(10,2)")
+    assert not errors(validator, col), col
+    assert col["dataType"] == "DECIMAL"
+
+
+def test_nested_struct_children_are_valid(validator, gi):
+    # `children` recurses into the same definition, so a malformed child is
+    # exactly the shape a flat check would miss.
+    col = gi.om_column("addr", {"type": "struct", "fields": [
+        {"name": "city", "type": "string", "nullable": True},
+        {"name": "zip", "type": "long", "nullable": False},
+    ]})
+    assert not errors(validator, col), col
+    assert [c["name"] for c in col["children"]] == ["city", "zip"]
+
+
+def test_array_element_type_is_valid(validator, gi):
+    col = gi.om_column("tags", {"type": "array", "elementType": "string"})
+    assert not errors(validator, col), col
+
+
+# --- the schema actually refuses things ---------------------------------------
+#
+# A validator that accepts everything passes every test above. These pin that it
+# does not.
+
+@pytest.mark.parametrize("bad,why", [
+    ({"name": "c", "dataType": "BIGINTT"}, "is not one of"),          # typo'd enum
+    ({"dataType": "BIGINT"}, "required"),                              # no name
+    ({"name": "c"}, "required"),                                       # no dataType
+    ({"name": "c", "dataType": "VARCHAR", "dataLength": "20"}, "is not of type"),
+    ({"name": "c", "dataType": "STRUCT",
+      "children": [{"dataType": "INT"}]}, "required"),                 # child has no name
+])
+def test_the_schema_refuses_malformed_columns(validator, bad, why):
+    msgs = errors(validator, bad)
+    assert msgs, f"schema accepted {bad}"
+    assert any(why in m for m in msgs), msgs
+
+
+def test_a_type_map_target_outside_the_enum_would_fail(validator, gi):
+    # The mutation the issue asks for, run as a test rather than by hand: point
+    # one mapping at a name OpenMetadata does not know and the column must be
+    # refused. If this passes, the enum is not really being checked.
+    col = gi.om_column("c", "string")
+    col["dataType"] = "STRINGG"
+    assert errors(validator, col), "a dataType outside the enum was accepted"
+
+
+# --- the vendored copy must be what we recorded, and what we run --------------
+
+def test_vendored_files_match_their_recorded_hashes():
+    # PROVENANCE.md's sha256 column is the tamper check third_party/README.md
+    # requires. Unverified, it is decoration.
+    provenance = (VENDOR / "PROVENANCE.md").read_text()
+    recorded = dict(
+        (m.group(1), m.group(3))
+        for m in re.finditer(r"^\| `([^`]+)` \| (\d+) \| `([0-9a-f]{64})` \|$", provenance, re.M)
+    )
+    assert recorded, "PROVENANCE.md has no integrity table"
+    on_disk = {
+        p.relative_to(VENDOR).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in VENDOR.rglob("*")
+        if p.is_file() and p.name != "PROVENANCE.md"
+    }
+    assert on_disk == recorded
+
+
+def test_the_pinned_schema_matches_the_version_docker_compose_runs():
+    # A schema validated against a version nobody runs is confidence, not
+    # coverage. The compose file pins OpenMetadata in THREE places (postgres,
+    # server, migration); all of them must agree with the vendored release, so
+    # bumping the image without re-vendoring fails here rather than in a
+    # container an hour later.
+    provenance = (VENDOR / "PROVENANCE.md").read_text()
+    m = re.search(r"tag `([0-9]+\.[0-9]+\.[0-9]+)-release`", provenance)
+    assert m, "PROVENANCE.md does not record which release the pin is"
+    vendored = m.group(1)
+
+    compose = (ROOT / "docker-compose.yml").read_text()
+    pins = set(re.findall(r"docker\.getcollate\.io/openmetadata/[a-z]+:([0-9.]+)", compose))
+    assert pins, "no OpenMetadata image pins found in docker-compose.yml"
+    assert pins == {vendored}, (
+        f"vendored schema is {vendored} but docker-compose.yml pins {sorted(pins)} — "
+        "re-vendor with scripts/vendor_openmetadata_schema.py or revert the image bump"
+    )

--- a/python/tests/test_vendor_openmetadata_schema.py
+++ b/python/tests/test_vendor_openmetadata_schema.py
@@ -1,0 +1,127 @@
+"""The refresh script's job is to vendor a COMPLETE set of schema files.
+
+An incomplete set is the failure that matters: the validator would raise
+"unresolvable $ref" at test time, which reads like a broken test rather than a
+missing file. So the closure walk is tested with a stubbed fetch — no network,
+and the interesting shapes (transitive refs, `#`-fragments, cycles, duplicate
+paths) can be constructed rather than waited for.
+"""
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+import vendor_openmetadata_schema as v  # noqa: E402
+
+
+@pytest.fixture
+def upstream(monkeypatch):
+    """A fake schema repo, keyed by the path under the spec root."""
+    files = {}
+
+    def fake_fetch(url):
+        # The script builds ".../<sha>/<SPEC>/<rel>"; recover <rel>.
+        rel = url.split(v.SPEC + "/", 1)[1] if v.SPEC + "/" in url else url.rsplit("/", 1)[-1]
+        if rel not in files:
+            raise AssertionError(f"fetched something not in the fake repo: {rel}")
+        return json.dumps(files[rel]).encode() if isinstance(files[rel], dict) else files[rel]
+
+    monkeypatch.setattr(v, "fetch", fake_fetch)
+    return files
+
+
+def column(*refs):
+    return {"definitions": {"column": {"properties": {
+        f"p{i}": {"$ref": r} for i, r in enumerate(refs)}}}}
+
+
+def test_closure_follows_refs_transitively(upstream):
+    upstream[v.ENTRY] = column("../../type/basic.json")
+    upstream["type/basic.json"] = {"properties": {"x": {"$ref": "tagLabel.json"}}}
+    upstream["type/tagLabel.json"] = {"properties": {}}
+
+    got = v.closure("deadbeef")
+    assert set(got) == {v.ENTRY, "type/basic.json", "type/tagLabel.json"}
+
+
+def test_closure_ignores_refs_outside_the_column_node(upstream):
+    # THE WHOLE POINT of validating `column` rather than `table`: table.json
+    # references databaseService.json, which drags in every connector config.
+    # Those must not be walked.
+    entry = column("../../type/basic.json")
+    entry["properties"] = {"service": {"$ref": "../services/databaseService.json"}}
+    upstream[v.ENTRY] = entry
+    upstream["type/basic.json"] = {"properties": {}}
+
+    got = v.closure("deadbeef")
+    assert "entity/services/databaseService.json" not in got
+    assert set(got) == {v.ENTRY, "type/basic.json"}
+
+
+def test_closure_strips_fragments_and_dedupes(upstream):
+    # `basic.json#/definitions/entityName` and `basic.json#/definitions/date`
+    # are one file. Fetching it twice would be harmless; recording it twice in
+    # PROVENANCE.md would not be.
+    upstream[v.ENTRY] = column(
+        "../../type/basic.json#/definitions/entityName",
+        "../../type/basic.json#/definitions/date",
+    )
+    upstream["type/basic.json"] = {"properties": {}}
+
+    got = v.closure("deadbeef")
+    assert set(got) == {v.ENTRY, "type/basic.json"}
+
+
+def test_closure_terminates_on_a_reference_cycle(upstream):
+    # tagLabel <-> tagLabelMetadata reference each other upstream; a walk
+    # without a seen-set would never return.
+    upstream[v.ENTRY] = column("../../type/a.json")
+    upstream["type/a.json"] = {"properties": {"x": {"$ref": "b.json"}}}
+    upstream["type/b.json"] = {"properties": {"y": {"$ref": "a.json"}}}
+
+    got = v.closure("deadbeef")
+    assert set(got) == {v.ENTRY, "type/a.json", "type/b.json"}
+
+
+def test_the_entry_document_is_vendored_whole(upstream):
+    # Subsetting table.json down to the column node would make the recorded
+    # sha256 describe a file that exists nowhere upstream.
+    upstream[v.ENTRY] = column()
+    got = v.closure("deadbeef")
+    assert json.loads(got[v.ENTRY]) == upstream[v.ENTRY]
+
+
+@pytest.mark.parametrize("bad", ["1.13.2", "main", "2763bf9", "ZZZZ" * 10])
+def test_a_moving_ref_is_refused(monkeypatch, capsys, bad):
+    # third_party/README.md requires a commit SHA, "never a moving branch/tag".
+    # A tag would make the vendored copy silently re-point on a retag.
+    monkeypatch.setattr(sys, "argv", ["vendor", bad])
+    assert v.main() == 1
+    assert "40-character commit SHA" in capsys.readouterr().out
+
+
+def test_a_full_sha_is_accepted(monkeypatch, capsys, upstream):
+    upstream[v.ENTRY] = column()
+    upstream_license = b"Apache License"
+    monkeypatch.setattr(v, "VENDOR", pathlib.Path(v.VENDOR))
+
+    real_fetch = v.fetch
+
+    def fetch_with_license(url):
+        if url.endswith("/LICENSE"):
+            return upstream_license
+        return real_fetch(url)
+
+    monkeypatch.setattr(v, "fetch", fetch_with_license)
+    written = {}
+    monkeypatch.setattr(pathlib.Path, "write_bytes", lambda self, b: written.__setitem__(self, b))
+    monkeypatch.setattr(pathlib.Path, "mkdir", lambda self, **kw: None)
+    monkeypatch.setattr(sys, "argv", ["vendor", "a" * 40])
+
+    assert v.main() == 0
+    out = capsys.readouterr().out
+    assert "| File | Bytes | sha256 |" in out, out
+    assert any(p.name == "LICENSE" for p in written), "the licence must be vendored too"

--- a/scripts/vendor_openmetadata_schema.py
+++ b/scripts/vendor_openmetadata_schema.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Re-fetch and re-pin the vendored OpenMetadata column schema.
+
+    scripts/vendor_openmetadata_schema.py <commit-sha> [--version 1.14.0]
+
+third_party/README.md requires a PROVENANCE.md carrying a sha256 and byte size
+for every vendored file. Maintaining that by hand is how a refresh ships with
+stale hashes — the one field whose whole job is to be exact. This does the fetch
+and rewrites the table, so bumping the pin is a command rather than a ritual.
+
+The FILE LIST is derived, not hardcoded: it walks `$ref`s from the validated
+node (`table.json#/definitions/column`) to a fixed point. If a future
+OpenMetadata adds a reference to the column subtree, the refresh picks it up
+instead of silently vendoring an unresolvable schema.
+"""
+import argparse
+import hashlib
+import json
+import pathlib
+import posixpath
+import re
+import sys
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+VENDOR = ROOT / "third_party" / "openmetadata-schema"
+RAW = "https://raw.githubusercontent.com/open-metadata/OpenMetadata"
+SPEC = "openmetadata-spec/src/main/resources/json/schema"
+ENTRY = "entity/data/table.json"
+NODE = "definitions/column"
+
+REF = re.compile(r'"\$ref":\s*"([^"#][^"]*)"')
+
+
+def fetch(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=30) as r:
+        return r.read()
+
+
+def closure(sha: str) -> dict[str, bytes]:
+    """Every schema file reachable from the column node, fetched.
+
+    The entry document is included whole — it is where `column` lives, and
+    subsetting it would make the recorded sha256 describe a file that exists
+    nowhere upstream.
+    """
+    entry = fetch(f"{RAW}/{sha}/{SPEC}/{ENTRY}")
+    node = json.loads(entry)
+    for part in NODE.split("/"):
+        node = node[part]
+
+    out = {ENTRY: entry}
+    queue = [posixpath.normpath(posixpath.join(posixpath.dirname(ENTRY), r.split("#")[0]))
+             for r in REF.findall(json.dumps(node))]
+    while queue:
+        rel = queue.pop()
+        if rel in out:
+            continue
+        out[rel] = fetch(f"{RAW}/{sha}/{SPEC}/{rel}")
+        queue += [posixpath.normpath(posixpath.join(posixpath.dirname(rel), r.split("#")[0]))
+                  for r in REF.findall(out[rel].decode())]
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("sha", help="upstream commit SHA (never a branch or tag)")
+    ap.add_argument("--version", help="the release this SHA is, e.g. 1.14.0")
+    args = ap.parse_args()
+    if len(args.sha) != 40 or not all(c in "0123456789abcdef" for c in args.sha):
+        print("refusing: pass a full 40-character commit SHA, not a tag or branch")
+        return 1
+
+    files = closure(args.sha)
+    files["LICENSE"] = fetch(f"{RAW}/{args.sha}/LICENSE")
+    for rel, body in files.items():
+        dest = VENDOR / ("schema/" + rel if rel != "LICENSE" else rel)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(body)
+
+    rows = []
+    for p in sorted(VENDOR.rglob("*")):
+        if p.is_file() and p.name != "PROVENANCE.md":
+            b = p.read_bytes()
+            rel = p.relative_to(VENDOR).as_posix()
+            rows.append(f"| `{rel}` | {len(b)} | `{hashlib.sha256(b).hexdigest()}` |")
+
+    print(f"fetched {len(files)} files at {args.sha[:8]}")
+    print("\nReplace the Integrity table in PROVENANCE.md with:\n")
+    print("| File | Bytes | sha256 |")
+    print("|---|---|---|")
+    print("\n".join(rows))
+    print("\nAlso update: Pinned revision, Retrieved, and the version the "
+          "docker-compose.yml pins must agree with.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -45,6 +45,10 @@ the golden truth is reviewable. Never let a reference float.
 - [`powerbi-rest-swagger/`](powerbi-rest-swagger/) — the official Power BI REST
   OpenAPI (MIT, copied in full). Golden reference for the `executeQueries` DAX
   query contract a semantic-model query endpoint would conform to.
+- [`openmetadata-schema/`](openmetadata-schema/) — OpenMetadata's own entity
+  schema for a table **column** (Apache-2.0, copied in full). Golden reference
+  for the payloads `scripts/govern_ingest.py` sends; only the eight files the
+  `column` node reaches are vendored, not the 146 the whole table schema pulls.
 - [`bi-shared-docs/`](bi-shared-docs/) — Microsoft's open BI documentation
   corpus (CC-BY-4.0, pinned by reference). Golden reference for the XMLA
   protocol, rowset encodings, schema rowsets, and the TMSL/TMDL model formats.

--- a/third_party/openmetadata-schema/LICENSE
+++ b/third_party/openmetadata-schema/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/openmetadata-schema/PROVENANCE.md
+++ b/third_party/openmetadata-schema/PROVENANCE.md
@@ -1,0 +1,66 @@
+# OpenMetadata entity schema — `column`
+
+Golden reference for the payloads `scripts/govern_ingest.py` POSTs to
+OpenMetadata. Copied in full (Apache-2.0, small).
+
+| Field | Value |
+|---|---|
+| **Upstream** | https://github.com/open-metadata/OpenMetadata — `openmetadata-spec/src/main/resources/json/schema/` |
+| **Pinned revision** | `2763bf97ce265662793a1a38d353147cc6d6c2e3` (tag `1.13.2-release`) |
+| **Retrieved** | 2026-08-07 |
+| **License** | Apache-2.0 — Collate Inc. / OpenMetadata contributors. Text in [`LICENSE`](LICENSE) |
+| **Used by** | `python/tests/test_govern_column_schema.py`, which validates every column `govern_ingest.om_column` produces against `table.json#/definitions/column` |
+| **Refresh** | `python3 scripts/vendor_openmetadata_schema.py <commit-sha>` — re-fetches, re-hashes, and rewrites the table below |
+
+## Why only these eight files
+
+The emulator builds **columns**, not whole tables, so the validated node is
+`table.json#/definitions/column`. That subtree reaches exactly three external
+schemas (`basic.json`, `tagLabel.json`, `customMetric.json`), whose own
+transitive closure adds four more. Eight files, 64 KB.
+
+Validating the whole of `table.json` instead would pull **146 files, 451 KB** —
+`table.json` → `databaseService.json` → every connector configuration
+OpenMetadata supports, so the repo would carry Snowflake, Oracle and Synapse
+connection schemas, pinned and kept in sync, in order to check a column. The
+narrower node buys the same coverage of what we actually send.
+
+Nothing here is edited. A subsetting script that rewrote upstream JSON would
+make the `sha256` column meaningless.
+
+## What this does NOT catch
+
+`dataLength` is required for `char`/`varchar`/`binary`/`varbinary` — and that
+rule is **not in this schema**. In 1.13.2 `column` declares only
+`required: ["name", "dataType"]`, and `dataLength` is a plain integer whose
+description states the constraint in prose. OpenMetadata enforces it in its
+Java service layer, which is why violating it returns a runtime 400 rather than
+a validation error.
+
+**A validator passes the exact payload that costs the whole table.** That is
+what `scripts/check_govern_types.py` exists for, and why it stays: three layers,
+each catching what the others cannot.
+
+## Integrity
+
+`sha256` and byte size of every vendored file, as retrieved.
+
+| File | Bytes | sha256 |
+|---|---|---|
+| `LICENSE` | 11356 | `43070e2d4e532684de521b885f385d0841030efa2b1a20bafb76133a5e1379c1` |
+| `schema/entity/data/table.json` | 43154 | `85275eba82dc01b6d82ad3600648501e00e11e31757bf6f3477b37b5bf08cf46` |
+| `schema/tests/customMetric.json` | 1551 | `4c96cf4fa7d9c58455bceb322e226b6f7c6940fb321d634543d64d2e3094feed` |
+| `schema/type/basic.json` | 11111 | `9c27781a905d71e5a7df94d7c2ab64c0ece35b8956cff575fec57119e67e2895` |
+| `schema/type/entityReference.json` | 2052 | `fb10ed9b19a05d2dfe5dc3e593573e4f569621b6e820dcf688baa3a4b0e2f47d` |
+| `schema/type/entityReferenceList.json` | 606 | `92b9ae8bd904b1d792bab74b936e74c70f2295db9373e709bce1efeeb61ceb57` |
+| `schema/type/tagLabel.json` | 2857 | `e4a656db038f6a81ba09d42abdcdc4c38ab3ce423176eb777ea89544f4a6b04c` |
+| `schema/type/tagLabelMetadata.json` | 756 | `0691ce9036ff862b60923a4131d57f969e1f32b4815b21d45408786990038ca2` |
+| `schema/type/tagLabelRecognizerMetadata.json` | 1989 | `f77b15815bd396585743e9c0963f884a13a322c1100a427644c2e042e01de210` |
+
+## The pin must match the running image
+
+This copy is only evidence if it is the version the stack runs.
+`docker-compose.yml` pins `1.13.2` in **three** places (the postgres, server and
+migration services), and `test_govern_column_schema.py` fails when any of them
+disagrees with the version recorded here — a schema validated against a version
+nobody runs is confidence, not coverage.

--- a/third_party/openmetadata-schema/schema/entity/data/table.json
+++ b/third_party/openmetadata-schema/schema/entity/data/table.json
@@ -1,0 +1,1339 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/data/table.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Table",
+  "$comment": "@om-entity-type",
+  "description": "A `Table` entity organizes data in rows and columns and is defined in a `Database Schema`.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.entity.data.Table",
+  "javaInterfaces": [
+    "org.openmetadata.schema.EntityInterface",
+    "org.openmetadata.schema.ColumnsEntityInterface"
+  ],
+  "definitions": {
+    "profileSampleType": {
+      "$ref": "../../type/basic.json#/definitions/profileSampleType"
+    },
+    "samplingMethodType": {
+      "$ref": "../../type/basic.json#/definitions/samplingMethodType"
+    },
+    "profileSampleConfig": {
+      "$ref": "../../type/samplingConfig.json#/definitions/profileSampleConfig"
+    },
+    "tableType": {
+      "javaType": "org.openmetadata.schema.type.TableType",
+      "description": "This schema defines the type used for describing different types of tables.",
+      "type": "string",
+      "enum": [
+        "Regular",
+        "External",
+        "Dynamic",
+        "View",
+        "SecureView",
+        "MaterializedView",
+        "Iceberg",
+        "Local",
+        "Partitioned",
+        "Foreign",
+        "Transient",
+        "Stream",
+        "Stage"
+      ],
+      "javaEnums": [
+        {
+          "name": "Regular"
+        },
+        {
+          "name": "External"
+        },
+        {
+          "name": "Dynamic"
+        },
+        {
+          "name": "View"
+        },
+        {
+          "name": "SecureView"
+        },
+        {
+          "name": "MaterializedView"
+        },
+        {
+          "name": "Iceberg"
+        },
+        {
+          "name": "Local"
+        },
+        {
+          "name": "Partitioned"
+        },
+        {
+          "name": "Foreign"
+        },
+        {
+          "name": "Transient"
+        },
+        {
+          "name": "Stream"
+        },
+        {
+          "name": "Stage"
+        }
+      ]
+    },
+    "dataType": {
+      "javaType": "org.openmetadata.schema.type.ColumnDataType",
+      "description": "This enum defines the type of data stored in a column.",
+      "type": "string",
+      "enum": [
+        "NUMBER",
+        "TINYINT",
+        "SMALLINT",
+        "INT",
+        "BIGINT",
+        "BYTEINT",
+        "BYTES",
+        "FLOAT",
+        "DOUBLE",
+        "DECIMAL",
+        "NUMERIC",
+        "TIMESTAMP",
+        "TIMESTAMPZ",
+        "TIME",
+        "DATE",
+        "DATETIME",
+        "INTERVAL",
+        "STRING",
+        "MEDIUMTEXT",
+        "TEXT",
+        "CHAR",
+        "LONG",
+        "VARCHAR",
+        "BOOLEAN",
+        "BINARY",
+        "VARBINARY",
+        "ARRAY",
+        "BLOB",
+        "LONGBLOB",
+        "MEDIUMBLOB",
+        "MAP",
+        "STRUCT",
+        "UNION",
+        "SET",
+        "GEOGRAPHY",
+        "ENUM",
+        "JSON",
+        "UUID",
+        "VARIANT",
+        "GEOMETRY",
+        "BYTEA",
+        "AGGREGATEFUNCTION",
+        "ERROR",
+        "FIXED",
+        "RECORD",
+        "NULL",
+        "SUPER",
+        "HLLSKETCH",
+        "PG_LSN",
+        "PG_SNAPSHOT",
+        "TSQUERY",
+        "TXID_SNAPSHOT",
+        "XML",
+        "MACADDR",
+        "TSVECTOR",
+        "UNKNOWN",
+        "CIDR",
+        "INET",
+        "CLOB",
+        "ROWID",
+        "LOWCARDINALITY",
+        "YEAR",
+        "POINT",
+        "POLYGON",
+        "TUPLE",
+        "SPATIAL",
+        "TABLE",
+        "NTEXT",
+        "IMAGE",
+        "IPV4",
+        "IPV6",
+        "DATETIMERANGE",
+        "HLL",
+        "LARGEINT",
+        "QUANTILE_STATE",
+        "AGG_STATE",
+        "BITMAP",
+        "UINT",
+        "BIT",
+        "MONEY",
+        "MEASURE HIDDEN",
+        "MEASURE VISIBLE",
+        "MEASURE",
+        "KPI",
+        "HEIRARCHY",
+        "HIERARCHYID"
+      ]
+    },
+    "constraint": {
+      "javaType": "org.openmetadata.schema.type.ColumnConstraint",
+      "description": "This enum defines the type for column constraint.",
+      "type": "string",
+      "enum": [
+        "NULL",
+        "NOT_NULL",
+        "UNIQUE",
+        "PRIMARY_KEY"
+      ],
+      "default": null,
+      "additionalProperties": false
+    },
+    "tableConstraint": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.TableConstraint",
+      "title": "TableConstraint",
+      "description": "This enum defines the type for table constraint.",
+      "properties": {
+        "constraintType": {
+          "type": "string",
+          "enum": [
+            "UNIQUE",
+            "PRIMARY_KEY",
+            "FOREIGN_KEY",
+            "SORT_KEY",
+            "DIST_KEY",
+            "CLUSTER_KEY"
+          ]
+        },
+        "columns": {
+          "description": "List of column names corresponding to the constraint.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "referredColumns": {
+          "description": "List of referred columns for the constraint.",
+          "type": "array",
+          "items": {
+            "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"
+          },
+          "default": null
+        },
+        "relationshipType": {
+          "type": "string",
+          "enum": [
+            "ONE_TO_ONE",
+            "ONE_TO_MANY",
+            "MANY_TO_ONE",
+            "MANY_TO_MANY"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "columnName": {
+      "description": "Local name (not fully qualified name) of the column. ColumnName is `-` when the column is not named in struct dataType. For example, BigQuery supports struct with unnamed fields.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^((?!::).)*$"
+    },
+    "partitionIntervalTypes": {
+      "javaType": "org.openmetadata.schema.type.PartitionIntervalTypes",
+      "description": "type of partition interval",
+      "type": "string",
+      "enum": [
+        "TIME-UNIT",
+        "INTEGER-RANGE",
+        "INGESTION-TIME",
+        "COLUMN-VALUE",
+        "INJECTED",
+        "ENUM",
+        "OTHER"
+      ]
+    },
+    "tablePartition": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.TablePartition",
+      "description": "This schema defines the partition column of a table and format the partition is created.",
+      "properties": {
+        "columns": {
+          "description": "List of column partitions with their type and interval.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/partitionColumnDetails"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "partitionColumnDetails": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.PartitionColumnDetails",
+      "description": "This schema defines the partition column of a table and format the partition is created.",
+      "properties": {
+        "columnName": {
+          "description": "List of column names corresponding to the partition.",
+          "type": "string"
+        },
+        "intervalType": {
+          "$ref": "#/definitions/partitionIntervalTypes"
+        },
+        "interval": {
+          "type": "string",
+          "description": "partition interval , example hourly, daily, monthly."
+        }
+      },
+      "additionalProperties": false
+    },
+    "column": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.Column",
+      "javaInterfaces": [
+        "org.openmetadata.schema.FieldInterface"
+      ],
+      "description": "This schema defines the type for a column in a table.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/columnName"
+        },
+        "displayName": {
+          "description": "Display Name that identifies this column name.",
+          "type": "string"
+        },
+        "dataType": {
+          "description": "Data type of the column (int, date etc.).",
+          "$ref": "#/definitions/dataType"
+        },
+        "arrayDataType": {
+          "description": "Data type used array in dataType. For example, `array<int>` has dataType as `array` and arrayDataType as `int`.",
+          "$ref": "#/definitions/dataType"
+        },
+        "dataLength": {
+          "description": "Length of `char`, `varchar`, `binary`, `varbinary` `dataTypes`, else null. For example, `varchar(20)` has dataType as `varchar` and dataLength as `20`.",
+          "type": "integer"
+        },
+        "precision": {
+          "description": "The precision of a numeric is the total count of significant digits in the whole number, that is, the number of digits to both sides of the decimal point. Precision is applicable Integer types, such as `INT`, `SMALLINT`, `BIGINT`, etc. It also applies to other Numeric types, such as `NUMBER`, `DECIMAL`, `DOUBLE`, `FLOAT`, etc.",
+          "type": "integer"
+        },
+        "scale": {
+          "description": "The scale of a numeric is the count of decimal digits in the fractional part, to the right of the decimal point. For Integer types, the scale is `0`. It mainly applies to non Integer Numeric types, such as `NUMBER`, `DECIMAL`, `DOUBLE`, `FLOAT`, etc.",
+          "type": "integer"
+        },
+        "dataTypeDisplay": {
+          "description": "Display name used for dataType. This is useful for complex types, such as `array<int>`, `map<int,string>`, `struct<>`, and union types.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the column.",
+          "$ref": "../../type/basic.json#/definitions/markdown"
+        },
+        "fullyQualifiedName": {
+          "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"
+        },
+        "tags": {
+          "description": "Tags associated with the column.",
+          "type": "array",
+          "items": {
+            "$ref": "../../type/tagLabel.json"
+          },
+          "default": []
+        },
+        "constraint": {
+          "description": "Column level constraint.",
+          "$ref": "#/definitions/constraint"
+        },
+        "ordinalPosition": {
+          "description": "Ordinal position of the column.",
+          "type": "integer"
+        },
+        "jsonSchema": {
+          "description": "Json schema only if the dataType is JSON else null.",
+          "type": "string"
+        },
+        "children": {
+          "description": "Child columns if dataType or arrayDataType is `map`, `struct`, or `union` else `null`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/column"
+          }
+        },
+        "profile": {
+          "description": "Latest Data profile for a Column.",
+          "$ref": "#/definitions/columnProfile",
+          "default": null
+        },
+        "customMetrics": {
+          "description": "List of Custom Metrics registered for a table.",
+          "type": "array",
+          "items": {
+            "$ref": "../../tests/customMetric.json"
+          },
+          "default": null
+        },
+        "extension": {
+          "description": "Entity extension data with custom attributes added to the entity.",
+          "$ref": "../../type/basic.json#/definitions/entityExtension"
+        }
+      },
+      "required": [
+        "name",
+        "dataType"
+      ],
+      "additionalProperties": false
+    },
+    "joinedWith": {
+      "description": "Fully qualified names of the fields/entities that this field/entity is joined with.",
+      "type": "object",
+      "properties": {
+        "fullyQualifiedName": {
+          "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"
+        },
+        "joinCount": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "fullyQualifiedName",
+        "joinCount"
+      ],
+      "additionalProperties": false
+    },
+    "columnJoins": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.ColumnJoin",
+      "description": "This schema defines the type to capture how frequently a column is joined with columns in the other tables.",
+      "properties": {
+        "columnName": {
+          "$ref": "#/definitions/columnName"
+        },
+        "joinedWith": {
+          "description": "Fully qualified names of the columns that this column is joined with.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/joinedWith"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "tableJoins": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.TableJoins",
+      "description": "This schema defines the type to capture information about how this table is joined with other tables and columns.",
+      "properties": {
+        "startDate": {
+          "description": "Date can be only from today going back to last 29 days.",
+          "$ref": "../../type/basic.json#/definitions/date"
+        },
+        "dayCount": {
+          "type": "integer",
+          "default": 1
+        },
+        "columnJoins": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/columnJoins"
+          }
+        },
+        "directTableJoins": {
+          "description": "Joins with other tables that are not on a specific column (e.g: UNION join)",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/joinedWith"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "tableData": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.TableData",
+      "description": "This schema defines the type to capture rows of sample data for a table.",
+      "properties": {
+        "columns": {
+          "description": "List of local column names (not fully qualified column names) of the table.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/columnName"
+          }
+        },
+        "rows": {
+          "description": "Data for multiple rows of the table.",
+          "type": "array",
+          "items": {
+            "description": "Data for a single row of the table within the same order as columns fields.",
+            "type": "array"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "customMetricProfile": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.CustomMetricProfile",
+      "description": "Profiling results of a Custom Metric.",
+      "properties": {
+        "name": {
+          "description": "Custom metric name.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Profiling results for the metric.",
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "columnProfile": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.ColumnProfile",
+      "description": "This schema defines the type to capture the table's column profile.",
+      "properties": {
+        "name": {
+          "description": "Column Name.",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Timestamp on which profile is taken.",
+          "$ref": "../../type/basic.json#/definitions/timestamp"
+        },
+        "valuesCount": {
+          "description": "Total count of the values in this column.",
+          "type": "number"
+        },
+        "valuesPercentage": {
+          "description": "Percentage of values in this column with respect to row count.",
+          "type": "number"
+        },
+        "validCount": {
+          "description": "Total count of valid values in this column.",
+          "type": "number"
+        },
+        "duplicateCount": {
+          "description": "No.of Rows that contain duplicates in a column.",
+          "type": "number"
+        },
+        "nullCount": {
+          "description": "No.of null values in a column.",
+          "type": "number"
+        },
+        "nullProportion": {
+          "description": "No.of null value proportion in columns.",
+          "type": "number"
+        },
+        "missingPercentage": {
+          "description": "Missing Percentage is calculated by taking percentage of validCount/valuesCount.",
+          "type": "number"
+        },
+        "missingCount": {
+          "description": "Missing count is calculated by subtracting valuesCount - validCount.",
+          "type": "number"
+        },
+        "uniqueCount": {
+          "description": "No. of unique values in the column.",
+          "type": "number"
+        },
+        "uniqueProportion": {
+          "description": "Proportion of number of unique values in a column.",
+          "type": "number"
+        },
+        "distinctCount": {
+          "description": "Number of values that contain distinct values.",
+          "type": "number"
+        },
+        "distinctProportion": {
+          "description": "Proportion of distinct values in a column.",
+          "type": "number"
+        },
+        "min": {
+          "description": "Minimum value in a column.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "../../type/basic.json#/definitions/dateTime"
+            },
+            {
+              "$ref": "../../type/basic.json#/definitions/time"
+            },
+            {
+              "$ref": "../../type/basic.json#/definitions/date"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "max": {
+          "description": "Maximum value in a column.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "../../type/basic.json#/definitions/dateTime"
+            },
+            {
+              "$ref": "../../type/basic.json#/definitions/time"
+            },
+            {
+              "$ref": "../../type/basic.json#/definitions/date"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "minLength": {
+          "description": "Minimum string length in a column.",
+          "type": "number"
+        },
+        "maxLength": {
+          "description": "Maximum string length in a column.",
+          "type": "number"
+        },
+        "mean": {
+          "description": "Avg value in a column.",
+          "type": "number"
+        },
+        "sum": {
+          "description": "Median value in a column.",
+          "type": "number"
+        },
+        "stddev": {
+          "description": "Standard deviation of a column.",
+          "type": "number"
+        },
+        "variance": {
+          "description": "Variance of a column.",
+          "type": "number"
+        },
+        "median": {
+          "description": "Median of a column.",
+          "type": "number"
+        },
+        "firstQuartile": {
+          "description": "First quartile of a column.",
+          "type": "number"
+        },
+        "thirdQuartile": {
+          "description": "First quartile of a column.",
+          "type": "number"
+        },
+        "interQuartileRange": {
+          "description": "Inter quartile range of a column.",
+          "type": "number"
+        },
+        "nonParametricSkew": {
+          "description": "Non parametric skew of a column.",
+          "type": "number"
+        },
+        "histogram": {
+          "description": "Histogram of a column.",
+          "properties": {
+            "boundaries": {
+              "description": "Boundaries of Histogram.",
+              "type": "array"
+            },
+            "frequencies": {
+              "description": "Frequencies of Histogram.",
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "customMetrics": {
+          "description": "Custom Metrics profile list bound to a column.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/customMetricProfile"
+          },
+          "default": null
+        },
+        "cardinalityDistribution": {
+          "description": "Cardinality distribution showing top categories with an 'Others' bucket.",
+          "type": "object",
+          "properties": {
+            "categories": {
+              "description": "List of category names including 'Others'.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "counts": {
+              "description": "List of counts corresponding to each category.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "percentages": {
+              "description": "List of percentages corresponding to each category.",
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "allValuesUnique": {
+              "description": "Flag indicating that all values in the column are unique, so no distribution is calculated.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "name",
+        "timestamp"
+      ],
+      "additionalProperties": false
+    },
+    "dmlOperationType": {
+      "javaType": "org.openmetadata.schema.type.DmlOperationType",
+      "description": "This schema defines the type of DML operation.",
+      "type": "string",
+      "enum": [
+        "UPDATE",
+        "INSERT",
+        "DELETE",
+        "WRITE"
+      ]
+    },
+    "systemProfile": {
+      "description": "This schema defines the System Profile object holding profile data from system tables.",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.SystemProfile",
+      "properties": {
+        "timestamp": {
+          "description": "Timestamp on which profile is taken.",
+          "$ref": "../../type/basic.json#/definitions/timestamp"
+        },
+        "operation": {
+          "description": "Operation performed.",
+          "$ref": "#/definitions/dmlOperationType"
+        },
+        "rowsAffected": {
+          "description": "Number of rows affected.",
+          "type": "integer"
+        }
+      }
+    },
+    "columnProfilerConfig": {
+      "description": "This schema defines the type for Table profile config include Columns.",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.ColumnProfilerConfig",
+      "properties": {
+        "columnName": {
+          "description": "Column Name of the table to be included.",
+          "type": "string"
+        },
+        "metrics": {
+          "description": "Include only following metrics.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        }
+      }
+    },
+    "partitionProfilerConfig": {
+      "description": "This schema defines the partition configuration used by profiler.",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.PartitionProfilerConfig",
+      "properties": {
+        "enablePartitioning": {
+          "description": "whether to use partition",
+          "type": "boolean",
+          "default": false
+        },
+        "partitionColumnName": {
+          "description": "name of the column to use for the partition",
+          "type": "string"
+        },
+        "partitionIntervalType": {
+          "$ref": "#/definitions/partitionIntervalTypes"
+        },
+        "partitionInterval": {
+          "description": "The interval to use for the partitioning",
+          "type": "integer"
+        },
+        "partitionIntervalUnit": {
+          "description": "unit used for the partition interval",
+          "type": "string",
+          "enum": [
+            "YEAR",
+            "MONTH",
+            "DAY",
+            "HOUR"
+          ]
+        },
+        "partitionValues": {
+          "description": "unit used for the partition interval",
+          "type": "array"
+        },
+        "partitionIntegerRangeStart": {
+          "description": "start of the integer range for partitioning",
+          "type": "integer",
+          "default": null
+        },
+        "partitionIntegerRangeEnd": {
+          "description": "end of the integer range for partitioning",
+          "type": "integer",
+          "default": null
+        }
+      }
+    },
+    "sparkTableProfilerConfig": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.SparkTableProfilerConfig",
+      "description": "Table Specific configuration for Profiling it with a Spark Engine. It is ignored for other engines.",
+      "properties": {
+        "partitioning": {
+          "type": "object",
+          "description": "When reading big tables from sources, we optimize the reading by partitioning the data. This configuration is responsible for it.",
+          "properties": {
+            "partitionColumn": {
+              "type": "string",
+              "description": "Column to partition on. It should be a date, timestamp or integer column. It is important for the data to be reasonably equally distributed across the partitions.",
+              "default": null
+            },
+            "lowerBound": {
+              "type": "string",
+              "description": "Lower bound of the partition range. If not provided, it will be fetched from the source.",
+              "default": null
+            },
+            "upperBound": {
+              "type": "string",
+              "description": "Upper bound of the partition range. If not provided, it will be fetched from the source.",
+              "default": null
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "partitionColumn"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "tableProfilerConfig": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.TableProfilerConfig",
+      "description": "This schema defines the type for Table profile config.",
+      "properties": {
+        "sampleDataCount": {
+          "description": "Number of sample rows to ingest when 'Generate Sample Data' is enabled",
+          "type": "integer",
+          "default": 50,
+          "title": "Sample Data Rows Count"
+        },
+        "randomizedSample": {
+          "description": "Whether to randomize the sample data or not.",
+          "type": "boolean",
+          "default": false
+        },
+        "profileQuery": {
+          "description": "Users' raw SQL query to fetch sample data and profile the table",
+          "type": "string",
+          "default": null
+        },
+        "excludeColumns": {
+          "description": "column names to exclude from profiling.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "includeColumns": {
+          "description": "Only run profiler on included columns with specific metrics.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/columnProfilerConfig"
+          },
+          "default": null
+        },
+        "partitioning": {
+          "description": "Partitioning configuration",
+          "$ref": "#/definitions/partitionProfilerConfig"
+        },
+        "computeTableMetrics": {
+          "description": "Option to turn on/off table metric computation. If enabled, profiler will compute table level metrics.",
+          "type": "boolean",
+          "default": true,
+          "title": "Compute Table Metrics"
+        },
+        "computeColumnMetrics": {
+          "description": "Option to turn on/off column metric computation. If enabled, profiler will compute column level metrics.",
+          "type": "boolean",
+          "default": true,
+          "title": "Compute Column Metrics"
+        },
+        "sparkTableProfilerConfig": {
+          "description": "Table Specific configuration for Profiling it with a Spark Engine. It is ignored for other engines.",
+          "$ref": "#/definitions/sparkTableProfilerConfig",
+          "default": null
+        },
+        "profileSampleConfig": {
+          "$ref": "#/definitions/profileSampleConfig"
+        }
+      }
+    },
+    "tableProfile": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.TableProfile",
+      "description": "This schema defines the type to capture the table's data profile.",
+      "properties": {
+        "timestamp": {
+          "description": "Timestamp on which profile is taken.",
+          "$ref": "../../type/basic.json#/definitions/timestamp"
+        },
+        "columnCount": {
+          "description": "No.of columns in the table.",
+          "type": "number"
+        },
+        "rowCount": {
+          "description": "No.of rows in the table. This is always executed on the whole table.",
+          "type": "number"
+        },
+        "sizeInByte": {
+          "description": "Table size in GB",
+          "type": "number"
+        },
+        "createDateTime": {
+          "description": "Table creation time.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "customMetrics": {
+          "description": "Custom Metrics profile list bound to a column.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/customMetricProfile"
+          },
+          "default": null
+        },
+        "profileSample": {
+          "description": "Percentage of data or no. of rows we want to execute the profiler and tests on",
+          "type": "number",
+          "default": null
+        },
+        "profileSampleType": {
+          "$ref": "#/definitions/profileSampleType"
+        }
+      },
+      "required": [
+        "timestamp"
+      ],
+      "additionalProperties": false
+    },
+    "modelType": {
+      "$comment": "Currently only DBT and DDL model type is supported",
+      "enum": [
+        "DBT",
+        "DDL"
+      ],
+      "javaEnums": [
+        {
+          "name": "DBT"
+        },
+        {
+          "name": "DDL"
+        }
+      ]
+    },
+    "dataModel": {
+      "description": "This captures information about how the table is modeled. Currently only DBT and DDL model is supported.",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.DataModel",
+      "properties": {
+        "modelType": {
+          "$ref": "#/definitions/modelType"
+        },
+        "resourceType": {
+          "description": "Resource Type of the model.",
+          "type": "string"
+        },
+        "dbtSourceProject": {
+          "description": "The DBT project name that served as the source for ingesting this table's metadata and lineage information.",
+          "type": "string",
+          "default": null
+        },
+        "description": {
+          "description": "Description of the Table from the model.",
+          "$ref": "../../type/basic.json#/definitions/markdown"
+        },
+        "path": {
+          "description": "Path to sql definition file.",
+          "type": "string"
+        },
+        "rawSql": {
+          "description": "This corresponds to rws SQL from `<model_name>.sql` in DBT. This might be null when SQL query need not be compiled as done in DBT.",
+          "$ref": "../../type/basic.json#/definitions/sqlQuery"
+        },
+        "sql": {
+          "description": "This corresponds to compile SQL from `<model_name>.sql` in DBT. In cases where compilation is not necessary, this corresponds to SQL that created the table.",
+          "$ref": "../../type/basic.json#/definitions/sqlQuery"
+        },
+        "upstream": {
+          "description": "Fully qualified name of Models/tables used for in `sql` for creating this table.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owners": {
+          "description": "Owners of this Table.",
+          "$ref": "../../type/entityReferenceList.json",
+          "default": null
+        },
+        "tags": {
+          "description": "Tags for this data model.",
+          "type": "array",
+          "items": {
+            "$ref": "../../type/tagLabel.json"
+          },
+          "default": []
+        },
+        "columns": {
+          "description": "Columns from the schema defined during modeling. In case of DBT, the metadata here comes from `schema.yaml`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/column"
+          },
+          "default": null
+        },
+        "generatedAt": {
+          "$ref": "../../type/basic.json#/definitions/dateTime"
+        }
+      },
+      "required": [
+        "modelType"
+      ],
+      "additionalProperties": false
+    },
+    "fileFormat": {
+      "description": "File format in case of file/datalake tables.",
+      "type": "string",
+      "enum": [
+        "csv",
+        "csv.gz",
+        "tsv",
+        "avro",
+        "parquet",
+        "pq",
+        "pqt",
+        "parq",
+        "parquet.snappy",
+        "json",
+        "json.gz",
+        "json.zip",
+        "jsonl",
+        "jsonl.gz",
+        "jsonl.zip",
+        "MF4"
+      ]
+    }
+  },
+  "properties": {
+    "id": {
+      "description": "Unique identifier of this table instance.",
+      "$ref": "../../type/basic.json#/definitions/uuid"
+    },
+    "name": {
+      "description": "Name of a table. Expected to be unique within a database.",
+      "$ref": "../../type/basic.json#/definitions/entityName"
+    },
+    "displayName": {
+      "description": "Display Name that identifies this table. It could be title or label from the source services.",
+      "type": "string"
+    },
+    "fullyQualifiedName": {
+      "description": "Fully qualified name of a table in the form `serviceName.databaseName.tableName`.",
+      "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"
+    },
+    "description": {
+      "description": "Description of a table.",
+      "$ref": "../../type/basic.json#/definitions/markdown"
+    },
+    "version": {
+      "description": "Metadata version of the entity.",
+      "$ref": "../../type/entityHistory.json#/definitions/entityVersion"
+    },
+    "updatedAt": {
+      "description": "Last update time corresponding to the new version of the entity in Unix epoch time milliseconds.",
+      "$ref": "../../type/basic.json#/definitions/timestamp"
+    },
+    "updatedBy": {
+      "description": "User who made the update.",
+      "type": "string"
+    },
+    "impersonatedBy": {
+      "description": "Bot user that performed the action on behalf of the actual user.",
+      "$ref": "../../type/basic.json#/definitions/impersonatedBy"
+    },
+    "href": {
+      "description": "Link to this table resource.",
+      "$ref": "../../type/basic.json#/definitions/href"
+    },
+    "tableType": {
+      "$ref": "#/definitions/tableType"
+    },
+    "columns": {
+      "description": "Columns in this table.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/column"
+      }
+    },
+    "tableConstraints": {
+      "description": "Table constraints.",
+      "type": "array",
+      "items": {
+        "title": "TableConstraint",
+        "$ref": "#/definitions/tableConstraint"
+      },
+      "default": null
+    },
+    "tablePartition": {
+      "$ref": "#/definitions/tablePartition"
+    },
+    "owners": {
+      "description": "Owners of this table.",
+      "$ref": "../../type/entityReferenceList.json",
+      "default": null
+    },
+    "databaseSchema": {
+      "description": "Reference to database schema that contains this table.",
+      "$ref": "../../type/entityReference.json"
+    },
+    "database": {
+      "description": "Reference to Database that contains this table.",
+      "$ref": "../../type/entityReference.json"
+    },
+    "service": {
+      "description": "Link to Database service this table is hosted in.",
+      "$ref": "../../type/entityReference.json"
+    },
+    "serviceType": {
+      "description": "Service type this table is hosted in.",
+      "$ref": "../services/databaseService.json#/definitions/databaseServiceType"
+    },
+    "location": {
+      "description": "Reference to the Location that contains this table.",
+      "$ref": "../../type/entityReference.json"
+    },
+    "locationPath": {
+      "description": "Full storage path in case of external and managed tables.",
+      "type": "string",
+      "default": null
+    },
+    "schemaDefinition": {
+      "description": "DDL for Tables and Views",
+      "$ref": "../../type/basic.json#/definitions/sqlQuery"
+    },
+    "tags": {
+      "description": "Tags for this table.",
+      "type": "array",
+      "items": {
+        "$ref": "../../type/tagLabel.json"
+      },
+      "default": null
+    },
+    "usageSummary": {
+      "description": "Latest usage information for this table.",
+      "$ref": "../../type/usageDetails.json",
+      "default": null
+    },
+    "followers": {
+      "description": "Followers of this table.",
+      "$ref": "../../type/entityReferenceList.json"
+    },
+    "joins": {
+      "description": "Details of other tables this table is frequently joined with.",
+      "$ref": "#/definitions/tableJoins",
+      "default": null
+    },
+    "sampleData": {
+      "description": "Sample data for a table.",
+      "$ref": "#/definitions/tableData",
+      "default": null
+    },
+    "tableProfilerConfig": {
+      "description": "Table Profiler Config to include or exclude columns from profiling.",
+      "$ref": "#/definitions/tableProfilerConfig"
+    },
+    "customMetrics": {
+      "description": "List of Custom Metrics registered for a table.",
+      "type": "array",
+      "items": {
+        "$ref": "../../tests/customMetric.json"
+      },
+      "default": null
+    },
+    "profile": {
+      "description": "Latest Data profile for a table.",
+      "$ref": "#/definitions/tableProfile",
+      "default": null
+    },
+    "testSuite": {
+      "description": "Executable test suite associated with this table",
+      "$ref": "../../type/entityReference.json"
+    },
+    "dataModel": {
+      "description": "This captures information about how the table is modeled. Currently only DBT model is supported.",
+      "$ref": "#/definitions/dataModel"
+    },
+    "changeDescription": {
+      "description": "Change that lead to this version of the entity.",
+      "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
+    },
+    "incrementalChangeDescription": {
+      "description": "Change that lead to this version of the entity.",
+      "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
+    },
+    "deleted": {
+      "description": "When `true` indicates the entity has been soft deleted.",
+      "type": "boolean",
+      "default": false
+    },
+    "retentionPeriod": {
+      "description": "Retention period of the data in the table. Period is expressed as duration in ISO 8601 format in UTC. Example - `P23DT23H`. When not set, the retention period is inherited from the parent database schema, if it exists.",
+      "$ref": "../../type/basic.json#/definitions/duration"
+    },
+    "compressionEnabled": {
+      "description": "Indicates whether compression is enabled on this table. Applicable for databases that support compression like Snowflake, TimescaleDB, ClickHouse, BigQuery, Redshift, etc.",
+      "type": "boolean",
+      "default": null
+    },
+    "compressionCodec": {
+      "description": "Compression algorithm/codec used. Examples: LZ4, ZSTD, Snappy, Gorilla, Delta, etc. Database-specific values allowed.",
+      "type": "string",
+      "default": null
+    },
+    "compressionStrategy": {
+      "description": "Compression strategy configuration including segment/partition/order keys",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.CompressionStrategy",
+      "properties": {
+        "compressionType": {
+          "description": "Type of compression: AUTOMATIC (Snowflake/BigQuery), MANUAL (Redshift), POLICY_BASED (TimescaleDB)",
+          "type": "string",
+          "enum": [
+            "AUTOMATIC",
+            "MANUAL",
+            "POLICY_BASED"
+          ],
+          "default": null
+        },
+        "segmentColumns": {
+          "description": "Columns used for segmenting/partitioning compressed data (TimescaleDB segment-by, ClickHouse partition key)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "orderColumns": {
+          "description": "Columns defining sort order within compressed blocks (TimescaleDB order-by, ClickHouse order by)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "compressionLevel": {
+          "description": "Compression level (1-9) for codecs that support it",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9,
+          "default": null
+        }
+      },
+      "additionalProperties": false,
+      "default": null
+    },
+    "extension": {
+      "description": "Entity extension data with custom attributes added to the entity.",
+      "$ref": "../../type/basic.json#/definitions/entityExtension"
+    },
+    "sourceUrl": {
+      "description": "Source URL of table.",
+      "$ref": "../../type/basic.json#/definitions/sourceUrl"
+    },
+    "domains": {
+      "description": "Domains the asset belongs to. When not set, the asset inherits the domain from the parent it belongs to.",
+      "$ref": "../../type/entityReferenceList.json"
+    },
+    "dataProducts": {
+      "description": "List of data products this entity is part of.",
+      "$ref": "../../type/entityReferenceList.json"
+    },
+    "dataContract": {
+      "description": "Reference to the data contract for this entity.",
+      "$ref": "../../type/entityReference.json"
+    },
+    "fileFormat": {
+      "description": "File format in case of file/datalake tables.",
+      "$ref": "#/definitions/fileFormat"
+    },
+    "votes": {
+      "description": "Votes on the entity.",
+      "$ref": "../../type/votes.json"
+    },
+    "lifeCycle": {
+      "description": "Life Cycle of the entity",
+      "$ref": "../../type/lifeCycle.json"
+    },
+    "certification": {
+      "$ref": "../../type/assetCertification.json"
+    },
+    "sourceHash": {
+      "description": "Source hash of the entity",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32
+    },
+    "processedLineage": {
+      "description": "Processed lineage for the table",
+      "type": "boolean",
+      "default": false
+    },
+    "queries": {
+      "description": "List of queries that are used to create this table.",
+      "type": "array",
+      "items": {
+        "$ref": "../../type/basic.json#/definitions/sqlQuery"
+      },
+      "default": null
+    },
+    "pipelineObservability": {
+      "description": "Pipeline observability information for the table. Multiple pipelines can process the same table.",
+      "type": "array",
+      "items": {
+        "$ref": "../../type/pipelineObservability.json"
+      },
+      "default": null
+    },
+    "entityStatus": {
+      "description": "Status of the Table.",
+      "$ref": "../../type/status.json"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "columns"
+  ],
+  "additionalProperties": false
+}

--- a/third_party/openmetadata-schema/schema/tests/customMetric.json
+++ b/third_party/openmetadata-schema/schema/tests/customMetric.json
@@ -1,0 +1,45 @@
+{
+  "$id": "https://open-metadata.org/schema/tests/customMetric.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CustomMetric",
+  "description": "Custom Metric definition that we will associate with a column.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.tests.CustomMetric",
+  "properties": {
+    "id": {
+      "description": "Unique identifier of this Custom Metric instance.",
+      "$ref": "../type/basic.json#/definitions/uuid"
+    },
+    "name": {
+      "description": "Name that identifies this Custom Metric.",
+      "$ref": "../type/basic.json#/definitions/entityName"
+    },
+    "description": {
+      "description": "Description of the Metric.",
+      "$ref": "../type/basic.json#/definitions/markdown"
+    },
+    "columnName": {
+      "description": "Name of the column in a table.",
+      "type": "string"
+    },
+    "expression": {
+      "description": "SQL expression to compute the Metric. It should return a single numerical value.",
+      "type": "string"
+    },
+    "owners": {
+      "description": "Owners of this Custom Metric.",
+      "$ref": "../type/entityReferenceList.json",
+      "default": null
+    },
+    "updatedAt": {
+      "description": "Last update time corresponding to the new version of the entity in Unix epoch time milliseconds.",
+      "$ref": "../type/basic.json#/definitions/timestamp"
+    },
+    "updatedBy": {
+      "description": "User who made the update.",
+      "type": "string"
+    }
+  },
+  "required": ["name", "expression"],
+  "additionalProperties": false
+}

--- a/third_party/openmetadata-schema/schema/type/basic.json
+++ b/third_party/openmetadata-schema/schema/type/basic.json
@@ -1,0 +1,320 @@
+{
+  "$id": "https://open-metadata.org/schema/type/basic.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Basic",
+  "description": "This schema defines basic common types that are used by other schemas.",
+  "definitions": {
+    "integer" : {
+      "$comment" : "@om-field-type",
+      "description": "An integer type.",
+      "type" : "integer"
+    },
+    "number" : {
+      "$comment" : "@om-field-type",
+      "description": "A numeric type that includes integer or floating point numbers.",
+      "type" : "number"
+    },
+    "string" : {
+      "$comment" : "@om-field-type",
+      "description": "A String type.",
+      "type" : "string"
+    },
+    "uuid": {
+      "description": "Unique id used to identify an entity.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "email": {
+      "$comment" : "@om-field-type",
+      "description": "Email address of a user or other entities.",
+      "type": "string",
+      "format": "email",
+      "pattern": "^[\\S.!#$%&’*+/=?^_`{|}~-]+@\\S+\\.\\S+$",
+      "minLength": 6,
+      "maxLength": 127
+    },
+    "timestamp": {
+      "$comment" : "@om-field-type",
+      "description": "Timestamp in Unix epoch time milliseconds.",
+      "@comment": "Note that during code generation this is converted into long",
+      "type": "integer",
+      "format": "utc-millisec"
+    },
+    "href": {
+      "description": "URI that points to a resource.",
+      "type": "string",
+      "format": "uri"
+    },
+    "timeInterval": {
+      "$comment" : "@om-field-type",
+      "type": "object",
+      "description": "Time interval in unixTimeMillis.",
+      "javaType": "org.openmetadata.schema.type.TimeInterval",
+      "properties": {
+        "start": {
+          "description": "Start time in unixTimeMillis.",
+          "type": "integer"
+        },
+        "end": {
+          "description": "End time in unixTimeMillis.",
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "duration": {
+      "$comment" : "@om-field-type",
+      "description": "Duration in ISO 8601 format in UTC. Example - 'P23DT23H'.",
+      "type": "string"
+    },
+    "date": {
+      "description": "Date in ISO 8601 format in UTC. Example - '2018-11-13'.",
+      "type": "string",
+      "format": "date"
+    },
+    "impersonatedBy": {
+      "description": "Bot user that performed the action on behalf of the actual user.",
+      "type": "string"
+    },
+    "dateTime": {
+      "description": "Date and time in ISO 8601 format. Example - '2018-11-13T20:20:39+00:00'.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "time": {
+      "description": "time in ISO 8601 format. Example - '20:20:39+00:00'.",
+      "type": "string",
+      "format": "time"
+    },
+    "date-cp": {
+      "$comment" : "@om-field-type",
+      "description": "Date as defined in custom property.",
+      "type": "string"
+    },
+    "dateTime-cp": {
+      "$comment" : "@om-field-type",
+      "description": "Date and time as defined in custom property.",
+      "type": "string"
+    },
+    "time-cp": {
+      "$comment" : "@om-field-type",
+      "description": "Time as defined in custom property.",
+      "type": "string"
+    },
+    "enum": {
+      "$comment" : "@om-field-type",
+      "description": "List of values in Enum.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "timezone": {
+      "description": "Timezone of the user in the format `America/Los_Angeles`, `Brazil/East`, etc.",
+      "type": "string",
+      "format": "timezone"
+    },
+    "entityLink": {
+      "description": "Link to an entity or field within an entity using this format `<#E::{entities}::{entityType}::{field}::{arrayFieldName}::{arrayFieldValue}`.",
+      "type": "string",
+      "pattern": "(?U)^<#E::\\w+::(?:[^:<>|]|:[^:<>|])+(?:::(?:[^:<>|]|:[^:<>|])+)*>$"
+    },
+    "entityName": {
+      "description": "Name that identifies an entity.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^((?!::).)*$"
+    },
+    "customPropertyName": {
+      "description": "Name of a custom property. Allowed characters: alphanumeric, _ - . % # @ ! , ; = | ' + ? ` space ( ) [ ] { }. Must start with an alphanumeric character. Disallowed characters: \" * & < > : ^ $ \\ / ~. The forward slash and tilde are reserved by JSON Pointer (RFC 6901) and cause silent corruption when the property name is interpolated into JSON Patch paths.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9 _\\-.,;%#@!'(){}\\[\\]|=+?`]*$"
+    },
+    "testCaseEntityName": {
+      "description": "Name that identifies a test definition and test case.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^((?!::).)*$"
+    },
+    "fullyQualifiedEntityName": {
+      "description": "A unique name that identifies an entity. Example for table 'DatabaseService.Database.Schema.Table'.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 3072
+    },
+    "sqlQuery": {
+      "$comment" : "@om-field-type",
+      "description": "SQL query statement. Example - 'select * from orders'.",
+      "type": "string"
+    },
+    "sqlFunction": {
+      "description": "SQL function. Example - 'AVG()`, `COUNT()`, etc..",
+      "type": "string"
+    },
+    "markdown": {
+      "$comment" : "@om-field-type",
+      "description": "Text in Markdown format.",
+      "type": "string"
+    },
+    "expression": {
+      "description": "Expression in SpEL.",
+      "type": "string"
+    },
+    "jsonSchema": {
+      "description": "JSON schema encoded as string. This will be used to validate the JSON fields using this schema.",
+      "type": "string"
+    },
+    "entityExtension" : {
+      "description": "Entity extension data with custom attributes added to the entity."
+    },
+    "providerType": {
+      "javaType": "org.openmetadata.schema.type.ProviderType",
+      "description": "Type of provider of an entity. Some entities are provided by the `system`. Some are entities created and provided by the `user`. Typically `system` provide entities can't be deleted and can only be disabled. Some apps such as AutoPilot create entities with `automation` provider type. These entities can be deleted by the user.",
+      "type": "string",
+      "enum": ["system", "user", "automation"],
+      "default": "user"
+    },
+    "componentConfig": {
+      "description": "key/value pairs to pass to workflow component.",
+      "type": "object",
+      "additionalProperties": {
+        ".{1,}": { "type": "string" }
+      }
+    },
+    "map":  {
+      "description": "A generic map that can be deserialized later.",
+      "existingJavaType" : "java.util.Map<String,Object>",
+      "type" : "object",
+      "additionalProperties": true
+    },
+    "status" : {
+      "javaType": "org.openmetadata.schema.type.ApiStatus",
+      "description": "State of an action over API.",
+      "type" : "string",
+      "enum" : ["success", "failure", "aborted", "partialSuccess", "running"]
+    },
+    "sourceUrl" : {
+      "description": "Source Url of the respective entity.",
+      "type" : "string",
+      "format": "url"
+    },
+    "coverImage": {
+      "description": "Cover image configuration for an entity. This is used to display a banner or header image for entities like Domain, Glossary, Data Product, etc.",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.entity.type.CoverImage",
+      "properties": {
+        "url": {
+          "description": "URL of the cover image.",
+          "type": "string",
+          "format": "url"
+        },
+        "position": {
+          "description": "Position of the cover image in CSS background-position format. Supports keywords (top, center, bottom) or pixel values (e.g., '20px 30px').",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "style": {
+      "description": "UI Style is used to associate a color code and/or icon to entity to customize the look of that entity in UI.",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.entity.type.Style",
+      "properties": {
+        "color": {
+          "description": "Hex Color Code to mark an entity such as GlossaryTerm, Tag, Domain or Data Product.",
+          "type": "string"
+        },
+        "iconURL": {
+          "description": "An icon to associate with GlossaryTerm, Tag, Domain or Data Product.",
+          "type" : "string",
+          "format": "url"
+        },
+        "coverImage": {
+          "description": "Cover image configuration for the entity.",
+          "$ref": "#/definitions/coverImage"
+        }
+      },
+      "additionalProperties": false
+    },
+    "semanticsRule": {
+      "type": "object",
+      "javaType": "org.openmetadata.schema.type.SemanticsRule",
+      "description": "Semantics rule defined in the data contract.",
+      "properties": {
+        "name": {
+          "title": "Rule Name",
+          "description": "Name of the semantics rule.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Rule Description",
+          "description": "Description of the semantics rule.",
+          "$ref": "#/definitions/markdown"
+        },
+        "rule": {
+          "title": "Rule Definition",
+          "description": "Definition of the semantics rule.",
+          "type": "string",
+          "outputType": "jsonlogic",
+          "format": "queryBuilder"
+        },
+        "enabled": {
+          "title": "Enabled",
+          "description": "Indicates if the semantics rule is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "entityType": {
+          "title": "Entity Type",
+          "description": "Type of the entity to which this semantics rule applies.",
+          "type": "string",
+          "default": null
+        },
+        "ignoredEntities": {
+          "title": "Ignored Entities",
+          "description": "List of entities to ignore for this semantics rule.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "jsonTree": {
+          "title": "JSON Tree to represents rule in UI.",
+          "description": "JSON Tree to represents rule in UI.",
+          "type": "string"
+        },
+        "provider": {
+          "$ref": "#/definitions/providerType"
+        },
+        "inherited": {
+          "title": "Inherited",
+          "description": "Whether this rule was inherited from a Data Product.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "rule",
+        "enabled"
+      ],
+      "additionalProperties": false
+    },
+    "profileSampleType": {
+      "description": "Type of Profile Sample (percentage or rows)",
+      "type": "string",
+      "enum": ["PERCENTAGE", "ROWS"],
+      "default": "PERCENTAGE"
+    },
+    "samplingMethodType": {
+      "description": "Type of Sampling Method (BERNOULLI or SYSTEM)",
+      "type": "string",
+      "enum": ["BERNOULLI", "SYSTEM"]
+    }
+  }
+}

--- a/third_party/openmetadata-schema/schema/type/entityReference.json
+++ b/third_party/openmetadata-schema/schema/type/entityReference.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://open-metadata.org/schema/type/entityReference.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Entity Reference",
+  "description": "This schema defines the EntityReference type used for referencing an entity. EntityReference is used for capturing relationships from one entity to another. For example, a table has an attribute called database of type EntityReference that captures the relationship of a table `belongs to a` database.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.type.EntityReference",
+  "properties": {
+    "id": {
+      "description": "Unique identifier that identifies an entity instance.",
+      "$ref": "basic.json#/definitions/uuid"
+    },
+    "type": {
+      "description": "Entity type/class name - Examples: `database`, `table`, `metrics`, `databaseService`, `dashboardService`...",
+      "type": "string"
+    },
+    "name": {
+      "description": "Name of the entity instance.",
+      "type": "string"
+    },
+    "fullyQualifiedName": {
+      "description": "Fully qualified name of the entity instance. For entities such as tables, databases fullyQualifiedName is returned in this field. For entities that don't have name hierarchy such as `user` and `team` this will be same as the `name` field.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Optional description of entity.",
+      "$ref": "basic.json#/definitions/markdown"
+    },
+    "displayName": {
+      "description": "Display Name that identifies this entity.",
+      "type": "string"
+    },
+    "deleted": {
+      "description": "If true the entity referred to has been soft-deleted.",
+      "type": "boolean"
+    },
+    "inherited": {
+      "description": "If true the relationship indicated by this entity reference is inherited from the parent entity.",
+      "type": "boolean"
+    },
+    "href": {
+      "description": "Link to the entity resource.",
+      "$ref": "basic.json#/definitions/href"
+    }
+  },
+  "required": ["id", "type"],
+  "additionalProperties": false
+}

--- a/third_party/openmetadata-schema/schema/type/entityReferenceList.json
+++ b/third_party/openmetadata-schema/schema/type/entityReferenceList.json
@@ -1,0 +1,11 @@
+{
+    "$id": "https://open-metadata.org/schema/type/entityReferenceList.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Entity Reference List",
+    "description": "This schema defines the EntityReferenceList type used for referencing an entity. EntityReference is used for capturing relationships from one entity to another. For example, a table has an attribute called database of type EntityReference that captures the relationship of a table `belongs to a` database.",
+    "type": "array",
+    "items": {
+        "$ref": "entityReference.json"
+    },
+    "default": null
+}

--- a/third_party/openmetadata-schema/schema/type/tagLabel.json
+++ b/third_party/openmetadata-schema/schema/type/tagLabel.json
@@ -1,0 +1,77 @@
+{
+  "$id": "https://open-metadata.org/schema/type/tagLabel.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TagLabel",
+  "description": "This schema defines the type for labeling an entity with a Tag.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.type.TagLabel",
+  "definitions": {
+    "tagFQN": {
+      "type": "string"
+    },
+    "TagSource": {
+      "type": "string",
+      "default": "Classification",
+      "enum": ["Classification", "Glossary"]
+    }
+  },
+  "properties": {
+    "tagFQN": {
+      "$ref": "#/definitions/tagFQN"
+    },
+    "name": {
+      "description": "Name of the tag or glossary term.",
+      "type": "string"
+    },
+    "displayName": {
+      "description": "Display Name that identifies this tag.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description for the tag label.",
+      "$ref": "../type/basic.json#/definitions/markdown"
+    },
+    "style": {
+      "$ref": "../type/basic.json#/definitions/style"
+    },
+    "source": {
+      "description": "Label is from Tags or Glossary.",
+      "$ref": "#/definitions/TagSource"
+    },
+    "labelType": {
+      "description": "Label type describes how a tag label was applied. 'Manual' indicates the tag label was applied by a person. 'Derived' indicates a tag label was derived using the associated tag relationship (see Classification.json for more details). 'Propagated` indicates a tag label was propagated from upstream based on lineage. 'Automated' is used when a tool was used to determine the tag label.",
+      "type": "string",
+      "enum": ["Manual", "Propagated", "Automated", "Derived", "Generated"],
+      "default": "Manual"
+    },
+    "state": {
+      "description": "'Suggested' state is used when a tag label is suggested by users or tools. Owner of the entity must confirm the suggested labels before it is marked as 'Confirmed'.",
+      "type": "string",
+      "enum": ["Suggested", "Confirmed"],
+      "default": "Confirmed"
+    },
+    "href": {
+      "description": "Link to the tag resource.",
+      "$ref": "basic.json#/definitions/href"
+    },
+    "reason": {
+      "type": "string",
+      "description": "An explanation of why this tag was proposed, specially for autoclassification tags"
+    },
+    "appliedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when this tag was applied in ISO 8601 format"
+    },
+    "appliedBy": {
+      "type": "string",
+      "description": "Who it is that applied this tag (e.g: a bot, AI or a human)"
+    },
+    "metadata": {
+      "description": "Additional metadata associated with this tag label, such as recognizer information for automatically applied tags.",
+      "$ref": "tagLabelMetadata.json"
+    }
+  },
+  "required": ["tagFQN", "source", "labelType", "state"],
+  "additionalProperties": false
+}

--- a/third_party/openmetadata-schema/schema/type/tagLabelMetadata.json
+++ b/third_party/openmetadata-schema/schema/type/tagLabelMetadata.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://open-metadata.org/schema/type/tagLabelMetadata.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TagLabelMetadata",
+  "description": "Additional metadata associated with a tag label, including information about how the tag was applied.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.type.TagLabelMetadata",
+  "properties": {
+    "recognizer": {
+      "description": "Metadata about the recognizer that automatically applied this tag",
+      "$ref": "tagLabelRecognizerMetadata.json"
+    },
+    "expiryDate": {
+      "description": "Epoch time in milliseconds when the certification tag expires",
+      "type": "integer",
+      "format": "utc-millisec"
+    }
+  },
+  "additionalProperties": false
+}

--- a/third_party/openmetadata-schema/schema/type/tagLabelRecognizerMetadata.json
+++ b/third_party/openmetadata-schema/schema/type/tagLabelRecognizerMetadata.json
@@ -1,0 +1,62 @@
+{
+  "$id": "https://open-metadata.org/schema/type/tagLabelRecognizerMetadata.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TagLabelRecognizerMetadata",
+  "description": "Metadata about the recognizer that applied a tag, including scoring and pattern information.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.type.TagLabelRecognizerMetadata",
+  "properties": {
+    "recognizerId": {
+      "description": "Unique identifier of the recognizer that applied this tag",
+      "$ref": "basic.json#/definitions/uuid"
+    },
+    "recognizerName": {
+      "description": "Human-readable name of the recognizer",
+      "type": "string"
+    },
+    "score": {
+      "description": "Confidence score assigned by the recognizer (0.0 to 1.0)",
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "target": {
+      "description": "What the recognizer analyzed to apply this tag",
+      "type": "string",
+      "enum": ["content", "column_name"]
+    },
+    "patterns": {
+      "description": "Details of patterns that matched during recognition",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/patternMatch"
+      }
+    }
+  },
+  "required": ["recognizerId", "recognizerName", "score"],
+  "additionalProperties": false,
+  "definitions": {
+    "patternMatch": {
+      "type": "object",
+      "description": "Information about a pattern that matched during recognition",
+      "properties": {
+        "name": {
+          "description": "Name of the pattern that matched",
+          "type": "string"
+        },
+        "regex": {
+          "description": "Regular expression or pattern definition",
+          "type": "string"
+        },
+        "score": {
+          "description": "Confidence score for this specific pattern match",
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        }
+      },
+      "required": ["name", "score"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1373,6 +1373,7 @@ spark-connect = [
 test = [
     { name = "fabric-emulator-notebookutils" },
     { name = "fabric-target" },
+    { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyyaml" },
@@ -1462,6 +1463,7 @@ spark-connect = [
 test = [
     { name = "fabric-emulator-notebookutils", editable = "python" },
     { name = "fabric-target", editable = "python/fabric-target" },
+    { name = "jsonschema", specifier = ">=4.21,<5" },
     { name = "pytest", specifier = ">=8.3,<10" },
     { name = "pytest-cov", specifier = ">=5,<8" },
     { name = "pyyaml", specifier = ">=6,<7" },


### PR DESCRIPTION
Closes #53.

## The change to the issue's plan

The issue proposes validating against OpenMetadata's schema and flags `$ref` resolution as the cost. I measured it before agreeing:

- Validating **`table.json`** pulls a transitive closure of **146 files, 451 KB** — `table.json` → `databaseService.json` → *every connector configuration OpenMetadata supports*. The repo would carry Snowflake, Oracle and Synapse connection schemas, pinned and kept in sync, in order to check a column.
- `govern_ingest` builds **columns**, not tables. Validating **`table.json#/definitions/column`** needs **8 files, 64 KB** — no connector configs.

Same coverage of what we actually send, 4% of the vendoring. Verified empirically that a column-scoped validator resolves without the rest of the closure present.

## What it catches

Everything the issue asked for, without starting a container:

| | |
|---|---|
| `dataType` outside the 86-value enum | ✅ |
| missing `name` | ✅ |
| `dataLength` of the wrong type | ✅ |
| malformed nested `children` on a struct column | ✅ |

Covered inputs: the whole `TYPE_MAP`, parameterised decimals, nested structs, array element types.

## What it explicitly does NOT catch

**`check_govern_types.py` stays, and its reason is now written down in two places.** In 1.13.2 `column` declares only `required: ["name", "dataType"]`; the `dataLength`-is-required rule exists as prose in a `description` and is enforced in OpenMetadata's Java service layer. **A schema validator passes the exact payload that costs the whole table.**

Three layers, each catching what the others cannot: the hand-written guard for the Java-layer rule, this for the payload shape, the containerized e2e for whether OM actually accepted it.

## Vendoring, per `third_party/README.md`

Pinned to commit `2763bf97` (tag `1.13.2-release`) — a SHA, not the moving tag. `PROVENANCE.md` carries upstream, revision, retrieval date, Apache-2.0 licence, users, and `sha256` + byte size for all nine files.

`scripts/vendor_openmetadata_schema.py` does the refresh and regenerates the hash table, so re-pinning is a command rather than a ritual — hand-maintained hashes are how a refresh ships with stale ones. Its file list is **derived by walking `$ref`s to a fixed point**, not hardcoded, so a future OpenMetadata that adds a reference to the column subtree gets vendored rather than silently leaving an unresolvable schema.

## Verification

Every guard mutation-checked:

| Mutation | Caught by |
|---|---|
| A `TYPE_MAP` target outside the enum (the issue's requested check) | `test_every_type_map_entry_produces_a_valid_column` |
| Image bumped without re-vendoring | `test_the_pinned_schema_matches_the_version_docker_compose_runs` |
| A vendored file edited | `test_vendored_files_match_their_recorded_hashes` |

The version check covers **all three** `1.13.2` pins in `docker-compose.yml` (the issue cites one, at line 256; they are at 220, 256 and 280).

Five tests assert the schema *refuses* malformed columns — a validator that accepts everything would otherwise pass every positive test above.

The refresh script has its own tests with a stubbed fetch (transitive refs, `#`-fragments, cycles, refusal of a tag instead of a SHA). Python coverage 73.2%, `make check`, `ruff`, `ty`, `go build/vet` clean.

Documented in `docs/22-openmetadata.md` rather than `docs/parity.md`: this hardens an existing capability, it does not add one, and crediting it as a parity witness would be padding.
