### PR TITLE
e2e: pin fab-driven's entra to the release carrying the new tenant

### DIFF
--- a/examples/fab-driven/.env
+++ b/examples/fab-driven/.env
@@ -15,7 +15,7 @@
 # reports the right name and the wrong bytes:
 #   docker inspect fab-driven-fabric-emulator-1 --format '{{.Image}}'
 FABRIC_EMULATOR_VERSION=0.15.1
-ENTRA_EMULATOR_VERSION=0.3.0
+ENTRA_EMULATOR_VERSION=0.4.0
 
 # Sail is LakeSail's Rust Spark-Connect server, and the agent is what the
 # emulator drives to execute a notebook. Both are published by the emulator's


### PR DESCRIPTION
Follow-up to #108, which merged with only its first commit — this fix was pushed a minute too late to be included.

#108 rewrote `examples/fab-driven/docker-compose.yml` to entra-emulator's new seeded tenant (`6f89cf12-…`), but `examples/fab-driven/.env` still pins:

```
ENTRA_EMULATOR_VERSION=0.3.0
```

0.3.0 serves the **old** tenant (`11111111-…`), so as of `main` that example hands a new tenant to an old emulator and cannot authenticate. Unlike the other 22 suites — which resolve entra at `:latest` and will pick the new tenant up automatically once it publishes — this one is pinned and has to be bumped by hand.

**If entra's release is numbered anything other than 0.4.0, this pin needs to match it.**

Same ordering caveat as #108: the example only works once entra v0.4.0 is actually published to ghcr.