### PR TITLE
deps: pin nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   postcss: '>=8.5.18'
   js-yaml: '>=4.3.1 <5'
+  nanoid: '>=3.3.17 <4'
 
 importers:
 
@@ -2570,8 +2571,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6160,7 +6161,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   neotraverse@0.6.18: {}
 
@@ -6287,7 +6288,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,14 @@ onlyBuiltDependencies:
 #                      Bounded `<5` deliberately: a bare `>=4.3.1` resolves to
 #                      5.2.3 and hands Astro's remark chain a different major.
 #                      The fix is a patch, so stay in the major that shipped it.
+#   nanoid   < 3.3.17  GHSA-2v37-7h3g-55p8, a custom generator loops forever
+#                      when `size` is zero. Arrives under postcss, which is
+#                      itself transitive. Bounded `<4` for the js-yaml reason
+#                      and then some: nanoid is at 6.x and went ESM-only after
+#                      3.x, so a bare `>=3.3.17` would hand postcss a package it
+#                      cannot require(). The fix shipped as 3.3.17, in the major
+#                      that needs it.
 overrides:
   postcss: ">=8.5.18"
   js-yaml: ">=4.3.1 <5"
+  nanoid: ">=3.3.17 <4"


### PR DESCRIPTION
Closes the one open Dependabot alert.

| | |
|---|---|
| **GHSA-2v37-7h3g-55p8** | `nanoid`: a custom generator loops indefinitely when `size` is zero |
| Severity | high (CVSS 5.9) |
| Range | `< 3.3.17` → patched in `3.3.17` |
| Present as | `3.3.16`, under `postcss@8.5.25` |

## Why an override rather than a bump

`nanoid` is transitive — nothing in this repo depends on it directly; it arrives under `postcss`, which is itself transitive through Astro/Starlight's chain. There is no manifest to bump, so the workspace `overrides` block is the only lever. That block already exists and carries the same reasoning for `postcss` and `js-yaml`.

## The bound is load-bearing

`nanoid` 3.x is at **3.3.18**; the package overall is at **6.0.1** and went **ESM-only after 3.x**. A bare `>=3.3.17` would resolve to 6.x and hand `postcss` a package it cannot `require()`. `>=3.3.17 <4` stays in the major that shipped the fix — the same trap `js-yaml` is bounded against, and the comment says so.

Resolves to **3.3.18**.

## Verified, not assumed

- **One package moved.** The entire lockfile diff is `nanoid@3.3.16` → `3.3.18` and the override line. Nothing else re-resolved.
- **Both consumers build**: portal (Vite) and the docs site (Astro, 75 pages).
- **`portal/dist` is unchanged** — it is committed for `go:embed` and CI fails on a stale copy. `nanoid` is build-time only, so the bundle is byte-identical; a fresh build produces no diff.
- Portal 248 tests, `svelte-check` 0 errors, `make check`, `go build`, Python 464 tests at 92.89% — all clean.

## State of the alert page

21 fixed, 1 dismissed, this was the only one open. The dismissed one is left as-is — reversing someone's dismissal is a decision, not housekeeping.
