### PR TITLE
sjd test: the assertion outlives the mechanism it named

### DIFF
--- a/internal/api/sparkjobdrive_test.go
+++ b/internal/api/sparkjobdrive_test.go
@@ -111,10 +111,19 @@ func TestADrivenSparkJobPublishesItsTerminalEvent(t *testing.T) {
 	waitForJobStatus(t, st, item.ID, jid)
 
 	// EXACTLY ONE, and only after the engine answered. The count is the half
-	// that catches the regression TestPipelineJobOutlivesItsPOST documents:
-	// listing a driven type in terminalStatusOf's executesNow publishes a
-	// terminal event at POST — a Completed announced while the main file has
-	// not run, which is the false green this whole path exists to prevent.
+	// that catches the regression TestPipelineJobOutlivesItsPOST documents.
+	//
+	// The MECHANISM this once named is gone: #91 deleted `terminalStatusOf`,
+	// the second switch that re-derived a job's outcome from its item type,
+	// and `startJob` now records what it settled where it settles it. Listing
+	// a driven type in that switch's `executesNow` USED TO publish a terminal
+	// event at POST. The assertion stays because the FAILURE it guards has not
+	// gone anywhere — a Completed announced while the main file has not run is
+	// the false green this whole path exists to prevent, and a future dispatch
+	// change can reintroduce it by a different route.
+	//
+	// Kept as history rather than deleted: an assertion whose reason is
+	// removed with its mechanism is the next reader's unexplained line.
 	var terminals []string
 	for _, ev := range drainEvents(t, sub.C) {
 		if ev.JobID == jid && (ev.Status == store.JobCompleted || ev.Status == store.JobFailed) {


### PR DESCRIPTION
A three-line comment fix in `internal/api/sparkjobdrive_test.go`, flagged by the Activities session and confirmed as mine before touching it.

## What was stale

The comment described `terminalStatusOf`'s `executesNow` in the **present tense** as a live mechanism. #91 (`a150fa1`) deleted that function — `startJob` now records what it settled where it settles it, so there is one list instead of two.

Verified rather than assumed, in both directions:
- **Authorship**: `git log -S "executesNow" -- internal/api/sparkjobdrive_test.go` → `eb39217` (#86), mine. I misattributed a commit once today; this one was checked.
- **The premise**: `terminalStatusOf` survives on main in four files, all as historical mentions in comments (`jobs.go:159` reads *"It replaces a second switch (`terminalStatusOf`)"*). The function is gone. Only this site still spoke of it as current.

## Why reworded rather than deleted

The assertion is unchanged and still correct — exactly one terminal event, only after the engine answered. What changed is that its stated *reason* named a mechanism that no longer exists.

Deleting the reason with the mechanism would leave a bare `len(terminals) == 1` and no explanation, which is the next reader's unexplained line. So the comment now says the mechanism is gone, names what replaced it, and keeps the failure it guards: **a `Completed` announced while the main file has not run**. That failure is not tied to the deleted switch — a future dispatch change can reintroduce it by a different route, which is precisely why the assertion should outlive the bug that motivated it.

This is the repo's *delete a corrected claim, don't annotate it* rule applied with its exception stated: delete a claim that is **wrong**, keep one that is **history**, and mark which it is. A present-tense description of a dead mechanism is the first; the reason an assertion exists is the second.

`go test ./internal/api/ -run 'SparkJob|Terminal'` green; comment-only change.