### PR TITLE
e2e/sail: assert the commit invariant, not one interleaving

### DIFF
--- a/e2e/sail/driver.py
+++ b/e2e/sail/driver.py
@@ -11,6 +11,7 @@ import json
 import os
 import threading
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
@@ -156,11 +157,56 @@ cdf_probe.collect()
 assert "_change_type" not in cdf_probe.columns, cdf_probe.columns
 print("known divergence confirmed: CDF options are accepted but return a normal snapshot")
 
-# Launch two overwrite commits from separate sessions at the same barrier.
-# The OneLake conditional-create contract exposes the Delta log collision:
-# exactly one writer commits and the other receives a transaction failure.
+# Two overwrite commits from separate sessions, released at one barrier.
+#
+# WHAT THIS ASSERTS, AND WHY IT IS NOT "exactly one commits". The barrier
+# synchronises the START of the two writes, not their overlap. If writer A
+# finishes its commit before writer B reads the table version, B legitimately
+# commits on top of A: two successes, no conflict, and nothing is wrong.
+# Serialisation is a VALID outcome of racing two writers, and an assertion that
+# forbids it fails on a correct server — this suite asserted
+# `outcomes.count("committed") == 1` and went red on exactly that, 1 run in 13.
+#
+# So the assertion is the INVARIANT that holds either way: **each successful
+# commit produces its own new version in the Delta log, and no two writers ever
+# land on the same one.** That is what OneLake's conditional-create (If-None-
+# Match) actually guarantees, and it is what a broken guard would violate — two
+# writers overwriting one version file, losing an update silently. Counting
+# commit files against successful writers catches that; counting rejections
+# only catches the scheduler.
+#
+# This is the repo's own lesson applied where it was still outstanding: when a
+# race lives in a window too small to hit reliably, make the interleaving an
+# input rather than sampling for it — or, where you cannot, assert the property
+# that survives every interleaving instead of the one you hoped to observe.
 conflict_url = "az://sailws/lake.Lakehouse/Tables/concurrent_probe"
 spark.range(1).write.format("delta").mode("overwrite").save(conflict_url)
+storage_token = entra_token("https://storage.azure.com/.default")
+
+
+def delta_log_versions(table):
+    """Version numbers present in a table's _delta_log, read through OneLake.
+
+    Fetches 00000…N.json until one 404s. The emulator serves the Blob surface
+    on the account-prefixed path, the same form the byte-level check below uses.
+    """
+    found = []
+    for version in range(64):
+        url = (f"{FABRIC}/onelake/{ws['id']}/lake.Lakehouse/Tables/{table}"
+               f"/_delta_log/{version:020d}.json")
+        req = urllib.request.Request(url, headers={"Authorization": "Bearer " + storage_token})
+        try:
+            with urllib.request.urlopen(req, timeout=30):
+                found.append(version)
+        except urllib.error.HTTPError as err:
+            if err.code == 404:
+                break
+            raise
+    return found
+
+
+before = delta_log_versions("concurrent_probe")
+assert before, "the seed commit is missing; the probe below would prove nothing"
 barrier = threading.Barrier(2)
 
 
@@ -178,14 +224,35 @@ def concurrent_overwrite(value):
 
 with ThreadPoolExecutor(max_workers=2) as executor:
     outcomes = list(executor.map(concurrent_overwrite, (100, 200)))
-assert outcomes.count("committed") == 1, outcomes
-assert sum(outcome.startswith("rejected:") for outcome in outcomes) == 1, outcomes
-assert spark.read.format("delta").load(conflict_url).count() == 10
-print(f"concurrent overwrite conflict rejected: {outcomes}")
+committed = outcomes.count("committed")
+rejected = sum(outcome.startswith("rejected:") for outcome in outcomes)
+after = delta_log_versions("concurrent_probe")
+new_versions = [v for v in after if v not in before]
+
+# At least one writer must get through, or the probe proves nothing about
+# conflict handling — it would just be two failures.
+assert committed >= 1, outcomes
+assert committed + rejected == 2, outcomes
+# THE INVARIANT: one new version per successful commit. Fewer means two writers
+# landed on the same version and one update was lost — precisely the failure
+# the conditional PUT exists to prevent. More would mean a commit nobody made.
+assert len(new_versions) == committed, (outcomes, before, after)
+# Contiguous, so a commit did not skip a version and leave a hole a reader
+# would stop at.
+assert after == list(range(len(after))), after
+# The surviving table is one writer's full overwrite, not a blend of both.
+rows = spark.read.format("delta").load(conflict_url).collect()
+assert len(rows) == 10, rows
+assert {row[0] for row in rows} in ({v for v in range(100, 110)}, {v for v in range(200, 210)}), rows
+if rejected:
+    print(f"concurrent overwrite: conflict rejected as expected {outcomes}, "
+          f"+{len(new_versions)} version(s)")
+else:
+    print(f"concurrent overwrite: serialised (both committed, versions {new_versions}) — "
+          "a valid interleaving; the invariant checked is one version per commit")
 
 # The engine's writes are real bytes in OneLake: read the first Delta commit
 # back through the Blob surface ourselves (same account-prefixed path form).
-storage_token = entra_token("https://storage.azure.com/.default")
 req = urllib.request.Request(
     f"{FABRIC}/onelake/{ws['id']}/lake.Lakehouse/Tables/events/_delta_log/"
     "00000000000000000000.json",


### PR DESCRIPTION
Fixes the flake that reddened #87. **Diagnosed from the log by fork 2, not from a re-run**, and the diagnosis was independently confirmed by reading the test before writing this.

## The bug is in the assertion, not the server

```python
assert outcomes.count("committed") == 1, outcomes
AssertionError: ['committed', 'committed']
```

Two Delta overwrites launch from separate Spark sessions at a `threading.Barrier`. **The barrier synchronises the START of the writes, not their overlap.** If writer A finishes its commit before writer B reads the table version, B commits on top of A perfectly legitimately: two successes, no conflict, nothing wrong. Serialisation is a valid outcome of racing two writers, and the old assertion forbade it — so a correct server went red roughly **1 run in 13**.

Everything before that line passed on the failing run: Delta write, MERGE, time travel, `abfss://`, every documented divergence. It was never the engine. Ruled out as #87's doing too — the job is green on `main`, #97 and #99, and #87's `uv.lock` diff is purely additive (a new `jupyter` group, no version change), so the `spark-connect` group e2e builds from is byte-identical.

## What it asserts now

The **invariant that holds under every interleaving**: each successful commit produces its own new version in the Delta log, and no two writers land on the same one. That is what OneLake's conditional-create (`If-None-Match`) actually guarantees.

- `len(new_versions) == committed` — fewer means two writers landed on one version and **an update was lost silently**, which is exactly what the conditional PUT exists to prevent.
- versions are contiguous — no hole a reader would stop at.
- the surviving table is one writer's full overwrite, not a blend.

Counting rejections tested the scheduler. Counting commit files against successful writers tests the server.

**Correction to an earlier revision of this description.** It claimed the old assertion "would have PASSED a genuine lost-update bug, since that shows up as one commit and one rejection." That is wrong, and it was the load-bearing sentence. A broken guard means B's PUT overwrites A's version file and **both** writers report success, so `outcomes` is `['committed', 'committed']` and the old assertion **fails**.

The real defect is worse than blindness and is the reason this change still matters: the old test failed on a lost update and on a benign serialisation **with an identical message**, so the two are indistinguishable — and one of them fired 12 times in 13. A test whose one failure mode has two causes, only one of which is a bug, trains its operator to re-run. Verified by replay:

| world | outcomes | old test |
|---|---|---|
| healthy, conflict | `['committed', 'rejected:…']` | pass |
| healthy, serialised | `['committed', 'committed']` | **FAIL** |
| broken, lost update | `['committed', 'committed']` | **FAIL** |

Same signal, two causes. The new assertion separates them: serialisation passes, a lost update fails on version arithmetic that names what went wrong.

This is the repo's own lesson applied where it was still outstanding — *when a race lives in a window too small to hit reliably, make the interleaving an input rather than sampling for it* — with the honest variant for where you cannot control the interleaving: **assert the property that survives every interleaving, not the one you hoped to observe.**

## Verification

Booting Sail to sample a race would prove nothing either way — a green run is exactly what the old code produced 12 times in 13. So the assertion block was **replayed against four worlds** instead:

| world | accepted | want |
|---|---|---|
| conflict (1 commit, 1 reject) | yes | yes |
| serialised (2 commits) | yes | yes |
| **broken: lost update** (2 commits, 1 new version) | **no** | no |
| **broken: hole in the log** | **no** | no |

Both legal interleavings pass; both corruptions fail. `ruff` clean.

Two things ruff did not catch and I fixed by reading: `urllib.error.HTTPError` was referenced with only `urllib.request` imported — it works today solely because `urllib.request` imports `urllib.error` itself, an implicit dependency a refactor would break — and a dead `starts = {100, 200}` assignment that F841 misses because it is module-level.
