### PR TITLE
ci: derive the expanded target list from `.PHONY`

### DIFF
--- a/.github/workflows/make-targets.yml
+++ b/.github/workflows/make-targets.yml
@@ -104,10 +104,34 @@ jobs:
           # -n prints the recipe without running it, so this exercises variable
           # expansion, quoting and the shell selection on every platform —
           # including the docker targets that cannot execute off Linux.
-          # Keep in step with .PHONY in the Makefile — a target nobody expands
-          # here is a target nobody notices breaking.
-          for t in help doctor up up-lite up-jvm down clean restart status \
-                   status-spark spark seed ps logs check lint test; do
+          #
+          # DERIVED from .PHONY rather than listed here. This used to be a
+          # hard-coded list with a comment asking the next person to keep it in
+          # step, and it drifted twice in one day — `up-jupyter` and `lint` were
+          # each added to .PHONY and not here, so each shipped as a target
+          # nobody expands, which is a target nobody notices breaking. A comment
+          # is not a mechanism.
+          #
+          # .PHONY is the right source: it is where this Makefile already
+          # declares its user-facing targets, and a target deliberately kept out
+          # of it (portal-types, which needs Node and an installed portal) is
+          # thereby excluded here too, which is the behaviour that list had.
+          targets=$(awk '/^\.PHONY:/{sub(/^\.PHONY:[[:space:]]*/,""); s=$0
+                           while (s ~ /\\$/) { sub(/\\[[:space:]]*$/,"",s); if ((getline nx) <= 0) break; s = s " " nx }
+                           print s}' Makefile | tr -s ' \t' '\n' | grep -v '^$' || true)
+          n=$(printf '%s\n' "$targets" | grep -c . || true)
+          echo "expanding $n targets derived from .PHONY: $(echo $targets)"
+          # A floor, not a specification. If .PHONY is renamed, reformatted or
+          # the parse otherwise breaks, this loop would expand nothing at all
+          # and the job would pass green having checked NOTHING — the same
+          # silent-skip failure the derivation exists to remove. The number is
+          # deliberately well below the real count so it never needs editing
+          # when a target is added or removed.
+          if [ "$n" -lt 10 ]; then
+            echo "::error::parsed only $n targets from .PHONY — the derivation is broken, not the Makefile"
+            exit 1
+          fi
+          for t in $targets; do
             echo "=== make -n $t ==="
             make -n "$t"
           done


### PR DESCRIPTION
`make-targets.yml` expands every target with `make -n`, from a **hard-coded list** carrying a comment asking the next person to keep it in step with `.PHONY`:

> Keep in step with `.PHONY` in the Makefile — a target nobody expands here is a target nobody notices breaking.

That comment was ignored twice in one day, by me, in both directions:

- **#90** added `lint` to `.PHONY` and not to the list.
- **#87** added `up-jupyter` to `.PHONY` and not to the list.

Each shipped a target no CI job would have noticed breaking — the exact thing the comment warns about, in the change that introduced the target. **A comment is not a mechanism.** This derives the list instead.

## Why `.PHONY`

It is where the Makefile already declares its user-facing targets. It also excludes the right thing for free: `portal-types` is deliberately kept out of `.PHONY` because it needs Node and an installed portal, and the old hard-coded list omitted it too. Derivation reproduces that behaviour rather than special-casing it.

The awk handles a continued (`\`) `.PHONY` line, which the current one-liner isn't but easily becomes.

## The guard matters more than the derivation

```
if [ "$n" -lt 10 ]; then
  echo "::error::parsed only $n targets from .PHONY — the derivation is broken, not the Makefile"
  exit 1
fi
```

If `.PHONY` is renamed, reformatted, or the parse otherwise breaks, the loop would expand **nothing** and the job would pass green having checked nothing — the same silent-skip class the derivation exists to remove, relocated into the mechanism. The floor is deliberately well below the real count (17), so it never needs editing when a target is added or removed.

## Verified by executing the real step body

I extracted the step's `run:` block from the YAML and ran it, rather than testing a paraphrase of it:

| Case | Result |
|---|---|
| current Makefile | `expanding 17 targets` — the same 17 the hard-coded list named |
| a new `.PHONY` entry | appears immediately: `expanding 18 …` and `=== make -n brandnew ===` |
| `.PHONY` renamed | **exit 1**, with the `::error::` line above |
| continued `.PHONY` across two lines | all 4 targets parsed |

The broken-`.PHONY` case needed a second pass. The first version exited 1 for the *wrong reason* — `set -e` killed the script at the assignment, because `grep -v` returns 1 on empty input, so the job failed **with an empty log** and my diagnostic never ran. A CI failure that explains nothing is the same defect one layer up, so the pipeline now ends `|| true` and the explicit guard does the failing and the talking.

## Note on merge order

This conflicts with #87, which adds `up-jupyter` to the hard-coded list. The resolution is trivial — this PR deletes that line entirely — but #87 should land first and I will rebase.

Deliberately **not** included: `timeout-minutes`. That is a separate change with per-job numbers chosen from observed durations, and it should not ride along with this.