### PR TITLE
make: `check` runs ruff + ty, not just the invariant scripts

### DIFF
--- a/.github/workflows/make-targets.yml
+++ b/.github/workflows/make-targets.yml
@@ -107,7 +107,7 @@ jobs:
           # Keep in step with .PHONY in the Makefile — a target nobody expands
           # here is a target nobody notices breaking.
           for t in help doctor up up-lite up-jvm down clean restart status \
-                   status-spark spark seed ps logs check test; do
+                   status-spark spark seed ps logs check lint test; do
             echo "=== make -n $t ==="
             make -n "$t"
           done

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endif
 PY ?= $(shell if command -v uv >/dev/null 2>&1; then echo "uv run --frozen --no-sync python"; \
 	else for c in python3 python py; do if "$$c" -c '' >/dev/null 2>&1; then echo "$$c"; break; fi; done; fi)
 
-.PHONY: help doctor up up-lite up-jvm down restart clean status status-spark spark logs ps seed test check
+.PHONY: help doctor up up-lite up-jvm down restart clean status status-spark spark logs ps seed test check lint
 
 help: ## Show the available targets
 	@grep -hE '^[a-z-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -117,7 +117,26 @@ ps: ## Container states for this project
 logs: ## Tail logs (SVC=<service> to narrow)
 	$(COMPOSE) logs -f --tail 100 $(SVC)
 
-check: ## Repo invariants — the checks that used to exist only in CI
+# The same two commands CI runs as the `ruff + ty` job, in the same order, both
+# configured in pyproject.toml. Local-only because they were CI-only: `make
+# check` covered the invariant scripts and nothing looked at the ~1800
+# statements of agent, shim and script Python until a push.
+#
+# ruff lints .ipynb sources too, which is how a notebook with its imports in the
+# wrong order reached CI as a red X on a green branch.
+#
+# `check` must stay runnable with nothing but Python (see PY above), and ruff
+# arrives through a uv dependency group. So a machine without uv gets a LOUD
+# skip: a quiet one would make "check passed" and "lint never ran" look alike.
+lint: ## ruff + ty over the Python sources — the CI lint job, locally
+	@if command -v uv >/dev/null 2>&1; then \
+	  uv run --frozen --group lint ruff check . && \
+	  uv run --frozen --group lint --group test ty check; \
+	else \
+	  echo "lint SKIPPED: no uv on PATH — CI still runs ruff + ty" >&2; \
+	fi
+
+check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_witnesses.py --strict
 	@$(PY) scripts/check_govern_types.py
 	@$(PY) scripts/check_example_parity.py


### PR DESCRIPTION
`make check` ran the Python invariant scripts and nothing else looked at Python. The ~1800 statements of spark-agent, notebookutils shim and check scripts had no local static enforcement at all — the first thing that saw them was CI's `ruff + ty` job, on a push.

That gap has now cost a red CI run: a notebook I added on #87 had `from pyspark.sql import SparkSession` above `import os`, and `make check` was green the whole time. ruff lints `.ipynb` sources; nothing local did.

**New `lint` target**, running the same two commands as the CI job, in the same order, both configured in `pyproject.toml`:

```
uv run --frozen --group lint ruff check .
uv run --frozen --group lint --group test ty check
```

`check` now depends on it, so `make check` and `make test` cover it.

**The one design constraint.** `check` is deliberately runnable with nothing but Python — that's why `PY` has a bare-interpreter fallback for machines without uv. ruff arrives through a uv dependency group, so on such a machine the target prints a **loud skip** and returns 0 rather than failing. A silent skip would make "check passed" and "lint never ran" look identical, which is the failure mode this PR exists to remove.

**Verified, not assumed:**

- `make lint` passes on `main`.
- An unsorted import in `scripts/` makes `make check` exit non-zero — the ruff half bites.
- A `-> int` returning `str` makes `make lint` exit non-zero — the ty half bites too, i.e. the second command's status really does propagate out of the `if`.
- `PATH` without uv prints `lint SKIPPED: no uv on PATH — CI still runs ruff + ty` and exits 0.
- `make help` lists it.

No CI change: the `ruff + ty` job stays exactly as it is. This makes the same failure reachable before a push.