### PR TITLE
xmla: Phase 0 answered — the client's call after routing, measured

### DIFF
--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -318,17 +318,102 @@ and `TryResolvePbiWorkspace` derives two values nothing in the reply carries —
 Splitting the URI and indexing absent segments fits every observation, but no
 run has yet varied path depth, so it is untested.
 
+### Screen 7 — RUN: **PHASE 0 IS ANSWERED.** The client advances past routing
+
+A ladder of `capacityUri` path depths, plus a host-label arm. Depth was the
+variable the failure mode pointed at — `IndexOutOfRange` means indexing past
+the end, so the thing to sweep is length, not URL format.
+
+| rung | outcome |
+| --- | --- |
+| `L0` — 0 segments | `IndexOutOfRangeException`, 1 request |
+| `L1`–`L5` — 1 to 5 segments | **ADVANCED**, 7 requests |
+| `H5`, `H7` — 5 and 7 host labels | identical to `L0` |
+
+**One path segment is enough**, and the host-label hypothesis is dead. That arm
+earned its two containers: screen 6's hosts had 3 and 4 dot-separated labels,
+so a parser wanting label 5 would have fitted every observation to that point.
+Retiring a live alternative is worth as much as confirming the leading one.
+
+With a segment present, `TryResolvePbiWorkspace` leaves the stack entirely, the
+`PbiPremiumAuthenticationHandle` **constructs** — `workspaceObjectId` and
+`capacityObjectId` both derived — and the client makes a call nobody in this
+project had ever seen:
+
+```
+GET  /powerbi/databases/v201606/workspaces?PreferClientRouting=true   (once)
+POST /metadata/v201606/generateastoken?PreferClientRouting=true       (per connection)
+POST /metadata/v201606/generateastoken
+```
+
+throwing at `PbiPremiumAuthenticationHandle::GetMwcToken` on the stub's reply.
+Note the **500 is ours** — the capture stub answers every POST with a SOAP
+fault — so that is the harness refusing, not the client failing. Note also that
+routing is resolved ONCE for the process while the token is fetched PER
+CONNECTION: the two have different cache lifetimes.
+
+**A harness regression, and what it cost.** Restructuring the loop for
+per-shape runs narrowed each run's record to `(method, path)`, dropping the
+body print the original had. So the `generateastoken` body — the first sight of
+anything past routing, and the entire point of getting there — was captured and
+discarded, costing a full extra run to recover. The record now keeps whole
+requests and prints headers and body in full, with `authorization` and `cookie`
+reduced to a length.
+
+### Screen 8 — RUN: the token request's contract, and the segment rule
+
+Three rungs with DISTINCT GUIDs per path position, so the value the client
+echoes names the index it read.
+
+| rung | segments offered | `capacityObjectId` sent |
+| --- | --- | --- |
+| `L1` | GUID-1 | `11111111-…-111111111111/` |
+| `L2` | GUID-1, GUID-2 | `11111111-…-111111111111/` |
+| `L5` | GUID-1 … GUID-5 | `11111111-…-111111111111/` |
+
+Always the FIRST segment, at every depth, retaining a TRAILING SLASH.
+
+**Inferred, but from a fingerprint rather than a fit.** That is precisely
+.NET's `Uri.Segments`, which yields `["/", "seg1/", "seg2/", …]` with each
+segment carrying its slash — so `capacityObjectId = new Uri(capacityUri)
+.Segments[1]`. The same rule explains `L0` without adjustment: an empty path
+gives `Segments` length 1, and `Segments[1]` throws `IndexOutOfRangeException`.
+One rule, four observations, no free parameters.
+
+The request the emulator must now answer:
+
+```
+POST /metadata/v201606/generateastoken[?PreferClientRouting=true]
+content-type: application/json        user-agent: ASClient/.NET-Core
+authorization: Bearer <token from the connection string>
+
+{"applyAuxiliaryPermission":false,"auxiliaryPermissionOwner":null,
+ "bypassBuildPermission":false,
+ "capacityObjectId":"<first path segment of capacityUri, trailing slash>",
+ "datasetName":null,"intendedUsage":0,"sourceCapacityObjectId":null,
+ "workspaceObjectId":"<the id sent in Workspace201606>"}
+```
+
+`workspaceObjectId` is echoed from the routing reply, so the emulator controls
+it. `datasetName` is null because the probe's Data Source carries no
+`Initial Catalog`; that is where a database name would appear.
+
 ### Where this leaves the search
 
-A **path-segment ladder** — `capacityUri` with 1, 2, 3, 4, 5 segments — to find
-how many the parser indexes. The failure mode dictates the experiment rather
-than a guess at a URL format: `IndexOutOfRange` means indexing past the end, so
-the variable to sweep is length.
+Phase 0's question — "what does the client ask after routing?" — is **answered**.
+The roadmap's largest unknown is now a recorded request with a known body.
 
-`pbiDedicatedRolloutFqdn` is the strategically important one. It is the host
-the client dials after routing, which makes it the hook for steering ADOMD.NET
-back to the emulator — the point at which Phase 0 ends and Phase 1 has a
-client to talk to.
+Next is `generateastoken`'s RESPONSE contract, and it should be read off the
+assembly rather than screened: `GetMwcToken` deserialises into a declared
+`[DataContract]` exactly as the routing reply did, and reading it once beat
+four screens of guessing last time. "MWC" is the token the client carries into
+the XMLA calls themselves, which is the boundary where Phase 0 ends and
+Phase 1 has a client to talk to.
+
+`pbiDedicatedRolloutFqdn` — the other value `TryResolvePbiWorkspace` derives —
+remains the hook for steering the client's later calls at a host of our
+choosing. It has not been exercised: every request so far has come back to the
+listener named in the Data Source.
 
 ### Original framing, kept because the reasoning still holds
 

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -161,6 +161,58 @@ cheap to overturn — the discriminator was already written down, so screen 3 on
 had to run it. A conclusion published without its discriminator would have been
 built on instead.
 
+### Screen 4 — RUN: the body IS read, and the serializer names itself
+
+Varied status, headers and emptiness; left the JSON alone. **The pairing guard
+fired** — `NOT PAIRED: 4 shape(s) served, 3 powerbi case(s) reported` — so the
+per-shape labels in that run are misaligned and were not read. Recording what
+is *directly observed* and what is *inferred*, separately, because the guard
+exists precisely to stop the second being published as the first.
+
+**Observed.** Two connections returned
+
+```
+SerializationException :: Expecting element 'root' from namespace ''..
+Encountered 'None' with name '', namespace ''.
+```
+
+one returned the familiar not-found, and four responses were served to three
+connections.
+
+**What that error names, and it is the biggest find so far.** "element 'root'
+from namespace ''" is not XML being demanded — it is
+**`DataContractJsonSerializer`**, which deserialises JSON by mapping it onto an
+XML infoset whose root element is literally called `root`. An empty body has no
+root, hence this exact message.
+
+Two consequences:
+
+1. **The body IS consulted.** The worry after screen 3 — that every shape was
+   varying something the client never reads — is answered: an empty body fails
+   *at deserialisation*, so the populated ones were deserialised and then found
+   wanting. Screens 2–3 were measuring a real variable after all.
+2. **The matching rule is a `[DataContract]`, not a guess.** With
+   `DataContractJsonSerializer`, member names come from `[DataMember(Name=…)]`
+   on a concrete type inside the shipped assembly. That is a fact **readable
+   from `Microsoft.AnalysisServices.AdomdClient`** rather than searchable by
+   trial — which makes the next step inspection, not another screen.
+
+**Inferred, and flagged as such.** Shapes rotate per REQUEST, so four requests
+across three connections means one connection made two — consistent with the
+`307` being followed, which would also explain a redirect-following connection
+receiving the next shape's body. That reconstruction fits every observed
+message, but it is arithmetic on a counter, not a captured sequence. **The
+harness printed the request log and the operator truncated it** when reading
+the output; re-run capturing full stdout before treating the redirect-follow as
+established.
+
+### Where this leaves the search
+
+Off screens entirely, for now. Reading the `DataMember` names off the ADOMD.NET
+assembly converts the remaining unknown from "which of infinitely many field
+spellings" into "what does this type declare" — the same move that turned
+`e2e/xmla` from speculation into measurement in the first place.
+
 ### The next experiment, now one edit and ~5 minutes### The next experiment, now one edit and ~5 minutes
 
 Vary a single field at a time against the same harness and read the error. The

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -206,19 +206,83 @@ harness printed the request log and the operator truncated it** when reading
 the output; re-run capturing full stdout before treating the redirect-follow as
 established.
 
+### The assembly read — DONE: the contract, no longer a guess
+
+Reflecting over `Microsoft.AnalysisServices.AdomdClient` **19.84.1.0** (429
+types, inspected in `mcr.microsoft.com/dotnet/sdk:8.0`) yields the reply's
+declared shape:
+
+```
+PbiPremiumAuthenticationHandle+Workspace201606
+    id · name · type · capacitySku · capacityUri        [DataMember] ×5
+WorkspaceType201606            = User | Group | Folder
+WorkspaceCapacitySkuType201606 = Shared | Premium
+ResolvePbiWorkspaceErrorReason = None | WorkspaceNotFound
+                               | WorkspaceNotOnPbiPremium | WorkspaceNameDuplicated
+```
+
+Two things follow that no screen could have reached:
+
+1. **No type in the assembly holds a `Workspace201606` collection.** The
+   payload is a **bare array**, not an enveloped list — so every enveloped
+   shape in screens 2–4 was answering a question the client never asks.
+   Screen 2's bare array failed for an unrelated reason, which is precisely
+   how it produced a wrong conclusion that survived a round.
+2. **Three of the five members were never sent.** Screens 1–4 sent `name` and
+   `id`; `type`, `capacitySku` and `capacityUri` deserialised null every time.
+   No amount of re-spelling could have helped — the names were already right
+   and the *set* was short.
+
+The error enum is also a free discriminator: a reply that reaches the workspace
+but fails its premium check reports `WorkspaceNotOnPbiPremium`, distinct from
+`WorkspaceNotFound`. Which error appears is therefore progress information, not
+just failure.
+
+### Screen 5 — RUN: routing is answered, and the failure moved downstream
+
+Shape A — bare array, all five members, `type=Group`, `capacitySku=Premium`,
+`capacityUri=https://<host>/`.
+
+**Observed.**
+
+- **One** routing request in the answered run, against **six** in the refusing
+  control (two per connection: with `PreferClientRouting=true`, then without).
+  The retry a rejected reply provokes did not happen.
+- All three `powerbi://` connections reported
+  `IndexOutOfRangeException :: Index was outside the bounds of the array.`
+- Neither error that pinned every earlier screen appeared: no
+  `SerializationException`, no `The specified Power BI workspace ('ws') is not
+  found`.
+- The listener ran `serve_forever` for the whole probe and was not shut down
+  between connections, so the two missing requests are the client's choice and
+  not the harness closing.
+- The probe's `catch` cannot raise this itself — its only indexing is
+  `e.Message.Split('\n')[0]`, and `Split` always yields index 0 — so the throw
+  is inside `AdomdConnection.Open()`.
+
+**Inferred, and flagged as such.** The reply deserialised and the workspace
+matched: both diagnostic errors are gone and the client stopped re-asking.
+Connections 2 and 3 issued no request at all, which fits a process-wide cache —
+consistent with the `WorkspaceResolver.Initialize` / `friendlyNameMap` /
+`personalWorkspace` members the same assembly read turned up, though nothing
+here observes the cache directly. The surviving failure is most plausibly
+`capacityUri` being parsed into a cluster host (the assembly carries
+`ASAzureUtility+PowerBIClusterResolutionResult` with `FixedClusterUri` and
+`DynamicClusterUri`), but that is **untested**.
+
+**Shapes B and C were never served, so they remain untested.** This is a real
+limit of the screen design, now recorded in the harness itself: rotating one
+shape per request only screens three hypotheses *while shapes fail*. The first
+shape the client accepts ends the request stream. A screen is a tool for
+failure; past the first success the harness must vary shapes across runs.
+
 ### Where this leaves the search
 
-Off screens entirely, for now. Reading the `DataMember` names off the ADOMD.NET
-assembly converts the remaining unknown from "which of infinitely many field
-spellings" into "what does this type declare" — the same move that turned
-`e2e/xmla` from speculation into measurement in the first place.
-
-### The next experiment, now one edit and ~5 minutes### The next experiment, now one edit and ~5 minutes
-
-Vary a single field at a time against the same harness and read the error. The
-client's message names the workspace it wanted, so a matching reply advances
-past routing for the first time — and that is the point at which
-`[MS-SSAS-T]`'s real size becomes observable rather than estimated.
+Routing is no longer the frontier. The next unknown is one layer down — what
+the client does with `capacityUri`, and which request it would make against a
+cluster host it could parse. That is again best answered by varying a single
+field against the same harness, with the `IndexOutOfRangeException` as the
+signal to clear.
 
 ### Original framing, kept because the reasoning still holds
 

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -105,6 +105,44 @@ the workspace name against**. The hypothesis sent `name`, `id`,
 and a suite that asserted it would pass by confirming its own guess. Both
 findings are printed observations; the next iteration turns one into a test.
 
+### Screen 2 — RUN: the envelope is required, the field spelling is not the variable
+
+Three candidate shapes, one per connection, in a single run. The single-shape
+run is the **control**: all three connection types reported identically there,
+so any difference here is attributable to the shape rather than to the Data
+Source form.
+
+| Shape | Client's answer |
+|---|---|
+| bare array (no `value`) | `ArgumentNullException :: Value cannot be null. (Parameter 'value')` |
+| `value` envelope + 10 field spellings | `…workspace ('ws') is not found` |
+| PascalCase (`Value`/`Name`/…) | `…workspace ('ws') is not found` |
+
+**What this establishes.** Removing the envelope changes the failure from a
+lookup to a *null argument*, so the client requires it — and PascalCase
+`Value` was accepted where a bare array was not, which says the deserialiser
+is case-insensitive on the envelope. With the envelope present the client
+parses, searches, and reports not-found against **ten** spellings at once
+(`name`, `workspaceName`, `displayName`, `folderName`, `id`, `objectId`,
+`capacityObjectId`, `clusterUri`, `fixedClusterUri`, `backendUri`). Field
+spelling is therefore **not** the remaining variable.
+
+**What it does NOT establish, stated because the correlation is tempting.**
+`ArgumentNullException (Parameter 'value')` is the standard .NET shape for
+`ArgumentNullException(nameof(value))` and may name a *method parameter*, not
+our JSON key. The correlation is suggestive — the only shape lacking a `value`
+key produced the only null error — but causation is unproven, and the cheap
+discriminator is `{"value": null}` versus `{"value": []}` versus a bare array.
+Nobody should build on the envelope claim without running that.
+
+**Where this leaves the next hypothesis: structural, not cosmetic.** The client
+matches the Data Source's workspace name against something that is not any
+plain string field on the workspace object. Candidates worth one run each:
+a nested object (the name under a `properties`/`workspace` sub-object), a
+different top-level key than `value`, or a match against something derived
+rather than carried — in which case no field spelling would ever have worked
+and the ten-spelling result is the evidence for it.
+
 ### The next experiment, now one edit and ~5 minutes
 
 Vary a single field at a time against the same harness and read the error. The

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -276,13 +276,59 @@ shape per request only screens three hypotheses *while shapes fail*. The first
 shape the client accepts ends the request stream. A screen is a tool for
 failure; past the first success the harness must vary shapes across runs.
 
+### Screen 6 — RUN: the frames name the parser, and `capacityUri` is the field
+
+Two changes made this screen possible, both forced by screen 5 succeeding:
+
+- **One probe run per shape.** An accepted reply is cached for the life of the
+  client process, so the 2nd and 3rd shapes of a rotating screen are never
+  requested. The phase-0 loop now restarts the container per shape.
+- **The probe prints the exception's frames.** `IndexOutOfRangeException`'s
+  message names nothing. Its stack names the method. One run collects that;
+  screening candidate URI formats costs one run per guess.
+
+**Observed — the throw moved one frame shallower.** In the refusing control the
+stack ends inside the resolver's HTTP call, with an inner
+`WebException :: (404) Not Found` under
+`ConnectivityHelper.ExecuteJsonBasedHttpRequestImpl(…, DataContractJsonSerializer
+responseSerializer, …)` — which also confirms screen 4's serializer reading from
+a frame rather than from an error string. With an accepted shape,
+`TryResolveWorkspaceWithWorkspaceResolver` is **absent from the stack** and the
+throw is in its caller, `PbiPremiumAuthenticationHandle.TryResolvePbiWorkspace`.
+The resolver returned successfully. That is screen 5's inference re-derived
+from the frames instead of from request counts.
+
+**Observed — the screen.**
+
+| shape | `capacityUri` | outcome |
+| --- | --- | --- |
+| A | `https://<listener>/` | `IndexOutOfRangeException` |
+| B | `""` | `InvalidDataException :: Internal error: the Power BI premium workspace's capacity uri is null or empty!` |
+| C | `https://wabi-…redirect.analysis.windows.net/` | same as A |
+| D | `host.docker.internal:18446`, no scheme | same as A |
+
+B was the built-in discriminator and it fired: the field is read, validated
+non-empty, then parsed, with the client's own text naming it. **`capacityUri`
+is implicated.** C and D rule out the two obvious candidates — not the scheme,
+and not that the host must resemble a real cluster.
+
+**Inferred, and flagged as such.** What A, C and D share is an **empty path**,
+and `TryResolvePbiWorkspace` derives two values nothing in the reply carries —
+`pbiDedicatedRolloutFqdn` and `capacityObjectId` (both `out` in its signature).
+Splitting the URI and indexing absent segments fits every observation, but no
+run has yet varied path depth, so it is untested.
+
 ### Where this leaves the search
 
-Routing is no longer the frontier. The next unknown is one layer down — what
-the client does with `capacityUri`, and which request it would make against a
-cluster host it could parse. That is again best answered by varying a single
-field against the same harness, with the `IndexOutOfRangeException` as the
-signal to clear.
+A **path-segment ladder** — `capacityUri` with 1, 2, 3, 4, 5 segments — to find
+how many the parser indexes. The failure mode dictates the experiment rather
+than a guess at a URL format: `IndexOutOfRange` means indexing past the end, so
+the variable to sweep is length.
+
+`pbiDedicatedRolloutFqdn` is the strategically important one. It is the host
+the client dials after routing, which makes it the hook for steering ADOMD.NET
+back to the emulator — the point at which Phase 0 ends and Phase 1 has a
+client to talk to.
 
 ### Original framing, kept because the reasoning still holds
 

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -118,32 +118,50 @@ Source form.
 | `value` envelope + 10 field spellings | `…workspace ('ws') is not found` |
 | PascalCase (`Value`/`Name`/…) | `…workspace ('ws') is not found` |
 
-**What this establishes.** Removing the envelope changes the failure from a
-lookup to a *null argument*, so the client requires it — and PascalCase
-`Value` was accepted where a bare array was not, which says the deserialiser
-is case-insensitive on the envelope. With the envelope present the client
-parses, searches, and reports not-found against **ten** spellings at once
-(`name`, `workspaceName`, `displayName`, `folderName`, `id`, `objectId`,
-`capacityObjectId`, `clusterUri`, `fixedClusterUri`, `backendUri`). Field
-spelling is therefore **not** the remaining variable.
+**What this appeared to establish — and screen 3 DISPROVED it.** The reading at
+the time was "removing the envelope changes the failure to a null argument, so
+the client requires it," with PascalCase `Value` seeming to confirm a
+case-insensitive envelope. That was one correlation with one data point, and it
+was wrong. Left here rather than deleted because the correction is the finding.
 
-**What it does NOT establish, stated because the correlation is tempting.**
-`ArgumentNullException (Parameter 'value')` is the standard .NET shape for
-`ArgumentNullException(nameof(value))` and may name a *method parameter*, not
-our JSON key. The correlation is suggestive — the only shape lacking a `value`
-key produced the only null error — but causation is unproven, and the cheap
-discriminator is `{"value": null}` versus `{"value": []}` versus a bare array.
-Nobody should build on the envelope claim without running that.
+### Screen 3 — RUN: the body is not the variable at all
 
-**Where this leaves the next hypothesis: structural, not cosmetic.** The client
-matches the Data Source's workspace name against something that is not any
-plain string field on the workspace object. Candidates worth one run each:
-a nested object (the name under a `properties`/`workspace` sub-object), a
-different top-level key than `value`, or a match against something derived
-rather than carried — in which case no field spelling would ever have worked
-and the ten-spelling result is the evidence for it.
+Designed so two slots would settle screen 2's `value` ambiguity from opposite
+sides. They settled it against screen 2's conclusion.
 
-### The next experiment, now one edit and ~5 minutes
+| Shape | Client's answer |
+|---|---|
+| A `{"value": []}` — key present, list empty | `…workspace ('ws') is not found` |
+| B name nested under `properties`/`workspace` | `…workspace ('ws') is not found` |
+| C `{"workspaces":[…]}` — **no `value` key at all** | `…workspace ('ws') is not found` |
+
+**C is the disproof.** Screen 2's bare array also lacked `value` and produced
+`ArgumentNullException`; C lacks it too and produces the ordinary not-found. Two
+shapes missing the same key, two different answers — so **the missing key was
+never the cause.** The variable in screen 2 was the top-level JSON *type*: an
+array where an object was expected deserialises to null, and the
+`ArgumentNullException` was about that, exactly as the "may name a method
+parameter, not our JSON key" caveat warned.
+
+**What is actually established, after three screens.** Every top-level JSON
+*object* tried so far returns the identical not-found, across: `value` present
+or absent, empty or populated, ten field spellings, PascalCase, and nesting.
+Only changing the top-level type changed anything. **The body's content does not
+determine this outcome.**
+
+That is a stronger negative than any of the individual shapes, and it redirects
+the search off the body entirely. Remaining candidates are things no body edit
+can reach: the response's `Content-Type`, its status code, a header the client
+requires, or a second request it makes and we have not yet answered. The next
+screen should vary one of those and leave the JSON alone.
+
+**Method note worth keeping.** Screen 2's conclusion survived exactly one round.
+It was a single correlation stated with a caveat, and the caveat is what made it
+cheap to overturn — the discriminator was already written down, so screen 3 only
+had to run it. A conclusion published without its discriminator would have been
+built on instead.
+
+### The next experiment, now one edit and ~5 minutes### The next experiment, now one edit and ~5 minutes
 
 Vary a single field at a time against the same harness and read the error. The
 client's message names the workspace it wanted, so a matching reply advances

--- a/e2e/xmla/probe/Program.cs
+++ b/e2e/xmla/probe/Program.cs
@@ -54,6 +54,29 @@ class Probe {
             } catch (Exception e) {
                 var first = e.Message.Split('\n')[0].Trim();
                 Console.WriteLine($"CASE {label} :: {e.GetType().Name} :: {first}");
+                // The exception carries the name of the method that threw. That
+                // is strictly more than the message says and costs one run to
+                // collect — where screening candidate payloads costs one run
+                // PER GUESS. Screen 5 ended on an IndexOutOfRangeException whose
+                // message ("Index was outside the bounds of the array") names
+                // nothing at all; the stack names the parser.
+                //
+                // Skipped for NotSupportedException: the Windows-only Data
+                // Source forms are settled, and frames for them are noise.
+                if (!(e is NotSupportedException)) {
+                    for (var x = e; x != null; x = x.InnerException) {
+                        if (!ReferenceEquals(x, e))
+                            Console.WriteLine($"  INNER {label} :: {x.GetType().Name} :: " +
+                                $"{x.Message.Split('\n')[0].Trim()}");
+                        if (x.TargetSite != null)
+                            Console.WriteLine($"  THREW {label} :: " +
+                                $"{x.TargetSite.DeclaringType}::{x.TargetSite.Name}");
+                        foreach (var frame in (x.StackTrace ?? "").Split('\n')) {
+                            var f = frame.Trim();
+                            if (f.Length > 0) Console.WriteLine($"  FRAME {label} :: {f}");
+                        }
+                    }
+                }
             }
         }
         return 0;

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -137,25 +137,33 @@ WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 # is a SCREEN, not a guess. If one advances, the next run narrows it; if none
 # does, four hypotheses die at once.
 def _shapes(host):
+    """SCREEN 3 — STRUCTURAL. Screen 2 killed field spelling (ten spellings, all
+    not-found) and left three structural hypotheses. Two of these slots also
+    settle the ambiguity screen 2 recorded but could not resolve: whether
+    `ArgumentNullException (Parameter 'value')` named OUR JSON key or a .NET
+    method parameter. A and C attack that from opposite sides — A supplies the
+    key with nothing in it, C supplies a well-formed object with no such key.
+
+      A `{"value": []}`      -> "not found" means the key IS ours and an empty
+                               list is handled; a null error means it is not.
+      B nested properties    -> is the name carried under a sub-object rather
+                               than on the workspace itself?
+      C no `value` key at all-> reproduces the null error from a different
+                               shape than a bare array, which is the second
+                               data point A cannot provide alone.
+    """
     cluster = f"https://{host}/"
-    rich = {                       # every plausible spelling, at once
-        "name": WORKSPACE, "workspaceName": WORKSPACE, "displayName": WORKSPACE,
-        "folderName": WORKSPACE, "id": "00000000-0000-0000-0000-000000000001",
-        "objectId": "00000000-0000-0000-0000-000000000001",
-        "capacityObjectId": "00000000-0000-0000-0000-000000000002",
-        "clusterUri": cluster, "fixedClusterUri": cluster, "backendUri": cluster,
-    }
     return [
-        # 1. BARE ARRAY — is the `value` envelope wrong rather than the fields?
-        ("bare-array", [dict(rich)]),
-        # 2. value ENVELOPE + every field spelling — isolates envelope from field.
-        ("value-envelope-rich", {"@odata.context": f"{cluster}powerbi/databases/v201606/$metadata#workspaces",
-                                 "value": [dict(rich)]}),
-        # 3. PascalCase — .NET deserialisers frequently bind these; if the
-        #    client is case-sensitive this is the difference.
-        ("pascal-case", {"Value": [{"Name": WORKSPACE, "Id": rich["id"],
-                                    "CapacityObjectId": rich["capacityObjectId"],
-                                    "ClusterUri": cluster, "FixedClusterUri": cluster}]}),
+        ("A-empty-value", {"@odata.context": f"{cluster}$metadata#workspaces", "value": []}),
+        ("B-nested-properties", {"value": [{
+            "properties": {"name": WORKSPACE, "displayName": WORKSPACE,
+                           "clusterUri": cluster},
+            "name": WORKSPACE,
+            "workspace": {"name": WORKSPACE, "id": "00000000-0000-0000-0000-000000000001"},
+            "id": "00000000-0000-0000-0000-000000000001",
+        }], "@odata.count": 1}),
+        ("C-no-value-key", {"workspaces": [{"name": WORKSPACE, "clusterUri": cluster}],
+                            "@odata.context": f"{cluster}$metadata#workspaces"}),
     ]
 
 
@@ -372,7 +380,14 @@ def run_probe():
         "-e", f"XMLA_TOKEN={TOKEN}",
         "-w", "/work", SDK_IMAGE,
         "sh", "-c",
-        "cp -r /probe/. /work/ && update-ca-certificates >/dev/null 2>&1 && dotnet run --nologo",
+        # Each step announces itself and update-ca-certificates keeps its
+        # stderr. The suppressed version produced a probe that exited 2 with
+        # BOTH streams empty — a failure with no evidence in it, which cost two
+        # runs to not-diagnose. Silencing the one command whose failure would
+        # otherwise be invisible is exactly backwards.
+        "set -e; echo 'STEP copy'; cp -r /probe/. /work/; "
+        "echo 'STEP ca'; update-ca-certificates >/dev/null; "
+        "echo 'STEP dotnet'; dotnet run --nologo",
     ], capture_output=True, text=True, timeout=900)
 
 
@@ -381,6 +396,13 @@ try:
 except subprocess.TimeoutExpired:
     srv.shutdown()
     raise SystemExit("FAILED: the ADOMD.NET probe did not finish within 15 minutes")
+if proc.returncode != 0 and not proc.stdout.strip() and not proc.stderr.strip():
+    # Both streams empty is not a test result, it is a missing measurement.
+    # Say so rather than letting it read as a probe verdict.
+    log(f"probe exited {proc.returncode} with NO output on either stream — "
+        f"the last STEP line above (if any) is where it stopped; no STEP line "
+        f"at all means it never started, which is an environment fault rather "
+        f"than a client contract change")
 
 print("\n---- probe stdout ----", flush=True)
 print(proc.stdout.strip() or "(empty)", flush=True)

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -137,36 +137,50 @@ WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 # is a SCREEN, not a guess. If one advances, the next run narrows it; if none
 # does, four hypotheses die at once.
 def _shapes(host):
-    """SCREEN 4 — NOT THE BODY. Screens 2 and 3 exhausted body content: every
-    top-level JSON object returned the identical not-found, across envelope
-    present/absent, empty/populated, ten field spellings, PascalCase and
-    nesting. Only the top-level TYPE ever changed anything. So this screen
-    leaves the JSON alone and varies what no body edit can reach.
+    """SCREEN 5 — DERIVED FROM THE ASSEMBLY, not guessed.
 
-    Each shape is (label, status, extra headers, body bytes).
+    Reflecting over Microsoft.AnalysisServices.AdomdClient 19.84.1 gives the
+    contract the routing reply deserialises into:
 
-      A 200 + EMPTY body -> the sharpest discriminator available. If not-found
-                            still appears, the body is not consulted for this
-                            decision AT ALL, and screens 2-3 were varying
-                            something the client never read. If instead a parse
-                            error appears, the body IS read and those shapes
-                            were parsed-but-unmatched.
-      B 307 redirect     -> `PreferClientRouting=true` may mean "tell me where
-                            to go" via a redirect rather than a payload. Points
-                            at this same listener, so following it is visible
-                            as a second captured request.
-      C text/plain       -> does Content-Type gate parsing? Same JSON that
-                            produced not-found under application/json.
+        PbiPremiumAuthenticationHandle+Workspace201606
+            id, name, type, capacitySku, capacityUri     (all [DataMember])
+
+        WorkspaceType201606            = User | Group | Folder
+        WorkspaceCapacitySkuType201606 = Shared | Premium
+        ResolvePbiWorkspaceErrorReason = None | WorkspaceNotFound
+                                       | WorkspaceNotOnPbiPremium
+                                       | WorkspaceNameDuplicated
+
+    Two things follow that no screen could have guessed. **No type in the
+    assembly holds a Workspace201606 collection**, so the payload is a BARE
+    ARRAY of these rather than an enveloped list — every enveloped shape tried
+    so far was answering a question the client never asked. And the earlier
+    screens sent `name` but never `type`, `capacitySku` or `capacityUri`, so
+    the objects deserialised with those null.
+
+    The error enum is the discriminator that makes this screen self-checking:
+    a reply that reaches the workspace but fails its premium check reports
+    WorkspaceNotOnPbiPremium, NOT WorkspaceNotFound. So a change in WHICH
+    error appears is progress even when the connection still fails.
+
+      A bare array, all five members, type=Group, capacitySku=Premium
+      B same, enveloped in {"value": …} — the control that should now FAIL
+        differently if the bare array is right
+      C bare array, type=User (the personal-workspace path, which the resolver
+        carries a dedicated `personalWorkspace` field for)
     """
     cluster = f"https://{host}/"
-    ok_body = json.dumps({
-        "@odata.context": f"{cluster}$metadata#workspaces",
-        "value": [{"name": WORKSPACE, "clusterUri": cluster}],
-    }).encode()
+    def ws(kind, sku="Premium"):
+        return {"id": "00000000-0000-0000-0000-000000000001", "name": WORKSPACE,
+                "type": kind, "capacitySku": sku, "capacityUri": cluster}
+    def j(o):
+        return json.dumps(o).encode()
+
+    ct = {"Content-Type": "application/json; charset=utf-8"}
     return [
-        ("A-200-empty-body", 200, {"Content-Type": "application/json; charset=utf-8"}, b""),
-        ("B-307-redirect", 307, {"Location": f"{cluster}powerbi/databases/v201606/workspaces"}, b""),
-        ("C-text-plain", 200, {"Content-Type": "text/plain; charset=utf-8"}, ok_body),
+        ("A-bare-array-Group-Premium", 200, ct, j([ws("Group")])),
+        ("B-enveloped-control", 200, ct, j({"value": [ws("Group")]})),
+        ("C-bare-array-User", 200, ct, j([ws("User")])),
     ]
 
 
@@ -475,6 +489,16 @@ if beyond:
 elif phase2 == phase1:
     print("UNCHANGED — the sequence is identical to the refused run, so the "
           "doubled routing call is unconditional rather than a 404 fallback.", flush=True)
+elif len(phase2) < len(phase1):
+    # The refusing run shows what rejection costs: every connection re-asks,
+    # once with PreferClientRouting and once without. FEWER calls than that
+    # means the client did not re-ask — it kept the answer. That is acceptance
+    # evidence independent of the error text, which is why it is a separate
+    # verdict rather than folded into "stopped at routing".
+    print(f"CONSUMED — {len(phase1)} routing call(s) when refused, {len(phase2)} "
+          f"when answered. The client stopped re-asking, so the reply was "
+          f"accepted; any failure below is DOWNSTREAM of routing, not the "
+          f"reply's shape:", flush=True)
 else:
     print("STOPPED AT ROUTING — the reply was rejected. The probe's own error "
           "text below is what the shape lacked:", flush=True)
@@ -486,10 +510,23 @@ print(proc2.stdout.strip() or "(empty)", flush=True)
 # nothing about which hypothesis died.
 print("\n---- shape screen ----", flush=True)
 outcomes = [ln for ln in proc2.stdout.splitlines() if ln.startswith("CASE powerbi")]
-if len(SHAPE_LOG) != len(outcomes):
-    print(f"  NOT PAIRED: {len(SHAPE_LOG)} shape(s) served, {len(outcomes)} powerbi "
-          f"case(s) reported — the 1:1 assumption does not hold, so nothing below "
-          f"is attributable.", flush=True)
+served = len(SHAPE_LOG)
+if served < len(outcomes):
+    # FEWER requests than connections is itself a result, not a malfunction:
+    # the client only re-asks when it rejected the last answer. Screen 5 hit
+    # this — one request served three connections — so the screen's
+    # one-shape-per-connection premise holds only while shapes FAIL. Say which
+    # shapes were never served rather than implying they were tried and lost.
+    print(f"  FEWER REQUESTS THAN CONNECTIONS: {served} shape(s) served, "
+          f"{len(outcomes)} powerbi case(s) reported. The client stopped asking, "
+          f"which happens when it ACCEPTED an answer and reused it. Only the "
+          f"first {served} shape(s) below were under test.", flush=True)
+    for label, _, _, _ in _shapes("")[served:]:
+        print(f"  {label:26} NOT SERVED — untested", flush=True)
+elif served > len(outcomes):
+    print(f"  NOT PAIRED: {served} shape(s) served, {len(outcomes)} powerbi case(s) "
+          f"reported — the 1:1 assumption does not hold, so nothing below is "
+          f"attributable.", flush=True)
 for (label, _), line in zip(SHAPE_LOG, outcomes):
     # DIFFERENT means "the client changed its mind", NOT "this shape is
     # closer". A shape can differ by failing EARLIER — which is what

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -123,6 +123,44 @@ def require_free_port(port, what):
 ANSWER_ROUTING = False
 WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 
+# CANDIDATE ROUTING SHAPES, screened one per request.
+#
+# The first Phase 0 run established that ADOMD.NET CONSUMES the reply — it
+# stopped complaining about the response and started complaining about the
+# CONTENT ("The specified Power BI workspace ('ws') is not found"). So the
+# remaining unknown is narrow: which field does it match the Data Source's
+# workspace name against, and does it expect the list wrapped?
+#
+# The probe opens three powerbi:// connections per run, each making exactly one
+# routing call once answered. That is three shapes per five-minute run instead
+# of one, and every shape is reported by its own connection's error — so this
+# is a SCREEN, not a guess. If one advances, the next run narrows it; if none
+# does, four hypotheses die at once.
+def _shapes(host):
+    cluster = f"https://{host}/"
+    rich = {                       # every plausible spelling, at once
+        "name": WORKSPACE, "workspaceName": WORKSPACE, "displayName": WORKSPACE,
+        "folderName": WORKSPACE, "id": "00000000-0000-0000-0000-000000000001",
+        "objectId": "00000000-0000-0000-0000-000000000001",
+        "capacityObjectId": "00000000-0000-0000-0000-000000000002",
+        "clusterUri": cluster, "fixedClusterUri": cluster, "backendUri": cluster,
+    }
+    return [
+        # 1. BARE ARRAY — is the `value` envelope wrong rather than the fields?
+        ("bare-array", [dict(rich)]),
+        # 2. value ENVELOPE + every field spelling — isolates envelope from field.
+        ("value-envelope-rich", {"@odata.context": f"{cluster}powerbi/databases/v201606/$metadata#workspaces",
+                                 "value": [dict(rich)]}),
+        # 3. PascalCase — .NET deserialisers frequently bind these; if the
+        #    client is case-sensitive this is the difference.
+        ("pascal-case", {"Value": [{"Name": WORKSPACE, "Id": rich["id"],
+                                    "CapacityObjectId": rich["capacityObjectId"],
+                                    "ClusterUri": cluster, "FixedClusterUri": cluster}]}),
+    ]
+
+
+SHAPE_LOG = []   # [(shape name, request path)] — which shape answered which call
+
 REQUESTS = []          # [{method, path, headers: {lower: value}, body}]
 HANDSHAKE_ERRORS = []  # TCP connected, TLS refused — a distinct diagnosis
 LOCK = threading.Lock()
@@ -153,15 +191,12 @@ class Capture(http.server.BaseHTTPRequestHandler):
             # and its NEXT request is captured — which is the entire deliverable
             # of Phase 0. If the client rejects this shape, its exception text
             # is the measurement instead, and just as useful.
-            body = json.dumps({
-                "@odata.context": f"https://{self.headers.get('Host', '')}/powerbi/databases/v201606/$metadata#workspaces",
-                "value": [{
-                    "name": WORKSPACE,
-                    "id": "00000000-0000-0000-0000-000000000001",
-                    "capacityObjectId": "00000000-0000-0000-0000-000000000002",
-                    "clusterUri": f"https://{self.headers.get('Host', '')}/",
-                }],
-            }).encode()
+            shapes = _shapes(self.headers.get("Host", ""))
+            with LOCK:
+                label, payload = shapes[len(SHAPE_LOG) % len(shapes)]
+                SHAPE_LOG.append((label, self.path))
+            print(f"    -> answering with shape {label!r}", flush=True)
+            body = json.dumps(payload).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
@@ -419,4 +454,28 @@ else:
           "text below is what the shape lacked:", flush=True)
 print("\n---- phase 0 probe stdout ----", flush=True)
 print(proc2.stdout.strip() or "(empty)", flush=True)
+
+# Attribute each connection's outcome to the shape that answered its routing
+# call. Without this pairing the screen is three unlabelled results and proves
+# nothing about which hypothesis died.
+print("\n---- shape screen ----", flush=True)
+outcomes = [ln for ln in proc2.stdout.splitlines() if ln.startswith("CASE powerbi")]
+if len(SHAPE_LOG) != len(outcomes):
+    print(f"  NOT PAIRED: {len(SHAPE_LOG)} shape(s) served, {len(outcomes)} powerbi "
+          f"case(s) reported — the 1:1 assumption does not hold, so nothing below "
+          f"is attributable.", flush=True)
+for (label, _), line in zip(SHAPE_LOG, outcomes):
+    # DIFFERENT means "the client changed its mind", NOT "this shape is
+    # closer". A shape can differ by failing EARLIER — which is what
+    # bare-array does — so the label states the fact and leaves the direction
+    # to the reader rather than implying progress.
+    verdict = "STILL NOT FOUND" if "is not found" in line else "*** DIFFERENT ***"
+    print(f"  {label:22} {verdict}", flush=True)
+    print(f"  {'':22} {line.strip()}", flush=True)
+print("\nDIFFERENT = the client reacted differently; read the message to see "
+      "whether that is progress or a regression. All STILL NOT FOUND means "
+      "field spelling is not the variable and the next hypothesis must be "
+      "structural. The single-shape run is the CONTROL: all three connection "
+      "types reported identically there, so a difference here is attributable "
+      "to the shape and not to the Data Source form.", flush=True)
 print("\nPASSED: the ADOMD.NET client contract is unchanged.")

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -137,33 +137,36 @@ WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 # is a SCREEN, not a guess. If one advances, the next run narrows it; if none
 # does, four hypotheses die at once.
 def _shapes(host):
-    """SCREEN 3 — STRUCTURAL. Screen 2 killed field spelling (ten spellings, all
-    not-found) and left three structural hypotheses. Two of these slots also
-    settle the ambiguity screen 2 recorded but could not resolve: whether
-    `ArgumentNullException (Parameter 'value')` named OUR JSON key or a .NET
-    method parameter. A and C attack that from opposite sides — A supplies the
-    key with nothing in it, C supplies a well-formed object with no such key.
+    """SCREEN 4 — NOT THE BODY. Screens 2 and 3 exhausted body content: every
+    top-level JSON object returned the identical not-found, across envelope
+    present/absent, empty/populated, ten field spellings, PascalCase and
+    nesting. Only the top-level TYPE ever changed anything. So this screen
+    leaves the JSON alone and varies what no body edit can reach.
 
-      A `{"value": []}`      -> "not found" means the key IS ours and an empty
-                               list is handled; a null error means it is not.
-      B nested properties    -> is the name carried under a sub-object rather
-                               than on the workspace itself?
-      C no `value` key at all-> reproduces the null error from a different
-                               shape than a bare array, which is the second
-                               data point A cannot provide alone.
+    Each shape is (label, status, extra headers, body bytes).
+
+      A 200 + EMPTY body -> the sharpest discriminator available. If not-found
+                            still appears, the body is not consulted for this
+                            decision AT ALL, and screens 2-3 were varying
+                            something the client never read. If instead a parse
+                            error appears, the body IS read and those shapes
+                            were parsed-but-unmatched.
+      B 307 redirect     -> `PreferClientRouting=true` may mean "tell me where
+                            to go" via a redirect rather than a payload. Points
+                            at this same listener, so following it is visible
+                            as a second captured request.
+      C text/plain       -> does Content-Type gate parsing? Same JSON that
+                            produced not-found under application/json.
     """
     cluster = f"https://{host}/"
+    ok_body = json.dumps({
+        "@odata.context": f"{cluster}$metadata#workspaces",
+        "value": [{"name": WORKSPACE, "clusterUri": cluster}],
+    }).encode()
     return [
-        ("A-empty-value", {"@odata.context": f"{cluster}$metadata#workspaces", "value": []}),
-        ("B-nested-properties", {"value": [{
-            "properties": {"name": WORKSPACE, "displayName": WORKSPACE,
-                           "clusterUri": cluster},
-            "name": WORKSPACE,
-            "workspace": {"name": WORKSPACE, "id": "00000000-0000-0000-0000-000000000001"},
-            "id": "00000000-0000-0000-0000-000000000001",
-        }], "@odata.count": 1}),
-        ("C-no-value-key", {"workspaces": [{"name": WORKSPACE, "clusterUri": cluster}],
-                            "@odata.context": f"{cluster}$metadata#workspaces"}),
+        ("A-200-empty-body", 200, {"Content-Type": "application/json; charset=utf-8"}, b""),
+        ("B-307-redirect", 307, {"Location": f"{cluster}powerbi/databases/v201606/workspaces"}, b""),
+        ("C-text-plain", 200, {"Content-Type": "text/plain; charset=utf-8"}, ok_body),
     ]
 
 
@@ -201,15 +204,16 @@ class Capture(http.server.BaseHTTPRequestHandler):
             # is the measurement instead, and just as useful.
             shapes = _shapes(self.headers.get("Host", ""))
             with LOCK:
-                label, payload = shapes[len(SHAPE_LOG) % len(shapes)]
+                label, status, headers, body = shapes[len(SHAPE_LOG) % len(shapes)]
                 SHAPE_LOG.append((label, self.path))
-            print(f"    -> answering with shape {label!r}", flush=True)
-            body = json.dumps(payload).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json; charset=utf-8")
+            print(f"    -> answering {status} with shape {label!r}", flush=True)
+            self.send_response(status)
+            for k, v in headers.items():
+                self.send_header(k, v)
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
-            self.wfile.write(body)
+            if body:
+                self.wfile.write(body)
             return
         self.send_response(404)
         self.send_header("Content-Length", "0")

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -137,7 +137,52 @@ WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 # is a SCREEN, not a guess. If one advances, the next run narrows it; if none
 # does, four hypotheses die at once.
 def _shapes(host):
-    """SCREEN 5 — DERIVED FROM THE ASSEMBLY, not guessed.
+    """SCREEN 6 — capacityUri, one shape per RUN.
+
+    Screen 5 got the routing reply CONSUMED: one call instead of six, both
+    diagnostic errors gone, and the failure moved downstream to an
+    `IndexOutOfRangeException` thrown inside `AdomdConnection.Open()`. That
+    success broke the screen's own mechanism — the client only re-asks when it
+    rejected the last answer, so an accepted shape ends the request stream and
+    the 2nd and 3rd shapes are never served. A screen is a tool for FAILURE.
+    Past the first success, shapes must vary across runs, one per process, so
+    each gets a cold client with no resolved workspace cached.
+
+    Two questions, answered together in one pass:
+
+    1. WHICH parser throws. The probe now prints the exception's frames, so the
+       method names itself instead of being guessed at one candidate URI per
+       run. This is the same move as reading the assembly: ask the shipped code
+       what it wants rather than screening the space of what it might.
+    2. WHETHER capacityUri is implicated at all. B sends it empty. If the
+       exception is unchanged between A and B, the field is not the variable
+       and the frames from (1) are the only thing worth reading.
+
+      A capacityUri = https://<listener>/  — screen 5's shape, the control that
+        must reproduce the IndexOutOfRangeException for B..D to mean anything
+      B capacityUri = ""                   — is this field implicated at all?
+      C a real-shaped Power BI cluster host (unreachable, deliberately: what is
+        under test is whether it PARSES, which happens before any connect)
+      D authority only, no scheme          — if the parser wants a bare host
+    """
+    cluster = f"https://{host}/"
+    real = "https://wabi-us-north-central-h-primary-redirect.analysis.windows.net/"
+
+    def ws(capacity_uri, kind="Group", sku="Premium"):
+        return {"id": "00000000-0000-0000-0000-000000000001", "name": WORKSPACE,
+                "type": kind, "capacitySku": sku, "capacityUri": capacity_uri}
+
+    ct = {"Content-Type": "application/json; charset=utf-8"}
+    return [
+        ("A-capacityUri-listener", 200, ct, json.dumps([ws(cluster)]).encode()),
+        ("B-capacityUri-empty", 200, ct, json.dumps([ws("")]).encode()),
+        ("C-capacityUri-real-shaped", 200, ct, json.dumps([ws(real)]).encode()),
+        ("D-capacityUri-no-scheme", 200, ct, json.dumps([ws(host)]).encode()),
+    ]
+
+
+def _shapes_screen5(host):
+    """SCREEN 5 — DERIVED FROM THE ASSEMBLY, not guessed. Kept for the record.
 
     Reflecting over Microsoft.AnalysisServices.AdomdClient 19.84.1 gives the
     contract the routing reply deserialises into:
@@ -184,6 +229,7 @@ def _shapes(host):
     ]
 
 
+SHAPE_INDEX = 0  # which shape this probe run serves; the phase-0 loop advances it
 SHAPE_LOG = []   # [(shape name, request path)] — which shape answered which call
 
 REQUESTS = []          # [{method, path, headers: {lower: value}, body}]
@@ -218,7 +264,12 @@ class Capture(http.server.BaseHTTPRequestHandler):
             # is the measurement instead, and just as useful.
             shapes = _shapes(self.headers.get("Host", ""))
             with LOCK:
-                label, status, headers, body = shapes[len(SHAPE_LOG) % len(shapes)]
+                # ONE shape per run, not per request. Rotating per request only
+                # screens while shapes fail: the moment one is accepted the
+                # client stops asking and the rest are never served (screen 5).
+                # SHAPE_INDEX is set by the phase-0 loop, which restarts the
+                # probe per shape so each meets a client with nothing cached.
+                label, status, headers, body = shapes[SHAPE_INDEX]
                 SHAPE_LOG.append((label, self.path))
             print(f"    -> answering {status} with shape {label!r}", flush=True)
             self.send_response(status)
@@ -462,83 +513,85 @@ if FAILURES:
 phase1 = [(r["method"], r["path"]) for r in REQUESTS]
 
 ANSWER_ROUTING = True
-with LOCK:
-    REQUESTS.clear()
-log("PHASE 0: answering the routing call, recording what follows")
-try:
-    proc2 = run_probe()
-except subprocess.TimeoutExpired:
-    srv.shutdown()
-    raise SystemExit("FAILED: the phase-0 probe did not finish within 15 minutes")
+
+# ONE PROBE RUN PER SHAPE. Screen 5 established that an accepted reply is
+# cached for the life of the client process, so a second shape in the same run
+# is never requested. Restarting the probe is what makes each shape meet a
+# cold client — the cost is one container per shape, and the alternative is
+# results that silently describe only the first.
+runs = []   # [(label, [(method, path)], stdout)]
+for SHAPE_INDEX, (label, *_) in enumerate(_shapes("")):
+    with LOCK:
+        REQUESTS.clear()
+        SHAPE_LOG.clear()
+    log(f"PHASE 0 shape {SHAPE_INDEX + 1}/{len(_shapes(''))}: {label}")
+    try:
+        proc2 = run_probe()
+    except subprocess.TimeoutExpired:
+        srv.shutdown()
+        raise SystemExit(f"FAILED: the phase-0 probe for {label} did not finish "
+                         f"within 15 minutes")
+    if not any(ln.startswith("CASE ") for ln in proc2.stdout.splitlines()):
+        # No CASE line at all means the probe never got as far as connecting —
+        # a compile error, a missing package, or the empty-streams failure this
+        # harness has seen before. Abort on the FIRST one: the alternative is
+        # N containers producing N identical non-results.
+        srv.shutdown()
+        raise SystemExit(
+            f"FAILED: the phase-0 probe for {label} reported no CASE line, so it "
+            f"never reached a connection (exit {proc2.returncode}).\n"
+            f"---- stdout ----\n{proc2.stdout.strip() or '(empty)'}\n"
+            f"---- stderr ----\n{proc2.stderr.strip() or '(empty)'}")
+    if not SHAPE_LOG:
+        print(f"  WARNING {label}: served to no request — the client never asked, "
+              f"so this shape was NOT under test.", flush=True)
+    runs.append((label, [(r["method"], r["path"]) for r in REQUESTS], proc2.stdout))
 srv.shutdown()
 
-phase2 = [(r["method"], r["path"]) for r in REQUESTS]
-print(f"\n---- PHASE 0: {len(phase2)} request(s) with routing ANSWERED ----", flush=True)
-for m, path in phase2:
-    print(f"  {m} {path}", flush=True)
-beyond = [x for x in phase2 if not x[1].startswith("/powerbi/databases/v201606/workspaces")]
-print("\n---- PHASE 0 verdict ----", flush=True)
-if beyond:
-    print("ADVANCED — requests past routing, never before observed:", flush=True)
-    for m, path in beyond:
-        print(f"    {m} {path}", flush=True)
-    body = next((r["body"] for r in REQUESTS
-                 if not r["path"].startswith("/powerbi/databases/v201606/workspaces")), "")
-    if body:
-        print(f"    first body (first 400 chars): {body[:400]}", flush=True)
-elif phase2 == phase1:
-    print("UNCHANGED — the sequence is identical to the refused run, so the "
-          "doubled routing call is unconditional rather than a 404 fallback.", flush=True)
-elif len(phase2) < len(phase1):
-    # The refusing run shows what rejection costs: every connection re-asks,
-    # once with PreferClientRouting and once without. FEWER calls than that
-    # means the client did not re-ask — it kept the answer. That is acceptance
-    # evidence independent of the error text, which is why it is a separate
-    # verdict rather than folded into "stopped at routing".
-    print(f"CONSUMED — {len(phase1)} routing call(s) when refused, {len(phase2)} "
-          f"when answered. The client stopped re-asking, so the reply was "
-          f"accepted; any failure below is DOWNSTREAM of routing, not the "
-          f"reply's shape:", flush=True)
-else:
-    print("STOPPED AT ROUTING — the reply was rejected. The probe's own error "
-          "text below is what the shape lacked:", flush=True)
-print("\n---- phase 0 probe stdout ----", flush=True)
-print(proc2.stdout.strip() or "(empty)", flush=True)
+for label, phase2, out in runs:
+    print(f"\n---- PHASE 0 · {label}: {len(phase2)} request(s) ----", flush=True)
+    for m, path in phase2:
+        print(f"  {m} {path}", flush=True)
+    beyond = [x for x in phase2
+              if not x[1].startswith("/powerbi/databases/v201606/workspaces")]
+    if beyond:
+        print("  ADVANCED — requests past routing, never before observed:", flush=True)
+        for m, path in beyond:
+            print(f"    {m} {path}", flush=True)
+    elif phase2 == phase1:
+        print("  UNCHANGED — identical to the refused run, so the doubled routing "
+              "call is unconditional rather than a 404 fallback.", flush=True)
+    elif len(phase2) < len(phase1):
+        # The refusing run shows what rejection costs: every connection re-asks,
+        # once with PreferClientRouting and once without. FEWER calls than that
+        # means the client did not re-ask — it kept the answer. That is
+        # acceptance evidence independent of the error text, which is why it is
+        # a separate verdict rather than folded into "stopped at routing".
+        print(f"  CONSUMED — {len(phase1)} routing call(s) when refused, "
+              f"{len(phase2)} here. The client stopped re-asking, so the reply "
+              f"was accepted and any failure below is DOWNSTREAM of routing.",
+              flush=True)
+    else:
+        print("  STOPPED AT ROUTING — the reply was rejected.", flush=True)
+    # The frames, not just the message. An IndexOutOfRangeException says
+    # "Index was outside the bounds of the array" and names nothing; its stack
+    # names the method, which is what turns the next step from screening
+    # candidate URIs into reading the parser.
+    for ln in out.splitlines():
+        if ln.startswith("CASE powerbi") or ln.lstrip().startswith(
+                ("FRAME powerbi", "THREW powerbi", "INNER powerbi")):
+            print(f"  {ln.strip()}", flush=True)
 
-# Attribute each connection's outcome to the shape that answered its routing
-# call. Without this pairing the screen is three unlabelled results and proves
-# nothing about which hypothesis died.
-print("\n---- shape screen ----", flush=True)
-outcomes = [ln for ln in proc2.stdout.splitlines() if ln.startswith("CASE powerbi")]
-served = len(SHAPE_LOG)
-if served < len(outcomes):
-    # FEWER requests than connections is itself a result, not a malfunction:
-    # the client only re-asks when it rejected the last answer. Screen 5 hit
-    # this — one request served three connections — so the screen's
-    # one-shape-per-connection premise holds only while shapes FAIL. Say which
-    # shapes were never served rather than implying they were tried and lost.
-    print(f"  FEWER REQUESTS THAN CONNECTIONS: {served} shape(s) served, "
-          f"{len(outcomes)} powerbi case(s) reported. The client stopped asking, "
-          f"which happens when it ACCEPTED an answer and reused it. Only the "
-          f"first {served} shape(s) below were under test.", flush=True)
-    for label, _, _, _ in _shapes("")[served:]:
-        print(f"  {label:26} NOT SERVED — untested", flush=True)
-elif served > len(outcomes):
-    print(f"  NOT PAIRED: {served} shape(s) served, {len(outcomes)} powerbi case(s) "
-          f"reported — the 1:1 assumption does not hold, so nothing below is "
-          f"attributable.", flush=True)
-for (label, _), line in zip(SHAPE_LOG, outcomes):
-    # DIFFERENT means "the client changed its mind", NOT "this shape is
-    # closer". A shape can differ by failing EARLIER — which is what
-    # bare-array does — so the label states the fact and leaves the direction
-    # to the reader rather than implying progress.
-    verdict = "STILL NOT FOUND" if "is not found" in line else "*** DIFFERENT ***"
-    print(f"  {label:22} {verdict}", flush=True)
-    print(f"  {'':22} {line.strip()}", flush=True)
-print("\nDIFFERENT = the client reacted differently; read the message to see "
-      "whether that is progress or a regression. All STILL NOT FOUND means "
-      "field spelling is not the variable and the next hypothesis must be "
-      "structural. The single-shape run is the CONTROL: all three connection "
-      "types reported identically there, so a difference here is attributable "
-      "to the shape and not to the Data Source form.", flush=True)
+print("\n---- capacityUri screen ----", flush=True)
+first = {label: next((ln for ln in out.splitlines()
+                      if ln.startswith("CASE powerbi")), "(no powerbi case)")
+         for label, _, out in runs}
+base = first.get("A-capacityUri-listener")
+for label, _, _ in runs:
+    line = first[label]
+    same = "  same as A" if label != "A-capacityUri-listener" and line == base else ""
+    print(f"  {label:26} {line.split('::', 1)[-1].strip()}{same}", flush=True)
+print("\nIf every shape reports what A reports, capacityUri is NOT the variable "
+      "and the frames above are the only thing that narrows it. A shape that "
+      "differs names the format the parser wanted.", flush=True)
 print("\nPASSED: the ADOMD.NET client contract is unchanged.")

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -137,7 +137,98 @@ WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 # is a SCREEN, not a guess. If one advances, the next run narrows it; if none
 # does, four hypotheses die at once.
 def _shapes(host):
-    """SCREEN 6 — capacityUri, one shape per RUN.
+    """SCREEN 8 — recover the generateastoken body, and name the segment read.
+
+    Screen 7 ADVANCED: at one path segment or more, the client accepts the
+    routing reply and POSTs `/metadata/v201606/generateastoken`. That body is
+    the contract of the next call and the first sight of anything past routing
+    — and screen 7 captured it and then failed to print it, because the run
+    record had been narrowed to (method, path). The harness now prints headers
+    and body in full; this run exists to collect what that one threw away.
+
+    It also settles a question screen 7 raised but could not answer. The path
+    segments are DISTINCT GUIDs, so whichever one the client echoes back as
+    `capacityObjectId` names the index it reads:
+
+      L1  one segment    — GUID-1 is the only candidate; the control
+      L2  two segments   — GUID-1 or GUID-2 distinguishes first from last
+      L5  five segments  — confirms against a long path, where an interior
+                           index would otherwise look like "the last one"
+
+    Nothing here sweeps depth again: screen 7 established that >=1 segment
+    advances and 0 does not. Re-running the full ladder would cost five
+    containers to re-derive a settled fact.
+    """
+    seg = [f"{n}" * 8 + f"-{n}{n}{n}{n}-{n}{n}{n}{n}-{n}{n}{n}{n}-" + f"{n}" * 12
+           for n in range(1, 7)]
+
+    def ws(capacity_uri, kind="Group", sku="Premium"):
+        return {"id": "00000000-0000-0000-0000-000000000001", "name": WORKSPACE,
+                "type": kind, "capacitySku": sku, "capacityUri": capacity_uri}
+
+    ct = {"Content-Type": "application/json; charset=utf-8"}
+    out = []
+    for depth in (1, 2, 5):
+        path = "".join(f"/{s}" for s in seg[:depth])
+        out.append((f"L{depth}-path-{depth}-segment", 200, ct,
+                    json.dumps([ws(f"https://{host}{path}/")]).encode()))
+    return out
+
+
+def _shapes_screen7(host):
+    """SCREEN 7 — the path-segment ladder, plus a host-label arm. For the record.
+
+    Screen 6 named the field: an empty `capacityUri` draws the client's own
+    `InvalidDataException :: … capacity uri is null or empty!`, so it is read
+    and validated; a non-empty one throws `IndexOutOfRangeException` inside
+    `PbiPremiumAuthenticationHandle.TryResolvePbiWorkspace`, which derives two
+    values nothing in the reply carries — `pbiDedicatedRolloutFqdn` and
+    `capacityObjectId`.
+
+    IndexOutOfRange means indexing past the end, so the variable to sweep is
+    LENGTH. The failure mode picks the experiment; nothing here guesses at a
+    URL format.
+
+    Two things can be indexed, and screen 6 excluded neither:
+
+      L0..L5  PATH DEPTH. The primary hypothesis — screen 6's A, C and D all
+              had an EMPTY path and all failed identically. Host stays the
+              listener so that a shape which finally parses dials back HERE and
+              its next request is captured, which is the whole deliverable.
+      H5, H7  HOST LABEL COUNT. NOT excluded by screen 6: its two hosts had 3
+              and 4 dot-separated labels, so a parser wanting label 5 would
+              fail on both exactly as observed. Cheap to rule out, and
+              expensive to discover later. These cannot capture a follow-up
+              request — the hosts do not resolve — so they are read for a
+              CHANGE IN ERROR only.
+
+    Every path segment is a distinct GUID. GUID-shaped because `capacityObjectId`
+    is likely one and a malformed value would fail differently, confounding
+    depth with format; DISTINCT so that if the client ever does dial back, the
+    value it carries names which position it read.
+    """
+    seg = [f"{n}" * 8 + f"-{n}{n}{n}{n}-{n}{n}{n}{n}-{n}{n}{n}{n}-" + f"{n}" * 12
+           for n in range(1, 7)]
+
+    def ws(capacity_uri, kind="Group", sku="Premium"):
+        return {"id": "00000000-0000-0000-0000-000000000001", "name": WORKSPACE,
+                "type": kind, "capacitySku": sku, "capacityUri": capacity_uri}
+
+    ct = {"Content-Type": "application/json; charset=utf-8"}
+    out = []
+    for depth in range(6):
+        path = "".join(f"/{s}" for s in seg[:depth])
+        out.append((f"L{depth}-path-{depth}-segment", 200, ct,
+                    json.dumps([ws(f"https://{host}{path}/")]).encode()))
+    for labels in (5, 7):
+        fqdn = ".".join(chr(ord("a") + i) for i in range(labels))
+        out.append((f"H{labels}-host-{labels}-label", 200, ct,
+                    json.dumps([ws(f"https://{fqdn}/")]).encode()))
+    return out
+
+
+def _shapes_screen6(host):
+    """SCREEN 6 — capacityUri, one shape per RUN. Kept for the record.
 
     Screen 5 got the routing reply CONSUMED: one call instead of six, both
     diagnostic errors gone, and the failure moved downstream to an
@@ -545,19 +636,34 @@ for SHAPE_INDEX, (label, *_) in enumerate(_shapes("")):
     if not SHAPE_LOG:
         print(f"  WARNING {label}: served to no request — the client never asked, "
               f"so this shape was NOT under test.", flush=True)
-    runs.append((label, [(r["method"], r["path"]) for r in REQUESTS], proc2.stdout))
+    # Keep the WHOLE request, not just method and path. Screen 7 advanced past
+    # routing for the first time and the new POST's body — the actual contract
+    # of the next call — was captured in memory and then not printed, because
+    # this list had been narrowed to two fields. The body is the deliverable;
+    # the path is only the label on it.
+    with LOCK:
+        runs.append((label, [dict(r) for r in REQUESTS], proc2.stdout))
 srv.shutdown()
 
-for label, phase2, out in runs:
+for label, reqs, out in runs:
+    phase2 = [(r["method"], r["path"]) for r in reqs]
     print(f"\n---- PHASE 0 · {label}: {len(phase2)} request(s) ----", flush=True)
     for m, path in phase2:
         print(f"  {m} {path}", flush=True)
-    beyond = [x for x in phase2
-              if not x[1].startswith("/powerbi/databases/v201606/workspaces")]
+    beyond = [r for r in reqs
+              if not r["path"].startswith("/powerbi/databases/v201606/workspaces")]
     if beyond:
         print("  ADVANCED — requests past routing, never before observed:", flush=True)
-        for m, path in beyond:
-            print(f"    {m} {path}", flush=True)
+        # Body and headers IN FULL. This is the first sight of the call after
+        # routing, and a truncated record of it costs another full run to
+        # recover — which is exactly what happened when only the path was kept.
+        for r in beyond:
+            print(f"    {r['method']} {r['path']}", flush=True)
+            for k, v in sorted(r.get("headers", {}).items()):
+                if k in ("authorization", "cookie"):
+                    v = f"<{len(v)} chars, not logged>"
+                print(f"      {k}: {v}", flush=True)
+            print(f"      BODY: {r.get('body') or '(empty)'}", flush=True)
     elif phase2 == phase1:
         print("  UNCHANGED — identical to the refused run, so the doubled routing "
               "call is unconditional rather than a 404 fallback.", flush=True)
@@ -586,12 +692,17 @@ print("\n---- capacityUri screen ----", flush=True)
 first = {label: next((ln for ln in out.splitlines()
                       if ln.startswith("CASE powerbi")), "(no powerbi case)")
          for label, _, out in runs}
-base = first.get("A-capacityUri-listener")
+# The BASELINE is the first shape, whatever it is called. Naming it in a string
+# is how a screen quietly stops comparing against anything when the shapes are
+# renamed for the next round.
+baseline, _, _ = runs[0]
+base = first[baseline]
 for label, _, _ in runs:
     line = first[label]
-    same = "  same as A" if label != "A-capacityUri-listener" and line == base else ""
+    same = f"  same as {baseline}" if label != baseline and line == base else ""
     print(f"  {label:26} {line.split('::', 1)[-1].strip()}{same}", flush=True)
-print("\nIf every shape reports what A reports, capacityUri is NOT the variable "
-      "and the frames above are the only thing that narrows it. A shape that "
-      "differs names the format the parser wanted.", flush=True)
+print(f"\nEvery shape reporting what {baseline} reports means the swept variable "
+      f"is NOT the one, and the frames above are all that narrows it. A shape "
+      f"that differs names what the parser wanted — and in a LADDER, the rung "
+      f"where the error changes is the index it reaches for.", flush=True)
 print("\nPASSED: the ADOMD.NET client contract is unchanged.")


### PR DESCRIPTION
Phase 0 of `docs/32-xmla-plan.md` asked one question: **what does ADOMD.NET ask
for after its routing call?** Nobody in this project had ever seen it — the
capture stub refused the first call, so the sequence past it was unobserved and
`[MS-SSAS-T]`'s real size was estimated rather than measured.

It is now a recorded request with a known body.

## What the client does

```
GET  /powerbi/databases/v201606/workspaces?PreferClientRouting=true   (once per process)
POST /metadata/v201606/generateastoken[?PreferClientRouting=true]     (once per connection)

content-type: application/json     user-agent: ASClient/.NET-Core
authorization: Bearer <token from the connection string>

{"applyAuxiliaryPermission":false,"auxiliaryPermissionOwner":null,
 "bypassBuildPermission":false,
 "capacityObjectId":"<first path segment of capacityUri, trailing slash>",
 "datasetName":null,"intendedUsage":0,"sourceCapacityObjectId":null,
 "workspaceObjectId":"<the id sent in Workspace201606>"}
```

Routing resolves ONCE for the process; the token is fetched PER CONNECTION.
Different cache lifetimes, both measured.

## The routing reply it accepts

A **bare array** of `Workspace201606` — `id`, `name`, `type`, `capacitySku`,
`capacityUri` — with `capacityUri` carrying **at least one path segment**.

`capacityObjectId = new Uri(capacityUri).Segments[1]`. Inferred, but from a
fingerprint rather than a fit: `Uri.Segments` yields `["/", "seg1/", …]` with
each segment keeping its slash, which is why the client sends a trailing slash,
why it reads the FIRST segment at every depth tested, and why an empty path
throws `IndexOutOfRangeException`. One rule, four observations, no free
parameters.

## How it was found, and what that cost

Screens 2-4 guessed at field spellings and envelope shapes across three runs,
and produced a conclusion that screen 3 then disproved. Reflecting over the
shipped `Microsoft.AnalysisServices.AdomdClient` assembly produced the answer in
one pass: the `[DataContract]` names, the enums, and the fact that **no type
holds a `Workspace201606` collection** — so every enveloped shape had been
answering a question the client never asks. Reading beats screening, and the
plan doc records that rather than quietly presenting the result.

Later screens are derived, not guessed. `IndexOutOfRange` means indexing past
the end, so the ladder sweeps LENGTH. The probe prints exception frames, so the
parser names itself instead of costing one run per candidate.

## Harness changes

- **One probe run per shape.** An accepted reply is cached for the life of the
  client process, so a rotating screen never serves its later shapes. A screen
  is a tool for failure; past the first success, shapes vary across runs.
- **Frames, headers and full bodies** are printed. `IndexOutOfRangeException`'s
  message names nothing; its stack names the method.
- **A `CONSUMED` verdict** keyed on the request count falling below the refusing
  control — acceptance evidence independent of the error text. The previous
  logic only looked for new paths, so a client that accepted and stopped asking
  was reported as "the reply was rejected", which was false.
- **Fail-fast** when a run reports no `CASE` line, so a compile error aborts on
  the first container instead of producing N identical non-results.
- Shapes never served are labelled `NOT SERVED — untested` rather than omitted.

The refusing first pass is unchanged and still asserts the twelve-point client
contract, so this adds measurement without weakening the regression witness.

## Not established

- `pbiDedicatedRolloutFqdn` — the other value `TryResolvePbiWorkspace` derives —
  is **unexercised**. Every request so far returns to the listener named in the
  Data Source, so nothing here shows the client can be steered to another host.
- `generateastoken`'s RESPONSE contract is unknown. That should be read off the
  assembly, not screened.
- No parity row changes. This is measurement; nothing here claims a green.
