### PR TITLE
govern: assert the rule the schema cannot see, and say so where it matters

### DIFF
--- a/python/tests/test_govern_column_schema.py
+++ b/python/tests/test_govern_column_schema.py
@@ -141,10 +141,19 @@ def test_the_schema_accepts_the_column_that_costs_the_whole_table(validator, gi)
     `dataLength` — the exact payload OpenMetadata answers with 400 for the
     ENTIRE table — validates clean here.
 
-    Asserting the gap rather than describing it means a schema that ever grows
-    the rule (an `if`/`then`, an `allOf`, a `dependentRequired`) fails this test
-    instead of silently making the prose above wrong. At that point the cheap
-    guard's job has changed and this test should be revisited, not deleted.
+    WHEN THIS FIRES, precisely — it does not watch upstream. It validates the
+    VENDORED 1.13.2 bytes, which change only when someone re-vendors, so an
+    OpenMetadata release that encodes the rule does not trip it on its own.
+    What closes the chain is the pin: `test_the_pinned_schema_matches_the_
+    version_docker_compose_runs` fails the moment the compose image is bumped
+    without re-vendoring, and re-vendoring is what brings new bytes here. So the
+    sequence is image bump -> pin test fails -> re-vendor -> this test fails if
+    the rule arrived. Do not read it as drift detection against upstream; it
+    cannot carry that.
+
+    If it does fail after a re-vendor, the schema has grown the rule (an
+    `if`/`then`, an `allOf`, a `dependentRequired`) and the cheap guard's job
+    has changed. Revisit both, do not delete either on the strength of one.
     """
     assert errors(validator, {"name": "c", "dataType": "BINARY"}) == []
 

--- a/python/tests/test_govern_column_schema.py
+++ b/python/tests/test_govern_column_schema.py
@@ -131,6 +131,32 @@ def test_a_type_map_target_outside_the_enum_would_fail(validator, gi):
     assert errors(validator, col), "a dataType outside the enum was accepted"
 
 
+# --- and the thing it cannot see, asserted rather than described --------------
+
+def test_the_schema_accepts_the_column_that_costs_the_whole_table(validator, gi):
+    """DO NOT DELETE check_govern_types.py IN FAVOUR OF THIS FILE.
+
+    The header says the `dataLength` rule is not in the schema. This proves it,
+    so the claim cannot quietly stop being true: a BINARY column with no
+    `dataLength` — the exact payload OpenMetadata answers with 400 for the
+    ENTIRE table — validates clean here.
+
+    Asserting the gap rather than describing it means a schema that ever grows
+    the rule (an `if`/`then`, an `allOf`, a `dependentRequired`) fails this test
+    instead of silently making the prose above wrong. At that point the cheap
+    guard's job has changed and this test should be revisited, not deleted.
+    """
+    assert errors(validator, {"name": "c", "dataType": "BINARY"}) == []
+
+    column = json.loads((SCHEMA_DIR / "entity/data/table.json").read_text())
+    column = column["definitions"]["column"]
+    assert column["required"] == ["name", "dataType"]
+    assert not any(k in column for k in ("if", "then", "allOf", "dependentRequired"))
+
+    # And the guard that DOES catch it still does, on the same input.
+    assert gi.om_column("b", "binary")["dataLength"] == gi.DEFAULT_BINARY_LENGTH
+
+
 # --- the vendored copy must be what we recorded, and what we run --------------
 
 def test_vendored_files_match_their_recorded_hashes():

--- a/scripts/check_govern_types.py
+++ b/scripts/check_govern_types.py
@@ -24,6 +24,17 @@ It does not replace the e2e — it cannot see anything about how OpenMetadata
 actually behaves, only that the payload satisfies the constraint OpenMetadata
 documents. It exists so that constraint is checked without containers.
 
+AND SCHEMA VALIDATION DOES NOT REPLACE THIS, which is the obvious next thought
+now that one exists. `python/tests/test_govern_column_schema.py` validates every
+column this drives against OpenMetadata's own vendored schema — a strictly wider
+check of the enum, required fields, field types and `children` nesting. It still
+cannot see the rule above: `column` declares only `required: ["name",
+"dataType"]`, with no `if`/`then`, no `allOf` and no `dependentRequired`. The
+`dataLength` constraint lives in prose in a `description` and is enforced in
+OpenMetadata's Java layer, so `{"name": "c", "dataType": "BINARY"}` VALIDATES
+CLEAN — the exact payload that costs the whole table. That is asserted, not
+merely written down, in `test_the_schema_accepts_the_column_that_costs_the_whole_table`.
+
 Usage:
     check_govern_types.py     exit non-zero on the first column OM would refuse
 """


### PR DESCRIPTION
Follow-up to #58 (which closed #53). Two items that issue asked for and #58 left undone. No code change to the checker.

### 1. The gap is asserted, not only described

`test_govern_column_schema.py`'s header says the `dataLength` rule is not in the schema — correctly. This turns that into a tripwire:

```python
assert errors(validator, {"name": "c", "dataType": "BINARY"}) == []
```

The exact payload OpenMetadata answers with a 400 for the **entire table** validates clean, and the test pins that `column` carries no `if`/`then`/`allOf`/`dependentRequired`.

**When it fires, precisely.** It validates the *vendored* 1.13.2 bytes, so it does **not** detect upstream drift on its own — an OpenMetadata release that encodes the rule does not trip it. #58's pin test closes the chain: bumping the compose image without re-vendoring fails there, and re-vendoring is what brings new bytes here. Sequence: image bump → pin test fails → re-vendor → this test fails if the rule arrived. The docstring states that chain so the next reader does not trust it further than it can carry.

Mutation-checked: typo the `dataType` and the test fails, so it is not asserting a vacuous truth.

### 2. The guard says why it survives, where that gets read

#53 asked for this explicitly:

> So `check_govern_types.py` stays, and its docstring should say why — the next reader will otherwise propose deleting it in favour of this.

#58 put the reasoning in the new test's header. The reader who proposes deleting the guard is reading **the guard**. Docstring only, no behaviour change.

### Verification

- 13/13 in `test_govern_column_schema.py`
- `scripts/check_govern_types.py` unchanged in behaviour — still reports `every mapped type produces a column OpenMetadata accepts`
- `ruff check .` clean
- coverage 93.38% against `fail_under = 92`

Both gaps independently confirmed against `origin/main` at `6f991a6` before opening.