### PR TITLE
tests: cover the value coercions and the pagination stop conditions

### DIFF
--- a/internal/api/restpagination_selectors_test.go
+++ b/internal/api/restpagination_selectors_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The pagination selectors decide whether a REST connector takes another page
+// or stops. They were the least-covered code in the connector — `headerSelector`
+// at 0%, `resolveValue` at 50%, `isEmptyNode` at 33% — and every uncovered arm
+// is either a selector spelling Fabric accepts or one of its documented STOP
+// conditions. An unreached stop condition is the dangerous half: a selector that
+// wrongly reports "keep going" pages forever against a real API.
+
+// headerSelector accepts the spellings Fabric's expressions use. The false
+// cases matter more than the true ones: each is a malformed selector that must
+// not resolve to the empty header name, which `hdr.Get("")` would answer with
+// "" and a caller could read as a legitimate empty value.
+func TestHeaderSelectorSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		expr string
+		want string
+		ok   bool
+	}{
+		{"headers.Link", "Link", true},
+		{"headers['X-Next-Page']", "X-Next-Page", true},
+		{`headers["X-Next-Page"]`, "X-Next-Page", true},
+		// Malformed: a name is required, and an empty one is not a name.
+		{"headers.", "", false},
+		{"headers['']", "", false},
+		{`headers[""]`, "", false},
+		// Bracket forms must be closed, and in the same quote style.
+		{"headers['X-Next", "", false},
+		{`headers["X-Next']`, "", false},
+		// Neither spelling at all.
+		{"headers", "", false},
+		{"headers-Link", "", false},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			got, ok := headerSelector(tc.expr)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("headerSelector(%q) = (%q, %v), want (%q, %v)",
+					tc.expr, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// resolveValue evaluates one pagination value against a response. `ok=false` is
+// a STOP, so each false case below is a page-loop terminator: a missing path, an
+// explicit null, an absent header, a malformed selector, an empty literal.
+func TestResolveValueAndItsStopConditions(t *testing.T) {
+	doc := map[string]any{
+		"next":   "cursor-2",
+		"count":  float64(17),
+		"null":   nil,
+		"nested": map[string]any{"token": "abc"},
+		"empty":  "",
+	}
+	hdr := http.Header{}
+	hdr.Set("X-Next", "page-3")
+	hdr.Set("X-Blank", "")
+
+	for _, tc := range []struct {
+		name, expr, want string
+		ok               bool
+	}{
+		{"jsonpath string", "$.next", "cursor-2", true},
+		{"jsonpath number renders without a float tail", "$.count", "17", true},
+		{"jsonpath nested", "$.nested.token", "abc", true},
+		{"jsonpath missing STOPS", "$.absent", "", false},
+		{"explicit null STOPS", "$.null", "", false},
+		{"header present", "headers.X-Next", "page-3", true},
+		{"header case-insensitive prefix", "Headers.X-Next", "page-3", true},
+		{"header absent STOPS", "headers.X-Missing", "", false},
+		{"header present but empty STOPS", "headers.X-Blank", "", false},
+		{"malformed selector STOPS", "headers.", "", false},
+		{"literal passes through", "42", "42", true},
+		{"empty literal STOPS", "", "", false},
+		{"whitespace-only literal STOPS", "   ", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := resolveValue(tc.expr, doc, hdr)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("resolveValue(%q) = (%q, %v), want (%q, %v)",
+					tc.expr, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// isEmptyNode is the other stop condition: a page whose collection came back
+// empty. It must recognise emptiness in each JSON shape a collection can take,
+// and must NOT call a zero or a false empty — those are values, and treating
+// them as end-of-collection would truncate a real result set.
+func TestIsEmptyNodeAcrossJSONShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		node any
+		want bool
+	}{
+		{"nil", nil, true},
+		{"empty array", []any{}, true},
+		{"empty object", map[string]any{}, true},
+		{"empty string", "", true},
+		{"populated array", []any{1}, false},
+		{"populated object", map[string]any{"a": 1}, false},
+		{"non-empty string", "x", false},
+		// Values, not emptiness — the cases a laxer check would truncate on.
+		{"zero is a value", float64(0), false},
+		{"false is a value", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEmptyNode(tc.node); got != tc.want {
+				t.Errorf("isEmptyNode(%#v) = %v, want %v", tc.node, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/semanticmodel/dax_coercion_test.go
+++ b/internal/semanticmodel/dax_coercion_test.go
@@ -1,0 +1,124 @@
+package semanticmodel
+
+import (
+	"strings"
+	"testing"
+)
+
+// The value-coercion helpers (`truthy`, `dstr`, `asNumber`, `toF`) decide what
+// every operator and every aggregate does with a value that is not already a
+// float64. They were the least-covered code in this package — 33-62% — and the
+// unreached arms are not exotic: booleans reach them through comparisons, and
+// the sized integer types reach them through Direct Lake, where rows arrive
+// from parquet as typed Go integers rather than as JSON numbers.
+//
+// So these tests drive the arms through real DAX rather than calling the
+// helpers directly, because a coercion that is right in isolation and unreached
+// from a query proves nothing about the evaluator.
+
+// A comparison yields a Go bool, so any operator applied to one lands in the
+// boolean arms. Real DAX renders those as TRUE/FALSE and counts them as 1/0.
+func TestDAXBooleanValuesConcatenateAndCount(t *testing.T) {
+	for _, tc := range []struct {
+		expr string
+		want any
+	}{
+		// dstr's boolean arm: `&` on a comparison result.
+		{`(1 = 1) & ""`, "TRUE"},
+		{`(1 = 2) & ""`, "FALSE"},
+		{`"units: " & (1 < 2)`, "units: TRUE"},
+		// asNumber's boolean arm: TRUE is 1, FALSE is 0, in arithmetic.
+		{`(1 = 1) + 1`, 2.0},
+		{`(1 = 2) + 1`, 1.0},
+		{`(1 = 1) * 7`, 7.0},
+		// And the two compose: a boolean is 1, then rendered as a number.
+		{`((1 = 1) + 1) & ""`, "2"},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			if got := evalScalar(t, tc.expr); fmtLike(got) != fmtLike(tc.want) {
+				t.Errorf("%s = %v (%T), want %v", tc.expr, got, got, tc.want)
+			}
+		})
+	}
+}
+
+// truthy decides IF's condition. Only its boolean arm was exercised; a
+// condition can also be blank, a number, or text — and DAX's rule is that
+// FALSE, BLANK, 0 and "" are false, everything else true.
+func TestDAXIfConditionCoercion(t *testing.T) {
+	for _, tc := range []struct {
+		expr string
+		want float64
+	}{
+		{`IF(1, 10, 20)`, 10},            // non-zero number is true
+		{`IF(0, 10, 20)`, 20},            // zero is false
+		{`IF(-1, 10, 20)`, 10},           // non-zero, including negative
+		{`IF(DIVIDE(1, 0), 10, 20)`, 20}, // BLANK is false
+		{`IF("x", 10, 20)`, 10},          // non-empty text is true
+		{`IF("", 10, 20)`, 20},           // empty text is false
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			if got := toF(evalScalar(t, tc.expr)); got != tc.want {
+				t.Errorf("%s = %v, want %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+// toF's sized-integer arms exist for Direct Lake: a parquet `int32` column
+// arrives as a Go int32, not a float64, and a SUM that silently returned 0 for
+// it would under-report a real table. Each type is summed with a second row so
+// a dropped value shows as a wrong total rather than a plausible one.
+func TestDAXSumsEveryNumericGoType(t *testing.T) {
+	m := loadModel(t)
+	for name, v := range map[string]any{
+		"int":     int(41),
+		"int8":    int8(41),
+		"int16":   int16(41),
+		"int32":   int32(41),
+		"int64":   int64(41),
+		"uint":    uint(41),
+		"uint8":   uint8(41),
+		"uint16":  uint16(41),
+		"uint32":  uint32(41),
+		"uint64":  uint64(41),
+		"float32": float32(41),
+		"float64": float64(41),
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := Data{"Sales": []Row{{"Units": v}, {"Units": 1}}}
+			res, err := Evaluate(m, d, `EVALUATE SUMMARIZECOLUMNS("v", SUM(Sales[Units]))`)
+			if err != nil {
+				t.Fatalf("SUM over a %s column: %v", name, err)
+			}
+			if got := toF(res.Rows[0]["[v]"]); got != 42 {
+				t.Errorf("SUM over a %s column = %v, want 42", name, got)
+			}
+		})
+	}
+}
+
+// A value of no numeric type at all must refuse rather than count as zero —
+// the fallback arm behind every coercion above, and the same rule the text
+// refusal enforces for strings.
+func TestDAXSumRefusesANonNumericGoValue(t *testing.T) {
+	m := loadModel(t)
+	d := Data{"Sales": []Row{{"Units": []int{1, 2}}, {"Units": 1}}}
+	_, err := Evaluate(m, d, `EVALUATE SUMMARIZECOLUMNS("v", SUM(Sales[Units]))`)
+	if err == nil {
+		t.Fatal("a slice-valued column summed; it must refuse rather than coerce to 0")
+	}
+	// dstr's own fallback renders it, so the message names what it could not read.
+	if want := "not a number"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err, want)
+	}
+}
+
+// fmtLike compares values the way the other suites do: numbers by value rather
+// than by Go type, everything else by its rendered form.
+func fmtLike(v any) string {
+	if f, ok := numeric(v); ok {
+		return dstr(f)
+	}
+	return dstr(v)
+}


### PR DESCRIPTION
Raises real Go coverage, because the 90% floor has **1.2 points of headroom by its own admission** (`ci.yml:192`) and both gated legs just measured **89.7–89.8%** on Go code that measured **90.8%** an hour earlier. #100 tripped it while changing two Python files. A gate with less headroom than its own measurement noise fails on whoever pushes next; re-running until it lands is gaming it.

Local repo total **88.4% → 88.7%** (no SQL Server here, so the warehouse tests skip — CI's gated legs read ~1.2 points higher).

## `internal/semanticmodel`: 92.7% → 94.9%

The value coercions — `truthy`, `dstr`, `asNumber`, `toF` — were at 33–62%, and the unreached arms are not exotic:

- **Booleans** reach them through comparisons. `(1 = 1) & ""` must render `"TRUE"`, and `(1 = 1) + 1` must be `2` — DAX renders booleans TRUE/FALSE and counts them 1/0.
- **`IF`'s condition** was only ever tested with a boolean. Blank, numeric and text conditions all have rules (`FALSE`, `BLANK`, `0`, `""` are false) and none was exercised.
- **Sized integers** reach `toF` through Direct Lake, where rows arrive from parquet as `int32`/`uint8`/`float32` rather than JSON `float64`. Each of the twelve numeric Go types is now summed with a second row, so a dropped value shows as a wrong total rather than a plausible one.
- A value of **no** numeric type must refuse rather than count as zero — the same rule the text refusal enforces.

Driven through real DAX rather than by calling the helpers directly: a coercion that is correct in isolation and unreachable from a query proves nothing about the evaluator.

## `internal/api/restpagination.go`: three selectors 0%/50%/33% → 100%

These decide whether a REST connector takes another page or stops, and the **stop conditions were the uncovered half** — which is the dangerous half, since a selector that wrongly reports "keep going" pages forever against a real API.

- `headerSelector` — every spelling Fabric accepts (`headers.X`, `headers['X']`, `headers["X"]`), plus the malformed ones that must not resolve to the empty header name, which `hdr.Get("")` answers with `""` and a caller could read as a legitimate empty value.
- `resolveValue` — each documented stop: missing JSONPath, explicit `null`, absent header, header present but empty, malformed selector, empty literal.
- `isEmptyNode` — emptiness in each JSON shape, **and** that `0` and `false` are values rather than emptiness. A laxer check truncates a real result set.

## Mutation-checked

Two mutations, each reverted after:

- accept an empty header name (`len(rest) > 1` → `true`) → **fails**
- treat `0` as an empty collection → **fails**

`go build`, `go vet`, full `go test ./...`, and `make check` pass.

## Not touched

Per `CLAIMS.md`: `internal/purview/*` and `internal/store/purview.go` (parity fork), `internal/auth`/`api/admin*` (tenant-admin gate), `pipelines.*` and the activity files (Activities session). `internal/warehouse` and `internal/tds/sqlserver.go` are DSN-gated and only measurable on a leg with an engine.