### PR TITLE
delta_ops: fix backticked column refs; make the coverage floor exact (93%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         run: |
           go_pct=$(go tool cover -func=cover.out | tail -1 | awk '{print $3}' | tr -d '%')
           py_pct=$(uv run --frozen --group test pytest python/tests -q \
-                   --cov --cov-report=term --cov-fail-under=90 2>&1 \
+                   --cov --cov-report=term 2>&1 \
                    | sed -n 's/.*Total coverage: \([0-9.]*\)%.*/\1/p' | tail -1)
           # Read from the machine-readable summary rather than scraped stdout:
           # the table's column layout is not a contract.
@@ -1196,7 +1196,7 @@ jobs:
       # caught it. What remains uncovered is deliberate: check_kind_exhaustiveness
       # shells out to a real toolchain and check_witnesses' reporting branches
       # print rather than decide.
-      - run: uv run --frozen --group test pytest python/tests -q --cov --cov-report=term-missing --cov-fail-under=90
+      - run: uv run --frozen --group test pytest python/tests -q --cov --cov-report=term-missing
       # Brings up entra + fabric + azure-keyvault and runs a real Fabric
       # notebook that drives the functional notebookutils shim: fs over
       # OneLake, credential tokens, Key Vault secret brokering, lakehouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,21 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 skip_covered = false
+# THE FLOOR MUST MEAN WHAT IT PRINTS. Without a precision, coverage compares the
+# ROUNDED percentage against --cov-fail-under, so 89.88% satisfied a floor of 90
+# while pytest-cov printed
+#
+#   FAIL Required test coverage of 90% not reached. Total coverage: 89.88%
+#
+# on a build that exited 0. A FAIL line that does not fail is how people learn
+# to skim CI output — and the effective floor was 89.5, not 90. Two decimals
+# makes the comparison exact and the message truthful.
+precision = 2
+# ONE number, here. It used to live in two workflow steps as
+# `--cov-fail-under=`, which is two things to move for one change and the way a
+# ratchet quietly stops ratcheting. 92 against a measured 93.03 leaves headroom
+# for a change that lands genuinely-hard-to-cover code, and no more.
+fail_under = 92
 
 
 # --- ruff ------------------------------------------------------------------

--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -287,13 +287,59 @@ def _split_top(text: str, sep: str = ","):
     return [p.strip() for p in parts if p.strip()]
 
 
+def _identifier_parts(ref: str):
+    """Split a possibly-quoted identifier on the dots BETWEEN its parts.
+
+    A dot inside backticks or double quotes belongs to the name, not to the
+    path: `` `my.col` `` is one part, `` `t`.`col` `` is two. Stripping quotes
+    from the whole string first cannot tell those apart, which is the bug this
+    exists to remove.
+    """
+    parts, buf, quote = [], [], None
+    for ch in ref.strip():
+        if quote:
+            if ch == quote:
+                quote = None
+            else:
+                buf.append(ch)
+        elif ch in "`\"":
+            quote = ch
+        elif ch == ".":
+            parts.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(ch)
+    parts.append("".join(buf).strip())
+    return [p for p in parts if p] or [""]
+
+
 def _plain_column(ref: str, alias: str) -> str:
-    """`t.\\`col\\``/`t.col`/`\\`col\\`` -> the bare column name."""
-    ref = ref.strip().strip("`\"")
-    prefix = alias + "."
-    if ref.lower().startswith(prefix.lower()):
-        ref = ref[len(prefix):]
-    return ref.strip().strip("`\"")
+    """`t.\\`col\\``/`\\`t\\`.\\`col\\``/`t.col`/`\\`col\\`` -> the bare column name.
+
+    delta-rs wants the target column's own name on the left of an update, so a
+    leading target alias has to go.
+
+    QUOTING IS PER SEGMENT, which the first version of this missed. It stripped
+    backticks from the ends of the whole string, so `` `t`.`amount` `` — valid
+    Spark SQL, and what a formatter produces — became the string
+    ``t`.`amount``: the alias prefix no longer matched, and delta-rs was handed
+    a column name no table has. A wrong answer rather than a refusal, which is
+    the shape this repo treats as worst.
+
+    A single quoted identifier that still spells the alias inside it
+    (`` `t.amount` ``) keeps its old reading. That form is ambiguous — SQL says
+    it is one column literally named "t.amount" — but anyone writing it in a
+    MERGE means the qualified column, and changing that reading is a separate
+    decision from fixing the bug above.
+    """
+    parts = _identifier_parts(ref)
+    if len(parts) > 1 and parts[0].lower() == alias.lower():
+        return ".".join(parts[1:])
+    if len(parts) == 1:
+        prefix = alias + "."
+        if parts[0].lower().startswith(prefix.lower()):
+            return parts[0][len(prefix):]
+    return ".".join(parts)
 
 
 def execute_merge(spark, params, resolve, storage_options=None):

--- a/python/tests/test_check_witnesses_verdicts.py
+++ b/python/tests/test_check_witnesses_verdicts.py
@@ -1,0 +1,207 @@
+"""`check_witnesses --strict` is what keeps every 🟢 honest — so its REFUSALS matter.
+
+`test_check_witnesses.py` covers the parsing helpers. What was never exercised
+is `main()`: the verdicts. Each `FAIL` branch encodes a rule that took a real
+incident to learn, and a rule whose enforcement is untested is a rule that can
+stop enforcing without anyone noticing — which is precisely the failure mode
+this script exists to prevent, turned on itself.
+
+Every case below builds a small parity map and manifest in a tmp dir, so the
+verdict under test is the only thing that can produce the exit code.
+"""
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+import check_witnesses as w  # noqa: E402
+
+
+def parity(rows, section="Platform / fundamentals"):
+    """A parity map with the given (feature, verdict) rows."""
+    out = [f"## {section}", "", "| Fabric feature | Emulator | Type |", "|---|---|---|"]
+    out += [f"| {feature} | does things | {verdict} |" for feature, verdict in rows]
+    return "\n".join(out) + "\n"
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """Point the checker at a parity map, a manifest and a CI file we control."""
+    def build(rows, manifest, ci_jobs=("build", "governance")):
+        p = tmp_path / "parity.md"
+        p.write_text(parity(rows), encoding="utf-8")
+        m = tmp_path / "witnesses.json"
+        m.write_text(json.dumps(manifest), encoding="utf-8")
+        c = tmp_path / "ci.yml"
+        c.write_text("jobs:\n" + "".join(f"  {j}:\n    runs-on: x\n" for j in ci_jobs))
+        monkeypatch.setattr(w, "PARITY", p)
+        monkeypatch.setattr(w, "MANIFEST", m)
+        monkeypatch.setattr(w, "CI", c)
+        # Go-test discovery walks the real repo; pin it so a claim's witness is
+        # decided by the manifest under test rather than by whatever exists.
+        monkeypatch.setattr(w, "go_test_names", lambda: {"TestReal", "TestGated"})
+        monkeypatch.setattr(w, "gated_go_tests", lambda: {"TestGated": "its own t.Skip"})
+        monkeypatch.setattr(w, "py_test_names", lambda: {"test_real"})
+    return build
+
+
+def run(strict=True, monkeypatch=None):
+    argv = ["check_witnesses.py"] + (["--strict"] if strict else [])
+    sys_argv = sys.argv
+    sys.argv = argv
+    try:
+        return w.main()
+    finally:
+        sys.argv = sys_argv
+
+
+# --- the happy path -----------------------------------------------------------
+
+def test_a_green_claim_with_a_real_witness_passes(repo, capsys):
+    repo([("Widgets", "🟢 Real")],
+         {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestReal"]}})
+    assert run() == 0
+    assert "supported capability claims: 1" in capsys.readouterr().out
+
+
+def test_a_non_green_row_is_not_required_to_have_a_witness(repo):
+    # 🟡/🔴 rows are the emulator saying what it does NOT do; demanding evidence
+    # for them would be demanding proof of an absence. A green row rides along
+    # because a map with NO green rows trips the parsed-nothing guard instead,
+    # which is a different verdict (tested below).
+    repo([("Widgets", "🟡 Emulated"), ("Gadgets", "🟢 Real")],
+         {"gadgets": {"section": "Platform / fundamentals", "claim": "Gadgets",
+                      "witnesses": ["go:TestReal"]}})
+    assert run() == 0
+
+
+# --- the four refusals --------------------------------------------------------
+
+def test_a_green_claim_missing_from_the_manifest_fails(repo, capsys):
+    repo([("Widgets", "🟢 Real")], {})
+    assert run() == 1
+    out = capsys.readouterr().out
+    assert "Claims with no manifest entry" in out
+    assert "needs an identified, existing witness" in out
+
+
+def test_a_witness_naming_a_test_that_does_not_exist_fails(repo, capsys):
+    # The whole promise: a claim names evidence that EXISTS.
+    repo([("Widgets", "🟢 Real")],
+         {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestVanished"]}})
+    assert run() == 1
+    out = capsys.readouterr().out
+    assert "Dangling witness references" in out and "no such Go test" in out
+
+
+def test_a_witness_naming_a_ci_job_that_does_not_exist_fails(repo, capsys):
+    repo([("Widgets", "🟢 Real")],
+         {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["ci:no-such-job"]}})
+    assert run() == 1
+    assert "no such CI job" in capsys.readouterr().out
+
+
+def test_a_python_witness_that_does_not_exist_fails(repo, capsys):
+    repo([("Widgets", "🟢 Real")],
+         {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["py:test_vanished"]}})
+    assert run() == 1
+    assert "no such Python test" in capsys.readouterr().out
+
+
+def test_a_todo_witness_fails_under_strict_but_not_otherwise(repo, capsys):
+    repo([("Widgets", "🟢 Real")],
+         {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["TODO"]}})
+    assert run(strict=True) == 1
+    assert run(strict=False) == 0, "without --strict this is a report, not a gate"
+
+
+def test_an_undeclared_gated_witness_fails_and_prints_the_line_to_add(repo, capsys):
+    # A gated witness is legitimate; an UNDECLARED one silently downgrades the
+    # evidence behind a green row.
+    repo([("Widgets", "🟢 Real")],
+         {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestGated", "go:TestReal"]}})
+    assert run() == 1
+    out = capsys.readouterr().out
+    assert "must be declared in the manifest's" in out
+    assert '"go:TestGated": "<reason>"' in out, "the message must be copy-pasteable"
+
+
+def test_a_declared_gate_is_accepted(repo):
+    repo([("Widgets", "🟢 Real")],
+         {"_gated": {"go:TestGated": "needs a real SQL Server"},
+          "widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestGated", "go:TestReal"]}})
+    assert run() == 0
+
+
+def test_a_stale_gate_declaration_fails(repo, capsys):
+    # A declaration for a witness that no longer skips is how the map drifts
+    # back out of step — the dual of the rule above.
+    #
+    # This ALSO pins `kind != "go"` in the accept-a-declared-gate branch: without
+    # it, a declared Go witness that stopped skipping is accepted as gated and
+    # never reaches `stale`, silently retiring this rule.
+    repo([("Widgets", "🟢 Real")],
+         {"_gated": {"go:TestReal": "it used to skip"},
+          "widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestReal"]}})
+    assert run() == 1
+    out = capsys.readouterr().out
+    assert "Stale gate declarations" in out
+    assert "remove the stale" in out
+
+
+def test_a_claim_whose_every_witness_can_skip_fails(repo, capsys):
+    # A green row that a default `go test ./...` proves nothing about.
+    repo([("Widgets", "🟢 Real")],
+         {"_gated": {"go:TestGated": "needs a real SQL Server"},
+          "widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestGated"]}})
+    assert run() == 1
+    out = capsys.readouterr().out
+    assert "Claims whose every witness can skip" in out
+    assert "at least one witness that runs unconditionally" in out
+
+
+def test_a_boundary_alone_does_not_count_as_running_evidence(repo, capsys):
+    # A documented boundary scopes a claim; it is not a test that runs.
+    repo([("Widgets", "🟢 Real")],
+         {"_gated": {"go:TestGated": "needs a real SQL Server"},
+          "widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestGated", "boundary:documented limit"]}})
+    assert run() == 1
+    assert "at least one witness that runs unconditionally" in capsys.readouterr().out
+
+
+# --- the self-check -----------------------------------------------------------
+
+def test_parsing_zero_claims_is_a_broken_checker_not_a_clean_repo(repo, capsys):
+    # This ran green on Windows for its whole life while matching zero claims:
+    # a locale-dependent read turned the glyphs to mojibake and every rule was
+    # vacuously satisfied.
+    repo([("Widgets", "🟡 Emulated")], {})
+    monkey = w.PARITY
+    monkey.write_text("# no rows at all\n", encoding="utf-8")
+    assert run() == 1
+    assert "parsed 0 supported claims" in capsys.readouterr().out
+
+
+def test_a_witness_carrying_many_claims_is_reported(repo, capsys):
+    # Bundling is where one witness quietly covers claims it does not assert.
+    rows = [(f"Widget {i}", "🟢 Real") for i in range(5)]
+    manifest = {w.key_for(f"Widget {i}"): {"section": "Platform / fundamentals",
+                                           "claim": f"Widget {i}",
+                                           "witnesses": ["go:TestReal"]}
+                for i in range(5)}
+    repo(rows, manifest)
+    assert run() == 0
+    assert "carrying many claims" in capsys.readouterr().out

--- a/python/tests/test_delta_ops.py
+++ b/python/tests/test_delta_ops.py
@@ -142,22 +142,54 @@ def test_split_top_on_a_simple_list():
     assert d._split_top("a, b, c") == ["a", "b", "c"]
 
 
-def test_plain_column_strips_the_target_alias():
-    # delta-rs wants the bare column name on the left of an update.
-    assert d._plain_column("t.amount", "t") == "amount"
-    assert d._plain_column("`t.amount`", "t") == "amount"
-    assert d._plain_column("amount", "t") == "amount"
-    assert d._plain_column("  T.amount  ", "t") == "amount", "alias match is case-insensitive"
+@pytest.mark.parametrize("ref,expected", [
+    ("t.amount", "amount"),                 # the ordinary form
+    ("`t`.`amount`", "amount"),             # per-segment quoting — this was BROKEN
+    ('"t"."amount"', "amount"),             # the double-quoted spelling
+    ("`t`.amount", "amount"),               # mixed
+    ("t.`amount`", "amount"),               # mixed the other way
+    ("  T.amount  ", "amount"),             # alias match is case-insensitive
+    ("amount", "amount"),                   # unqualified
+    ("`amount`", "amount"),
+    ("s.amount", "s.amount"),               # a DIFFERENT alias is not stripped
+    ("`t.amount`", "amount"),               # one quoted identifier: old reading kept
+])
+def test_plain_column_strips_the_target_alias(ref, expected):
+    # delta-rs wants the target column's own name on the left of an update, so a
+    # leading target alias has to go — in every spelling Spark SQL accepts.
+    # `\`t\`.\`amount\`` used to yield "t`.`amount": a column no table has,
+    # handed to delta-rs as a wrong answer rather than a refusal.
+    assert d._plain_column(ref, "t") == expected
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "A fully backticked reference (`t`.`amount`) is valid Spark SQL, but "
-    "_plain_column only strips backticks from the OUTSIDE, so the alias prefix "
-    "no longer matches and delta-rs is handed the column name 't`.`amount'. "
-    "Narrow — the medallion MERGEs write `t.col` — but it is a wrong answer, "
-    "not a refusal. Remove this marker when it is fixed."))
-def test_a_fully_backticked_reference_should_also_lose_its_alias():
-    assert d._plain_column("`t`.`amount`", "t") == "amount"
+def test_a_dot_inside_quotes_belongs_to_the_name_not_the_path():
+    # `my.col` is ONE column whose name contains a dot. Splitting it would
+    # invent a qualifier that was never written.
+    assert d._plain_column("`my.col`", "t") == "my.col"
+    assert d._identifier_parts("`my.col`") == ["my.col"]
+    assert d._identifier_parts("`t`.`my.col`") == ["t", "my.col"]
+
+
+def test_identifier_parts_never_returns_nothing():
+    # A caller indexes [0]; an empty list would be an IndexError naming this
+    # file rather than the malformed input.
+    assert d._identifier_parts("") == [""]
+    assert d._identifier_parts("``") == [""]
+
+
+def test_a_backticked_merge_maps_to_real_column_names(fake_deltalake):
+    # The end-to-end shape of the bug: a MERGE written with quoted identifiers
+    # must reach delta-rs with the target's own column names as update keys.
+    spark = types.SimpleNamespace(
+        table=lambda n: types.SimpleNamespace(toArrow=lambda: "arrow"))
+    _, params = d.match(
+        "MERGE INTO silver.orders AS t USING updates AS s ON t.id = s.id "
+        "WHEN MATCHED THEN UPDATE SET `t`.`amt` = s.amt "
+        "WHEN NOT MATCHED THEN INSERT (`t`.`id`, `t`.`amt`) VALUES (s.id, s.amt)")
+    d.execute_merge(spark, params, lambda n: "abfss://lake/orders")
+    merger = FakeDeltaTable.last.merger
+    assert merger.updates == {"amt": "s.amt"}
+    assert merger.inserts == {"id": "s.id", "amt": "s.amt"}
 
 
 def test_table_uri_prefers_an_explicit_delta_path():

--- a/python/tests/test_delta_ops.py
+++ b/python/tests/test_delta_ops.py
@@ -518,3 +518,134 @@ def test_an_empty_change_feed_says_how_to_enable_it(monkeypatch, fake_deltalake)
     fake_deltalake.DeltaTable = CDFTable
     with pytest.raises(d.DeltaOpError, match=r"delta\.enableChangeDataFeed"):
         d.read_change_feed(FakeSpark(), "abfss://lake/t")
+
+
+# --- DESCRIBE, answered from the Delta log -----------------------------------
+#
+# The failure this replaces: Sail returns the right SHAPE and no rows for
+# DESCRIBE, so an empty answer that raises nothing reads as "the table has no
+# columns" rather than "the engine did not implement this".
+
+@pytest.mark.parametrize("sql,kind", [
+    ("DESCRIBE DETAIL silver.orders", "describe_detail"),
+    ("describe detail delta.`abfss://lake/t`", "describe_detail"),
+    ("DESCRIBE TABLE silver.orders", "describe_table"),
+    ("DESCRIBE silver.orders", "describe_table"),
+    ("DESC silver.orders", "describe_table"),
+    ("DESCRIBE delta.`abfss://lake/t`", "describe_table"),
+])
+def test_describe_statements_are_intercepted(sql, kind):
+    # DESCRIBE TABLE is answered only for a table this emulator can LOCATE.
+    d.remember("orders", "abfss://lake/Tables/orders", "silver")
+    got = d.match(sql)
+    assert got and got[0] == kind, sql
+
+
+@pytest.mark.parametrize("sql", [
+    "DESCRIBE my_temp_view",     # a temp view is the engine's own business
+    "DESCRIBE some_function",
+    "DESC unregistered.table",
+])
+def test_describe_of_something_we_cannot_locate_falls_through(sql):
+    # Answering these from the Delta log would mean inventing a table.
+    assert d.match(sql) is None, sql
+
+
+def test_describe_detail_wins_over_describe_table():
+    # `DESCRIBE DETAIL x` also matches the looser DESCRIBE pattern; order in
+    # `match` is what keeps it from being answered with a column list.
+    assert d.match("DESCRIBE DETAIL x")[0] == "describe_detail"
+
+
+class Field:
+    def __init__(self, name, type_):
+        self.name, self.type = name, type_
+
+
+def describe_table_stub(fields, partitions=(), version=3, files=2):
+    class T(FakeDeltaTable):
+        def metadata(self):
+            return types.SimpleNamespace(
+                id="abc-123", name="orders", description="",
+                partition_columns=list(partitions), configuration={"delta.enableCDF": "true"})
+
+        def version(self):
+            return version
+
+        def file_uris(self):
+            return ["f"] * files
+
+        def schema(self):
+            return types.SimpleNamespace(fields=fields)
+    return T
+
+
+def test_describe_detail_reports_the_log_not_a_guess(fake_deltalake):
+    fake_deltalake.DeltaTable = describe_table_stub([])
+    spark = FakeSpark()
+    _, params = d.match("DESCRIBE DETAIL delta.`abfss://lake/t`")
+    d.describe_detail(spark, params, lambda n: n)
+    rows, cols = spark.frames[0]
+    assert cols == ["format", "id", "name", "description", "location",
+                    "version", "numFiles", "partitionColumns", "properties"]
+    (fmt, ident, name, _desc, loc, version, numfiles, parts, props) = rows[0]
+    assert fmt == "delta" and ident == "abc-123" and name == "orders"
+    assert loc == "abfss://lake/t"
+    assert (version, numfiles) == (3, 2)
+    assert parts == [] and props == {"delta.enableCDF": "true"}
+
+
+def test_describe_detail_omits_columns_it_cannot_answer_truthfully(fake_deltalake):
+    # sizeInBytes and the reader/writer versions are LEFT OUT rather than filled
+    # with a plausible number — the documented subset is the honest answer.
+    fake_deltalake.DeltaTable = describe_table_stub([])
+    spark = FakeSpark()
+    _, params = d.match("DESCRIBE DETAIL t")
+    d.describe_detail(spark, params, lambda n: "uri")
+    assert "sizeInBytes" not in spark.frames[0][1]
+    assert not any("Version" in c for c in spark.frames[0][1])
+
+
+def test_describe_table_returns_the_real_column_list(fake_deltalake):
+    fake_deltalake.DeltaTable = describe_table_stub(
+        [Field("id", 'PrimitiveType("long")'), Field("region", 'PrimitiveType("string")')],
+        partitions=["region"])
+    d.remember("t", "abfss://lake/Tables/t")
+    spark = FakeSpark()
+    _, params = d.match("DESCRIBE TABLE t")
+    d.describe_table(spark, params, lambda n: "uri")
+    rows, cols = spark.frames[0]
+    assert cols == ["col_name", "data_type", "comment"]
+    assert rows == [("id", "bigint", ""), ("region", "string", "partition")]
+
+
+def test_a_delta_log_declaring_no_columns_is_an_error_not_an_empty_answer(fake_deltalake):
+    # The exact shape being replaced: no rows and no error reads as "no columns".
+    fake_deltalake.DeltaTable = describe_table_stub([])
+    d.remember("t", "abfss://lake/Tables/t")
+    spark = FakeSpark()
+    _, params = d.match("DESCRIBE t")
+    with pytest.raises(d.DeltaOpError, match="declares no columns"):
+        d.describe_table(spark, params, lambda n: "uri")
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ('PrimitiveType("long")', "bigint"),
+    ('PrimitiveType("string")', "string"),
+    ('PrimitiveType("integer")', "int"),
+    ("StructType(...)", "StructType(...)"),   # structured types pass through
+])
+def test_spark_type_renders_primitives_and_passes_the_rest_through(raw, expected):
+    # A wrong nested type would be worse than an unfamiliar one, so anything
+    # structured is delta-rs's own rendering rather than a guess.
+    assert d._spark_type(raw) == expected
+
+
+def test_install_routes_describe_through_the_delta_log(fake_deltalake):
+    fake_deltalake.DeltaTable = describe_table_stub([Field("id", 'PrimitiveType("long")')])
+    d.remember("t", "abfss://lake/Tables/t")
+    spark = FakeSpark()
+    d.install(spark, storage_options={})
+    spark.sql("DESCRIBE TABLE t")
+    assert spark.frames, "DESCRIBE must be answered here, not passed to the engine"
+    assert spark.frames[-1][1] == ["col_name", "data_type", "comment"]

--- a/scripts/check_witnesses.py
+++ b/scripts/check_witnesses.py
@@ -249,7 +249,7 @@ def main() -> int:
                 dangling.append(f"{key} → {witness} (no such Python test)")
             if kind == "go" and name in gated_tests:
                 gated_used[witness] = gated_tests[name]
-            elif witness in declared_gates:
+            elif kind != "go" and witness in declared_gates:
                 # A gate this script cannot DETECT, only accept: a CI job that
                 # skips on absent secrets is invisible to the Go body scan, and
                 # `ci:real-fabric` — the differential leg against a real tenant —
@@ -257,6 +257,12 @@ def main() -> int:
                 # let a claim rest entirely on a job that never runs on a fork.
                 # The declaration is the author's assertion; the stale check
                 # below cannot police these, which is the price of accepting them.
+                #
+                # `kind != "go"` IS LOAD-BEARING. Without it a declared Go
+                # witness that has STOPPED skipping lands here, enters
+                # `gated_used`, and so never appears in `stale` — defeating the
+                # stale-declaration rule for precisely the case it was written
+                # for. Go gates are detected, never merely asserted.
                 gated_used[witness] = "a declared gate this checker cannot detect"
             else:
                 # A boundary is not evidence that runs, so it does not count


### PR DESCRIPTION
Two things: the `_plain_column` defect the strict `xfail` recorded, and the coverage floor that printed `FAIL` on green builds. Coverage **89.98% → 93.03%**.

## 1. `_plain_column` handed delta-rs a column that does not exist

It stripped quotes from the **ends of the whole string**, then looked for an `alias.` prefix:

```python
ref = ref.strip().strip("`\"")            # `t`.`amount`  ->  t`.`amount
if ref.lower().startswith(alias + "."):   # "t`.`" is not "t." — no match
```

So `` `t`.`amount` `` — valid Spark SQL, and what a formatter emits — became the MERGE update key ``t`.`amount``. **A wrong answer rather than a refusal.**

Now the identifier is split on the dots *between* segments, respecting quotes. A dot **inside** quotes stays part of the name (`` `my.col` `` is one column, not a path). One reading is preserved deliberately: `` `t.amount` `` still resolves to `amount` — SQL says that is one column literally named "t.amount", but anyone writing it in a MERGE means the qualified column, and changing that is a separate decision.

## 2. The coverage floor did not mean what it printed

`--cov-fail-under=90` **exited 0** at 89.88% while printing:

```
FAIL Required test coverage of 90% not reached. Total coverage: 89.88%
```

coverage compares the *rounded* percentage, so the effective floor was 89.5 and `main` emitted that line on every green build. A `FAIL` that does not fail is how people learn to skim CI output — I nearly filed `main` as broken because of it.

`precision = 2` makes the comparison exact and the message truthful. The floor also moves from **two workflow steps into one config key** (`fail_under = 92`): two numbers to move for one change is how a ratchet quietly stops ratcheting — the same lesson as the triplicated golden-query count. 92 against a measured 93.03 leaves headroom for a change that lands genuinely-hard-to-cover code, and no more.

Both directions verified: floor 92 passes at 93.03, floor 94 exits 1.

## 3. A regression of mine, found by writing these tests

Covering `check_witnesses`' verdicts surfaced that **#57 broke its stale-gate rule**. I had added:

```python
elif witness in declared_gates:      # accept a gate the scanner cannot detect
```

so a declared **Go** witness that had *stopped skipping* landed there, entered `gated_used`, and never reached `stale` — retiring the rule for exactly the case it was written for. Now `kind != "go"`: Go gates are *detected*, never merely asserted. `ci:` declarations still work, which is what that branch was for.

## What gained coverage

| | Before | After |
|---|---|---|
| `check_witnesses.py` — the four `FAIL` verdicts | 78% | 96% |
| `delta_ops.py` — the DESCRIBE surface #61 added | 87% | 97% |

`check_witnesses`' refusals had never been exercised. Each encodes a rule that took a real incident to learn, and a rule whose enforcement is untested can stop enforcing unnoticed — the failure this script exists to prevent, turned on itself. Now covered: dangling `go:`/`ci:`/`py:` references, TODO under and without `--strict`, undeclared gates, stale declarations, a claim whose every witness can skip, a `boundary:` not counting as running evidence, and the parsed-nothing self-check.

For `DESCRIBE`: what is intercepted, what deliberately falls through (a temp view is the engine's business), that a Delta log declaring no columns **errors rather than answering empty** — the exact Sail failure it replaces — and that `sizeInBytes` is omitted rather than filled with a plausible number.

## Mutation-checked

Restoring the pre-fix `_plain_column` fails 4 tests. That same mutation caught a mistake in this PR's own construction: a script raised before its write, so for a few minutes the branch had **deleted the record of the defect and added no replacement**, with every test green. The mutation run was the only thing that noticed.

`make check`, `ruff`, `ty`, `go build/vet` clean. 446 tests.