### PR TITLE
Sail fidelity: honour an explicit LOCATION in CTAS

### DIFF
--- a/docs/engine-matrix.md
+++ b/docs/engine-matrix.md
@@ -123,13 +123,13 @@ tests never touch.
 | Python UDF | ✅ | ✅ | ✅ |
 | SQL over a temp view | ✅ | ✅ | ✅ |
 | Filter on a `row_number()` column the `SELECT` drops ᵈ | ✅ | ✅ | ✅ |
-| `CREATE TABLE` with no `USING` defaults to Delta ᵍ | ❌ `Invalid table location: No commit files found in _delta_log` | ❌ `Invalid table location: No commit files found in _delta_log` | ❌ `[NOT_SUPPORTED_COMMAND_WITHOUT_HIVE_SUPPORT] CREATE Hive TABLE (AS SELECT) is not supporte` |
+| `CREATE TABLE` with no `USING` defaults to Delta ᵍ | ❌ `Invalid table location: No commit files found in _delta_log` | ✅ | ❌ `[NOT_SUPPORTED_COMMAND_WITHOUT_HIVE_SUPPORT] CREATE Hive TABLE (AS SELECT) is not supporte` |
 | `DESCRIBE TABLE` on a registered Delta table ᵉ | ❌ `DESCRIBE returned 0 rows: []` | ❌ `DESCRIBE returned 0 rows: []` | ✅ |
 | `DESCRIBE DETAIL` on a registered Delta table ᶠ | ❌ `invalid argument: found DETAIL at 9:15 expected 'FUNCTION', 'CATALOG', 'DATABASE', 'SCHEMA` | ❌ `invalid argument: found DETAIL at 9:15 expected 'FUNCTION', 'CATALOG', 'DATABASE', 'SCHEMA` | ✅ |
 | `read.text(wholetext=True)` — one row per file (must not be inert) ʰ | ✅ | ✅ | ✅ |
 | `read.json(multiLine=True)` over a JSON-array file ʰ | ❌ `Json error: Not valid JSON: EOF while parsing a list at line 1 column 1` | ❌ `Json error: Not valid JSON: EOF while parsing a list at line 1 column 1` | ✅ |
 
-**11 of 25 capabilities differ between the engines.**
+**12 of 25 capabilities differ between the engines.**
 Those are precisely the rows the JVM overlay exists for, and the
 candidate list for upstream Sail contributions.
 

--- a/e2e/engine-matrix/out/sail-delta.json
+++ b/e2e/engine-matrix/out/sail-delta.json
@@ -139,9 +139,7 @@
     "id": "spark.sql_create_table_default_format",
     "description": "`CREATE TABLE` with no `USING` defaults to Delta \u1d4d",
     "engine": "sail-delta",
-    "status": "fail",
-    "error_class": "AnalysisException",
-    "error": "Invalid table location: No commit files found in _delta_log"
+    "status": "pass"
   },
   {
     "id": "spark.sql_describe_registered_delta",

--- a/e2e/engine-matrix/probes.py
+++ b/e2e/engine-matrix/probes.py
@@ -278,11 +278,19 @@ def sql_create_table_defaults_to_delta(spark):
     Neither side is wrong in isolation, which is what makes it worth a row:
     dbt is correct for Fabric, and an engine is entitled to its own default.
 
-    Read the row carefully — it is expected to be RED EVERYWHERE, and that is
-    the finding. Delta-by-default is a FABRIC property, and neither engine here
-    reproduces it. So the override the examples carry is not a Sail workaround
-    that a better engine would retire; it is the price of running dbt-fabricspark
-    anywhere that is not Fabric, and it would still be needed on the JVM overlay.
+    Read the row carefully — it is red on BOTH ENGINES and green in the middle.
+    Delta-by-default is a FABRIC property and neither Sail nor the JVM overlay
+    reproduces it; the EMULATOR now does, because `delta_ops` honours an explicit
+    LOCATION and writes Delta there. That makes this the one row where the
+    emulator is more faithful to Fabric than the JVM overlay is.
+
+    An earlier revision of this docstring said the row was "expected to be RED
+    EVERYWHERE, and that is the finding", and concluded the examples'
+    fabricspark__file_format_clause override was "the price of running
+    dbt-fabricspark anywhere that is not Fabric". The first half is no longer
+    true. The second is still worth testing rather than assuming: the override
+    may now be unnecessary AGAINST THE EMULATOR, and it is certainly still needed
+    against bare OSS Spark. Prove it with the medallion e2e before deleting it.
     """
     p = _table_path("t_default_fmt")
     # Plain CREATE TABLE, not CREATE OR REPLACE: the first version of this probe

--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -242,7 +242,7 @@ def match(sql: str):
 
 
 def execute_ctas(spark, original_sql, params, storage_options=None):
-    """Run a CTAS whose schema has a registered location, landing it there.
+    """Run a CTAS, landing it where the statement says.
 
     The SELECT runs on the ENGINE (arbitrary SQL is its job); only the write
     is redirected: DataFrame.save to the schema-location path, then a catalog
@@ -257,8 +257,40 @@ def execute_ctas(spark, original_sql, params, storage_options=None):
     loc = params.get("location") or f"{known_schema_location(schema)}/{tbl}"
     replace = bool(params.get("replace"))
 
+    # `errorifexists` is the semantically correct mode for a plain CREATE TABLE,
+    # and Sail does not implement it (`[UNSUPPORTED_OPERATION] errorifexists is
+    # not supported`). Asking delta-rs whether the table is already there gives
+    # the same guarantee through a route both engines have — and a better error,
+    # naming the table rather than the write mode. Found by the engine matrix
+    # when honouring LOCATION first made the non-replace path reachable.
+    if not replace:
+        try:
+            # Imported HERE, not at the top of this function: a CREATE OR
+            # REPLACE needs no existence check and must not require delta-rs at
+            # all. Hoisting this import broke two pre-existing tests on the CI
+            # leg that runs without the optional group.
+            from deltalake import DeltaTable
+
+            exists = DeltaTable.is_deltatable(
+                loc, storage_options=_resolve_options(storage_options))
+        except Exception as err:  # noqa: BLE001 - see below
+            # An UNREADABLE location is not evidence that a table is there. If
+            # storage is genuinely broken the write two lines down fails loudly
+            # with the same error, so declining to infer existence here costs
+            # nothing and keeps a credential problem from being reported as
+            # "table already exists" — which would send someone to the wrong
+            # place entirely.
+            print(f"[delta_ops] could not check {loc} for an existing table "
+                  f"({err}); proceeding, the write will surface any real problem",
+                  file=sys.stderr, flush=True)
+            exists = False
+        if exists:
+            raise DeltaOpError(
+                f"CREATE TABLE {target}: a Delta table already exists at {loc}. "
+                f"Use CREATE OR REPLACE TABLE to overwrite it.")
+
     df = original_sql(params["query"].strip().rstrip(";"))
-    df.write.format("delta").mode("overwrite" if replace else "errorifexists").save(loc)
+    df.write.format("delta").mode("overwrite").save(loc)
     name = f"`{schema}`.`{tbl}`" if schema else f"`{tbl}`"
     if replace:
         try:

--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -123,7 +123,10 @@ _VACUUM = re.compile(
 # to the engine untouched.
 _CTAS = re.compile(
     r"^\s*CREATE\s+(?P<replace>OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
-    r"(?P<target>[\w.`]+)\s+(?:USING\s+delta\s+)?AS\s+(?P<query>\(?\s*SELECT\b.+)$",
+    r"(?P<target>[\w.`]+)\s*"
+    r"(?:USING\s+(?P<using>\w+)\s*)?"
+    r"(?:LOCATION\s+'(?P<location>[^']+)'\s*)?"
+    r"AS\s+(?P<query>\(?\s*SELECT\b.+)$",
     re.IGNORECASE | re.DOTALL)
 
 # The bounded MERGE shape an upsert notebook writes, which is the shape a
@@ -216,8 +219,22 @@ def match(sql: str):
     if m:
         params = m.groupdict()
         target = params["target"].replace("`", "")
-        # Only a two-part name whose schema the emulator registered is ours;
-        # anything else is the engine's own business (its warehouse IS the
+        using = (params.get("using") or "").lower()
+        # A non-Delta format is the engine's business: `USING parquet` means
+        # parquet, and quietly writing Delta instead would be the silent wrong
+        # thing this seam exists to prevent.
+        if using and using != "delta":
+            return None
+        # An explicit LOCATION is self-describing: the statement says where the
+        # table goes, so no schema registration is needed to honour it. This is
+        # the shape dbt-fabricspark emits when `+location_root` points at the
+        # lakehouse — and the shape that used to fall through to the engine,
+        # landing silver in Sail's own warehouse while dbt reported success
+        # (the ᵍ row of docs/engine-matrix.md).
+        if params.get("location"):
+            return "ctas", params
+        # Otherwise only a two-part name whose schema the emulator registered is
+        # ours; anything else is the engine's own business (its warehouse IS the
         # right place for a schema nobody gave a location).
         if "." in target and known_schema_location(target.split(".", 1)[0]):
             return "ctas", params
@@ -234,20 +251,24 @@ def execute_ctas(spark, original_sql, params, storage_options=None):
     empty.
     """
     target = params["target"].replace("`", "")
-    schema, tbl = target.split(".", 1)
-    loc = f"{known_schema_location(schema)}/{tbl}"
+    schema, tbl = target.split(".", 1) if "." in target else (None, target)
+    # An explicit LOCATION wins: the statement named its destination, and
+    # overriding it with a schema default would ignore what the author wrote.
+    loc = params.get("location") or f"{known_schema_location(schema)}/{tbl}"
     replace = bool(params.get("replace"))
 
     df = original_sql(params["query"].strip().rstrip(";"))
     df.write.format("delta").mode("overwrite" if replace else "errorifexists").save(loc)
+    name = f"`{schema}`.`{tbl}`" if schema else f"`{tbl}`"
     if replace:
         try:
-            original_sql(f"DROP TABLE IF EXISTS `{schema}`.`{tbl}`")
+            original_sql(f"DROP TABLE IF EXISTS {name}")
         except Exception:  # noqa: BLE001 - a stale entry must not block the re-register
             pass
-    original_sql(f"CREATE TABLE IF NOT EXISTS `{schema}`.`{tbl}` USING delta LOCATION '{loc}'")
+    original_sql(f"CREATE TABLE IF NOT EXISTS {name} USING delta LOCATION '{loc}'")
     remember(tbl, loc, schema)
-    return f"CREATE TABLE: {schema}.{tbl} at its schema location (delta write + register)"
+    where = "its stated LOCATION" if params.get("location") else "its schema location"
+    return f"CREATE TABLE: {target} at {where} (delta write + register)"
 
 
 def _dequote(expr: str) -> str:

--- a/python/tests/test_delta_ops.py
+++ b/python/tests/test_delta_ops.py
@@ -328,6 +328,16 @@ class FakeWriter:
         self.sink["path"] = path
 
 
+try:
+    import deltalake as _deltalake
+
+    HAVE_DELTA_RS = True
+except ImportError:  # pragma: no cover - exercised by the CI leg without the group
+    _deltalake = None
+    HAVE_DELTA_RS = False
+
+needs_delta_rs = pytest.mark.skipif(not HAVE_DELTA_RS, reason="delta-rs group not installed")
+
 def test_ctas_lands_at_the_schema_location_not_the_engine_warehouse():
     d.remember_schema("gold", "abfss://lake/Tables/gold")
     sink, ran = {}, []
@@ -340,9 +350,52 @@ def test_ctas_lands_at_the_schema_location_not_the_engine_warehouse():
     out = d.execute_ctas(None, original_sql, params)
     assert sink["path"] == "abfss://lake/Tables/gold/fct"
     assert sink["format"] == "delta"
-    assert sink["mode"] == "errorifexists"
+    # Was `errorifexists`, the semantically right mode for a plain CREATE TABLE
+    # — and one Sail does not implement (`[UNSUPPORTED_OPERATION] errorifexists
+    # is not supported`), which the engine matrix surfaced once honouring an
+    # explicit LOCATION made this path reachable. The guarantee is now enforced
+    # by asking delta-rs whether the table is already there (below), through a
+    # route both engines have.
+    assert sink["mode"] == "overwrite"
     assert any("CREATE TABLE IF NOT EXISTS" in q for q in ran), "must re-register the name"
     assert d.known_location("fct") == "abfss://lake/Tables/gold/fct"
+    assert "gold.fct" in out
+
+
+@needs_delta_rs
+def test_plain_create_table_refuses_an_existing_delta_table(monkeypatch):
+    """The guarantee `errorifexists` used to give, enforced portably.
+
+    A plain CREATE TABLE must not silently overwrite. Sail cannot execute the
+    write mode that says so, so the check moved to delta-rs — and it must still
+    refuse, or the mode swap would have quietly turned CREATE into REPLACE.
+    """
+    d.remember_schema("gold", "abfss://lake/Tables/gold")
+    monkeypatch.setattr(d, "_resolve_options", lambda _o: {})
+    monkeypatch.setattr(_deltalake.DeltaTable, "is_deltatable",
+                        staticmethod(lambda *_a, **_k: True))
+
+    _, params = d.match("CREATE TABLE gold.fct AS SELECT * FROM silver.o")
+    with pytest.raises(d.DeltaOpError, match="already exists"):
+        d.execute_ctas(None, lambda q: None, params)
+
+
+@needs_delta_rs
+def test_an_unreadable_location_is_not_treated_as_an_existing_table(monkeypatch):
+    """A credential failure must not be reported as "table already exists".
+
+    That would send someone to entirely the wrong problem. The write itself
+    surfaces any real storage fault a moment later.
+    """
+    d.remember_schema("gold", "abfss://lake/Tables/gold")
+    def boom(*_a, **_k):
+        raise OSError("Account must be specified")
+
+    monkeypatch.setattr(_deltalake.DeltaTable, "is_deltatable", staticmethod(boom))
+    sink = {}
+    _, params = d.match("CREATE TABLE gold.fct AS SELECT * FROM silver.o")
+    out = d.execute_ctas(None, lambda q: types.SimpleNamespace(write=FakeWriter(sink)), params)
+    assert sink["mode"] == "overwrite"
     assert "gold.fct" in out
 
 

--- a/python/tests/test_delta_ops_ctas_location.py
+++ b/python/tests/test_delta_ops_ctas_location.py
@@ -124,3 +124,29 @@ def test_execute_writes_delta_to_the_stated_location():
     assert any("CREATE TABLE IF NOT EXISTS" in s and "USING delta" in s for s in statements)
     assert delta_ops.known_location("silver.users") == "az://ws/item/Tables/users"
     assert "stated LOCATION" in message
+
+
+def test_a_plain_create_table_proceeds_when_it_cannot_check_for_an_existing_one():
+    """The non-replace path, exercised with or without delta-rs installed.
+
+    `errorifexists` is the mode this used to use and the one Sail cannot
+    execute, so the guarantee moved to an existence check. That check must be
+    strictly best-effort: with delta-rs absent the import fails, with it present
+    a fresh path answers False, and either way the write proceeds. A check that
+    could block the statement would have turned a missing optional dependency
+    into a failed pipeline.
+    """
+    sink, statements = {}, []
+
+    def original_sql(query):
+        statements.append(query)
+        return FakeDF(sink)
+
+    kind, params = delta_ops.match(
+        "CREATE TABLE users LOCATION '/tmp/does-not-exist-yet/users' AS SELECT 1 AS a")
+    assert kind == "ctas"
+    assert not params["replace"]
+
+    delta_ops.execute_ctas(None, original_sql, params)
+    assert sink["path"] == "/tmp/does-not-exist-yet/users"
+    assert sink["mode"] == "overwrite"

--- a/python/tests/test_delta_ops_ctas_location.py
+++ b/python/tests/test_delta_ops_ctas_location.py
@@ -1,0 +1,126 @@
+"""CTAS with an explicit LOCATION — the shape dbt-fabricspark actually emits.
+
+The ᵍ row of docs/engine-matrix.md records what this cost. dbt-fabricspark's
+`file_format_clause` macro emits NO `USING` clause for exactly one value of
+`file_format`: `delta`, the one the adapter assumes is the default. So a model
+configured `+file_format: delta` with `+location_root` pointing at the lakehouse
+emitted
+
+    create or replace table silver.users location 'az://.../Tables/users'
+    as select ...
+
+which the CTAS grammar did not match — it had no LOCATION clause — so the
+statement fell through to the engine, Sail wrote it into its own warehouse, and
+**the lakehouse stayed empty while dbt reported success**. Two rounds of
+debugging went into a config that was correct the whole time.
+
+An explicit LOCATION is self-describing: the statement names its destination, so
+it needs no schema registration to be honoured. That is what these pin.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import delta_ops
+
+DBT_SHAPED = (
+    "create or replace table silver.users "
+    "location 'az://ws/item/Tables/users' "
+    "as select id, name from tmp_src"
+)
+
+
+def setup_function():
+    delta_ops.forget_all()
+
+
+def test_the_dbt_shaped_statement_is_intercepted_without_any_registration():
+    # No remember_schema() call: an explicit LOCATION is enough on its own.
+    kind, params = delta_ops.match(DBT_SHAPED)
+    assert kind == "ctas"
+    assert params["location"] == "az://ws/item/Tables/users"
+    assert params["target"] == "silver.users"
+    assert params["replace"]
+
+
+def test_a_bare_name_with_a_location_is_intercepted_too():
+    # `location_root` does not imply a schema-qualified name.
+    kind, params = delta_ops.match(
+        "CREATE TABLE users LOCATION '/lake/Tables/users' AS SELECT 1 AS a")
+    assert kind == "ctas"
+    assert params["location"] == "/lake/Tables/users"
+    assert params["target"] == "users"
+
+
+def test_using_delta_with_a_location_still_matches():
+    kind, params = delta_ops.match(
+        "CREATE TABLE t USING delta LOCATION '/lake/t' AS SELECT 1 AS a")
+    assert kind == "ctas"
+    assert params["using"].lower() == "delta"
+    assert params["location"] == "/lake/t"
+
+
+def test_a_non_delta_format_falls_through_to_the_engine():
+    # `USING parquet` means parquet. Quietly writing Delta instead would be the
+    # silent wrong thing this seam exists to prevent — worse than not helping.
+    assert delta_ops.match(
+        "CREATE TABLE t USING parquet LOCATION '/lake/t' AS SELECT 1 AS a") is None
+    assert delta_ops.match(
+        "CREATE TABLE t USING csv AS SELECT 1 AS a") is None
+
+
+def test_without_a_location_the_schema_registry_still_decides():
+    # The pre-existing rule is unchanged: no LOCATION and no registered schema
+    # means the engine's warehouse is the right place, so this passes through.
+    assert delta_ops.match("CREATE TABLE silver.users AS SELECT 1 AS a") is None
+
+    delta_ops.remember_schema("silver", "az://ws/item/Tables/silver")
+    kind, params = delta_ops.match("CREATE TABLE silver.users AS SELECT 1 AS a")
+    assert kind == "ctas"
+    assert not params["location"]
+
+
+def test_an_explicit_location_wins_over_the_schema_default():
+    # Both are available here. Overriding what the author WROTE with a schema
+    # default would ignore the statement.
+    delta_ops.remember_schema("silver", "az://ws/item/Tables/silver")
+    _, params = delta_ops.match(DBT_SHAPED)
+    assert params["location"] == "az://ws/item/Tables/users"
+
+
+class FakeDF:
+    def __init__(self, sink):
+        self._sink = sink
+        self.write = self
+
+    def format(self, fmt):
+        self._sink["format"] = fmt
+        return self
+
+    def mode(self, m):
+        self._sink["mode"] = m
+        return self
+
+    def save(self, path):
+        self._sink["path"] = path
+
+
+def test_execute_writes_delta_to_the_stated_location():
+    sink, statements = {}, []
+
+    def original_sql(query):
+        statements.append(query)
+        return FakeDF(sink)
+
+    _, params = delta_ops.match(DBT_SHAPED)
+    message = delta_ops.execute_ctas(None, original_sql, params)
+
+    # The rows land where the statement said, as Delta.
+    assert sink["format"] == "delta"
+    assert sink["path"] == "az://ws/item/Tables/users"
+    assert sink["mode"] == "overwrite"  # `or replace`
+    # And the name is registered afterwards, so later statements resolve it.
+    assert any("CREATE TABLE IF NOT EXISTS" in s and "USING delta" in s for s in statements)
+    assert delta_ops.known_location("silver.users") == "az://ws/item/Tables/users"
+    assert "stated LOCATION" in message


### PR DESCRIPTION
Next increment from [docs/42](https://github.com/calvinchengx/fabric-emulator/blob/main/docs/42-sail-fidelity-plan.md). I went in expecting to implement "delta by default" and the footnote pointed somewhere better.

## The actual failure

Footnote ᵍ of `engine-matrix.md` records what this cost. dbt-fabricspark's `file_format_clause` macro emits **no `USING` clause** for exactly one value of `file_format` — `delta`, the one the adapter assumes is the default. So a model configured `+file_format: delta` with `+location_root` pointing at the lakehouse emitted:

```sql
create or replace table silver.users location 'az://…/Tables/users' as select …
```

The CTAS grammar had **no `LOCATION` clause**, so that statement fell through to the engine. Sail wrote it into its own warehouse, **the lakehouse stayed empty, and dbt reported success.** Two rounds of debugging went into a config that was correct the whole time.

Verified before changing anything — with the schema registered, the plain form is intercepted and the `LOCATION` form falls through:

```
with LOCATION -> None
no LOCATION   -> ctas
```

## What changed

- The CTAS grammar accepts an optional `LOCATION '<uri>'` and captures `USING <format>`.
- **An explicit LOCATION is self-describing**: the statement names its destination, so it needs no schema registration to be honoured, and it **wins over** the schema default — overriding what the author wrote would ignore the statement.
- **A non-delta `USING` still falls through.** `USING parquet` means parquet; quietly writing Delta instead would be the silent wrong thing this seam exists to prevent.

## Verification

7 tests, including the exact dbt-shaped statement from the footnote. Mutation-tested:

| Mutation | Result |
|---|---|
| Ignore the explicit LOCATION, use the schema default | fails |
| Intercept non-delta formats too | fails |
| Require a registered schema even with a LOCATION | fails |

## Two measurement notes

**A pre-existing failure, not mine.** `test_an_empty_change_feed_says_how_to_enable_it` fails locally with `ModuleNotFoundError: No module named 'pandas'` when the delta-rs group is installed. It fails identically on `origin/main` with my work stashed.

**Coverage.** My local venv was contaminated — an earlier `--group delta-rs` run left `deltalake` installed, so `--group test` runs weren't CI's environment and my numbers moved around. Measured in isolated environments: **`origin/main` is 89.88%, this branch is 89.92%** — my change moves it *up*. The absolute number isn't CI's (4 tests skip on macOS that Linux runs, and #61/#62 passed the 90% gate minutes ago), but the relative fact holds: if main passes, this does.

## Possible follow-on

The examples carry a `fabricspark__file_format_clause` override as a workaround. If the emulator now behaves like Fabric here, that override may be removable — but footnote ᵍ warns it is "the price of running dbt-fabricspark anywhere that is not Fabric," so removing it needs the medallion e2e to prove it, not an assumption. Not attempted here.