### PR TITLE
xmla: Phase 0 — answer the routing call, and record what changed

### DIFF
--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -66,9 +66,53 @@ The evaluator is the load-bearing one. `executeQueries` and XMLA are two
 envelopes around the same DAX, so most of what an XMLA `Execute` must answer is
 already answered somewhere else in this repository.
 
-## Phase 0 — answer the routing call
+## Phase 0 — RUN, and it answered two questions
 
-**Do this one regardless of whether Phases 1–3 ever happen.**
+**Status: DONE as measurement.** `e2e/xmla` now runs the probe **twice** — once
+refusing the routing call (the regression witness for the first-call contract,
+unchanged) and once answering it. Answering in the same pass would have
+destroyed the thing the first pass pins, which is why it is a second run rather
+than an edited stub.
+
+**Finding 1 — the doubled routing call is a 404 FALLBACK, not unconditional.**
+This is the question `e2e/xmla`'s README flags as unestablished, and it is now
+settled by contrast rather than by reading:
+
+| Listener | Captured |
+|---|---|
+| Refuses (404) | `…workspaces?PreferClientRouting=true` **then** `…workspaces` — twice per connection |
+| Answers (200) | `…workspaces?PreferClientRouting=true` **only** — once per connection |
+
+An implementation therefore does *not* need to serve the un-flagged form to a
+client it answers; that form only ever appears after a refusal.
+
+**Finding 2 — the reply is CONSUMED, and the failure moved from transport to
+lookup.** With a JSON body of the hypothesised shape, ADOMD.NET no longer
+complains about the response at all. It reports:
+
+```
+AdomdConnectionException :: The specified Power BI workspace ('ws') is not found.
+```
+
+That is a *lookup* failure, not a parse failure — the client deserialised the
+body, searched it for the workspace named in the Data Source, and did not find
+a match. So the envelope is close enough to be consumed, and what remains
+unknown is narrower than "what shape": it is **which field the client matches
+the workspace name against**. The hypothesis sent `name`, `id`,
+`capacityObjectId` and `clusterUri`; one of those is wrong or one is missing.
+
+**Nothing here is asserted as a contract.** The reply shape is still a guess,
+and a suite that asserted it would pass by confirming its own guess. Both
+findings are printed observations; the next iteration turns one into a test.
+
+### The next experiment, now one edit and ~5 minutes
+
+Vary a single field at a time against the same harness and read the error. The
+client's message names the workspace it wanted, so a matching reply advances
+past routing for the first time — and that is the point at which
+`[MS-SSAS-T]`'s real size becomes observable rather than estimated.
+
+### Original framing, kept because the reasoning still holds
 
 Replace the capture stub's 404 with a real handler for
 `GET /powerbi/databases/v201606/workspaces`. It is JSON REST over the workspace

--- a/e2e/xmla/README.md
+++ b/e2e/xmla/README.md
@@ -55,10 +55,11 @@ Microsoft's own ADOMD.NET client
    Recording the requests rather than printing them surfaced something the
    original one-off measurement missed: **each connection makes the call twice**
    — once with `PreferClientRouting=true`, then immediately again without it.
-   That is what the client does when the first call is refused with a 404; this
-   harness has never seen it against a server that answers, so whether the
-   second call is a fallback or unconditional is not established here. Either
-   way, an implementation should expect both forms;
+   That is what the client does when the first call is refused with a 404.
+   **Since Phase 0 the harness HAS seen it against a server that answers, and
+   the doubling is a 404 fallback**: with the routing call answered, only the
+   `PreferClientRouting=true` form is sent, once per connection. An
+   implementation that answers therefore never sees the un-flagged form;
 6. the **`Data Source=https://…/xmla` and bare `host:port` forms remain
    Windows-only** on .NET Core —
 

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -45,6 +45,7 @@ elsewhere). stdlib-only orchestrator.
 """
 
 import http.server
+import json
 import os
 import shutil
 import socket
@@ -113,6 +114,15 @@ def require_free_port(port, what):
 # first-call contract would no longer be the one a fresh client performs.
 # ---------------------------------------------------------------------------
 
+# PHASE 0 (docs/32-xmla-plan.md): answering the routing call is a SEPARATE run,
+# never a change to the refusing one. The refusal is what pins the first-call
+# contract — answer it in the same pass and the recorded contract becomes the
+# one a client performs against a server that replies, which is a different
+# fact. So the suite runs the probe TWICE: once refusing (the regression
+# witness), once answering (the measurement).
+ANSWER_ROUTING = False
+WORKSPACE = "ws"   # the workspace the probe names in its Data Source
+
 REQUESTS = []          # [{method, path, headers: {lower: value}, body}]
 HANDSHAKE_ERRORS = []  # TCP connected, TLS refused — a distinct diagnosis
 LOCK = threading.Lock()
@@ -135,6 +145,29 @@ class Capture(http.server.BaseHTTPRequestHandler):
 
     def do_GET(self):
         self._record()
+        if ANSWER_ROUTING and self.path.startswith("/powerbi/databases/v201606/workspaces"):
+            # The routing reply, as a HYPOTHESIS rather than a known contract.
+            # Nobody in this project has seen a real one; what is documented is
+            # only that the client asks. The cluster is pointed back at this
+            # same listener so that a client which follows routing returns here
+            # and its NEXT request is captured — which is the entire deliverable
+            # of Phase 0. If the client rejects this shape, its exception text
+            # is the measurement instead, and just as useful.
+            body = json.dumps({
+                "@odata.context": f"https://{self.headers.get('Host', '')}/powerbi/databases/v201606/$metadata#workspaces",
+                "value": [{
+                    "name": WORKSPACE,
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "capacityObjectId": "00000000-0000-0000-0000-000000000002",
+                    "clusterUri": f"https://{self.headers.get('Host', '')}/",
+                }],
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
         self.send_response(404)
         self.send_header("Content-Length", "0")
         self.end_headers()
@@ -291,10 +324,11 @@ log(f"TLS capture listener on :{PORT}")
 
 target = f"{CONTAINER_HOST}:{PORT}"
 log(f"running ADOMD.NET against {target} (linux/amd64, {SDK_IMAGE})")
-try:
-    # The project is mounted READ-ONLY and copied inside, so a restore never
-    # writes bin/obj into the repo.
-    proc = subprocess.run([
+def run_probe():
+    """One ADOMD.NET run against the listener. Identical both phases — only the
+    listener's behaviour differs, so any change in what the client does is
+    attributable to the routing reply and to nothing else."""
+    return subprocess.run([
         "docker", "run", "--rm", "--platform", "linux/amd64",
         "--add-host", f"{CONTAINER_HOST}:host-gateway",
         "-v", f"{os.path.join(DIR, 'probe')}:/probe:ro",
@@ -305,11 +339,13 @@ try:
         "sh", "-c",
         "cp -r /probe/. /work/ && update-ca-certificates >/dev/null 2>&1 && dotnet run --nologo",
     ], capture_output=True, text=True, timeout=900)
+
+
+try:
+    proc = run_probe()
 except subprocess.TimeoutExpired:
     srv.shutdown()
     raise SystemExit("FAILED: the ADOMD.NET probe did not finish within 15 minutes")
-
-srv.shutdown()
 
 print("\n---- probe stdout ----", flush=True)
 print(proc.stdout.strip() or "(empty)", flush=True)
@@ -326,6 +362,61 @@ print("\n---- client contract ----", flush=True)
 assert_contract(proc.stdout)
 
 if FAILURES:
+    srv.shutdown()
     raise SystemExit("\nFAILED: the ADOMD.NET client contract changed:\n  - " +
                      "\n  - ".join(FAILURES))
+
+# ---------------------------------------------------------------------------
+# PHASE 0 — answer the routing call and record what the client does next.
+#
+# docs/32-xmla-plan.md: "The deliverable is not the feature. It is measurement."
+# Nothing below is asserted as a contract, because no contract is known: the
+# routing reply here is a HYPOTHESIS about a shape nobody in this project has
+# observed. Three outcomes are all informative and all recorded:
+#
+#   * the client advances     -> its next request is printed; that is the thing
+#                                the roadmap could not price
+#   * the client rejects it   -> its exception names what the shape lacked
+#   * nothing changes         -> the doubled routing call is unconditional
+#                                rather than a 404 fallback, which the README
+#                                flags as unestablished
+#
+# A future phase turns whichever of these happened into an assertion. Today it
+# is a printed observation, so the suite cannot pass by confirming a guess.
+# ---------------------------------------------------------------------------
+phase1 = [(r["method"], r["path"]) for r in REQUESTS]
+
+ANSWER_ROUTING = True
+with LOCK:
+    REQUESTS.clear()
+log("PHASE 0: answering the routing call, recording what follows")
+try:
+    proc2 = run_probe()
+except subprocess.TimeoutExpired:
+    srv.shutdown()
+    raise SystemExit("FAILED: the phase-0 probe did not finish within 15 minutes")
+srv.shutdown()
+
+phase2 = [(r["method"], r["path"]) for r in REQUESTS]
+print(f"\n---- PHASE 0: {len(phase2)} request(s) with routing ANSWERED ----", flush=True)
+for m, path in phase2:
+    print(f"  {m} {path}", flush=True)
+beyond = [x for x in phase2 if not x[1].startswith("/powerbi/databases/v201606/workspaces")]
+print("\n---- PHASE 0 verdict ----", flush=True)
+if beyond:
+    print("ADVANCED — requests past routing, never before observed:", flush=True)
+    for m, path in beyond:
+        print(f"    {m} {path}", flush=True)
+    body = next((r["body"] for r in REQUESTS
+                 if not r["path"].startswith("/powerbi/databases/v201606/workspaces")), "")
+    if body:
+        print(f"    first body (first 400 chars): {body[:400]}", flush=True)
+elif phase2 == phase1:
+    print("UNCHANGED — the sequence is identical to the refused run, so the "
+          "doubled routing call is unconditional rather than a 404 fallback.", flush=True)
+else:
+    print("STOPPED AT ROUTING — the reply was rejected. The probe's own error "
+          "text below is what the shape lacked:", flush=True)
+print("\n---- phase 0 probe stdout ----", flush=True)
+print(proc2.stdout.strip() or "(empty)", flush=True)
 print("\nPASSED: the ADOMD.NET client contract is unchanged.")


### PR DESCRIPTION
[docs/32](docs/32-xmla-plan.md) Phase 0: *"The deliverable is not the feature. It is measurement."* This is the measurement, and it answered two questions.

### Structure: a second run, not an edited stub

The capture stub's own comment names the constraint — answering the routing call sends the client down a different path, so the recorded first-call contract would no longer be the one a fresh client performs. So the suite now runs the probe **twice**: once refusing (the regression witness, byte-for-byte unchanged) and once answering. Any difference is attributable to the reply and nothing else.

### Finding 1 — the doubled routing call is a **404 fallback**, not unconditional

`e2e/xmla`'s README flagged this as unestablished. Settled by contrast:

| Listener | Captured per connection |
|---|---|
| Refuses (404) | `…workspaces?PreferClientRouting=true` **then** `…workspaces` |
| Answers (200) | `…workspaces?PreferClientRouting=true` **only** |

An implementation that answers never sees the un-flagged form. README updated; the open question is now a recorded fact.

### Finding 2 — the reply is **consumed**; the failure moved from transport to lookup

With a JSON body of the hypothesised shape, ADOMD.NET stops complaining about the response and reports:

```
AdomdConnectionException :: The specified Power BI workspace ('ws') is not found.
```

A **lookup** failure, not a parse failure — it deserialised the body, searched for the workspace named in the Data Source, and found no match. The unknown is now much narrower than "what shape": it is *which field the client matches the name against*.

### What is deliberately NOT asserted

The reply shape is still a guess. A suite that asserted it would pass by confirming its own guess — the failure mode this repo keeps paying for. Both findings are **printed observations**; the verdict block distinguishes ADVANCED / STOPPED AT ROUTING / UNCHANGED so the next run classifies itself. The next iteration turns one into a test.

### Cost of the next step, now that the harness exists

One field edit and ~5 minutes. A matching reply advances past routing for the first time — the point at which `[MS-SSAS-T]`'s real size becomes observable rather than estimated, which is exactly what Phase 0 existed to unlock.

Verified: full suite runs green (`PASSED: the ADOMD.NET client contract is unchanged` — all six original assertions intact), `ruff` clean, `make check` green.