### PR TITLE
ci: enforce the ci.yml / make-targets.yml concurrency coupling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ on:
 # either way. Do NOT copy the PR-side cancellation to a workflow that publishes:
 # docs-site.yml uses `cancel-in-progress: false` because a cancelled deploy put
 # the github-pages environment into `error`.
+# make-targets.yml must group and cancel by the SAME rule (different prefix, or
+# the two would share a group and cancel each other). Enforced by
+# scripts/check_workflow_concurrency.py rather than by whoever edits this next.
 concurrency:
   group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}

--- a/.github/workflows/make-targets.yml
+++ b/.github/workflows/make-targets.yml
@@ -33,7 +33,10 @@ on:
 # not. Safe either way — these jobs only build and check, so cancelling one
 # leaves nothing half-done. Kept in step with ci.yml deliberately; the two
 # together are what "main is green" means, and a verdict from one of them is
-# half an answer.
+# half an answer. **That coupling is now ENFORCED** by
+# scripts/check_workflow_concurrency.py (run by `make check`), because this
+# sentence on its own was a defect report with no owner: it named the failure
+# and nothing would have caught the drift.
 #
 # The RELEASE GATE still cannot be cancelled, but by a different mechanism than
 # before. release.yml triggers on a tag push and calls this workflow, so the

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_conformance.py
 	@$(PY) scripts/check_arch_services.py
 	@$(PY) scripts/check_docs_sidebar.py
+	@$(PY) scripts/check_workflow_concurrency.py
 	@$(PY) scripts/gen_event_kinds.py --check
 
 # Not part of `check`: these need Node and an installed portal, and `check` is

--- a/python/tests/test_check_workflow_concurrency.py
+++ b/python/tests/test_check_workflow_concurrency.py
@@ -1,0 +1,138 @@
+"""Tests for the ci.yml / make-targets.yml concurrency coupling check.
+
+The checker guards a coupling that is currently SATISFIED, which is the awkward
+case to test: a check that passes today passes whether or not it works. So
+every test here drives it with a divergence it must catch, and the real-repo
+case is the single control at the end.
+
+The divergences are the ones that actually change behaviour, not cosmetic
+differences — a check that fired on whitespace would be turned off within a
+week.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+import check_workflow_concurrency as c  # noqa: E402
+
+GOOD_CI = """\
+name: CI
+on: [push]
+
+concurrency:
+  group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+"""
+
+GOOD_MT = GOOD_CI.replace("name: CI", "name: Make targets").replace("group: ci-", "group: make-targets-")
+
+
+@pytest.fixture
+def workflows(tmp_path, monkeypatch):
+    """Write a pair of workflow files and point the checker at them."""
+    def build(ci=GOOD_CI, mt=GOOD_MT):
+        d = tmp_path / "workflows"
+        d.mkdir(exist_ok=True)
+        (d / "ci.yml").write_text(ci)
+        (d / "make-targets.yml").write_text(mt)
+        monkeypatch.setattr(c, "WORKFLOWS", d)
+        return d
+    return build
+
+
+def test_passes_when_the_two_agree(workflows, capsys):
+    workflows()
+    assert c.main() == 0
+    assert "agree" in capsys.readouterr().out
+
+
+# --- the divergences that change behaviour -----------------------------------
+
+def test_a_different_group_expression_fails(workflows, capsys):
+    # The failure this exists to catch: one workflow groups by ref on main, so
+    # a later commit cancels an earlier commit's run and that commit never gets
+    # a verdict — while the other workflow still reports green.
+    workflows(mt=GOOD_MT.replace(
+        "${{ github.event_name == 'push' && github.sha || github.ref }}",
+        "${{ github.ref }}"))
+    assert c.main() == 1
+    out = capsys.readouterr().out
+    assert "EXPRESSION differs" in out
+    assert "github.sha" in out and "github.ref" in out, "the message must show both sides"
+
+
+def test_a_different_cancel_policy_fails(workflows, capsys):
+    workflows(mt=GOOD_MT.replace(
+        "cancel-in-progress: ${{ github.event_name != 'push' }}",
+        "cancel-in-progress: true"))
+    assert c.main() == 1
+    assert "cancel-in-progress differs" in capsys.readouterr().out
+
+
+def test_an_identical_prefix_fails(workflows, capsys):
+    # The INVERSE failure, and the reason the prefix is excluded from the
+    # expression comparison rather than ignored: same prefix + same expression
+    # means one shared group, so the two workflows cancel each other and only
+    # one of them ever reports. Comparing expressions alone would pass this.
+    workflows(mt=GOOD_MT.replace("group: make-targets-", "group: ci-"))
+    assert c.main() == 1
+    assert "share a group" in capsys.readouterr().out
+
+
+# --- refusing to pass vacuously ----------------------------------------------
+
+def test_a_missing_concurrency_block_fails(workflows, capsys):
+    # A workflow that dropped its block is UNPROTECTED. Reading that as
+    # "nothing to compare, therefore fine" is the permissive default that turns
+    # every gap into a silent success.
+    workflows(mt="name: Make targets\non: [push]\n\njobs:\n  build:\n    runs-on: ubuntu-latest\n")
+    assert c.main() == 1
+    assert "no top-level `concurrency:` block" in capsys.readouterr().out
+
+
+def test_a_job_level_block_is_not_mistaken_for_the_workflows(workflows, capsys):
+    # `concurrency:` is legal inside a job too. An indented one must not be
+    # picked up as the workflow's, or a file with no workflow-level block would
+    # be compared against a job's and could pass while unprotected.
+    workflows(mt="""\
+name: Make targets
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: make-targets-${{ github.event_name == 'push' && github.sha || github.ref }}
+      cancel-in-progress: ${{ github.event_name != 'push' }}
+""")
+    assert c.main() == 1
+    assert "no top-level `concurrency:` block" in capsys.readouterr().out
+
+
+def test_a_constant_group_fails(workflows, capsys):
+    # A constant group puts every run of that workflow in one bucket, so each
+    # push cancels the last — including main commits that must each get a verdict.
+    workflows(mt=GOOD_MT.replace(
+        "group: make-targets-${{ github.event_name == 'push' && github.sha || github.ref }}",
+        "group: make-targets"))
+    assert c.main() == 1
+    assert "constant" in capsys.readouterr().out
+
+
+def test_a_missing_file_fails(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(c, "WORKFLOWS", tmp_path / "nowhere")
+    assert c.main() == 1
+    assert "cannot read" in capsys.readouterr().out
+
+
+# --- the control -------------------------------------------------------------
+
+def test_the_real_repo_passes_its_own_check(capsys):
+    assert c.main() == 0, capsys.readouterr().out

--- a/scripts/check_workflow_concurrency.py
+++ b/scripts/check_workflow_concurrency.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""ci.yml and make-targets.yml must group and cancel by the same rule.
+
+WHY THIS EXISTS. Together these two workflows are what "main is green" means —
+a verdict from one of them is half an answer. Their `concurrency:` blocks decide
+which runs supersede which: a PR ref's in-flight run is cancelled when the ref
+moves, while every main commit gets its own group so every commit gets a
+verdict. If one workflow drifts, it cancels a run the other protects, and the
+release gate's behaviour changes with nothing failing to say so.
+
+The coupling is currently satisfied and is stated only in a comment —
+"Kept in step with ci.yml deliberately". A comment is not enforcement, and
+neither is a test that names the right failure and measures next to it: the
+docs-sidebar checker kept a copied regex under a comment AND a test asserting
+that the string "DOC_RE" still appeared in the file it was copied from, which
+stayed green through any edit to the pattern itself.
+
+WHY A CHECKER RATHER THAN DERIVING OR COLLAPSING. Those are the better fixes
+where they are available, and here neither is:
+
+  * DERIVE is impossible — GitHub Actions has no cross-file include, and YAML
+    anchors do not span documents, so neither expression can be computed from
+    the other.
+  * COLLAPSE is impossible — every workflow file must carry its own
+    `concurrency:` block. The platform forces this one question to be asked
+    twice.
+
+So this is the residual case: two genuinely independent artifacts that must
+merely agree. That is what a checker is for, and reaching for one when derive
+or collapse was available would be the mistake — a checker is a second thing to
+maintain and it only reports drift after the fact.
+
+WHAT IS COMPARED. The `${{ … }}` expression of `group:` (the literal prefix
+before it MUST differ, or the two workflows would share a group and cancel each
+other) and the whole of `cancel-in-progress:`.
+
+Usage:
+    check_workflow_concurrency.py     exit non-zero describing any divergence
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOWS = ROOT / ".github" / "workflows"
+COUPLED = ("ci.yml", "make-targets.yml")
+
+# A top-level `concurrency:` block and its two keys. Anchored at column 0 so a
+# job-level concurrency block (indented) is never mistaken for the workflow's.
+_BLOCK = re.compile(
+    r"^concurrency:\s*$\n"
+    r"(?P<body>(?:^[ \t]+.*$\n?)+)",
+    re.M,
+)
+_GROUP = re.compile(r"^\s*group:\s*(?P<value>.+?)\s*$", re.M)
+_CANCEL = re.compile(r"^\s*cancel-in-progress:\s*(?P<value>.+?)\s*$", re.M)
+# The prefix that must differ, and the expression that must not.
+_EXPR = re.compile(r"\$\{\{.*\}\}")
+
+
+class ConcurrencyUnreadable(RuntimeError):
+    """A workflow's concurrency block is absent or unparseable."""
+
+
+def read_concurrency(path):
+    """Return (group_prefix, group_expression, cancel_in_progress).
+
+    Raises rather than returning a default: a workflow whose block cannot be
+    read must fail the check, not silently agree with everything.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConcurrencyUnreadable(f"cannot read {path}: {exc}") from exc
+    block = _BLOCK.search(source)
+    if not block:
+        raise ConcurrencyUnreadable(
+            f"{path.name} has no top-level `concurrency:` block — the two workflows "
+            "can no longer be compared, and one of them is now unprotected")
+    body = block.group("body")
+    group = _GROUP.search(body)
+    cancel = _CANCEL.search(body)
+    if not group or not cancel:
+        raise ConcurrencyUnreadable(
+            f"{path.name}'s concurrency block is missing `group:` or `cancel-in-progress:`")
+    expr = _EXPR.search(group.group("value"))
+    if not expr:
+        raise ConcurrencyUnreadable(
+            f"{path.name}'s concurrency group is a constant ({group.group('value')!r}); "
+            "it must be an expression, or every run of that workflow shares one group")
+    prefix = group.group("value")[: expr.start()]
+    return prefix, expr.group(0), cancel.group("value")
+
+
+def main():
+    try:
+        read = {name: read_concurrency(WORKFLOWS / name) for name in COUPLED}
+    except ConcurrencyUnreadable as exc:
+        print(f"check_workflow_concurrency: {exc}")
+        return 1
+
+    a, b = COUPLED
+    prefix_a, expr_a, cancel_a = read[a]
+    prefix_b, expr_b, cancel_b = read[b]
+    problems = []
+
+    if expr_a != expr_b:
+        problems.append(
+            f"concurrency group EXPRESSION differs — one workflow will cancel a run the "
+            f"other protects:\n    {a}: {expr_a}\n    {b}: {expr_b}")
+    if cancel_a != cancel_b:
+        problems.append(
+            f"cancel-in-progress differs:\n    {a}: {cancel_a}\n    {b}: {cancel_b}")
+    # The inverse invariant, and the reason the prefix is excluded above rather
+    # than ignored: identical prefixes would put both workflows in ONE group, so
+    # each new run would cancel the other's — the opposite failure, and one that
+    # comparing only the expressions would happily wave through.
+    if prefix_a.strip() == prefix_b.strip():
+        problems.append(
+            f"both workflows use the concurrency group prefix {prefix_a.strip()!r}; they "
+            "would share a group and cancel each other's runs")
+
+    if problems:
+        print("check_workflow_concurrency: " + "\n\n".join(problems))
+        print(f"\n{a} and {b} together are what \"main is green\" means; a verdict from "
+              "one of them is half an answer.")
+        return 1
+
+    print(f"check_workflow_concurrency: {a} and {b} agree "
+          f"(group {expr_a}, cancel-in-progress {cancel_a})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The last real hit from the "keep in sync" sweep. `make-targets.yml` carried:

> Kept in step with ci.yml deliberately; the two together are what "main is green" means, and a verdict from one of them is half an answer.

A correct diagnosis, stated in prose, with nothing enforcing it.

## Why a checker, when derive and collapse are better

Running it through the selection rule rather than reaching for the familiar tool:

- **Derive** — unavailable. GitHub Actions has no cross-file include and YAML anchors don't span documents, so neither expression can be computed from the other.
- **Collapse** — unavailable. Every workflow file must carry its own `concurrency:` block. The platform forces this one question to be asked twice.
- **Check** — the residual case: two genuinely independent artifacts that must merely agree.

Reaching for a checker when derive was available is the failure mode worth avoiding; this is the case where it's the honest answer. (The sweep's other hit, #100, was a derive case and got derived.)

## What it compares, and the inverse invariant

The `${{ … }}` expression of `group:`, and the whole of `cancel-in-progress:`. The literal **prefix** is deliberately excluded from that comparison and then asserted to *differ* — identical prefixes would put both workflows in one group so each run cancels the other's, which is the opposite failure and one that comparing expressions alone waves straight through.

It also refuses to pass vacuously: an absent file, a missing top-level block, a **job-level** `concurrency:` mistaken for the workflow's, or a constant group all fail with the reason named. A workflow that dropped its block is *unprotected*, and reading that as "nothing to compare, therefore fine" is the permissive default that turns every gap into a silent success.

## Verification

- `make check` — new line, everything else unchanged. `ruff` clean.
- **9 tests**, every one driving a divergence the checker must catch, plus the real repo as the single control. A check guarding a coupling that is *currently satisfied* passes whether or not it works, so the tests can't rely on the happy path.
- **Mutation-checked with a passing control**: changing `make-targets.yml` to group by `github.ref` fails with both sides printed. First attempt at that mutation **did not land** — shell escaping mangled the `${{ }}` — and `grep -c` said `0` while the checker still said "agree". Re-run through a Python heredoc with `git diff --numstat` confirming the edit before believing the result.

The comments in both workflows now point at the enforcement instead of asking the next editor to remember.