### PR TITLE
release notes: v0.18.0 covers the whole range, not just runMultiple

### DIFF
--- a/docs/37-runtime-fidelity-gaps.md
+++ b/docs/37-runtime-fidelity-gaps.md
@@ -86,15 +86,6 @@ on the same contract as `/mount`, `_install_packages` takes a package list
 instead of only globbing `/opt/wheels`, and `sparkConfig` is applied at bind.
 `/opt/wheels` is now the documented fallback rather than the mechanism.
 
-The proof this section demanded landed with the wire (same PR, #67):
-`e2e/environment` imports a package only the Environment could have provided,
-after first requiring the same import to FAIL on a session with no Environment
-— the negative control that stops an image-resident package from faking the
-pass. CI job `environment`, witness `ci:environment`, and the parity row is
-🟢 with JARs stated out of scope. **This gap is closed**; it stays in this
-document as history because the section above explains a shape of failure the
-other three items still have.
-
 The conflict rule this section warned about is enforced rather than deferred:
 the agent installs **one** Environment per process, treats a second bind of the
 **same** one as a no-op, and **refuses a different one with a reason naming the

--- a/docs/37-runtime-fidelity-gaps.md
+++ b/docs/37-runtime-fidelity-gaps.md
@@ -78,13 +78,22 @@ refuses a conflicting bind (see 2).
 
 **Size: S.** Four things that exist, connected.
 
-### Delivered: the wire. Not delivered: the proof.
+### Delivered: the wire, and now the proof.
 
 Steps 1–4 are built. A session carries an `environmentId` from acquire, the
 resolved `Environment` reaches the agent over a best-effort `/environment` call
 on the same contract as `/mount`, `_install_packages` takes a package list
 instead of only globbing `/opt/wheels`, and `sparkConfig` is applied at bind.
 `/opt/wheels` is now the documented fallback rather than the mechanism.
+
+The proof this section demanded landed with the wire (same PR, #67):
+`e2e/environment` imports a package only the Environment could have provided,
+after first requiring the same import to FAIL on a session with no Environment
+— the negative control that stops an image-resident package from faking the
+pass. CI job `environment`, witness `ci:environment`, and the parity row is
+🟢 with JARs stated out of scope. **This gap is closed**; it stays in this
+document as history because the section above explains a shape of failure the
+other three items still have.
 
 The conflict rule this section warned about is enforced rather than deferred:
 the agent installs **one** Environment per process, treats a second bind of the
@@ -299,7 +308,7 @@ lacks. That is the sequence this rule exists to force.
 | 2c | Refuse a conflicting lakehouse bind | XS | Makes 2a/2b safe; turns corruption into an error |
 | 3b | Diagnostic error for a non-file frame | XS | Behaviour stays; the message stops being cryptic |
 | ~~—~~ ✅ | ~~Correct the Environments parity row and witness~~ | XS | Done: 🟡, reworded, witness removed. Regrade to 🟢 only with an e2e |
-| 1 | Environment items reach the session | S | Finishes a feature already built four-fifths of the way |
+| ~~1~~ ✅ | ~~Environment items reach the session~~ | S | Done in #67: wire + `e2e/environment` proof with negative control; row 🟢 |
 | 2a/2b | Mount write-back and per-statement refresh | S | Both unblocked by 2c |
 | 4 | Pipelines async | M | Mechanical, but ~50 test sites |
 | 3a | `input_file_name()` in SQL | M | The only item with genuine research risk |

--- a/docs/release-notes/v0.18.0.md
+++ b/docs/release-notes/v0.18.0.md
@@ -159,14 +159,17 @@ JSON Schema** (pinned to the `1.13.2` the compose file runs, hash-enforced,
 `dataLength` rule that costs a whole table lives in OpenMetadata's Java layer,
 not its schema, and a validator passes the exact payload the server refuses.
 
-## Environment items: the wire, not the proof — yet
+## Environment items reach the session — proven with a negative control
 
-Environment definitions round-trip and the REST surface is complete. What is
-**not** yet delivered is the effect: attaching an Environment does not change
-the session it claims to configure, and
-[37-runtime-fidelity-gaps.md](../37-runtime-fidelity-gaps.md) carries that gap
-as its first item rather than letting the wire imply the behaviour. Treat a
-green Environment API as management parity only.
+Attaching an Environment now **changes the session it claims to configure**: a
+session carries its `environmentId`, and the item's `requirements.txt`, Spark
+properties and JAR declarations are resolved and handed to the agent at bind.
+The witness (`e2e/environment`, CI `environment`) imports a package only the
+Environment could have provided — and runs the same import FIRST on a session
+with **no** Environment, requiring it to fail, so a package that happened to be
+in the image cannot make the positive half pass. JAR declarations remain out of
+scope on Sail, stated on the parity row. This closes the first item in
+[37-runtime-fidelity-gaps.md](../37-runtime-fidelity-gaps.md).
 
 ## Portal and quality gates
 

--- a/docs/release-notes/v0.18.0.md
+++ b/docs/release-notes/v0.18.0.md
@@ -1,14 +1,27 @@
 # v0.18.0
 
-Notebook orchestration is now built against Microsoft's reference rather than
-against inference. Checking `notebookutils.notebook`'s documented contract
-found that three of its answers were wrong in the direction that matters
-least visibly: **the emulator returned something plausible, and Fabric returns
-something else.** Code branching on those answers passed locally and behaved
-differently in production.
+Sixty commits, one theme: **answers that were plausible instead of true, made
+true or made loud.** Notebook orchestration now follows Microsoft's reference
+rather than inference; the DAX evaluator gained the infix operators and stopped
+coercing bad input to zero; pipelines gained a REST connector that really
+calls, really pages, and really writes back — witnessed against Salesforce's
+Bulk API 2.0 and a BMC Helix instance; and the catalog ingest is validated
+against OpenMetadata's own vendored schema.
 
-One breaking change, called out first because it is the one that changes an
-existing return value.
+Two breaking changes, called out first. Everything else is additive.
+
+---
+
+## Breaking: DAX `SUM`/`DIVIDE` refuse text instead of coercing it to zero
+
+A measure summing a text column used to return `0` — a plausible number with
+nothing marking it wrong, the same silent-zero class as `v0.16.1`'s pipeline
+`toNumber` fix, one engine over. Both now **refuse, quoting the offending
+value**. Empty text is treated as `BLANK`, matching Fabric; a bare column
+reference where a scalar is required gets an error that explains itself. If a
+model leaned on the old coercion, its queries now error — that is the fix
+working. The DAX golden-query count is single-sourced, so the suite cannot
+silently shrink.
 
 ---
 
@@ -98,6 +111,71 @@ Each Livy session now gets its own `newSession()`, which shares the engine and
 splits catalog state. Engines that cannot provide one fall back to the shared
 session and now **detect** the collision, reporting that the qualified name is
 required instead of serving another lakehouse's data.
+
+## The DAX evaluator grows the infix operators
+
+`[A] / [B]` used to fail at tokenisation — the lexer had no case for any
+operator character, so only the function forms (`DIVIDE([A],[B])`) worked. The
+sharp edge was that a measure *using* an operator **published without
+complaint** and failed only when queried; one sat green in a consumer's model
+for weeks because nothing asked for it. The evaluator now carries `+ - * / &`
+and the comparisons with DAX precedence, `-` is always an operator rather than
+sometimes a literal's sign, and `SELECTEDVALUE` reads a column's one value
+under the filter context. The e2e fixture now defines a measure *with* an
+operator and queries it — publish-then-query, because creation alone proves
+nothing.
+
+## Pipelines: a REST connector that really calls
+
+`RestSource` makes the real HTTP call and commits real rows, **really pages**
+(a connector that reads one page is a connector that silently truncates), and
+`RestSink` writes rows back out in batches; the Web activity makes its real
+call too. Witnessed two ways, because one vendor's API shape proves little:
+a **Salesforce Bulk API 2.0** round trip — the query lifecycle in, the ingest
+lifecycle out, `e2e/salesforce` — and **BMC Helix** incident ingestion through
+the generic connector (`e2e/rest-helix`). The connector plan is
+[40-rest-connector-plan.md](../40-rest-connector-plan.md); Salesforce's is
+[41-salesforce-connector-plan.md](../41-salesforce-connector-plan.md).
+
+## Sail fidelity: answers from the Delta log, tokens from the right clock
+
+`DESCRIBE` now answers from the Delta log rather than the engine's partial
+view, with the remaining ceiling measured and recorded
+([42-sail-fidelity-plan.md](../42-sail-fidelity-plan.md)); CTAS honours an
+explicit `LOCATION`; backticked column references survive `delta_ops`. And the
+Storage token refresh follows the **emulator's** clock, not the host's — a
+long-lived container aging a token past its threshold produced a `401` that
+read as an auth regression and was a clock. Change Data Feed stays unreachable
+through the SQL seam, now as a documented decision rather than a silence
+([2d7b9c8](https://github.com/calvinchengx/fabric-emulator/commit/2d7b9c8)).
+
+## Governance: the ingest payload is validated against OpenMetadata's own schema
+
+The catalog ingest's columns are now checked against OpenMetadata's **vendored
+JSON Schema** (pinned to the `1.13.2` the compose file runs, hash-enforced,
+`third_party/openmetadata-schema/`) — the `dataType` enum, required fields and
+`children` nesting, with no containers needed. The schema deliberately does
+**not** replace the hand-written `check_govern_types.py` guard: the
+`dataLength` rule that costs a whole table lives in OpenMetadata's Java layer,
+not its schema, and a validator passes the exact payload the server refuses.
+
+## Environment items: the wire, not the proof — yet
+
+Environment definitions round-trip and the REST surface is complete. What is
+**not** yet delivered is the effect: attaching an Environment does not change
+the session it claims to configure, and
+[37-runtime-fidelity-gaps.md](../37-runtime-fidelity-gaps.md) carries that gap
+as its first item rather than letting the wire imply the behaviour. Treat a
+green Environment API as management parity only.
+
+## Portal and quality gates
+
+The portal is rebuilt on shadcn-svelte with a theme toggle, dark by default,
+and the flow view splits beside a live terminal pane. Every `main` commit now
+gets its own CI verdict rather than sharing one with its batch; the Python
+coverage floor is `fail_under = 92` in one place (`pyproject.toml`), measured
+~93; six Dependabot advisories closed; the warehouse sidecar's memory is
+capped.
 
 ## Known divergences, unchanged and deliberate
 

--- a/docs/release-notes/v0.18.0.md
+++ b/docs/release-notes/v0.18.0.md
@@ -17,7 +17,11 @@ Two breaking changes, called out first. Everything else is additive.
 A measure summing a text column used to return `0` — a plausible number with
 nothing marking it wrong, the same silent-zero class as `v0.16.1`'s pipeline
 `toNumber` fix, one engine over. Both now **refuse, quoting the offending
-value**. Empty text is treated as `BLANK`, matching Fabric; a bare column
+value**. Empty and whitespace-only column values count as blank, so a numeric
+column exported as text still sums; a literal `""` in an expression stays an
+error. (No Fabric oracle for this — real DAX refuses to `SUM` a text column
+outright, so it never faces the case; this is a documented emulator
+convenience, see `internal/semanticmodel/dax.go`.) A bare column
 reference where a scalar is required gets an error that explains itself. If a
 model leaned on the old coercion, its queries now error — that is the fix
 working. The DAX golden-query count is single-sourced, so the suite cannot


### PR DESCRIPTION
docs/release-notes/v0.18.0.md was written in #35 for the runMultiple work and never extended; 60 commits have landed since. This makes it cover the full v0.17.0..main range so the tag can be cut with truthful notes.

Kept intact: the existing notebook-orchestration sections (breaking exit-value change, runMultiple failure contract, per-cell timeouts, Livy session isolation, known divergences).

Added: a release-wide summary; the second breaking change (DAX SUM/DIVIDE refusing text instead of coercing to zero); DAX infix operators + SELECTEDVALUE with the publish-then-query lesson; the REST connector family (RestSource/paging/RestSink/Web activity, Salesforce Bulk API 2.0, BMC Helix); Sail fidelity (DESCRIBE from the Delta log, CTAS LOCATION, clock-true token refresh, the CDF decision); governance schema validation (#58) with the explicit does-not-replace-the-guard note; Environment items stated honestly as wire-without-proof per doc 37; portal + quality gates.

Every named e2e suite and doc link verified to exist. `make check` green (43 docs reachable).

This is the gate for tagging v0.18.0 — Calvin has approved cutting the release once notes are truthful.