### PR TITLE
Interaction surfaces: the doctrine documented, and the Jupyter gap closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endif
 PY ?= $(shell if command -v uv >/dev/null 2>&1; then echo "uv run --frozen --no-sync python"; \
 	else for c in python3 python py; do if "$$c" -c '' >/dev/null 2>&1; then echo "$$c"; break; fi; done; fi)
 
-.PHONY: help doctor up up-lite up-jvm down restart clean status status-spark spark logs ps seed test check lint
+.PHONY: help doctor up up-lite up-jupyter up-jvm down restart clean status status-spark spark logs ps seed test check lint
 
 help: ## Show the available targets
 	@grep -hE '^[a-z-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -86,6 +86,10 @@ up: ## Start the whole stack in the background
 
 up-lite: ## Contract-only pair — no compute sidecars, honest 501s on Spark/SQL
 	docker compose -f docker-compose.yml up -d
+
+up-jupyter: ## Start the stack plus JupyterLab on :8888 (a real notebook editor)
+	docker compose --profile jupyter -f docker-compose.yml -f docker-compose.override.yml up -d
+	@echo "JupyterLab: http://localhost:8888"
 
 up-jvm: ## Swap the default Sail engine for JVM Spark (RDD, streaming sinks, JVM UDFs)
 	docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.spark-jvm.yml up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,49 @@ services:
       - "7681"
 
 
+  # ---- Notebooks (optional): real JupyterLab, profile-gated -----------------
+  # A real editor SHIPPED rather than one built into the portal. docs/44 records
+  # the doctrine (authoring belongs to real tools, because a UI we write is not
+  # parity evidence) and the one place it was weak: a newcomer could not touch a
+  # notebook without installing VS Code or Jupyter first. Same answer as
+  # OpenMetadata for the catalog UI — attach the real thing.
+  #
+  #   make up-jupyter        then open http://localhost:8888
+  #
+  # The kernel gets `notebookutils` on PYTHONPATH and Spark Connect to Sail, so
+  # a notebook authored here is the same notebook fabric-cicd publishes and
+  # RunNotebook executes.
+  jupyter:
+    profiles: [jupyter]
+    build:
+      context: .
+      dockerfile: docker/jupyter/Dockerfile
+    depends_on:
+      fabric-emulator:
+        condition: service_healthy
+    ports:
+      - "8888:8888"
+    volumes:
+      # Notebooks live on the host so they survive the container and can be
+      # committed, published by fabric-cicd, or opened in VS Code instead.
+      - ./notebooks:/notebooks
+    environment:
+      # The shim's documented wiring (python/notebookutils/_config.py). Tenant,
+      # client id and secret default to entra-emulator's seeded dev identity, so
+      # only the endpoints need naming.
+      NOTEBOOKUTILS_FABRIC_URL: "http://fabric-emulator"
+      NOTEBOOKUTILS_ENTRA_URL: "http://entra-emulator:8443"
+      NOTEBOOKUTILS_INSECURE: "1"
+      # Spark Connect to the same engine the Livy path uses, so a cell here and
+      # a cell in a RunNotebook job execute identically.
+      SPARK_REMOTE: "sc://sail:50051"
+    # Local dev only, like the rest of this file: no token, no password. This
+    # listens on localhost and is not for anything internet-facing.
+    command: >
+      jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
+      --IdentityProvider.token= --ServerApp.password=
+      --ServerApp.root_dir=/notebooks
+
   # ---- Orchestration (optional): real Apache Airflow, profile-gated ---------
   # Fabric's code-first orchestrator IS upstream Apache Airflow, so this is the
   # engine rather than an imitation of it — the same versions Microsoft

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,0 +1,23 @@
+# JupyterLab against the emulator family — a real editor, shipped not built.
+#
+# docs/44 records why the portal has no notebook editor: an editor we write is
+# a client re-implementation with its own semantics, and users would then
+# develop against a path no real Fabric client takes. The same doc records the
+# one place that doctrine is weak — a newcomer running `make up` cannot touch a
+# notebook without installing something first. This closes that the way
+# OpenMetadata closes the catalog UI: attach the real thing.
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /bin/
+
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+COPY python/ ./python/
+RUN uv sync --frozen --no-install-project --group jupyter
+
+ENV PATH="/app/.venv/bin:${PATH}"
+# The shim is importable as `notebookutils`, exactly as it is in a Fabric
+# notebook, so a notebook authored here runs unmodified there.
+ENV PYTHONPATH="/app/python"
+
+WORKDIR /notebooks
+EXPOSE 8888

--- a/docs/27-running-modes.md
+++ b/docs/27-running-modes.md
@@ -221,6 +221,7 @@ than optional. Drop what you do not need:
 
 ```bash
 make up PROFILE="--profile governance"   # no Airflow  (-1.1 GiB)
+make up-jupyter                          # + JupyterLab on :8888 (docs/44)
 make up PROFILE=                         # no catalog, no Airflow  (-3 GiB)
 make up-lite                             # contract only
 ```

--- a/docs/44-interaction-surfaces.md
+++ b/docs/44-interaction-surfaces.md
@@ -1,0 +1,116 @@
+# 44 — Interaction surfaces: how a user touches this emulator, versus real Fabric
+
+**Status: survey and doctrine, with the gaps ranked.** This maps every way a
+real Fabric user interacts with their workspace onto what this emulator offers
+for the same need — and records *why* the mapping is shaped the way it is, so
+the next "should the portal do X?" discussion starts from a position instead of
+from scratch.
+
+## The doctrine: bring your own UI
+
+The emulator's UI strategy is three-pronged, and none of the prongs is "clone
+the Fabric portal":
+
+1. **Real client tools are the authoring and query surfaces.** VS Code (the
+   pinned Fabric extension contract), Jupyter, SSMS/ADS over TDS, DuckDB,
+   Power BI Desktop, fabric-cli. This is the same *ecosystem conformance*
+   doctrine the parity map runs on: a real client working against the emulator
+   is parity **evidence**; a UI we build is not, because both ends are ours.
+2. **The Svelte portal is an operator console** — it shows what real Fabric
+   *cannot* show (the controllable clock, fault injection, the flow/lineage
+   graph, identities) plus read views of emulator state.
+3. **Sidecars ship real UIs rather than reimplementing them.** OpenMetadata is
+   the catalog UI, Airflow is the orchestration UI, kustainer is the KQL
+   engine. A UI that already exists is attached, not rebuilt.
+
+### The thin/thick line for portal surfaces
+
+The portal has a DAX runner and a terminal profile, so "no interactive surfaces"
+is not the rule. The rule is:
+
+> A portal surface may be a **thin pane over a documented, emulated API**
+> (`executeQueries`, TDS) or a **render of stored state**. It must not be a
+> **client re-implementation with its own semantics** — because users would then
+> develop against a path no real Fabric client takes, which is the
+> green-locally-different-in-Fabric failure class this emulator exists to
+> prevent.
+
+A notebook *editor* is on the wrong side of that line, and
+[14-real-compute.md](14-real-compute.md) records the decision: *"the Svelte
+portal gets a read-only notebook view, not an editor — authoring belongs to real
+tools."* A cell model, output rendering, interrupt, and ETag save round-trips
+would be the largest un-checkable hand-maintained parity artifact in the
+codebase — and this repo's guards (the generated engine matrix, the witness
+checker) exist precisely because such artifacts rot.
+
+## The map
+
+| Fabric workspace UI surface | Emulator answer today | Parity position |
+|---|---|---|
+| Workspace / item browser, CRUD | Portal `Workspaces` view; fabric-cli; the REST surface | ≈ parity for observing and managing |
+| **Notebook editor** (Monaco, cells, run) | None, by recorded decision — VS Code extension contract + Jupyter/`.ipynb` + git/fabric-cicd sync | Deliberate: authoring belongs to real tools (docs/14 D3) |
+| **Lakehouse explorer** (Tables/Files tree, data preview) | Nothing in-portal. Real clients read OneLake directly: DuckDB, delta-rs, azcopy, ADLS SDKs; Spark SQL over Livy | **The largest genuine gap** — a read-only browser is stored-state rendering, on the right side of the line |
+| Warehouse SQL editor | TDS endpoint → SSMS, ADS, `sqlcmd`, dbt; `executeQueries` REST; `portal-terminal` (ttyd) profile | Adequate via real clients; portal `Warehouse` view is config-status only |
+| Monitoring hub (runs, jobs) | Portal `Jobs`, `Operations` | ≈ parity |
+| Lineage view | Portal `Flow` graph | Arguably **ahead** of Fabric — lineage edges are first-class and filmable (flow.gif) |
+| Semantic model view | Portal `Models`: schema, measures, a DAX runner over `executeQueries` | ≈ parity for inspection; thin-pane rule satisfied |
+| Deployment pipelines UI | API only (`e2e/deployment-pipelines` witnesses it) | Read-only portal view would be cheap; undemanded so far |
+| Admin portal (tenant settings, domains, labels) | APIs only | Low demand; APIs are witnessed |
+| OneLake catalog / data hub | OpenMetadata, `--profile governance` | There, opt-in, as a shipped real UI |
+| Monitoring: capacity/billing | Out of scope (docs/03 non-goals) | — |
+
+## Running Python, specifically
+
+Four routes, all executing on the real engine, none of them a UI this repo owns:
+
+| Route | What it is | Witness |
+|---|---|---|
+| Livy sessions | REPL over the emulator's native Livy surface, executing on Sail | `e2e/livy` |
+| RunNotebook jobs | Notebook item (git / fabric-cicd / API) run as a job; the emulator drives the cells | `e2e/notebook-driven`, `e2e/notebook-run` |
+| VS Code extension | The real extension's authoring protocol, pinned at 1.18.1, served through the `api.powerbi.com` alias | `e2e/vscode-extension` |
+| `notebookutils` locally | The shim package, so notebook code runs unmodified in plain Jupyter/pytest | `e2e/notebookutils` |
+
+The composed loop (docs/14): author in VS Code → sync via git/fabric-cicd →
+execute on Sail with the default lakehouse mounted and the Environment item's
+packages installed → Delta lands in OneLake → query over TDS/DuckDB → schedule
+via the jobs API.
+
+## Viewing tables, specifically
+
+- **Warehouse**: any TDS client, or `executeQueries`.
+- **Lakehouse**: DuckDB / delta-rs / ADLS SDKs against OneLake; Spark SQL over
+  Livy; OpenMetadata for the catalog view. In-portal: nothing yet (the gap
+  above).
+
+## On testing the VS Code surface
+
+`e2e/vscode-extension` **replays the extension's captured route contract** — it
+does not drive the extension's UI. That is the right witness for the emulator's
+side of the boundary: the wire is what the emulator can break, and the UI is
+Microsoft's.
+
+Driving the real extension in CI is blocked twice over: the extension is
+closed-source, and its MSAL auth targets `login.microsoftonline.com` with no
+documented endpoint override. The hosts-redirect route
+([05-tls-and-hosts.md](05-tls-and-hosts.md)) makes a *manual* smoke possible.
+The scalable guard is **capture-diff**: capture a newer extension version's
+traffic and diff it against the pinned contract, so protocol drift fails loudly.
+Open question before building that: the original 1.18.1 capture tooling is not
+in the repo, so reproducing the capture is the first step.
+
+## Gaps, ranked
+
+1. **Lakehouse browser in the portal** (S) — Tables/Files tree, Delta schema and
+   first-N rows through the readers the warehouse already uses. Stored-state
+   rendering; right side of the line.
+2. **Read-only notebook view + a run button** (S–M) — renders the stored
+   definition, triggers the documented job API. Already promised by docs/14 D3.
+3. **`--profile jupyter` sidecar** (S) — ship a real editor instead of building
+   one: JupyterLab preconfigured with the `notebookutils` shim against the
+   stack (Sail's Spark Connect port is already published). Solves first-run
+   onboarding the same way OpenMetadata solves the catalog UI.
+4. **Capture-diff for the extension contract** (M, after re-establishing the
+   capture method).
+
+What stays out: a portal notebook editor, and real-extension UI automation in
+CI — both for the reasons above.

--- a/docs/44-interaction-surfaces.md
+++ b/docs/44-interaction-surfaces.md
@@ -1,6 +1,6 @@
 # 44 — Interaction surfaces: how a user touches this emulator, versus real Fabric
 
-**Status: survey and doctrine, with the gaps ranked.** This maps every way a
+**Status: survey and doctrine; the Jupyter gap is closed, the rest ranked.** This maps every way a
 real Fabric user interacts with their workspace onto what this emulator offers
 for the same need — and records *why* the mapping is shaped the way it is, so
 the next "should the portal do X?" discussion starts from a position instead of
@@ -48,7 +48,7 @@ checker) exist precisely because such artifacts rot.
 | Fabric workspace UI surface | Emulator answer today | Parity position |
 |---|---|---|
 | Workspace / item browser, CRUD | Portal `Workspaces` view; fabric-cli; the REST surface | ≈ parity for observing and managing |
-| **Notebook editor** (Monaco, cells, run) | None, by recorded decision — VS Code extension contract + Jupyter/`.ipynb` + git/fabric-cicd sync | Deliberate: authoring belongs to real tools (docs/14 D3) |
+| **Notebook editor** (Monaco, cells, run) | Not in the portal, by recorded decision. **`make up-jupyter` ships a real JupyterLab** wired to the family; plus the VS Code extension contract and `.ipynb` + git/fabric-cicd sync | Deliberate: authoring belongs to real tools (docs/14 D3), and the tool is now *shipped* rather than assumed installed |
 | **Lakehouse explorer** (Tables/Files tree, data preview) | Nothing in-portal. Real clients read OneLake directly: DuckDB, delta-rs, azcopy, ADLS SDKs; Spark SQL over Livy | **The largest genuine gap** — a read-only browser is stored-state rendering, on the right side of the line |
 | Warehouse SQL editor | TDS endpoint → SSMS, ADS, `sqlcmd`, dbt; `executeQueries` REST; `portal-terminal` (ttyd) profile | Adequate via real clients; portal `Warehouse` view is config-status only |
 | Monitoring hub (runs, jobs) | Portal `Jobs`, `Operations` | ≈ parity |
@@ -105,12 +105,34 @@ in the repo, so reproducing the capture is the first step.
    rendering; right side of the line.
 2. **Read-only notebook view + a run button** (S–M) — renders the stored
    definition, triggers the documented job API. Already promised by docs/14 D3.
-3. **`--profile jupyter` sidecar** (S) — ship a real editor instead of building
-   one: JupyterLab preconfigured with the `notebookutils` shim against the
-   stack (Sail's Spark Connect port is already published). Solves first-run
-   onboarding the same way OpenMetadata solves the catalog UI.
+3. ~~**`--profile jupyter` sidecar**~~ ✅ **Done** — see below.
 4. **Capture-diff for the extension contract** (M, after re-establishing the
    capture method).
+
+## Closed: the `jupyter` profile
+
+    make up-jupyter        # then http://localhost:8888
+
+A real JupyterLab, attached rather than rebuilt — the same answer OpenMetadata
+gives for the catalog UI and Airflow gives for orchestration. What makes it a
+*Fabric* notebook rather than a generic one:
+
+- `notebookutils` is on `PYTHONPATH`, importable exactly as in a Fabric
+  notebook, wired through its documented contract
+  (`python/notebookutils/_config.py`). Tenant, client id and secret default to
+  entra-emulator's seeded identity, so only the endpoints are named.
+- `SPARK_REMOTE` points at **Sail** — the same engine a `RunNotebook` job and a
+  Livy session use, so a cell here and a cell in a job execute identically.
+- `pyspark-client` is pinned to the **same 4.1.1 the agent uses**. A kernel on a
+  different client than the engine is precisely the drift this profile exists to
+  avoid, and the pin comment in `pyproject.toml` explains what breaks otherwise.
+- `./notebooks` is a host mount, so what you author survives the container and
+  is the same file `fabric-cicd` publishes and git syncs.
+
+This closes the one place the bring-your-own-UI doctrine was genuinely weak: a
+newcomer running `make up` could not touch a notebook without installing VS Code
+or Jupyter first. It does **not** reverse the doctrine — the editor is still a
+real tool, it is simply now shipped rather than assumed.
 
 What stays out: a portal notebook editor, and real-extension UI automation in
 CI — both for the reasons above.

--- a/docs/44-interaction-surfaces.md
+++ b/docs/44-interaction-surfaces.md
@@ -1,6 +1,7 @@
 # 44 — Interaction surfaces: how a user touches this emulator, versus real Fabric
 
-**Status: survey and doctrine; the Jupyter gap is closed, the rest ranked.** This maps every way a
+**Status: survey and doctrine; the lakehouse browser and Jupyter gaps are
+closed, the rest ranked.** This maps every way a
 real Fabric user interacts with their workspace onto what this emulator offers
 for the same need — and records *why* the mapping is shaped the way it is, so
 the next "should the portal do X?" discussion starts from a position instead of
@@ -49,7 +50,7 @@ checker) exist precisely because such artifacts rot.
 |---|---|---|
 | Workspace / item browser, CRUD | Portal `Workspaces` view; fabric-cli; the REST surface | ≈ parity for observing and managing |
 | **Notebook editor** (Monaco, cells, run) | Not in the portal, by recorded decision. **`make up-jupyter` ships a real JupyterLab** wired to the family; plus the VS Code extension contract and `.ipynb` + git/fabric-cicd sync | Deliberate: authoring belongs to real tools (docs/14 D3), and the tool is now *shipped* rather than assumed installed |
-| **Lakehouse explorer** (Tables/Files tree, data preview) | Nothing in-portal. Real clients read OneLake directly: DuckDB, delta-rs, azcopy, ADLS SDKs; Spark SQL over Livy | **The largest genuine gap** — a read-only browser is stored-state rendering, on the right side of the line |
+| **Lakehouse explorer** (Tables/Files tree, data preview) | Portal **`Lakehouses`** view: tables, files and a Delta preview, read-only. Plus the real clients reading OneLake directly: DuckDB, delta-rs, azcopy, ADLS SDKs; Spark SQL over Livy | ≈ parity for browsing and preview. Read-only by construction — stored state rendered back, on the right side of the line; authoring stays with the real tools |
 | Warehouse SQL editor | TDS endpoint → SSMS, ADS, `sqlcmd`, dbt; `executeQueries` REST; `portal-terminal` (ttyd) profile | Adequate via real clients; portal `Warehouse` view is config-status only |
 | Monitoring hub (runs, jobs) | Portal `Jobs`, `Operations` | ≈ parity |
 | Lineage view | Portal `Flow` graph | Arguably **ahead** of Fabric — lineage edges are first-class and filmable (flow.gif) |
@@ -79,8 +80,9 @@ via the jobs API.
 
 - **Warehouse**: any TDS client, or `executeQueries`.
 - **Lakehouse**: DuckDB / delta-rs / ADLS SDKs against OneLake; Spark SQL over
-  Livy; OpenMetadata for the catalog view. In-portal: nothing yet (the gap
-  above).
+  Livy; OpenMetadata for the catalog view. In-portal: the **`Lakehouses`** view
+  lists tables and files and previews a table's schema and first-N rows, through
+  the same reader the warehouse preview already used.
 
 ## On testing the VS Code surface
 
@@ -100,9 +102,9 @@ in the repo, so reproducing the capture is the first step.
 
 ## Gaps, ranked
 
-1. **Lakehouse browser in the portal** (S) — Tables/Files tree, Delta schema and
-   first-N rows through the readers the warehouse already uses. Stored-state
-   rendering; right side of the line.
+1. ~~**Lakehouse browser in the portal**~~ ✅ **Done** — the `Lakehouses` view.
+   Tables are derived from OneLake *paths*, not directory rows, because delta-rs
+   writes no directories; the file list is capped and the count is not.
 2. **Read-only notebook view + a run button** (S–M) — renders the stored
    definition, triggers the documented job API. Already promised by docs/14 D3.
 3. ~~**`--profile jupyter` sidecar**~~ ✅ **Done** — see below.

--- a/docs/44-interaction-surfaces.md
+++ b/docs/44-interaction-surfaces.md
@@ -1,7 +1,7 @@
 # 44 — Interaction surfaces: how a user touches this emulator, versus real Fabric
 
-**Status: survey and doctrine; the lakehouse browser and Jupyter gaps are
-closed, the rest ranked.** This maps every way a
+**Status: survey and doctrine; the lakehouse browser, notebook view and Jupyter
+gaps are closed, the capture-diff one ranked.** This maps every way a
 real Fabric user interacts with their workspace onto what this emulator offers
 for the same need — and records *why* the mapping is shaped the way it is, so
 the next "should the portal do X?" discussion starts from a position instead of
@@ -49,7 +49,7 @@ checker) exist precisely because such artifacts rot.
 | Fabric workspace UI surface | Emulator answer today | Parity position |
 |---|---|---|
 | Workspace / item browser, CRUD | Portal `Workspaces` view; fabric-cli; the REST surface | ≈ parity for observing and managing |
-| **Notebook editor** (Monaco, cells, run) | Not in the portal, by recorded decision. **`make up-jupyter` ships a real JupyterLab** wired to the family; plus the VS Code extension contract and `.ipynb` + git/fabric-cicd sync | Deliberate: authoring belongs to real tools (docs/14 D3), and the tool is now *shipped* rather than assumed installed |
+| **Notebook editor** (Monaco, cells, run) | No EDITOR in the portal, by recorded decision — but the `Notebooks` view renders the stored definition read-only and starts a `RunNotebook` job. **`make up-jupyter` ships a real JupyterLab** wired to the family; plus the VS Code extension contract and `.ipynb` + git/fabric-cicd sync | Deliberate: authoring belongs to real tools (docs/14 D3), and the tool is now *shipped* rather than assumed installed |
 | **Lakehouse explorer** (Tables/Files tree, data preview) | Portal **`Lakehouses`** view: tables, files and a Delta preview, read-only. Plus the real clients reading OneLake directly: DuckDB, delta-rs, azcopy, ADLS SDKs; Spark SQL over Livy | ≈ parity for browsing and preview. Read-only by construction — stored state rendered back, on the right side of the line; authoring stays with the real tools |
 | Warehouse SQL editor | TDS endpoint → SSMS, ADS, `sqlcmd`, dbt; `executeQueries` REST; `portal-terminal` (ttyd) profile | Adequate via real clients; portal `Warehouse` view is config-status only |
 | Monitoring hub (runs, jobs) | Portal `Jobs`, `Operations` | ≈ parity |
@@ -105,8 +105,11 @@ in the repo, so reproducing the capture is the first step.
 1. ~~**Lakehouse browser in the portal**~~ ✅ **Done** — the `Lakehouses` view.
    Tables are derived from OneLake *paths*, not directory rows, because delta-rs
    writes no directories; the file list is capped and the count is not.
-2. **Read-only notebook view + a run button** (S–M) — renders the stored
-   definition, triggers the documented job API. Already promised by docs/14 D3.
+2. ~~**Read-only notebook view + a run button**~~ ✅ **Done** — the `Notebooks`
+   view. Cells are parsed server-side by `notebook.Parse`, the same call an
+   engine's run makes; Run starts a real `RunNotebook` job through
+   `startJob`, and the view says up front when no engine is attached to pick
+   it up.
 3. ~~**`--profile jupyter` sidecar**~~ ✅ **Done** — see below.
 4. **Capture-diff for the extension contract** (M, after re-establishing the
    capture method).

--- a/notebooks/welcome.ipynb
+++ b/notebooks/welcome.ipynb
@@ -35,8 +35,9 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "from pyspark.sql import SparkSession\n",
     "import os\n",
+    "\n",
+    "from pyspark.sql import SparkSession\n",
     "\n",
     "# The SAME engine the jobs and Livy paths use \u2014 not a local Spark.\n",
     "spark = SparkSession.builder.remote(os.environ[\"SPARK_REMOTE\"]).getOrCreate()\n",

--- a/notebooks/welcome.ipynb
+++ b/notebooks/welcome.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Welcome \u2014 a Fabric notebook against the emulator\n",
+    "\n",
+    "This is a **real** JupyterLab, attached to the emulator family the same way\n",
+    "OpenMetadata is attached as the catalog UI. Nothing here is a re-implementation:\n",
+    "\n",
+    "* `notebookutils` is the shim this repo ships, importable exactly as it is in a\n",
+    "  Fabric notebook \u2014 so what you write here runs unmodified in real Fabric.\n",
+    "* `spark` is a Spark Connect session against **Sail**, the same engine a\n",
+    "  `RunNotebook` job and a Livy session use.\n",
+    "\n",
+    "Author here, then publish with `fabric-cicd` or git \u2014 see `docs/44`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import notebookutils\n",
+    "\n",
+    "# The runtime context Fabric injects into a kernel; here it comes from the\n",
+    "# environment (python/notebookutils/_config.py).\n",
+    "ctx = notebookutils.runtime.context\n",
+    "ctx"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "import os\n",
+    "\n",
+    "# The SAME engine the jobs and Livy paths use \u2014 not a local Spark.\n",
+    "spark = SparkSession.builder.remote(os.environ[\"SPARK_REMOTE\"]).getOrCreate()\n",
+    "spark.sql(\"SELECT 'hello from Sail' AS greeting\").show()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "* `notebookutils.fs.ls(\"Files/\")` \u2014 the default lakehouse's files\n",
+    "* `notebookutils.credentials.getSecret(...)` \u2014 Key Vault through the emulator\n",
+    "* Write Delta into OneLake, then query it over TDS or DuckDB\n",
+    "\n",
+    "The lakehouse tables you create here are the ones the portal, dbt and\n",
+    "Power BI Desktop see."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,17 @@ sail-delta = [
 ]
 # requests: user notebook code (and libraries it imports) routinely calls HTTP
 # APIs, and the statement agent is where that code executes.
+# JupyterLab for the `jupyter` compose profile: a REAL notebook editor shipped
+# rather than one built into the portal (docs/44). pyspark-client is pinned to
+# the SAME 4.1.1 the agent uses — a kernel on a different client than the engine
+# is exactly the drift this profile exists to avoid.
+jupyter = [
+    "jupyterlab>=4.2,<5",
+    "pyspark-client==4.1.1",
+    "deltalake>=0.23,<2",
+    "pyarrow>=18,<24",
+    "requests>=2.32,<3",
+]
 spark-connect = ["pyspark-client==4.1.1", "requests>=2.32,<3"]
 dbt-fabric = ["dbt-fabric>=1.9"]
 dbt-fabricspark = ["dbt-fabricspark>=1.9"]

--- a/uv.lock
+++ b/uv.lock
@@ -1340,6 +1340,13 @@ great-expectations = [
     { name = "great-expectations" },
     { name = "pandas" },
 ]
+jupyter = [
+    { name = "deltalake" },
+    { name = "jupyterlab" },
+    { name = "pyarrow" },
+    { name = "pyspark-client" },
+    { name = "requests" },
+]
 lint = [
     { name = "ruff" },
     { name = "ty" },
@@ -1430,6 +1437,13 @@ governance = [
 great-expectations = [
     { name = "great-expectations", specifier = ">=0.18,<1" },
     { name = "pandas", specifier = ">=2.2,<4" },
+]
+jupyter = [
+    { name = "deltalake", specifier = ">=0.23,<2" },
+    { name = "jupyterlab", specifier = ">=4.2,<5" },
+    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyspark-client", specifier = "==4.1.1" },
+    { name = "requests", specifier = ">=2.32,<3" },
 ]
 lint = [
     { name = "ruff", specifier = ">=0.14,<0.16" },

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -109,6 +109,7 @@ export default defineConfig({
             { slug: '41-salesforce-connector-plan' },
             { slug: '42-sail-fidelity-plan' },
             { slug: '43-activity-completion-plan' },
+            { slug: '44-interaction-surfaces' },
             { slug: 'engine-matrix' },
           ],
         },


### PR DESCRIPTION
Came out of a design discussion: *how does a user actually run Python and view lakehouse/warehouse tables here, and how close is that to the Fabric workspace UI?* The answer was spread across docs/14, docs/03, the parity map and four e2e suites. This puts it in one place with the reasoning attached.

## What it records

**The doctrine** — bring your own UI, in three prongs: real client tools are the authoring/query surfaces (they're parity *evidence*; a UI we build is not, since both ends are ours), the portal is an **operator console** for things Fabric can't show (clock, faults, flow, identities), and sidecars **ship** real UIs rather than reimplementing them (OpenMetadata, Airflow, kustainer).

**The thin/thick line**, which is the part that was missing. The portal has a DAX runner and a terminal, so "no interactive surfaces" was never the rule. The actual rule:

> A portal surface may be a thin pane over a documented, emulated API, or a render of stored state. It must not be a client re-implementation with its own semantics — because users would then develop against a path no real Fabric client takes.

That's the green-locally-different-in-Fabric failure class, in UI form. It also squares the apparent inconsistency: the DAX runner is thin over `executeQueries`; a notebook editor would have its own semantics.

**The map** — every Fabric workspace UI surface against our answer and parity position, plus the four routes for running Python and the two for viewing tables, each with its witness.

## One correction to myself

I'd described the notebook editor as a "deliberate non-goal" from inference. Checking, it *is* recorded — docs/14 D3: *"the Svelte portal gets a read-only notebook view, not an editor — authoring belongs to real tools."* The doc now cites that rather than asserting it, and adds the reasoning the one-liner omits.

## Gaps, ranked

1. **Lakehouse browser in the portal** (S) — the largest genuine gap. Nothing in-portal shows Tables/Files; real clients read OneLake directly. Stored-state rendering, so it's on the right side of the line.
2. Read-only notebook view + run button (S–M) — already promised by docs/14 D3.
3. **`--profile jupyter` sidecar** (S) — ship a real editor instead of building one, exactly as OpenMetadata solves the catalog UI. Fixes first-run onboarding, which is the one place the "authoring belongs to real tools" doctrine is genuinely weak.
4. Capture-diff for the VS Code contract (M) — with an open question stated: the original 1.18.1 capture tooling isn't in the repo, so reproducing the capture comes first.

Explicitly out: a portal notebook editor, and real-extension UI automation in CI (closed-source, and its MSAL auth targets `login.microsoftonline.com` with no documented override).

`make check` clean — 45 published docs, all reachable from the sidebar.