### PR TITLE
ci check: every job must declare timeout-minutes

### DIFF
--- a/python/tests/test_check_workflow_concurrency.py
+++ b/python/tests/test_check_workflow_concurrency.py
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 """
 
 GOOD_MT = GOOD_CI.replace("name: CI", "name: Make targets").replace("group: ci-", "group: make-targets-")
@@ -135,4 +136,93 @@ def test_a_missing_file_fails(tmp_path, monkeypatch, capsys):
 # --- the control -------------------------------------------------------------
 
 def test_the_real_repo_passes_its_own_check(capsys):
+    assert c.main() == 0, capsys.readouterr().out
+
+
+# --- second invariant: every job declares timeout-minutes --------------------
+#
+# GitHub's default is SIX HOURS, so an untimed job does not fail when it wedges
+# — it holds a runner all afternoon and reads as "still pending" to anything
+# watching. A Sail job did exactly that for 78 minutes while a merge watcher
+# waited on it. The timeouts were added to all 47 jobs in one pass; nothing
+# stopped the 48th arriving without one.
+
+TIMED = """\
+name: CI
+on: [push]
+
+concurrency:
+  group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+"""
+
+
+def test_a_job_without_a_timeout_fails(workflows, capsys):
+    workflows(ci=TIMED.replace("  test:\n    runs-on: ubuntu-latest\n    timeout-minutes: 30\n",
+                               "  test:\n    runs-on: ubuntu-latest\n"))
+    assert c.main() == 1
+    out = capsys.readouterr().out
+    assert "timeout-minutes" in out and "test" in out, out
+    assert "6-hour" in out, "the message must say what the default costs"
+
+
+def test_every_job_timed_passes(workflows, capsys):
+    workflows(ci=TIMED, mt=TIMED.replace("group: ci-", "group: make-targets-"))
+    assert c.main() == 0
+    assert "declare timeout-minutes" in capsys.readouterr().out
+
+
+# A job that CALLS a reusable workflow cannot carry timeout-minutes — GitHub
+# rejects the key. Demanding one there is a false positive, and a check that
+# fires on something you cannot fix is a check somebody deletes. Found by
+# running the first draft against the real repo: it flagged release.yml's two
+# `uses:` jobs, which are exactly this case.
+def test_a_reusable_workflow_call_is_exempt(workflows, capsys):
+    workflows(ci=TIMED + """  call:
+    uses: ./.github/workflows/make-targets.yml
+""", mt=TIMED.replace("group: ci-", "group: make-targets-"))
+    assert c.main() == 0, capsys.readouterr().out
+
+
+# ...but the exemption must be narrow: `uses:` on a STEP is not a workflow call,
+# and a job full of actions still needs its own timeout. Widening the rule to
+# "any uses: anywhere" would silently exempt most of the matrix.
+def test_a_step_level_uses_is_not_exempt(workflows, capsys):
+    workflows(ci=TIMED + """  stepped:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+""", mt=TIMED.replace("group: ci-", "group: make-targets-"))
+    assert c.main() == 1
+    assert "stepped" in capsys.readouterr().out
+
+
+# `on:` also carries two-space keys (push:, pull_request:). Counting those as
+# jobs was the first draft's bug — it read 47 jobs where there were 45 and
+# reported `push:` as missing a timeout.
+def test_on_block_keys_are_not_counted_as_jobs(workflows, capsys):
+    workflows(ci="""\
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+""", mt=TIMED.replace("group: ci-", "group: make-targets-"))
     assert c.main() == 0, capsys.readouterr().out

--- a/scripts/check_workflow_concurrency.py
+++ b/scripts/check_workflow_concurrency.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""ci.yml and make-targets.yml must group and cancel by the same rule.
+"""Workflow invariants nothing else enforces: concurrency coupling, and job timeouts.
 
 WHY THIS EXISTS. Together these two workflows are what "main is green" means —
 a verdict from one of them is half an answer. Their `concurrency:` blocks decide
@@ -33,6 +33,15 @@ maintain and it only reports drift after the fact.
 WHAT IS COMPARED. The `${{ … }}` expression of `group:` (the literal prefix
 before it MUST differ, or the two workflows would share a group and cancel each
 other) and the whole of `cancel-in-progress:`.
+
+SECOND INVARIANT: EVERY JOB DECLARES `timeout-minutes`. GitHub's default is
+**six hours**, so a job without one does not fail when it wedges — it occupies
+a runner until the afternoon and reads as "still pending" to anything watching.
+That is not hypothetical here: a Sail job sat `in_progress` for 78 minutes while
+a merge watcher waited on it, because "running" and "wedged" are the same status
+to `gh pr checks`. The timeouts were added to all 47 jobs in one pass; nothing
+stopped the 48th from arriving without one, which is the same
+maintained-by-attention coupling this file already exists to remove.
 
 Usage:
     check_workflow_concurrency.py     exit non-zero describing any divergence
@@ -92,6 +101,55 @@ def read_concurrency(path):
     return prefix, expr.group(0), cancel.group("value")
 
 
+# A job key: exactly two-space indent, inside the top-level `jobs:` block.
+# Anchored that way because `on:` also carries two-space keys (`push:`,
+# `pull_request:`) — counting those was the first draft's bug, and it inflated
+# 45 jobs to 47 while reporting `push:` as missing a timeout.
+_JOBS_START = re.compile(r"^jobs:\s*$", re.M)
+_JOB_KEY = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+
+
+def jobs_of(text):
+    """[(job name, its body lines)] for every job in a workflow."""
+    out, in_jobs = [], False
+    for line in text.split("\n"):
+        if _JOBS_START.match(line):
+            in_jobs = True
+            continue
+        if in_jobs and line[:1].strip():  # a new top-level key ends the block
+            break
+        if in_jobs:
+            match = _JOB_KEY.match(line)
+            if match:
+                out.append((match.group(1), []))
+            elif out:
+                out[-1][1].append(line)
+    return out
+
+
+def jobs_missing_timeout(path):
+    """Job names in path that declare no `timeout-minutes`."""
+    text = path.read_text(encoding="utf-8")
+    found = jobs_of(text)
+    if not found:
+        raise ConcurrencyUnreadable(
+            f"{path.name} parsed to zero jobs — a check that inspects nothing "
+            "passes vacuously, which is worse than no check")
+    missing = []
+    for name, body in found:
+        # A job that CALLS a reusable workflow (`uses:` at job level) cannot
+        # carry `timeout-minutes` — GitHub rejects the key there. Its timeout
+        # lives in the called workflow's own jobs, and since this check globs
+        # every workflow in the directory, those jobs ARE covered: coverage is
+        # preserved, not waived. Demanding a key the platform refuses is how a
+        # check gets switched off, which costs more than the check was worth.
+        if any(re.match(r"^    uses:\s", line) for line in body):
+            continue
+        if not any("timeout-minutes:" in line for line in body):
+            missing.append(name)
+    return missing
+
+
 def main():
     try:
         read = {name: read_concurrency(WORKFLOWS / name) for name in COUPLED}
@@ -120,14 +178,30 @@ def main():
             f"both workflows use the concurrency group prefix {prefix_a.strip()!r}; they "
             "would share a group and cancel each other's runs")
 
+    # Every job in every workflow, not only the coupled pair — an untimed job
+    # is a wedged runner wherever it lives.
+    try:
+        for path in sorted((WORKFLOWS).glob("*.yml")):
+            missing = jobs_missing_timeout(path)
+            if missing:
+                problems.append(
+                    f"{path.name}: {len(missing)} job(s) declare no `timeout-minutes`, so they "
+                    f"inherit GitHub's 6-hour default and a wedged run reads as 'still pending':\n    "
+                    + "\n    ".join(missing))
+    except ConcurrencyUnreadable as exc:
+        problems.append(str(exc))
+
     if problems:
         print("check_workflow_concurrency: " + "\n\n".join(problems))
         print(f"\n{a} and {b} together are what \"main is green\" means; a verdict from "
               "one of them is half an answer.")
         return 1
 
+    total = sum(len(jobs_of((WORKFLOWS / p.name).read_text(encoding="utf-8")))
+                for p in sorted(WORKFLOWS.glob("*.yml")))
     print(f"check_workflow_concurrency: {a} and {b} agree "
-          f"(group {expr_a}, cancel-in-progress {cancel_a})")
+          f"(group {expr_a}, cancel-in-progress {cancel_a}); "
+          f"all {total} jobs declare timeout-minutes")
     return 0
 
 


### PR DESCRIPTION
Extends `scripts/check_workflow_concurrency.py` (landed in #101) with the second invariant nothing enforces.

**This work was written on #101's branch and missed that PR's merge** — I force-pushed to a branch my own merge watcher was armed on, and the watcher merged the head it had verified, which is exactly what a head pin is for. My mistake, not the tooling's; re-homed here off current main.

## The invariant

`timeout-minutes` on every job. GitHub's default is **six hours**, so an untimed job does not fail when it wedges — it holds a runner all afternoon and reads as *"still pending"* to anything watching. Not hypothetical: a Sail job sat `in_progress` for 78 minutes while a merge watcher waited on it, because "running" and "wedged" are the same status to `gh pr checks`.

#103 added timeouts to all 47 jobs in one pass. Nothing stops the 48th arriving without one — the same maintained-by-attention coupling this script already exists to remove.

## Two boundaries, both found by running it rather than reasoning about it

**Reusable-workflow calls are exempt.** The first draft flagged `release.yml`'s `make-targets` and `fabric-qualification` jobs — both `uses:` calls, and **GitHub rejects `timeout-minutes` on those**. Demanding a key the platform refuses is how a check gets switched off, which costs more than the check was worth. Coverage is not waived, though: the called workflow's own jobs are checked by the same sweep, since it globs every workflow in the directory.

**The exemption is narrow: `uses:` at job level only.** A step-level `uses:` is an action, not a workflow call, and a job full of actions still needs its own timeout. Widening it to "any `uses:` anywhere" would silently exempt most of the matrix — mutation-checked, and that mutation fails `test_a_step_level_uses_is_not_exempt` against a passing control.

**And the job parser was wrong first.** `on:` also carries two-space keys (`push:`, `pull_request:`), so the naive regex read 47 jobs where there were 45 and reported `push:` as missing a timeout. Job keys are now anchored to the top-level `jobs:` block, with a test pinning it.

## Verification

- 14 tests (5 new), each driving a case the check must catch or must not; `make check` reports **all 61 jobs declare timeout-minutes**.
- Full `python/tests`: 494 passed, 6 skipped. `ruff` clean.
- Refuses to pass vacuously: a workflow parsing to zero jobs is an error, not a pass.