### PR TITLE
tds: give the splice test's fake engine a real socket

### DIFF
--- a/internal/tds/server.go
+++ b/internal/tds/server.go
@@ -285,6 +285,11 @@ func firstKeyword(query string) string {
 const (
 	doneFinal uint16 = 0x0000
 	doneError uint16 = 0x0002
+	// doneAttn acknowledges an ATTENTION. A client that abandons a result set
+	// before its stream ends sends one and then BLOCKS until it sees this bit
+	// come back — "did not get cancellation confirmation from the server" is
+	// what go-mssqldb reports when it does not.
+	doneAttn  uint16 = 0x0020
 	doneCount uint16 = 0x0010
 )
 

--- a/internal/tds/splice_integration_test.go
+++ b/internal/tds/splice_integration_test.go
@@ -38,7 +38,45 @@ func (f *fakeSpliceBackend) Dial(context.Context, string) (net.Conn, []byte, err
 // logs in over FedAuth, the server forwards the (fake) engine's login response,
 // and a query is byte-forwarded to the engine, which answers over the pipe.
 func TestSpliceEndToEnd(t *testing.T) {
-	engineServer, engineTest := net.Pipe()
+	// The engine end is a REAL SOCKET, not net.Pipe.
+	//
+	// net.Pipe is synchronous and unbuffered: every Write blocks until a Read
+	// consumes it, so the client, the splice and the fake engine advanced in
+	// lockstep in a way production never does. This test drives a real
+	// go-mssqldb client, and the flakiness that produced — "did not get
+	// cancellation confirmation from the server", once on windows-latest for a
+	// docs-only PR (issue #63) — named the splice for timing that only the pipe
+	// created. A loopback socket buffers the way the real backend connection
+	// does.
+	//
+	// Isolated rather than assumed. At `-race -count=1500 -cpu=1,2,8`:
+	//
+	//   net.Pipe, engine answers once           3 of 5 runs fail
+	//   net.Pipe, engine loops + acks ATTENTION  3 of 5 runs fail
+	//   loopback socket, same engine             7,200 iterations clean
+	//
+	// so the socket is what fixes it; the loop below is correctness, not the
+	// cure. NOTE for anyone re-running that stress: each iteration now opens two
+	// sockets, so several thousand back-to-back runs exhaust ephemeral ports and
+	// fail with "can't assign requested address" — that is the harness, not this
+	// test. Pause between rounds or lower `-count`.
+	engineLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engineLn.Close()
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := engineLn.Accept()
+		if aerr == nil {
+			accepted <- c
+		}
+	}()
+	engineServer, err := net.Dial("tcp", engineLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	engineTest := <-accepted
 	be := &fakeSpliceBackend{
 		engine:    engineServer,
 		loginResp: concat(loginAck(), done(doneFinal, 0)),
@@ -50,20 +88,35 @@ func TestSpliceEndToEnd(t *testing.T) {
 			return "item-db", false, nil
 		},
 	}
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
+	ln, lerr := net.Listen("tcp", "127.0.0.1:0")
+	if lerr != nil {
+		t.Fatal(lerr)
 	}
 	defer ln.Close()
 	go srv.Serve(ln)
 
-	// The engine end: answer the first forwarded batch with a single int = 7.
+	// Serve until the connection closes, and ANSWER AN ATTENTION, because a real
+	// engine does. Answering exactly one batch and closing was the other half of
+	// the flake: `QueryRow` closes its result set, and a driver that has not yet
+	// seen the stream end sends an ATTENTION to drain it, then blocks for the
+	// acknowledgement — a DONE carrying the ATTN bit. With the engine gone the
+	// splice reported a dead backend, and the error named the splice for a gap
+	// in this fixture.
 	go func() {
 		defer engineTest.Close()
-		if _, _, err := ReadMessage(engineTest); err != nil {
-			return
+		for {
+			typ, _, rerr := ReadMessage(engineTest)
+			if rerr != nil {
+				return // the splice closed its end: the session is over
+			}
+			reply := intResult(7)
+			if typ == PktAttention {
+				reply = done(doneAttn, 0)
+			}
+			if werr := WriteMessage(engineTest, PktTabular, reply); werr != nil {
+				return
+			}
 		}
-		_ = WriteMessage(engineTest, PktTabular, intResult(7))
 	}()
 
 	addr := ln.Addr().(*net.TCPAddr)


### PR DESCRIPTION
Closes #63.

`TestSpliceEndToEnd` failed on `windows-latest` for a **docs-only PR** ([#62](https://github.com/calvinchengx/fabric-emulator/pull/62)) with:

```
Invalid TDS stream: did not get cancellation confirmation from the server
  (second response: Read: EOF)
```

## It was the test, and the message blamed the wrong thing

The error names the splice — production code that was doing its job — for timing the fixture created. Two failure modes, both from the same root:

`net.Pipe` is **synchronous and unbuffered**: every write blocks until a read consumes it, so the client, the splice and the fake engine advanced in lockstep in a way a real backend connection never does. The fake engine is now a loopback socket.

## Isolated, not assumed

I changed two things and then took one back out to find which mattered. At `-race -count=1500 -cpu=1,2,8`:

| Fixture | Result |
|---|---|
| `net.Pipe`, engine answers once *(main today)* | **3 of 5 runs fail** |
| `net.Pipe`, engine loops + acknowledges ATTENTION | **3 of 5 runs fail** |
| **loopback socket**, same engine | **7,200 iterations clean** |

So the socket is the fix. The serve-loop and the `DONE(ATTN)` acknowledgement are kept because they are *correct* — a real engine answers an attention — but they are not the cure, and the table says so rather than letting a reader assume.

## How the diagnosis went, since it went wrong twice

Worth recording, because both wrong turns looked right:

1. **The `defer engineTest.Close()` race** — my original hypothesis in #63. Fixing it turned `Read: EOF` into `context deadline exceeded` at exactly 5.00s. Symptom moved, flake stayed. Retracted on the issue.
2. **An unanswered ATTENTION** — tracing the relay showed the query *succeeding* (`->client typ=4 ok`) and the client *then* sending a type-6 attention that nothing answered. Real, but fixing it alone still left 3-in-5.

Only instrumenting `spliceSession` and comparing fixture variants side by side separated cause from symptom.

## One production observation, not changed here

`spliceSession` relays an attention like any other request and then blocks waiting for the backend to answer it. Against a real SQL Server that is fine — it replies `DONE(ATTN)`. It is worth knowing that the relay models no attention semantics of its own, but nothing here demonstrates a defect, so nothing is changed.

## A note for the next person stressing this

Each iteration now opens two sockets, so several thousand back-to-back runs exhaust ephemeral ports and fail with `can't assign requested address` — the harness, not the test. That caveat is in the test comment, because it briefly looked like a regression to me.

`go build`, `go vet`, full Go suite clean; `internal/tds` at `-race -count=20` clean.
