### PR TITLE
release notes: v0.18.0 also carries the DML count fix and the re-grade

### DIFF
--- a/docs/release-notes/v0.18.0.md
+++ b/docs/release-notes/v0.18.0.md
@@ -184,6 +184,24 @@ coverage floor is `fail_under = 92` in one place (`pyproject.toml`), measured
 ~93; six Dependabot advisories closed; the warehouse sidecar's memory is
 capped.
 
+## A DML's row count now survives to the client
+
+DataFusion reports an `INSERT`/`MERGE` row count as `uint64`, the Arrow
+conversion to the Connect client rejects it (Spark has no unsigned types), and
+the agent absorbed that failure as an **empty envelope** — "wrote 3 rows"
+indistinguishable from "wrote nothing". The count is now recovered from the
+statement's cached result relation, which does not re-run the statement:
+measured, a 3-row INSERT stays 3 rows through recovery, and the `e2e/livy`
+witness asserts the envelope **and** the count-back for exactly that reason.
+parity.md's "DML row-count envelopes" row goes 🟢.
+
+Two smaller truths in the same release: the "Pipeline → notebook activity" row
+was re-graded 🟢 — its cells were already witnessed end-to-end by `ci:medallion`
+(the engine-reported `Notebook` lineage edge exists only if they ran), the map
+had simply lagged the witness — and the GitPython/dompurify bumps close seven
+more Dependabot advisories on top of #38's six. The e2e installers also stopped
+using `@latest` for helper binaries, pinning them to go.mod's versions.
+
 ## Known divergences, unchanged and deliberate
 
 - **`runMultiple` runs sequentially.** Fabric defaults `concurrency` to 3× the


### PR DESCRIPTION
Final notes addendum before tagging. #72 was written while #74 was still in flight; #74, #71 and #75 have since merged, so the tag will contain work the notes did not describe — the exact failure this release keeps correcting. One section covers: the DML row-count recovery (with the no-re-execution measurement and the e2e witness), the TridentNotebook re-grade, thirteen total advisories closed, and the @latest pin removal.

Tag v0.18.0 is cut at this PR's merge SHA once green. `make check` green.