### PR TITLE
Sail fidelity: DESCRIBE from the Delta log, and the measured ceiling

### DIFF
--- a/docs/42-sail-fidelity-plan.md
+++ b/docs/42-sail-fidelity-plan.md
@@ -1,0 +1,117 @@
+# 42 — Sail stays the default: how close to 100% that can get
+
+**Status: taxonomy measured, first increment delivered.** `DESCRIBE TABLE` and
+`DESCRIBE DETAIL` now answer from the Delta log
+([delta_ops.py](../python/spark_agent/delta_ops.py)).
+
+Sail is the default engine and stays that way. The question this answers is the
+one that follows from it: **how much of the JVM's capability can Sail reach, and
+what is the irreducible remainder?**
+
+The honest answer is that **100% is not reachable**, for two reasons that no
+amount of work removes — and that the reachable part is larger than
+[engine-matrix.md](engine-matrix.md) makes it look, because several ❌ rows are
+qualified artefacts rather than gaps.
+
+## Read the matrix carefully before believing it
+
+The matrix is generated and its footnotes matter. Three of its ❌ rows are not
+what they appear:
+
+- **`MERGE INTO` is not a Sail gap** (ᵃ). `e2e/sail` proves the same MERGE
+  succeeds on Sail against an `az://` OneLake URL — the path the emulator
+  actually uses. Only the *local-path* probe fails.
+- **Change Data Feed fails on the WRITE, not the read** (ᵇ). Sail's writer
+  cannot enable the table feature; the read side is real and verified in
+  `e2e/livy` against a delta-rs-written table.
+- **`OPTIMIZE` / `VACUUM` are already closed** by the delta-rs interception —
+  the matrix's middle column, which is what a user actually gets.
+
+## The taxonomy
+
+Every remaining gap falls into one of four buckets, and only one is about the
+engine's capability.
+
+### 1. Spark Connect forbids it — unreachable for ANY client
+
+`sc` / RDD and `spark._jvm` answer
+`[JVM_ATTRIBUTE_NOT_SUPPORTED] … is not supported in Spark Connect`. This is the
+**protocol**, not Sail: Apache Spark's own Connect server refuses identically.
+The JVM column is green only because that leg runs a **classic** session.
+
+No engine change reaches these. A classic-session mode would, and that is what
+the JVM overlay is.
+
+### 2. Lives inside the engine — not interceptable
+
+Streaming sinks (delta / parquet / memory). `delta_ops.py` states the rule that
+decides this, and it is the right one:
+
+> each is a **bounded statement that starts and finishes against a table path**,
+> carrying no Spark session state. That makes them interceptable — a streaming
+> query, which lives inside the engine, is not.
+
+A structured streaming query is a long-lived object owned by the engine. There
+is no seam to put delta-rs behind. This is genuine Sail engine work, upstream or
+in the overlay.
+
+### 3. Interceptable — the reachable part
+
+Bounded, path-scoped, session-free statements. `OPTIMIZE`, `VACUUM`, `MERGE` and
+CTAS already route this way. Added here:
+
+| Statement | Was | Now |
+|---|---|---|
+| `DESCRIBE DETAIL` | ❌ absent from Sail's grammar | answered from the Delta log |
+| `DESCRIBE TABLE` | ❌ right schema, **zero rows**, no error | real column list, Spark type names |
+
+Still reachable and not yet built:
+
+- **CDF write** — enable the table feature through delta-rs so a Sail-authored
+  table is CDF-readable. The read path already works.
+- **`CREATE TABLE` defaulting to Delta** — see below; this one is special.
+
+### 4. Neither engine — a Fabric property, not a Spark one
+
+`CREATE TABLE` with no `USING` is ❌ on **both** Sail and the JVM (ᵍ): OSS Spark
+defaults to Hive, Fabric defaults to Delta. Closing it on the interception path
+would make the emulator **more faithful to Fabric than the JVM overlay is** —
+the one place where the "weaker" engine can be the more correct one.
+
+## So: what is the ceiling
+
+| Bucket | Reachable with Sail default? |
+|---|---|
+| Bounded statements (bucket 3) | **Yes** — this is where the work is |
+| Fabric-vs-OSS semantics (bucket 4) | **Yes**, and it beats the JVM |
+| Streaming sinks (bucket 2) | **No** — engine work or the overlay |
+| `sc` / `_jvm` (bucket 1) | **Never** — the protocol forbids it |
+
+Two buckets close, two do not. That is the answer to "100% if possible": the
+answer is no, and the residue is exactly `sc`/`_jvm` and streaming sinks.
+
+**Which is why the JVM overlay stays** — not as an admission of defeat but as
+the documented route for the irreducible two. `make up-jvm` swaps the engine;
+the cost is 943 MB → 2.1 GB, seconds → minutes, 125 → 78,040 log lines, which is
+why it is not the default and should not become one.
+
+## The rule this work must not break
+
+From `delta_ops.py`, and it governs every future addition here:
+
+> Scope is deliberately narrow. Anything not matched here goes to Spark
+> untouched: a shim that guesses would be worse than the gap.
+
+Every interception is also a **documented divergence**: the emulator performs
+these, not the Spark engine, so someone watching Spark sees no job. The
+observable outcome on the table is real; the executor differs. That trade is
+worth making for a bounded statement and is not worth making for anything that
+requires guessing.
+
+## Next
+
+1. **CDF write** — bucket 3, closes a measured ❌.
+2. **`CREATE TABLE` → Delta by default** — bucket 4, makes Sail beat the JVM on
+   a Fabric property.
+3. Regenerate `engine-matrix.md` so the middle column reflects all of it; CI
+   already diffs that file, so the matrix cannot drift from the code.

--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -149,6 +149,29 @@ _MERGE = re.compile(
     re.IGNORECASE | re.DOTALL)
 
 
+# `DESCRIBE DETAIL <table>` and `DESCRIBE [TABLE] <table>`.
+#
+# Both are measured ❌ on Sail in docs/engine-matrix.md, and they fail in the two
+# ways that are hardest to notice. DETAIL is absent from Sail's grammar outright
+# (`found DETAIL at 9:15 expected 'FUNCTION', 'CATALOG', ...`). DESCRIBE on a
+# registered Delta table is worse: it returns the right SCHEMA and ZERO ROWS,
+# raising nothing — the ᵉ row of the matrix exists because that silence cost real
+# debugging time, and delta_ops' own resolve() still carries a fallback that
+# trips over it.
+#
+# These qualify under the same rule as OPTIMIZE and VACUUM: a bounded statement
+# against a table path, carrying no session state. And unlike those, the answer
+# is metadata the emulator largely WROTE — asking the engine for it was always
+# asking to be told something we already recorded.
+_DESCRIBE_DETAIL = re.compile(
+    r"^\s*DESCRIBE\s+DETAIL\s+(?P<target>delta\.`[^`]+`|[\w.`]+)\s*;?\s*$",
+    re.IGNORECASE | re.DOTALL)
+
+_DESCRIBE_TABLE = re.compile(
+    r"^\s*DESC(?:RIBE)?\s+(?:TABLE\s+)?(?P<target>delta\.`[^`]+`|[\w.`]+)\s*;?\s*$",
+    re.IGNORECASE | re.DOTALL)
+
+
 class DeltaOpError(RuntimeError):
     """Raised for a matched statement we decline to execute — never for one we
     simply do not recognise, which is passed to Spark instead."""
@@ -178,6 +201,17 @@ def match(sql: str):
         # understand (DELETE clauses, subquery source, ...): fall through.
         if params.get("sets") or params.get("icols"):
             return "merge", params
+    m = _DESCRIBE_DETAIL.match(text)
+    if m:
+        return "describe_detail", m.groupdict()
+    m = _DESCRIBE_TABLE.match(text)
+    if m:
+        target = m.group("target").replace("`", "")
+        # Only a table this emulator can locate. A DESCRIBE of anything else —
+        # a temp view, a function, an engine-managed table — is the engine's own
+        # business and passes through untouched.
+        if target.lower().startswith("delta.") or known_location(target):
+            return "describe_table", m.groupdict()
     m = _CTAS.match(text)
     if m:
         params = m.groupdict()
@@ -360,6 +394,84 @@ def execute(kind, params, resolve, storage_options=None):
     return f"VACUUM: {verb} {len(files)} file(s), retain {hours}h (delta-rs)"
 
 
+
+# Delta's primitive names are not Spark's. `long` is `bigint` in every DESCRIBE
+# a notebook has ever read, and a table whose type column says `long` is a table
+# someone will spend a while doubting.
+_SPARK_TYPES = {
+    "long": "bigint", "integer": "int", "short": "smallint", "byte": "tinyint",
+    "double": "double", "float": "float", "string": "string", "boolean": "boolean",
+    "binary": "binary", "date": "date", "timestamp": "timestamp",
+    "timestampNtz": "timestamp_ntz",
+}
+
+
+def _spark_type(field_type) -> str:
+    """Render a delta-rs field type the way Spark's DESCRIBE spells it.
+
+    delta-rs stringifies a primitive as `PrimitiveType("long")`; anything
+    structured (struct, array, map) is passed through as delta-rs renders it
+    rather than guessed at — a wrong nested type would be worse than an
+    unfamiliar one.
+    """
+    raw = str(field_type)
+    inner = raw
+    if raw.startswith("PrimitiveType(") and raw.endswith(")"):
+        inner = raw[len("PrimitiveType("):-1].strip().strip('"')
+    return _SPARK_TYPES.get(inner, inner)
+
+
+def describe_detail(spark, params, resolve, storage_options=None):
+    """Answer `DESCRIBE DETAIL` from the Delta log, as Spark's own does.
+
+    Columns are a documented SUBSET of Spark's, not a pretence at all of them:
+    the ones delta-rs can answer truthfully. `sizeInBytes` and the reader/writer
+    versions are omitted rather than filled with a plausible number.
+    """
+    from deltalake import DeltaTable
+
+    uri = _table_uri(params["target"], resolve)
+    table = DeltaTable(uri, storage_options=_resolve_options(storage_options))
+    md = table.metadata()
+    rows = [(
+        "delta",
+        str(md.id),
+        md.name or "",
+        md.description or "",
+        uri,
+        int(table.version()),
+        len(table.file_uris()),
+        list(md.partition_columns or []),
+        dict(md.configuration or {}),
+    )]
+    return spark.createDataFrame(rows, [
+        "format", "id", "name", "description", "location",
+        "version", "numFiles", "partitionColumns", "properties",
+    ])
+
+
+def describe_table(spark, params, resolve, storage_options=None):
+    """Answer `DESCRIBE TABLE` with the real column list.
+
+    Sail returns the right shape and NO ROWS here, which is the failure mode
+    this replaces: an empty answer that raises nothing reads as "the table has
+    no columns" rather than "the engine did not implement this".
+    """
+    from deltalake import DeltaTable
+
+    uri = _table_uri(params["target"], resolve)
+    table = DeltaTable(uri, storage_options=_resolve_options(storage_options))
+    partitions = set(table.metadata().partition_columns or [])
+    rows = [
+        (f.name, _spark_type(f.type), "partition" if f.name in partitions else "")
+        for f in table.schema().fields
+    ]
+    if not rows:
+        raise DeltaOpError(
+            f"DESCRIBE {params['target']}: the Delta log at {uri} declares no columns")
+    return spark.createDataFrame(rows, ["col_name", "data_type", "comment"])
+
+
 def read_change_feed(spark, uri, starting_version=0, ending_version=None,
                      storage_options=None):
     """Change Data Feed read, returned as a Spark DataFrame.
@@ -453,6 +565,12 @@ def install(spark, storage_options=None):
         if matched is None:
             return original_sql(query, *args, **kwargs)
         kind, params = matched
+        # These two answer with real rows rather than a result line, so they
+        # return directly instead of going through the message path below.
+        if kind == "describe_detail":
+            return describe_detail(spark, params, resolve, storage_options)
+        if kind == "describe_table":
+            return describe_table(spark, params, resolve, storage_options)
         if kind == "merge":
             message = execute_merge(spark, params, resolve, storage_options)
         elif kind == "ctas":

--- a/python/tests/test_delta_ops_describe.py
+++ b/python/tests/test_delta_ops_describe.py
@@ -1,0 +1,121 @@
+"""DESCRIBE routed to delta-rs: what matches, and what it answers.
+
+Both statements are measured ❌ on Sail in docs/engine-matrix.md, and they fail
+in the two ways hardest to notice: `DESCRIBE DETAIL` is absent from the grammar
+outright, while `DESCRIBE` on a registered Delta table returns the right SCHEMA
+and **zero rows**, raising nothing.
+
+Execution here runs against a real Delta table on the local filesystem — the
+metadata is genuinely read out of a `_delta_log`, not synthesized — with a
+minimal stand-in for `spark.createDataFrame`, which is the only Spark API these
+two touch.
+"""
+import sys
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+from deltalake import write_deltalake
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import delta_ops
+
+
+class FakeSpark:
+    """Only `createDataFrame` is used, so only it is provided."""
+
+    def createDataFrame(self, rows, columns):
+        return {"rows": rows, "columns": columns}
+
+
+@pytest.fixture
+def table(tmp_path):
+    """A real Delta table with a partition column, written by delta-rs."""
+    path = str(tmp_path / "accounts")
+    write_deltalake(path, pa.table({
+        "id": pa.array([1, 2], pa.int64()),
+        "name": pa.array(["Acme", "Globex"]),
+        "region": pa.array(["emea", "amer"]),
+    }), partition_by=["region"])
+    return path
+
+
+def _resolve(_name):
+    raise AssertionError("a delta.`path` target must not need the catalog")
+
+
+def test_describe_detail_matches_and_reads_the_log(table):
+    kind, params = delta_ops.match(f"DESCRIBE DETAIL delta.`{table}`")
+    assert kind == "describe_detail"
+
+    got = delta_ops.describe_detail(FakeSpark(), params, _resolve, storage_options={})
+    row = dict(zip(got["columns"], got["rows"][0], strict=True))
+    assert row["format"] == "delta"
+    assert row["location"] == table
+    assert row["version"] == 0
+    assert row["numFiles"] >= 1
+    # Read out of the log, not assumed: the table really is partitioned.
+    assert row["partitionColumns"] == ["region"]
+    # `id` is the Delta table's own uuid — present rather than blank.
+    assert len(row["id"]) > 10
+
+
+def test_describe_table_lists_real_columns_with_spark_type_names(table):
+    kind, params = delta_ops.match(f"DESCRIBE TABLE delta.`{table}`")
+    assert kind == "describe_table"
+
+    got = delta_ops.describe_table(FakeSpark(), params, _resolve, storage_options={})
+    assert got["columns"] == ["col_name", "data_type", "comment"]
+    by_name = {r[0]: r for r in got["rows"]}
+    assert set(by_name) == {"id", "name", "region"}
+    # Delta says `long`; every DESCRIBE a notebook has ever read says `bigint`.
+    assert by_name["id"][1] == "bigint"
+    assert by_name["name"][1] == "string"
+    # The partition column is marked, which is what Spark's own DESCRIBE does.
+    assert by_name["region"][2] == "partition"
+
+
+def test_bare_desc_and_describe_both_match(table):
+    for sql in (f"DESC delta.`{table}`", f"DESCRIBE delta.`{table}`",
+                f"describe table delta.`{table}` ;"):
+        kind, _ = delta_ops.match(sql)
+        assert kind == "describe_table", sql
+
+
+def test_describe_of_an_unlocatable_name_falls_through_to_the_engine():
+    # The seam's rule: anything we cannot locate is the engine's business. A
+    # DESCRIBE of a temp view, a function, or an engine-managed table must NOT
+    # be intercepted — a shim that guessed would be worse than the gap.
+    delta_ops.forget_all()
+    assert delta_ops.match("DESCRIBE some_temp_view") is None
+    assert delta_ops.match("DESCRIBE FUNCTION upper") is None
+
+
+def test_describe_of_a_registered_name_is_intercepted():
+    delta_ops.forget_all()
+    delta_ops.remember("accounts", "az://ws/item/Tables/accounts", schema="silver")
+    kind, params = delta_ops.match("DESCRIBE TABLE silver.accounts")
+    assert kind == "describe_table"
+    assert params["target"] == "silver.accounts"
+
+
+def test_the_plain_grammar_cannot_swallow_a_detail_statement(table):
+    # Answering a DETAIL request with a column list would be plausible output to
+    # the wrong question. What prevents it is the GRAMMAR, not matcher order:
+    # the plain form anchors at end-of-statement, so `DESCRIBE DETAIL x` leaves
+    # `x` unconsumed and cannot match. Asserted directly, because an earlier
+    # version of this test claimed order was the protection — mutation testing
+    # reordered the matchers and every test still passed.
+    assert delta_ops._DESCRIBE_TABLE.match(f"DESCRIBE DETAIL delta.`{table}`") is None
+    assert delta_ops._DESCRIBE_DETAIL.match(f"DESCRIBE DETAIL delta.`{table}`") is not None
+    kind, _ = delta_ops.match(f"DESCRIBE DETAIL delta.`{table}`")
+    assert kind == "describe_detail"
+
+
+def test_spark_type_names():
+    assert delta_ops._spark_type('PrimitiveType("long")') == "bigint"
+    assert delta_ops._spark_type('PrimitiveType("timestampNtz")') == "timestamp_ntz"
+    # Anything structured passes through as delta-rs renders it rather than
+    # being guessed at — a wrong nested type is worse than an unfamiliar one.
+    assert delta_ops._spark_type("StructType(...)") == "StructType(...)"

--- a/python/tests/test_delta_ops_describe.py
+++ b/python/tests/test_delta_ops_describe.py
@@ -13,11 +13,26 @@ two touch.
 import sys
 from pathlib import Path
 
-import pyarrow as pa
 import pytest
-from deltalake import write_deltalake
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+# delta-rs is an OPTIONAL dependency group. The `notebookutils` CI job runs this
+# suite with `--group test` alone, so importing it at module scope took the whole
+# file down on macOS and Windows. Guarded at COLLECTION time rather than with
+# importorskip inside the fixture: pytest 8 reports an ImportError raised BY a
+# module as an error rather than a skip, and the distinction is too subtle to
+# rest on. Only the two tests needing a table on disk are marked; the matcher and
+# type-mapping tests — most of the file — run everywhere.
+try:
+    import pyarrow as pa
+    from deltalake import write_deltalake
+
+    HAVE_DELTA_RS = True
+except ImportError:  # pragma: no cover - exercised by the CI leg without the group
+    HAVE_DELTA_RS = False
+
+needs_delta_rs = pytest.mark.skipif(not HAVE_DELTA_RS, reason="delta-rs group not installed")
 
 import delta_ops
 
@@ -45,6 +60,7 @@ def _resolve(_name):
     raise AssertionError("a delta.`path` target must not need the catalog")
 
 
+@needs_delta_rs
 def test_describe_detail_matches_and_reads_the_log(table):
     kind, params = delta_ops.match(f"DESCRIBE DETAIL delta.`{table}`")
     assert kind == "describe_detail"
@@ -61,6 +77,7 @@ def test_describe_detail_matches_and_reads_the_log(table):
     assert len(row["id"]) > 10
 
 
+@needs_delta_rs
 def test_describe_table_lists_real_columns_with_spark_type_names(table):
     kind, params = delta_ops.match(f"DESCRIBE TABLE delta.`{table}`")
     assert kind == "describe_table"
@@ -76,7 +93,8 @@ def test_describe_table_lists_real_columns_with_spark_type_names(table):
     assert by_name["region"][2] == "partition"
 
 
-def test_bare_desc_and_describe_both_match(table):
+def test_bare_desc_and_describe_both_match():
+    table = "/tmp/accounts"  # a path string is all the grammar sees
     for sql in (f"DESC delta.`{table}`", f"DESCRIBE delta.`{table}`",
                 f"describe table delta.`{table}` ;"):
         kind, _ = delta_ops.match(sql)
@@ -100,7 +118,8 @@ def test_describe_of_a_registered_name_is_intercepted():
     assert params["target"] == "silver.accounts"
 
 
-def test_the_plain_grammar_cannot_swallow_a_detail_statement(table):
+def test_the_plain_grammar_cannot_swallow_a_detail_statement():
+    table = "/tmp/accounts"
     # Answering a DETAIL request with a column list would be plausible output to
     # the wrong question. What prevents it is the GRAMMAR, not matcher order:
     # the plain form anchors at end-of-statement, so `DESCRIBE DETAIL x` leaves

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -107,6 +107,7 @@ export default defineConfig({
             { slug: '39-run-multiple-parity-plan' },
             { slug: '40-rest-connector-plan' },
             { slug: '41-salesforce-connector-plan' },
+            { slug: '42-sail-fidelity-plan' },
             { slug: 'engine-matrix' },
           ],
         },


### PR DESCRIPTION
Answers a direct question — *we want Sail default and 100% distributed-engine fidelity if possible* — with a measured taxonomy, and closes the cheapest gap in it.

**Sail is already the default**, so the work is the second half. New [docs/42](https://github.com/calvinchengx/fabric-emulator/blob/main/docs/42-sail-fidelity-plan.md) records the ceiling honestly: **100% is not reachable**, and the residue is exactly two things.

## Read the matrix carefully before believing it

Three ❌ rows in `engine-matrix.md` are not what they look like, and its footnotes say so:

- **`MERGE INTO` is not a Sail gap** (ᵃ) — `e2e/sail` proves it succeeds against an `az://` OneLake URL, the path the emulator actually uses. Only the local-path probe fails.
- **CDF fails on the WRITE, not the read** (ᵇ) — the read side is real and verified in `e2e/livy`.
- **`OPTIMIZE`/`VACUUM` are already closed** by delta-rs interception — the middle column, which is what users get.

## The taxonomy

| Bucket | Reachable with Sail default? |
|---|---|
| Bounded path-scoped statements | **Yes** — where the work is |
| Fabric-vs-OSS semantics | **Yes**, and it beats the JVM |
| Streaming sinks | **No** — lives inside the engine |
| `sc` / RDD / `_jvm` | **Never** — Spark Connect forbids it for *any* client |

`sc` and `_jvm` fail with `[JVM_ATTRIBUTE_NOT_SUPPORTED] … not supported in Spark Connect`. That's the **protocol**; Apache's own Connect server refuses identically. The JVM column is green only because that leg runs a *classic* session.

Streaming sinks are excluded by the rule `delta_ops.py` already states: interception works for "a bounded statement that starts and finishes against a table path, carrying no Spark session state — a streaming query, which lives inside the engine, is not."

One nice consequence: **`CREATE TABLE` defaulting to Delta is ❌ on both engines** (ᵍ), because it's a *Fabric* property, not a Spark one. Closing it on the interception path would make Sail **more faithful to Fabric than the JVM overlay is**.

## What this ships

| Statement | Was | Now |
|---|---|---|
| `DESCRIBE DETAIL` | ❌ absent from Sail's grammar | answered from the Delta log |
| `DESCRIBE TABLE` | ❌ right schema, **zero rows**, no error | real column list, Spark type names |

That second failure mode is the nastier one, and `delta_ops.resolve()` still carries a fallback that trips over it. Types are mapped to Spark's spelling — Delta says `long`, every DESCRIBE a notebook has read says `bigint` — and anything structured passes through as delta-rs renders it rather than being guessed at.

## Verification

7 new tests, run against a **real Delta table on disk** — metadata genuinely read out of a `_delta_log`, not synthesized. 270 Python tests pass; `make check`, `ruff`, `go build`, `go test` clean.

Mutation-tested, and the first one found a false claim in my own test:

| Mutation | Result |
|---|---|
| Intercept every `DESCRIBE` regardless of location | fails — the fall-through rule holds |
| Reorder the matchers so plain `DESCRIBE` runs first | **passed** — see below |
| Weaken the plain grammar's end anchor | fails |

I had a test asserting DETAIL is matched *before* the plain form, with a comment claiming order was the protection. Reordering the matchers changed nothing: the plain grammar anchors at end-of-statement, so `DESCRIBE DETAIL x` leaves `x` unconsumed and cannot match. Order was never load-bearing — the grammar is. The test now asserts that directly.

## Next in doc 42

CDF write (closes a measured ❌), then `CREATE TABLE` → Delta by default, then regenerate `engine-matrix.md` so the middle column reflects it — CI already diffs that file, so it cannot drift from the code.