### PR TITLE
e2e/sail: pin the conditional-create refusal with no race

### DIFF
--- a/e2e/sail/driver.py
+++ b/e2e/sail/driver.py
@@ -11,6 +11,7 @@ import json
 import os
 import threading
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
@@ -195,5 +196,38 @@ with urllib.request.urlopen(req, timeout=30) as r:
     first_commit = r.read().decode()
 assert '"protocol"' in first_commit and '"metaData"' in first_commit, first_commit[:200]
 print("delta log readable through the Blob surface (protocol + metaData present)")
+
+# The conditional-create contract itself, with the interleaving as an INPUT
+# rather than sampled for.
+#
+# The racing writers above can only observe a rejection when they happen to
+# collide, and they legitimately may not (see that block). This asserts the
+# same guarantee with no race at all: version 0 of the events table exists, so
+# a put-if-absent against that exact path must be refused. It is the rejection
+# half of the concurrency story, held to a deterministic standard, and it is
+# the 409 the racing writers see when they DO collide.
+#
+# TestConcurrentDeltaCommitRace pins the same mechanism at unit level; this
+# pins it end-to-end, through the Blob surface a real client reaches, with the
+# token a real client mints.
+conflict_probe = urllib.request.Request(
+    f"{FABRIC}/onelake/{ws['id']}/lake.Lakehouse/Tables/events/_delta_log/"
+    "00000000000000000000.json",
+    method="PUT",
+    data=b'{"commitInfo":{"operation":"SHOULD NOT LAND"}}',
+    headers={"Authorization": "Bearer " + storage_token, "If-None-Match": "*"},
+)
+try:
+    urllib.request.urlopen(conflict_probe, timeout=30)
+    raise AssertionError("put-if-absent overwrote an existing Delta commit")
+except urllib.error.HTTPError as refused:
+    assert refused.code == 409, refused.code
+print("put-if-absent on an existing commit refused with 409")
+
+# And it refused WITHOUT damaging what was there. A 409 that still replaced the
+# bytes would satisfy the status assertion and lose the commit anyway.
+with urllib.request.urlopen(req, timeout=30) as r:
+    assert r.read().decode() == first_commit, "the refused PUT modified the commit"
+print("the refused PUT left the existing commit byte-identical")
 
 print("PASS: sail e2e")


### PR DESCRIPTION
**Scoped down after #106.** This originally also rewrote the racing-writers assertion. #106 does that better and **owns it now** — see below. What is left here is the half #106 does not have.

## What this adds

A direct put-if-absent against a commit path that already exists — no second writer, no barrier, no timing:

```
PUT …/_delta_log/00000000000000000000.json   If-None-Match: *   ->  409
```

plus a re-read asserting the refused PUT left the commit **byte-identical**. A 409 that still replaced the bytes would satisfy a status assertion and lose the commit anyway.

**Why it is worth having alongside #106.** The racing writers can only observe a rejection when they *happen* to collide — and #106 correctly stops requiring that they do. So after #106, nothing in this suite asserts end-to-end that a conflicting commit is refused. `TestConcurrentDeltaCommitRace` pins the mechanism at unit level; this pins it through the Blob surface a real client reaches, with the token a real client mints.

## On #106, which is the better fix for the part it covers

I wrote a rows-invariant for the race arm — the surviving table must be one writer's contiguous range. **#106's version accounting is strictly stronger, and I checked rather than deferred:**

| a lost update (broken `If-None-Match`, two writers land on version 1) | verdict |
|---|---|
| my rows-invariant | **accepts it** — the survivor's 10 rows are still contiguous |
| #106's `len(new_versions) == committed` | **rejects it** |

That is the exact bug the conditional PUT exists to prevent, and my assertion could not see it. #106's framing is right: *counting rejections tests the scheduler; counting commit files against successful writers tests the server.*

## Verification

Full `e2e/sail` suite run locally end to end, green, with the two new lines present:

```
put-if-absent on an existing commit refused with 409
the refused PUT left the existing commit byte-identical
```

Mutation: pointing the probe at a version that does **not** exist fails with `put-if-absent overwrote an existing Delta commit` — the 409 assertion is load-bearing, not vacuous.

## Sequencing

**#106 first.** Both touch `e2e/sail/driver.py`, so I will rebase this onto it; the two changes are in different regions and the resolution is additive. Touches neither `parity.md` nor `witnesses.json`.