### PR TITLE
tests: bound async job polls at 30s, not 5

### DIFF
--- a/internal/api/notebookdrive_test.go
+++ b/internal/api/notebookdrive_test.go
@@ -114,9 +114,17 @@ func (f *fakeAgent) statements() []string {
 // awaitJob polls for a terminal status. The driver runs in a goroutine because
 // submitting a job returns 202 and the caller polls — so the test polls too,
 // rather than sleeping a guessed interval and hoping.
+//
+// The deadline is generous on purpose: nothing here measures timing, so it only
+// bounds the failure case. Five seconds was too tight — a windows runner under
+// load took 106s for this package while another spent 72s on SQL Server, and a
+// pipeline doing real work missed a 5s window (TestPipelineSQLActivitiesE2E).
+// Polling every 10ms means a fast machine still returns immediately; raising
+// the ceiling costs nothing and removes a whole class of runner-starvation
+// flakes.
 func awaitJob(t *testing.T, a *API, wid, iid, jid string) string {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		if s := jobStatus(t, a, wid, iid, jid); s != "InProgress" && s != "NotStarted" {
 			return s

--- a/internal/server/pipeline_sql_test.go
+++ b/internal/server/pipeline_sql_test.go
@@ -90,8 +90,12 @@ func TestPipelineSQLActivitiesE2E(t *testing.T) {
 	// winning a race the CI runner lost — the goroutine usually finishes before
 	// one GET on a fast machine, which is exactly why a synchronous read here
 	// is wrong rather than merely flaky.
+	//
+	// 30s, not 5: nothing here measures timing, so the deadline only bounds the
+	// failure case — and 5s was missed on a loaded windows runner. See awaitJob
+	// in internal/api for the measurement.
 	var job struct{ Status string }
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for {
 		f.mustStatus(f.call("GET", base+"/"+jid, f.token, nil, &job), http.StatusOK, "get job")
 		if job.Status != "InProgress" && job.Status != "NotStarted" {

--- a/internal/server/pipeline_test.go
+++ b/internal/server/pipeline_test.go
@@ -106,8 +106,12 @@ func TestPipelineRunE2E(t *testing.T) {
 
 	// Async (doc 37 §4): the 202 returns while the pipeline executes, so the
 	// test polls exactly as a real client does.
+	//
+	// 30s, not 5: nothing here measures timing, so the deadline only bounds the
+	// failure case — and 5s was missed on a loaded windows runner. See awaitJob
+	// in internal/api for the measurement.
 	var job struct{ Status string }
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for {
 		f.mustStatus(f.call("GET", base+"/"+jid, f.token, nil, &job), http.StatusOK, "get job")
 		if job.Status != "InProgress" && job.Status != "NotStarted" {


### PR DESCRIPTION
Fixes the `windows-latest` failure blocking #102 (and reachable from any PR — the flake is on `main`).

## The failure

```
--- FAIL: TestPipelineSQLActivitiesE2E (7.54s)
    pipeline_sql_test.go:101: pipeline job never reached a terminal state
FAIL	github.com/calvinchengx/fabric-emulator/internal/server	106.740s
```

Not caused by #102 — that PR changes one line of `pnpm-lock.yaml` and cannot affect Go tests. It is a poll deadline introduced by the async-pipelines conversion in #81: the job POST now returns before the pipeline finishes, so the test polls, and the poll gives up at 5 seconds.

Five seconds is too tight on a saturated runner. In that run `internal/server` took **106s** while `internal/warehouse` spent **72s** driving a real SQL Server in the same job, and this test's pipeline runs real Script/StoredProcedure activities. `pipeline_sql_test.go`'s own comment already anticipates the shape — *"winning a race the CI runner lost … which is exactly why a synchronous read here is wrong rather than merely flaky"* — it just left the replacement window too small.

## The change

Three async-job poll deadlines, 5s → 30s:

- `internal/api/notebookdrive_test.go` — the `awaitJob` helper, used by the ~50 sites #81 converted
- `internal/server/pipeline_test.go`
- `internal/server/pipeline_sql_test.go` — the one that failed

**None of them measures timing.** They poll every 10ms and return on the first terminal status, so a fast machine is unaffected; the deadline only bounds the failure case. Raising it removes a class of runner-starvation flakes at no cost — the same argument as the ten 5s deadlines still outstanding in `internal/tds`.

Verified: `go build`, `go vet`, `internal/server` at `-count=2` and the full `internal/api` suite pass.

## Note on the other two PRs the queue is showing red

- **#87** — its failing Sail check predates the current head. `bb750f0` already contains `b386e2a` (the commit-invariant fix) and `a26d7a0` (the entra GUID migration); the branch needs no change, only for its checks to finish.
- **#100** — `RuntimeError: failed to download … <urlopen error timed out>` during a build backend fetch. Transient network, no code defect. Needs a job re-run once its run leaves the queue (it cannot be re-run while other jobs in the run are still queued).