### PR TITLE
test: raise coverage back over the floor, and derive the docs-sidebar set

### DIFF
--- a/internal/api/restpagination_values_test.go
+++ b/internal/api/restpagination_values_test.go
@@ -1,0 +1,345 @@
+package api
+
+// Where a pagination VALUE comes from, as opposed to how the loop steps.
+//
+// restpagination_test.go drives whole paging sequences and asserts the requests
+// the server saw. That covers the loop well and the value layer barely: a
+// cursor read out of a response HEADER — half of what the file's own doc
+// comment promises ("a JSONPath into the body, or `Headers.x`") — had no test
+// at all, and neither did the scalar rendering every rule depends on.
+//
+// These are direct unit tests because the functions are pure, and because the
+// interesting cases are refusals: a value that cannot be resolved must report
+// false so the loop STOPS. A helper that returned ("", true) instead would page
+// forever against a live endpoint, and no happy-path sequence would show it.
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHeaderSelectorSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		expr string
+		want string
+		ok   bool
+	}{
+		{"headers.x-next-page", "x-next-page", true},
+		{"headers['X-Next']", "X-Next", true},
+		{`headers["X-Next"]`, "X-Next", true},
+		// A selector naming nothing is not a header called "": resolving it
+		// would read an absent header and stop the loop for the wrong reason.
+		{"headers.", "", false},
+		{"headers['']", "", false},
+		{"headers", "", false},
+		// Unbalanced quoting is a malformed rule, not a header named `'X`.
+		{"headers['X", "", false},
+	} {
+		got, ok := headerSelector(tc.expr)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("headerSelector(%q) = (%q, %v), want (%q, %v)", tc.expr, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestResolveValueReadsBodyHeaderAndLiteral(t *testing.T) {
+	doc := map[string]any{
+		"paging": map[string]any{"next": "https://example.test/p2", "done": nil},
+		"count":  float64(42),
+	}
+	hdr := http.Header{}
+	hdr.Set("X-Next-Cursor", "abc")
+
+	for _, tc := range []struct {
+		name string
+		expr string
+		want string
+		ok   bool
+	}{
+		{"jsonpath", "$.paging.next", "https://example.test/p2", true},
+		{"jsonpath number", "$.count", "42", true},
+		// Null is Fabric's documented stop condition — not the string "null".
+		{"jsonpath null", "$.paging.done", "", false},
+		{"jsonpath missing", "$.paging.absent", "", false},
+		{"header", "Headers.X-Next-Cursor", "abc", true},
+		{"header bracket", "Headers['X-Next-Cursor']", "abc", true},
+		// An absent header stops the loop; it does not send an empty cursor.
+		{"header missing", "Headers.X-Absent", "", false},
+		{"header malformed", "Headers.", "", false},
+		// A constant is unambiguous: it can be neither a path nor a header.
+		{"literal", "static-token", "static-token", true},
+		{"empty", "", "", false},
+	} {
+		got, ok := resolveValue(tc.expr, doc, hdr)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("%s: resolveValue(%q) = (%q, %v), want (%q, %v)",
+				tc.name, tc.expr, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// A cursor lands in a URL, so 1000 must not render as 1000.0 — JSON has one
+// number type and every offset arrives here as a float64.
+func TestScalarStringRendersJSONScalars(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   any
+		want string
+		ok   bool
+	}{
+		{"string", "abc", "abc", true},
+		{"empty string", "", "", false},
+		{"integral float", float64(1000), "1000", true},
+		{"negative integral", float64(-5), "-5", true},
+		{"fractional", 1.5, "1.5", true},
+		{"bool", true, "true", true},
+		// A cursor cannot be an object or an array: rendering one would put
+		// `map[...]` in a URL rather than stopping.
+		{"object", map[string]any{"a": 1}, "", false},
+		{"array", []any{1}, "", false},
+		{"nil", nil, "", false},
+	} {
+		got, ok := scalarString(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("%s: scalarString(%#v) = (%q, %v), want (%q, %v)",
+				tc.name, tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// `EndCondition: Empty` is how an endpoint that returns `{"items":[]}` forever
+// terminates, so what counts as empty is load-bearing.
+func TestIsEmptyNode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   any
+		want bool
+	}{
+		{"nil", nil, true},
+		{"empty array", []any{}, true},
+		{"empty object", map[string]any{}, true},
+		{"empty string", "", true},
+		{"populated array", []any{1}, false},
+		{"populated object", map[string]any{"a": 1}, false},
+		{"non-empty string", "x", false},
+		// Zero is a value, not an absence: an offset of 0 must keep paging.
+		{"zero", float64(0), false},
+		{"false", false, false},
+	} {
+		if got := isEmptyNode(tc.in); got != tc.want {
+			t.Errorf("%s: isEmptyNode(%#v) = %v, want %v", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// Rule keys are the author's spelling of where a value goes. Every accepted
+// spelling has to resolve to the same place, and anything else has to be
+// refused by name — a rule silently ignored is a paging loop that quietly reads
+// page one and reports success, which is the failure R1 existed to prevent.
+func TestSplitRuleKeyAcceptsEverySpellingAndRefusesTheRest(t *testing.T) {
+	for _, tc := range []struct {
+		key       string
+		where     string
+		sel       string
+		wantError bool
+	}{
+		{key: "AbsoluteUrl", where: "AbsoluteUrl"},
+		{key: "QueryParameters.offset", where: "QueryParameters", sel: "offset"},
+		{key: "QueryParameters['offset']", where: "QueryParameters", sel: "offset"},
+		{key: `QueryParameters["offset"]`, where: "QueryParameters", sel: "offset"},
+		{key: "Headers.X-Token", where: "Headers", sel: "X-Token"},
+		{key: "Headers['X-Token']", where: "Headers", sel: "X-Token"},
+		// Not a family we implement.
+		{key: "Body.next", wantError: true},
+		// Right family, unparseable selector: the brackets never close.
+		{key: "QueryParameters['offset", wantError: true},
+		// Case matters — Fabric's keys are capitalised, and guessing at
+		// `queryparameters` would accept a rule the product rejects.
+		{key: "queryParameters.offset", wantError: true},
+		{key: "", wantError: true},
+	} {
+		where, sel, err := splitRuleKey("act", tc.key)
+		if tc.wantError {
+			if err == nil {
+				t.Errorf("splitRuleKey(%q) = (%q, %q, nil), want an error", tc.key, where, sel)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("splitRuleKey(%q): %v", tc.key, err)
+			continue
+		}
+		if where != tc.where || sel != tc.sel {
+			t.Errorf("splitRuleKey(%q) = (%q, %q), want (%q, %q)", tc.key, where, sel, tc.where, tc.sel)
+		}
+	}
+}
+
+// RANGE:start:end:step. A malformed range must be refused at parse time rather
+// than producing a loop that steps by zero and never terminates.
+func TestParseRangeRefusesMalformedRanges(t *testing.T) {
+	ok := []struct {
+		val    string
+		start  float64
+		step   float64
+		hasEnd bool
+		end    float64
+	}{
+		{val: "RANGE:0::1000", start: 0, step: 1000},
+		{val: "RANGE:0:5000:1000", start: 0, step: 1000, hasEnd: true, end: 5000},
+		{val: "range:10:20:5", start: 10, step: 5, hasEnd: true, end: 20},
+		// Negative steps page backwards, which is unusual but well-defined.
+		{val: "RANGE:100:0:-10", start: 100, step: -10, hasEnd: true, end: 0},
+	}
+	for _, tc := range ok {
+		r, err := parseRange("act", "QueryParameters.{offset}", tc.val)
+		if err != nil {
+			t.Errorf("parseRange(%q): %v", tc.val, err)
+			continue
+		}
+		if r.cur != tc.start || r.step != tc.step || r.hasEnd != tc.hasEnd || (tc.hasEnd && r.end != tc.end) {
+			t.Errorf("parseRange(%q) = %+v, want start %v step %v hasEnd %v end %v",
+				tc.val, r, tc.start, tc.step, tc.hasEnd, tc.end)
+		}
+	}
+	for _, bad := range []string{
+		"0::1000",           // not a RANGE at all
+		"RANGE:0:1000",      // two fields, not three
+		"RANGE:0::1000:2",   // four
+		"RANGE:x::1000",     // start is not a number
+		"RANGE:0::y",        // step is not a number
+		"RANGE:0::0",        // a zero step never advances
+		"RANGE:0:notanum:1", // end is not a number
+	} {
+		if _, err := parseRange("act", "QueryParameters.{offset}", bad); err == nil {
+			t.Errorf("parseRange(%q) was accepted, want a refusal", bad)
+		}
+	}
+}
+
+func TestResolveRelativeHandlesAbsoluteRelativeAndMalformed(t *testing.T) {
+	for _, tc := range []struct{ base, next, want string }{
+		{"http://h/a/b", "https://other/x", "https://other/x"},
+		{"http://h/a/b", "/page2", "http://h/page2"},
+		{"http://h/a/b", "page2", "http://h/a/page2"},
+		{"http://h/a/b?x=1", "?x=2", "http://h/a/b?x=2"},
+		// An unparseable base or next is returned as-is rather than mangled:
+		// the request will fail loudly at dial time, which is the honest place.
+		{"http://h/\x7f", "next", "next"},
+		{"http://h/a", "http://\x7f", "http://\x7f"},
+	} {
+		if got := resolveRelative(tc.base, tc.next); got != tc.want {
+			t.Errorf("resolveRelative(%q, %q) = %q, want %q", tc.base, tc.next, got, tc.want)
+		}
+	}
+}
+
+// The half of the documented cursor sources that had no test: the next page's
+// token arrives in a response header rather than the body.
+func TestPaginationFollowsACursorFromAResponseHeader(t *testing.T) {
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.log(r)
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			w.Header().Set("X-Next-Cursor", "a")
+			fmt.Fprint(w, `{"entries":[{"id":1}]}`)
+		case "a":
+			w.Header().Set("X-Next-Cursor", "b")
+			fmt.Fprint(w, `{"entries":[{"id":2}]}`)
+		default:
+			// No header on the last page: absence is the stop.
+			fmt.Fprint(w, `{"entries":[{"id":3}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	tbl, _, err := restSrc(t, &API{}, map[string]any{
+		"type": "RestSource", "url": srv.URL + "/",
+		"paginationRules": map[string]any{"QueryParameters.cursor": "Headers.X-Next-Cursor"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tbl.Rows) != 3 {
+		t.Fatalf("want 3 rows across 3 pages, got %d", len(tbl.Rows))
+	}
+	want := []string{"GET /", "GET /?cursor=a", "GET /?cursor=b"}
+	if got := rec.requests(); strings.Join(got, " | ") != strings.Join(want, " | ") {
+		t.Fatalf("request sequence = %v, want %v", got, want)
+	}
+}
+
+// A rule can also SET a header on the next request from one on the response —
+// the shape APIs use when the continuation token is not URL-safe.
+func TestPaginationCarriesACursorIntoTheNextRequestHeader(t *testing.T) {
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.log(r)
+		if r.Header.Get("X-Continuation") == "" {
+			w.Header().Set("X-Token", "tok-1")
+			fmt.Fprint(w, `{"entries":[{"id":1}]}`)
+			return
+		}
+		fmt.Fprint(w, `{"entries":[{"id":2}]}`)
+	}))
+	defer srv.Close()
+
+	tbl, _, err := restSrc(t, &API{}, map[string]any{
+		"type": "RestSource", "url": srv.URL + "/",
+		"paginationRules": map[string]any{"Headers.X-Continuation": "Headers.X-Token"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tbl.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(tbl.Rows))
+	}
+	if len(rec.hdrs) != 2 {
+		t.Fatalf("saw %d requests, want 2", len(rec.hdrs))
+	}
+	if got := rec.hdrs[1].Get("X-Continuation"); got != "tok-1" {
+		t.Fatalf("second request X-Continuation = %q, want the token from page one", got)
+	}
+}
+
+// An EndCondition can name a response header, not just a body path.
+func TestPaginationEndConditionOnAResponseHeader(t *testing.T) {
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.log(r)
+		page := r.URL.Query().Get("cursor")
+		if page == "a" {
+			// Still a cursor to follow, but the end condition fires first —
+			// which is the only way to tell the two rules apart.
+			w.Header().Set("X-Complete", "true")
+			w.Header().Set("X-Next-Cursor", "b")
+			fmt.Fprint(w, `{"entries":[{"id":2}]}`)
+			return
+		}
+		w.Header().Set("X-Next-Cursor", "a")
+		fmt.Fprint(w, `{"entries":[{"id":1}]}`)
+	}))
+	defer srv.Close()
+
+	tbl, _, err := restSrc(t, &API{}, map[string]any{
+		"type": "RestSource", "url": srv.URL + "/",
+		"paginationRules": map[string]any{
+			"QueryParameters.cursor":          "Headers.X-Next-Cursor",
+			"EndCondition:$.unused":           "Exist",
+			"EndCondition:Headers.X-Complete": "Const:true",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tbl.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2 — the header end condition did not stop the loop", len(tbl.Rows))
+	}
+	if got := rec.requests(); len(got) != 2 {
+		t.Fatalf("request sequence = %v, want 2 pages", got)
+	}
+}

--- a/internal/purview/handlers_test.go
+++ b/internal/purview/handlers_test.go
@@ -1,0 +1,422 @@
+package purview
+
+// The routes the first increment mounted but never exercised.
+//
+// `datamap_test.go` covers registration, createOrUpdate and the refusals that
+// prove the type system is real. It stops there: the read, update and delete
+// halves of both the type system and the entity store shipped with no test at
+// all, which is how a mounted route can 500 on its first real client.
+//
+// The theme here is the same as next door — an assertion only earns its place
+// if a stub would fail it. So each handler is checked for the thing that makes
+// it *that* handler rather than a near neighbour: a header read must return a
+// header and not the whole entity, a bulk read must answer for every GUID it
+// was given, a delete must soft-delete, and an update must keep the server's
+// GUID rather than take the client's.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// createEntity posts one entity and returns its assigned GUID, so the read and
+// delete tests below start from something that genuinely exists.
+func createEntity(t *testing.T, mux *http.ServeMux, typeName, qname string) string {
+	t.Helper()
+	body := `{"entity":{"typeName":"` + typeName + `","attributes":{` +
+		`"qualifiedName":"` + qname + `","name":"` + qname + `"}}}`
+	w := do(t, mux, "POST", BasePath+"/atlas/v2/entity", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create %s = %d %s", qname, w.Code, w.Body)
+	}
+	var resp EntityMutationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.MutatedEntities[opCreate]) != 1 {
+		t.Fatalf("create %s did not report a CREATE: %s", qname, w.Body)
+	}
+	return resp.MutatedEntities[opCreate][0].GUID
+}
+
+// --- the type system: read, update, delete -----------------------------------
+
+// PUT /types/typedefs. The GUID is the server's: an update that adopted the
+// client's would invalidate every reference already handed out, and the only
+// way to see it is to read the definition back after the write.
+func TestUpdatingATypeDefKeepsTheServersGUID(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+
+	get := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedef/name/my_table", "")
+	var before typeDefBody
+	if err := json.Unmarshal(get.Body.Bytes(), &before); err != nil {
+		t.Fatal(err)
+	}
+	if before.GUID == "" {
+		t.Fatal("the seeded type has no guid to preserve")
+	}
+
+	// A different guid and a changed description, both from the client.
+	body := `{"entityDefs":[{"name":"my_table","guid":"client-supplied","superTypes":["DataSet"],` +
+		`"description":"second version","attributeDefs":[]}]}`
+	w := do(t, mux, "PUT", BasePath+"/atlas/v2/types/typedefs", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update = %d %s", w.Code, w.Body)
+	}
+
+	after := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedef/name/my_table", "")
+	var got map[string]any
+	if err := json.Unmarshal(after.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["guid"] != before.GUID {
+		t.Fatalf("guid = %v, want the server's %s — an update reassigned identity", got["guid"], before.GUID)
+	}
+	if got["description"] != "second version" {
+		t.Fatalf("description = %v — the update did not take", got["description"])
+	}
+}
+
+// Updating a type that was never registered is a 404, not a create. Silently
+// upserting would let a typo register a second type that no entity can use.
+func TestUpdatingAnUnregisteredTypeIsRefused(t *testing.T) {
+	_, mux := newService(t)
+	body := `{"entityDefs":[{"name":"never_registered","superTypes":["DataSet"],"attributeDefs":[]}]}`
+	w := do(t, mux, "PUT", BasePath+"/atlas/v2/types/typedefs", body)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("update of an unknown type = %d, want 404 (%s)", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != "ATLAS-404-00-001" {
+		t.Fatalf("errorCode = %s, want ATLAS-404-00-001", code)
+	}
+}
+
+// DELETE /types/typedefs is the bulk form of the single-name delete, and it
+// inherits the same in-use guard. If it did not, the bulk route would be a way
+// around a rule the single route enforces.
+func TestBulkTypeDefDeleteHonoursTheInUseGuard(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+	createEntity(t, mux, "my_table", "mssql://s/db/in_use")
+
+	body := `{"entityDefs":[{"name":"my_table"}]}`
+	w := do(t, mux, "DELETE", BasePath+"/atlas/v2/types/typedefs", body)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("bulk delete of a type in use = %d, want 409 (%s)", w.Code, w.Body)
+	}
+
+	// Unreferenced, it goes — otherwise the guard would be indistinguishable
+	// from the route simply never deleting anything.
+	seedType(t, mux, "unused_table")
+	free := do(t, mux, "DELETE", BasePath+"/atlas/v2/types/typedefs",
+		`{"entityDefs":[{"name":"unused_table"}]}`)
+	if free.Code != http.StatusNoContent {
+		t.Fatalf("bulk delete of an unused type = %d, want 204 (%s)", free.Code, free.Body)
+	}
+	if g := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedef/name/unused_table", ""); g.Code != http.StatusNotFound {
+		t.Fatalf("the deleted type still resolves: %d", g.Code)
+	}
+}
+
+// GET /types/typedefs, with and without ?type=. The narrowing matters: a client
+// asking for entity definitions and receiving the seeded classifications and
+// enums as well has to filter them itself, which is the bug the parameter exists
+// to prevent.
+func TestListingTypeDefsNarrowsByCategory(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+
+	all := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedefs", "")
+	if all.Code != http.StatusOK {
+		t.Fatalf("list = %d %s", all.Code, all.Body)
+	}
+	var full AtlasTypesDef
+	if err := json.Unmarshal(all.Body.Bytes(), &full); err != nil {
+		t.Fatal(err)
+	}
+	if len(full.EntityDefs) == 0 {
+		t.Fatalf("no entityDefs listed, but the base hierarchy is seeded: %s", all.Body)
+	}
+
+	narrowed := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedefs?type=entity", "")
+	var only AtlasTypesDef
+	if err := json.Unmarshal(narrowed.Body.Bytes(), &only); err != nil {
+		t.Fatal(err)
+	}
+	if len(only.EntityDefs) != len(full.EntityDefs) {
+		t.Fatalf("?type=entity returned %d entityDefs, unfiltered returned %d",
+			len(only.EntityDefs), len(full.EntityDefs))
+	}
+	// The query is case-insensitive (`entity` above, uppercased server-side),
+	// and it must actually exclude the other categories.
+	if len(only.ClassificationDefs)+len(only.EnumDefs)+len(only.StructDefs) != 0 {
+		t.Fatalf("?type=entity leaked other categories: %s", narrowed.Body)
+	}
+}
+
+// GET /types/typedefs/headers is the listing a client pages through before
+// fetching anything in full, so it must carry the three fields that make a
+// definition addressable — and not silently omit the guid.
+func TestTypeDefHeadersCarryGUIDNameAndCategory(t *testing.T) {
+	_, mux := newService(t)
+	w := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedefs/headers", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("headers = %d %s", w.Code, w.Body)
+	}
+	var headers []typeDefHeader
+	if err := json.Unmarshal(w.Body.Bytes(), &headers); err != nil {
+		t.Fatal(err)
+	}
+	if len(headers) == 0 {
+		t.Fatalf("no headers returned, but the base hierarchy is seeded: %s", w.Body)
+	}
+	var dataset *typeDefHeader
+	for i := range headers {
+		if headers[i].Name == "DataSet" {
+			dataset = &headers[i]
+		}
+	}
+	if dataset == nil {
+		t.Fatalf("DataSet missing from the headers listing: %s", w.Body)
+	}
+	if dataset.GUID == "" || dataset.Category != "ENTITY" {
+		t.Fatalf("DataSet header = %+v, want a guid and category ENTITY", *dataset)
+	}
+	// The guid a header advertises must be the one the guid route resolves,
+	// or paging the headers gives a client identifiers it cannot use.
+	if g := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedef/guid/"+dataset.GUID, ""); g.Code != http.StatusOK {
+		t.Fatalf("the guid from the header listing does not resolve: %d %s", g.Code, g.Body)
+	}
+}
+
+func TestGetTypeDefByGUIDMissesOnAnUnknownGUID(t *testing.T) {
+	_, mux := newService(t)
+	w := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedef/guid/00000000-0000-0000-0000-000000000000", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unknown typedef guid = %d, want 404 (%s)", w.Code, w.Body)
+	}
+}
+
+// The per-category read has two spellings, by name and by guid, and only the
+// name form was tested. They must agree: a guid that resolves to a
+// classification is not an entitydef, however it was looked up.
+func TestAPerCategoryGUIDReadDoesNotCastAcrossCategories(t *testing.T) {
+	_, mux := newService(t)
+	body := `{"classificationDefs":[{"name":"PII","superTypes":[],"attributeDefs":[]}]}`
+	if w := do(t, mux, "POST", BasePath+"/atlas/v2/types/typedefs", body); w.Code != http.StatusOK {
+		t.Fatalf("register classification = %d %s", w.Code, w.Body)
+	}
+	get := do(t, mux, "GET", BasePath+"/atlas/v2/types/typedef/name/PII", "")
+	var def typeDefBody
+	if err := json.Unmarshal(get.Body.Bytes(), &def); err != nil {
+		t.Fatal(err)
+	}
+	if def.GUID == "" {
+		t.Fatalf("the registered classification has no guid: %s", get.Body)
+	}
+
+	hit := do(t, mux, "GET", BasePath+"/atlas/v2/types/classificationdef/guid/"+def.GUID, "")
+	if hit.Code != http.StatusOK {
+		t.Fatalf("classificationdef by guid = %d, want 200 (%s)", hit.Code, hit.Body)
+	}
+	miss := do(t, mux, "GET", BasePath+"/atlas/v2/types/entitydef/guid/"+def.GUID, "")
+	if miss.Code != http.StatusNotFound {
+		t.Fatalf("a classification read as an entitydef = %d, want 404 (%s)", miss.Code, miss.Body)
+	}
+}
+
+// --- entities: header, bulk read, bulk delete, delete by attribute -----------
+
+// GET /entity/guid/{guid}/header returns a header, not the entity. The
+// distinction is the whole point of the route — a client that paged headers and
+// received full bodies would lose the bandwidth saving it asked for.
+func TestEntityHeaderIsAHeaderNotTheEntity(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+	guid := createEntity(t, mux, "my_table", "mssql://s/db/orders")
+
+	w := do(t, mux, "GET", BasePath+"/atlas/v2/entity/guid/"+guid+"/header", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("header = %d %s", w.Code, w.Body)
+	}
+	var h entityHeader
+	if err := json.Unmarshal(w.Body.Bytes(), &h); err != nil {
+		t.Fatal(err)
+	}
+	if h.GUID != guid || h.TypeName != "my_table" {
+		t.Fatalf("header = %+v, want guid %s of my_table", h, guid)
+	}
+	if h.Status != statusActive {
+		t.Fatalf("header status = %q, want %s", h.Status, statusActive)
+	}
+	// displayText is what a UI lists; falling back to qualifiedName when there
+	// is no name is the documented behaviour, and here `name` is set.
+	if h.DisplayText != "mssql://s/db/orders" {
+		t.Fatalf("displayText = %q, want the entity's name", h.DisplayText)
+	}
+	// The full read is a different shape — if these were the same response the
+	// route would be redundant rather than lighter.
+	full := do(t, mux, "GET", BasePath+"/atlas/v2/entity/guid/"+guid, "")
+	if full.Body.String() == w.Body.String() {
+		t.Fatal("the header route returned the same payload as the full entity read")
+	}
+}
+
+func TestEntityHeaderMissesOnAnUnknownGUID(t *testing.T) {
+	_, mux := newService(t)
+	w := do(t, mux, "GET", BasePath+"/atlas/v2/entity/guid/does-not-exist/header", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("header of an unknown guid = %d, want 404 (%s)", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != "ATLAS-404-00-005" {
+		t.Fatalf("errorCode = %s, want ATLAS-404-00-005", code)
+	}
+}
+
+// GET /entity/bulk?guid=…&guid=… — the read a client uses after a bulk create.
+// Answering for only the first GUID would look correct against a single-item
+// call and silently truncate every real one.
+func TestBulkEntityReadAnswersForEveryGUID(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+	a := createEntity(t, mux, "my_table", "mssql://s/db/a")
+	b := createEntity(t, mux, "my_table", "mssql://s/db/b")
+
+	w := do(t, mux, "GET", BasePath+"/atlas/v2/entity/bulk?guid="+a+"&guid="+b, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("bulk read = %d %s", w.Code, w.Body)
+	}
+	var out AtlasEntitiesWithExtInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Entities) != 2 {
+		t.Fatalf("bulk read returned %d entities for 2 guids: %s", len(out.Entities), w.Body)
+	}
+}
+
+// No `guid` at all is a client error, not an empty 200. An empty list would
+// read as "these entities do not exist", which is a different fact.
+func TestBulkEntityReadRequiresAtLeastOneGUID(t *testing.T) {
+	_, mux := newService(t)
+	w := do(t, mux, "GET", BasePath+"/atlas/v2/entity/bulk", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("bulk read with no guid = %d, want 400 (%s)", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != "ATLAS-400-00-001" {
+		t.Fatalf("errorCode = %s, want ATLAS-400-00-001", code)
+	}
+}
+
+// DELETE /entity/bulk reports one mutated header per entity and soft-deletes
+// each. Atlas keeps deleted entities readable; a hard delete here would break
+// the lineage and audit reads later increments add.
+func TestBulkDeleteSoftDeletesEveryEntity(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+	a := createEntity(t, mux, "my_table", "mssql://s/db/a")
+	b := createEntity(t, mux, "my_table", "mssql://s/db/b")
+
+	w := do(t, mux, "DELETE", BasePath+"/atlas/v2/entity/bulk?guid="+a+"&guid="+b, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("bulk delete = %d %s", w.Code, w.Body)
+	}
+	var resp EntityMutationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.MutatedEntities[opDelete]) != 2 {
+		t.Fatalf("bulk delete reported %d DELETEs for 2 guids: %s",
+			len(resp.MutatedEntities[opDelete]), w.Body)
+	}
+	for _, guid := range []string{a, b} {
+		got := do(t, mux, "GET", BasePath+"/atlas/v2/entity/guid/"+guid, "")
+		if got.Code != http.StatusOK {
+			t.Fatalf("entity %s is gone after delete (%d) — the delete was not soft", guid, got.Code)
+		}
+		var ext AtlasEntityWithExtInfo
+		if err := json.Unmarshal(got.Body.Bytes(), &ext); err != nil {
+			t.Fatal(err)
+		}
+		var generic map[string]any
+		if err := json.Unmarshal(ext.Entity, &generic); err != nil {
+			t.Fatal(err)
+		}
+		if generic["status"] != statusDeleted {
+			t.Fatalf("entity %s status = %v, want %s", guid, generic["status"], statusDeleted)
+		}
+	}
+}
+
+// DELETE /entity/uniqueAttribute/type/{typeName}?attr:qualifiedName=… — the
+// delete a client issues when it has a name and no GUID.
+func TestDeleteByUniqueAttributeSoftDeletesTheRightEntity(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+	target := createEntity(t, mux, "my_table", "mssql://s/db/target")
+	bystander := createEntity(t, mux, "my_table", "mssql://s/db/bystander")
+
+	w := do(t, mux, "DELETE", BasePath+
+		"/atlas/v2/entity/uniqueAttribute/type/my_table?attr:qualifiedName=mssql://s/db/target", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete by unique attribute = %d %s", w.Code, w.Body)
+	}
+	var resp EntityMutationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(resp.MutatedEntities[opDelete]); n != 1 {
+		t.Fatalf("reported %d DELETEs, want 1: %s", n, w.Body)
+	}
+	if got := resp.MutatedEntities[opDelete][0].GUID; got != target {
+		t.Fatalf("deleted %s, want the entity matching the qualifiedName (%s)", got, target)
+	}
+	// The other entity of the same type is untouched — a delete keyed on the
+	// type alone would take both, and only a second entity reveals it.
+	other := do(t, mux, "GET", BasePath+"/atlas/v2/entity/guid/"+bystander, "")
+	var ext AtlasEntityWithExtInfo
+	if err := json.Unmarshal(other.Body.Bytes(), &ext); err != nil {
+		t.Fatal(err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(ext.Entity, &generic); err != nil {
+		t.Fatal(err)
+	}
+	if generic["status"] == statusDeleted {
+		t.Fatal("deleting by qualifiedName also deleted a different entity of the same type")
+	}
+}
+
+// The single-entity routes each have a miss branch, and a 500 there would send
+// a client chasing a server fault for what is really "no such entity".
+func TestSingleEntityRoutesMissCleanlyOnAnUnknownGUID(t *testing.T) {
+	_, mux := newService(t)
+	for _, tc := range []struct{ method, path string }{
+		{"GET", "/atlas/v2/entity/guid/does-not-exist"},
+		{"DELETE", "/atlas/v2/entity/guid/does-not-exist"},
+	} {
+		w := do(t, mux, tc.method, BasePath+tc.path, "")
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s %s = %d, want 404 (%s)", tc.method, tc.path, w.Code, w.Body)
+			continue
+		}
+		if code := errorCode(t, w); code != "ATLAS-404-00-005" {
+			t.Errorf("%s %s errorCode = %s, want ATLAS-404-00-005", tc.method, tc.path, code)
+		}
+	}
+}
+
+func TestDeleteByUniqueAttributeMissesOnAnUnknownName(t *testing.T) {
+	_, mux := newService(t)
+	seedType(t, mux, "my_table")
+	w := do(t, mux, "DELETE", BasePath+
+		"/atlas/v2/entity/uniqueAttribute/type/my_table?attr:qualifiedName=mssql://s/db/nope", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("delete of an unknown qualifiedName = %d, want 404 (%s)", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != "ATLAS-404-00-00A" {
+		t.Fatalf("errorCode = %s, want ATLAS-404-00-00A", code)
+	}
+}

--- a/internal/semanticmodel/dax_coercion_test.go
+++ b/internal/semanticmodel/dax_coercion_test.go
@@ -1,0 +1,124 @@
+package semanticmodel
+
+import (
+	"strings"
+	"testing"
+)
+
+// The value-coercion helpers (`truthy`, `dstr`, `asNumber`, `toF`) decide what
+// every operator and every aggregate does with a value that is not already a
+// float64. They were the least-covered code in this package — 33-62% — and the
+// unreached arms are not exotic: booleans reach them through comparisons, and
+// the sized integer types reach them through Direct Lake, where rows arrive
+// from parquet as typed Go integers rather than as JSON numbers.
+//
+// So these tests drive the arms through real DAX rather than calling the
+// helpers directly, because a coercion that is right in isolation and unreached
+// from a query proves nothing about the evaluator.
+
+// A comparison yields a Go bool, so any operator applied to one lands in the
+// boolean arms. Real DAX renders those as TRUE/FALSE and counts them as 1/0.
+func TestDAXBooleanValuesConcatenateAndCount(t *testing.T) {
+	for _, tc := range []struct {
+		expr string
+		want any
+	}{
+		// dstr's boolean arm: `&` on a comparison result.
+		{`(1 = 1) & ""`, "TRUE"},
+		{`(1 = 2) & ""`, "FALSE"},
+		{`"units: " & (1 < 2)`, "units: TRUE"},
+		// asNumber's boolean arm: TRUE is 1, FALSE is 0, in arithmetic.
+		{`(1 = 1) + 1`, 2.0},
+		{`(1 = 2) + 1`, 1.0},
+		{`(1 = 1) * 7`, 7.0},
+		// And the two compose: a boolean is 1, then rendered as a number.
+		{`((1 = 1) + 1) & ""`, "2"},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			if got := evalScalar(t, tc.expr); fmtLike(got) != fmtLike(tc.want) {
+				t.Errorf("%s = %v (%T), want %v", tc.expr, got, got, tc.want)
+			}
+		})
+	}
+}
+
+// truthy decides IF's condition. Only its boolean arm was exercised; a
+// condition can also be blank, a number, or text — and DAX's rule is that
+// FALSE, BLANK, 0 and "" are false, everything else true.
+func TestDAXIfConditionCoercion(t *testing.T) {
+	for _, tc := range []struct {
+		expr string
+		want float64
+	}{
+		{`IF(1, 10, 20)`, 10},            // non-zero number is true
+		{`IF(0, 10, 20)`, 20},            // zero is false
+		{`IF(-1, 10, 20)`, 10},           // non-zero, including negative
+		{`IF(DIVIDE(1, 0), 10, 20)`, 20}, // BLANK is false
+		{`IF("x", 10, 20)`, 10},          // non-empty text is true
+		{`IF("", 10, 20)`, 20},           // empty text is false
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			if got := toF(evalScalar(t, tc.expr)); got != tc.want {
+				t.Errorf("%s = %v, want %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+// toF's sized-integer arms exist for Direct Lake: a parquet `int32` column
+// arrives as a Go int32, not a float64, and a SUM that silently returned 0 for
+// it would under-report a real table. Each type is summed with a second row so
+// a dropped value shows as a wrong total rather than a plausible one.
+func TestDAXSumsEveryNumericGoType(t *testing.T) {
+	m := loadModel(t)
+	for name, v := range map[string]any{
+		"int":     int(41),
+		"int8":    int8(41),
+		"int16":   int16(41),
+		"int32":   int32(41),
+		"int64":   int64(41),
+		"uint":    uint(41),
+		"uint8":   uint8(41),
+		"uint16":  uint16(41),
+		"uint32":  uint32(41),
+		"uint64":  uint64(41),
+		"float32": float32(41),
+		"float64": float64(41),
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := Data{"Sales": []Row{{"Units": v}, {"Units": 1}}}
+			res, err := Evaluate(m, d, `EVALUATE SUMMARIZECOLUMNS("v", SUM(Sales[Units]))`)
+			if err != nil {
+				t.Fatalf("SUM over a %s column: %v", name, err)
+			}
+			if got := toF(res.Rows[0]["[v]"]); got != 42 {
+				t.Errorf("SUM over a %s column = %v, want 42", name, got)
+			}
+		})
+	}
+}
+
+// A value of no numeric type at all must refuse rather than count as zero —
+// the fallback arm behind every coercion above, and the same rule the text
+// refusal enforces for strings.
+func TestDAXSumRefusesANonNumericGoValue(t *testing.T) {
+	m := loadModel(t)
+	d := Data{"Sales": []Row{{"Units": []int{1, 2}}, {"Units": 1}}}
+	_, err := Evaluate(m, d, `EVALUATE SUMMARIZECOLUMNS("v", SUM(Sales[Units]))`)
+	if err == nil {
+		t.Fatal("a slice-valued column summed; it must refuse rather than coerce to 0")
+	}
+	// dstr's own fallback renders it, so the message names what it could not read.
+	if want := "not a number"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err, want)
+	}
+}
+
+// fmtLike compares values the way the other suites do: numbers by value rather
+// than by Go type, everything else by its rendered form.
+func fmtLike(v any) string {
+	if f, ok := numeric(v); ok {
+		return dstr(f)
+	}
+	return dstr(v)
+}

--- a/python/tests/test_check_docs_sidebar.py
+++ b/python/tests/test_check_docs_sidebar.py
@@ -5,10 +5,11 @@ was published by the site and linked from no sidebar group, so nothing reached
 it — but the checker itself was executed by no test, which is the state it
 exists to prevent elsewhere.
 
-The interesting part is the PUBLISHED pattern: it mirrors `DOC_RE` in
-website/scripts/sync-docs.mjs, and a mismatch there means the checker guards a
-different set of files than the site actually publishes. That is the drift worth
-pinning.
+The interesting part is which set of files counts as published. That is decided
+by `DOC_RE` in website/scripts/sync-docs.mjs, and the checker used to keep a
+copy of it — a mismatch there meant the checker guarded a different set than the
+site published, silently. The copy is gone; the pattern is derived, and the
+tests below pin the derivation rather than a restatement of it.
 """
 import pathlib
 import sys
@@ -81,15 +82,72 @@ def test_only_site_published_docs_are_required(site, capsys, name, published):
     assert (rc == 1) == published, f"{name}: published={published} but rc={rc}"
 
 
-def test_the_pattern_matches_the_sites_own_regex():
-    # The checker guards the set sync-docs.mjs publishes. If that regex is
-    # edited and this one is not, the check silently guards a different set.
-    mjs = (ROOT / "website" / "scripts" / "sync-docs.mjs").read_text()
-    assert "DOC_RE" in mjs, "sync-docs.mjs no longer defines DOC_RE"
-    for name in ("01-quickstart.md", "parity.md", "engine-matrix.md"):
-        assert c.PUBLISHED.match(name), name
-    for name in ("README.md", "AUDIT.md"):
-        assert not c.PUBLISHED.match(name), name
+# THE COUPLING THIS USED TO PRETEND TO PIN.
+#
+# The checker guards the set sync-docs.mjs publishes. It used to keep its own
+# copy of that regex under a comment saying "Mirrors DOC_RE in …", and the test
+# here asserted `"DOC_RE" in mjs` — that the NAME still appeared in the file —
+# then checked the local copy against a hand-written list of filenames.
+#
+# Both halves passed for the wrong reason. Editing DOC_RE to publish a
+# different set left the name present and the hand-written list matching the
+# stale copy, so the check silently guarded a set the site no longer used. The
+# assertion matched a phrase that co-occurs with the claim, not the claim.
+#
+# The pattern is now DERIVED from the .mjs, so these test the derivation — and
+# the first one cannot pass against a hardcoded copy, which is the point.
+
+def test_the_pattern_is_read_from_the_site_not_copied(tmp_path):
+    # A DIFFERENT DOC_RE must produce a DIFFERENT published set. A copy in
+    # check_docs_sidebar.py would ignore this file and fail here.
+    mjs = tmp_path / "sync-docs.mjs"
+    mjs.write_text("const DOC_RE = /^(chapter-.*|glossary)\\.md$/;\n")
+    pattern = c.published_pattern(mjs)
+    assert pattern.match("chapter-01.md"), "the site's own regex was not used"
+    assert pattern.match("glossary.md")
+    assert not pattern.match("01-quickstart.md"), (
+        "the OLD hardcoded pattern is still in force — the derivation is not wired up")
+
+
+def test_the_real_sites_pattern_publishes_the_documented_set():
+    pattern = c.published_pattern()
+    for name in ("01-quickstart.md", "39-run-multiple.md", "parity.md", "engine-matrix.md"):
+        assert pattern.match(name), name
+    for name in ("README.md", "AUDIT.md", "1-short.md"):
+        assert not pattern.match(name), name
+
+
+def test_a_missing_declaration_fails_loudly(tmp_path):
+    # Falling back to a copied default here would rebuild the exact bug this
+    # change removes: a check guarding a guessed set, silently.
+    mjs = tmp_path / "sync-docs.mjs"
+    mjs.write_text("const OTHER_RE = /^x$/;\n")
+    with pytest.raises(c.PatternUnavailable, match="DOC_RE"):
+        c.published_pattern(mjs)
+
+
+def test_an_absent_file_fails_loudly(tmp_path):
+    with pytest.raises(c.PatternUnavailable, match="cannot read"):
+        c.published_pattern(tmp_path / "nope.mjs")
+
+
+def test_a_regex_python_cannot_compile_fails_loudly(tmp_path):
+    # JS and Python share the subset this pattern uses; if DOC_RE ever leaves
+    # it, that must be a loud translation decision, not a silent mismatch.
+    mjs = tmp_path / "sync-docs.mjs"
+    # JS named groups are `(?<name>…)`; Python spells them `(?P<name>…)` and
+    # rejects the JS form. (Lookbehind would NOT work as a probe here — both
+    # languages accept `(?<=…)`, and the first draft of this test used it and
+    # failed to raise, which is the same "assert the substance" lesson again.)
+    mjs.write_text("const DOC_RE = /^(?<kind>\\d{2})-.*\\.md$/;\n")
+    with pytest.raises(c.PatternUnavailable):
+        c.published_pattern(mjs)
+
+
+def test_main_reports_an_underivable_pattern_instead_of_guessing(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(c, "SYNC_DOCS", tmp_path / "gone.mjs")
+    assert c.main() == 1
+    assert "cannot read" in capsys.readouterr().out
 
 
 # --- refusing to pass vacuously ----------------------------------------------

--- a/scripts/check_docs_sidebar.py
+++ b/scripts/check_docs_sidebar.py
@@ -15,9 +15,23 @@ convention held perfectly by hand until it wasn't.
 
 WHAT COUNTS AS PUBLISHED. website/scripts/sync-docs.mjs decides, via DOC_RE:
 `NN-name.md` chapters plus the two un-numbered living references (parity,
-engine-matrix). That regex is mirrored below rather than re-derived, so a file
-this check considers is exactly a file the site publishes. Anything else in
-docs/ (release notes, subdirectories) is not synced and not required.
+engine-matrix). **That regex is READ FROM sync-docs.mjs, not copied here.**
+
+It used to be copied, under a comment saying "Mirrors DOC_RE in
+website/scripts/sync-docs.mjs" — and a comment telling a future reader to keep
+two things in step is a defect already filed, with no owner and no failing
+test. The test that claimed to pin the coupling asserted only that the STRING
+"DOC_RE" still appeared in the .mjs, then checked the local copy against a
+hand-written list of filenames. Edit DOC_RE to publish a different set and
+everything stayed green: the name was still there, and the hand-written list
+still matched the stale copy. The assertion matched a phrase that co-occurs
+with the claim rather than the claim itself.
+
+Deriving it removes the second list instead of guarding it. The two regexes
+share a syntax for this pattern (character classes, alternation, anchors), so
+the JS source compiles in Python as-is. If it ever stops doing so, this fails
+loudly rather than falling back to a copy — a silent fallback would rebuild
+exactly the bug being removed.
 
 ONE DIRECTION ONLY. Sidebar entries with no docs/ source are legitimate — the
 landing page and the generated parity-history pages are synthesized by
@@ -35,13 +49,51 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 DOCS = ROOT / "docs"
 CONFIG = ROOT / "website" / "astro.config.mjs"
 
-# Mirrors DOC_RE in website/scripts/sync-docs.mjs — the set the site publishes.
-PUBLISHED = re.compile(r"^(\d{2}-.*|parity|engine-matrix)\.md$")
+SYNC_DOCS = ROOT / "website" / "scripts" / "sync-docs.mjs"
+
+# `const DOC_RE = /…/;` — the literal, unanchored to any particular body so a
+# future edit to the pattern is picked up rather than rejected.
+_DOC_RE_DECL = re.compile(r"^const\s+DOC_RE\s*=\s*/(?P<body>.+)/(?P<flags>[a-z]*);\s*$", re.M)
+
+
+class PatternUnavailable(RuntimeError):
+    """sync-docs.mjs could not be read, found, or compiled."""
+
+
+def published_pattern(path=None):
+    """Compile the site's own DOC_RE so this check guards exactly its set.
+
+    Raises rather than falling back: guarding a *guessed* set silently is the
+    failure this function exists to remove.
+    """
+    path = path or SYNC_DOCS
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PatternUnavailable(f"cannot read {path}: {exc}") from exc
+    match = _DOC_RE_DECL.search(source)
+    if not match:
+        raise PatternUnavailable(
+            f"{path} no longer declares `const DOC_RE = /…/;` — the published set "
+            "cannot be derived, so this check cannot know what to guard")
+    body = match.group("body")
+    try:
+        return re.compile(body)
+    except re.error as exc:
+        raise PatternUnavailable(
+            f"DOC_RE in {path} does not compile as a Python regex ({exc}); it has "
+            "diverged from the shared subset and must be translated deliberately") from exc
 
 
 def main():
     if not CONFIG.exists():
         print(f"check_docs_sidebar: {CONFIG} not found")
+        return 1
+
+    try:
+        published = published_pattern()
+    except PatternUnavailable as exc:
+        print(f"check_docs_sidebar: {exc}")
         return 1
 
     slugs = set(re.findall(r"slug:\s*'([^']+)'", CONFIG.read_text()))
@@ -50,7 +102,7 @@ def main():
         print("check_docs_sidebar: parsed no slugs from website/astro.config.mjs")
         return 1
 
-    docs = sorted(p.name for p in DOCS.glob("*.md") if PUBLISHED.match(p.name))
+    docs = sorted(p.name for p in DOCS.glob("*.md") if published.match(p.name))
     if not docs:
         print("check_docs_sidebar: parsed no published docs from docs/")
         return 1


### PR DESCRIPTION
`main` is below the 90% coverage floor (89.8% on CI), so every PR inherits a red `Build, vet & tests` job — including ones that touch no Go at all, like #100 and #102. This unblocks that and takes the next-worst gap with it.

## 1. purview — the routes that shipped untested

#104 (`049e487`) added 1,413 production Go lines against 386 test lines. `internal/purview` shipped at **57.4%** with **15 of 57 functions never executed** — createOrUpdate was tested, the read/update/delete halves were not.

| File | Handlers covered |
|---|---|
| `typedefs.go` | `updateTypeDefs`, `deleteTypeDefs`, `listTypeDefs`, `listTypeDefHeaders`, `getTypeDefByGUID` |
| `entities.go` | `getEntityHeaderByGUID`, `getEntitiesByGUIDs`, `deleteEntitiesByGUIDs`, `deleteEntityByUniqueAttr` |

Plus the per-category *guid* read (only the *name* spelling was tested) and the 404 branches of the single-entity routes.

Each assertion is something a stub would fail: an update keeps the server's GUID rather than the client's; the bulk typedef delete honours the same in-use guard the single-name route does; `?type=` genuinely excludes other categories; the header route returns a header, not the whole entity; a bulk read answers for every GUID rather than the first; deletes are soft; and deleting by `qualifiedName` leaves a second entity of the same type untouched.

## 2. REST pagination — the value layer

`restpagination.go` was the worst-covered substantial file in `internal/api` at **74.6%**, and `headerSelector` was at **0%** — the header half of what the file's own doc comment promises (*"a JSONPath into the body, or `Headers.x`"*) had never been executed. Header-sourced cursors are a documented Fabric shape and were entirely unverified.

The existing tests drive full paging sequences and assert the request log, which covers the loop well and the value layer barely. Added: direct unit tests for the pure helpers, plus integration tests for a cursor read from a response header, a cursor carried into the next request's header, and an `EndCondition` on a header.

Mostly refusals, deliberately — a resolver returning `("", true)` where it should return `false` pages forever against a live endpoint, and no happy-path sequence would reveal it. Two that matter: **zero is a value, not an absence** (`isEmptyNode(0)` false, or an offset of 0 stops on page one), and `scalarString(1000.0)` → `"1000"`, since every offset arrives as a float64 and `1000.0` in a URL is a different request.

## Result

```
internal/purview    57.4%  ->  78.7%
restpagination.go   74.6%  ->  ~99%   (every function >= 88.9%)
repo total          88.4%  ->  89.6%  (local, no SQL Server)
```

CI runs ~1.4pp above local because the DSN-gated suites (`warehouse`, `tds`, `pipeline_sql`) execute there — the same gap that made main read 89.8% on CI and 88.4% here. The purview half alone already measured **90.6%** on CI; with the pagination tests this should land near **91%**.

Only `clientError.Error()` remains uncovered in purview — an interface method nothing on the write path calls.

## 3. DAX value coercions

Taken verbatim from #114 (now closed) so its distinct half is not lost: four tests over `internal/semanticmodel` covering boolean concatenation and counting, `IF` condition coercion, `SUM` across every numeric Go type, and `SUM` refusing a non-numeric value. `internal/semanticmodel` is at 94.9%.

#114 also carried pagination tests that duplicated section 2 — including a test function named identically to one here, which would have broken `main` on the second merge with a redeclaration error neither PR's CI could see. Those are dropped; its branch is kept.

Revised total: **89.7%** locally (from 88.4%).

## 4. docs sidebar check

`7d110e3` cherry-picked verbatim from #100 (now closed): the check derives the published doc set from the site's own regex instead of keeping a second copy in sync by hand. Its 19 tests pass; `check_docs_sidebar` reports 45 published docs, all reachable.

#100 touched no Go, but was failing anyway on main's sub-90% floor — so it was blocked on this PR regardless of being folded into it.
