### PR TITLE
xmla: read generateastoken's reply contract off the assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ portal/coverage/
 
 # Intermediate frames and video from the flow.gif recording (docs/demo/flow.py).
 docs/demo/.capture/
+
+# .NET build output from the e2e probes (they build in-container).
+bin/
+obj/

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -433,6 +433,42 @@ prints any matching `[DataContract]`'s member names. Reach for it *before*
 screening a payload shape: a screen is right when the client's behaviour is
 unknown, wrong when the answer is already written in an assembly on disk.
 
+### Screen 9 — RUN: the token is accepted, and the client leaves for :443
+
+Serving `{"Token":"emulator-mwc-token"}` — the contract read above, not a
+hypothesis — against the `L1`/`L2`/`L5` capacity-path rungs.
+
+**Observed.** The token was served three times (once per rung). Every
+connection then failed with
+
+```
+SocketException :: Connection refused  host.docker.internal:443
+```
+
+thrown from `XmlaClient.OpenConnection` → `HttpStream.Create` →
+`ConnectionInfo.ResolveHTTPConnectionPropertiesForPaaSInfrastructure`.
+
+**What that establishes.** The token is accepted — nothing rejected it, and the
+client proceeded to open its XMLA connection. It went to the routing host on
+**port 443**, discarding the port named in the Data Source. That is the first
+time the client has tried to reach anything other than the listener it was
+pointed at, and it exercises the hook `docs/32` recorded as untested:
+`pbiDedicatedRolloutFqdn`. With no rollout FQDN in the reply, the fallback is
+host-from-routing plus the default HTTPS port.
+
+**The consequence for Phase 1.** The XMLA endpoint's address is *derived*, not
+taken from the connection string, so a suite cannot reach it by pointing the
+Data Source somewhere. Either the reply must carry a host:port the client will
+honour, or the listener must occupy 443. The next screen should vary
+`capacityUri`'s **authority** — it already carries the path segment the client
+reads as `capacityObjectId`, and its host is the obvious candidate for the one
+it dials.
+
+**Not established.** Whether the client would accept a port in that authority
+at all, and whether `pbiDedicatedRolloutFqdn` is settable from any field in
+`Workspace201606` (the contract has five members, and `capacityUri` is the only
+one shaped like a host). No run has varied it.
+
 ### Where this leaves the search
 
 Phase 0's question — "what does the client ask after routing?" — is **answered**.

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -398,17 +398,58 @@ authorization: Bearer <token from the connection string>
 it. `datasetName` is null because the probe's Data Source carries no
 `Initial Catalog`; that is where a database name would appear.
 
+### The token read — DONE: `generateastoken`'s reply is one field
+
+Read off the same assembly (19.84.1.0) rather than screened, because the
+routing read had already shown that beats guessing. `GetMwcToken` returns
+`PbiPremiumAuthenticationHandle+MWCToken`, and the contract is:
+
+```
+MWCToken
+    Token : string        [DataMember] ×1
+```
+
+One member, PascalCase. **The emulator's reply to `generateastoken` is
+`{"Token":"<string>"}`** — and the token is one the emulator mints, so its
+contents are ours to choose.
+
+**A free check on the method.** The same read dumped the *request* contract:
+
+```
+MWCASTokenRequest
+    capacityObjectId · workspaceObjectId · datasetName · applyAuxiliaryPermission
+    auxiliaryPermissionOwner · bypassBuildPermission · intendedUsage
+    sourceCapacityObjectId
+```
+
+That matches screen 8's captured wire body field for field. The declared
+contract and the observed request agree, so the reflection route is confirmed
+against a measurement rather than trusted on its own — which is the check the
+routing read never got.
+
+The read is now a tool rather than an ad-hoc run:
+[`e2e/xmla/contract`](../e2e/xmla/contract/README.md). `run.py [substring]`
+prints any matching `[DataContract]`'s member names. Reach for it *before*
+screening a payload shape: a screen is right when the client's behaviour is
+unknown, wrong when the answer is already written in an assembly on disk.
+
 ### Where this leaves the search
 
 Phase 0's question — "what does the client ask after routing?" — is **answered**.
 The roadmap's largest unknown is now a recorded request with a known body.
 
-Next is `generateastoken`'s RESPONSE contract, and it should be read off the
-assembly rather than screened: `GetMwcToken` deserialises into a declared
-`[DataContract]` exactly as the routing reply did, and reading it once beat
-four screens of guessing last time. "MWC" is the token the client carries into
-the XMLA calls themselves, which is the boundary where Phase 0 ends and
-Phase 1 has a client to talk to.
+~~Next is `generateastoken`'s RESPONSE contract~~ — **done**, see the token
+read above: `{"Token":"<string>"}`. "MWC" is the token the client carries into
+the XMLA calls themselves, so answering this is the boundary where Phase 0 ends
+and Phase 1 has a client to talk to.
+
+**The next unknown is therefore what the client does with a token it accepts.**
+Nothing in this project has seen a request past `generateastoken`, and that is
+the first XMLA/SOAP call — the point where `[MS-SSAS-T]` stops being a paper
+spec and becomes a recorded sequence. The step is small: serve
+`{"Token":"…"}` from the capture stub and record what arrives next. Whether
+`pbiDedicatedRolloutFqdn` can then steer that call at a host of our choosing
+remains untested and is the other half of the same run.
 
 `pbiDedicatedRolloutFqdn` — the other value `TryResolvePbiWorkspace` derives —
 remains the hook for steering the client's later calls at a host of our

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -469,6 +469,69 @@ at all, and whether `pbiDedicatedRolloutFqdn` is settable from any field in
 `Workspace201606` (the contract has five members, and `capacityUri` is the only
 one shaped like a host). No run has varied it.
 
+### Screen 10 — RUN: a call nobody knew existed, and 443 is reachable after all
+
+Screen 9 left the client dialling `:443`, which looked like a hard constraint:
+the harness cannot bind a privileged port. It is not — **the Docker daemon
+publishes 443 without sudo**, and socat piping 443 to the capture listener
+keeps TLS terminating on the same self-signed cert. A door, not a proxy.
+
+With that door open the client got further and revealed a request this plan
+had never recorded:
+
+```
+POST /webapi/clusterResolve
+content-type: application/json      host: host.docker.internal   (portless — it came in on 443)
+
+{"databaseName":null,"premiumPublicXmlaEndpoint":true,
+ "serverName":"11111111-1111-1111-1111-111111111111/"}
+```
+
+`serverName` is the `capacityObjectId` — the first `capacityUri` path segment,
+trailing slash intact, exactly as screen 8 established. `databaseName` is null
+because the Data Source carries no `Initial Catalog`. The call appears **twice
+per connection**: once before routing and once after the token.
+
+**This also retired a screen before it was run.** The plan was to vary
+`capacityUri`'s authority to test whether a port is honoured. Checking first
+showed the shape is built from the request's `Host` header, so `capacityUri`
+already carried `:18446` — and the client dialled `:443` regardless. The port
+is not unhandled, it is **discarded**, and the screen would have spent several
+containers re-deriving that.
+
+### Screen 11 — RUN: the client asks us where to go, and takes an answer
+
+`PowerBIClusterResolutionResult` — read from the assembly with
+[`e2e/xmla/contract`](../e2e/xmla/contract/README.md), one run, no screening:
+
+```
+FixedClusterUri · DynamicClusterUri · NewTenantId · RuleDescription · TTLSeconds
+```
+
+That is the steering hook open since screen 5. The client does not derive its
+XMLA endpoint unilaterally — **it asks, and we answer.**
+
+Answering with `{"FixedClusterUri":"https://host.docker.internal:18446", …}`
+moved the failure again:
+
+| screen | reply to clusterResolve | client's answer |
+|---|---|---|
+| 10 | SOAP fault (the stub's refusal) | `NotSupportedException :: Specified method is not supported` |
+| 11 | the declared contract, URIs as full URLs | `AdomdConnectionException :: A connection cannot be made` |
+
+**Consumed, then rejected.** `NotSupportedException` was the client refusing to
+parse a SOAP body where JSON belongs; it is gone, so the contract is right. The
+new throw is inside `ASAzureUtility.ResolvePaaSConnectionEndpointDetail` — the
+same method that posts `clusterResolve` — and **no request reached the listener
+afterwards**. So this is resolution rejecting the value, not a failed dial.
+
+**The next screen, and it is one variable.** The URIs were sent as full URLs.
+If the client prefixes a scheme itself, `https://https://…` would fail exactly
+like this without a socket ever opening. Send `FixedClusterUri` as a bare
+`host:port`, and as a bare host, in one run each. The discriminator is already
+known: a value the client accepts produces a request at the listener, and that
+request is the first XMLA/SOAP envelope this project has seen.
+
 ### Where this leaves the search
 
 Phase 0's question — "what does the client ask after routing?" — is **answered**.

--- a/e2e/xmla/contract/Program.cs
+++ b/e2e/xmla/contract/Program.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+// Read the DataContract that GetMwcToken deserialises its reply into.
+// docs/32 established the routing reply's shape this way rather than by
+// screening; the same method should settle generateastoken's response.
+class Read {
+    // CONTRACT_FILTER narrows both sweeps; empty means the token exchange,
+    // which is what this was first written to answer.
+    static readonly string[] Filters =
+        (Environment.GetEnvironmentVariable("CONTRACT_FILTER") ?? "").Trim() is { Length: > 0 } f
+            ? new[] { f } : new[] { "Token", "Mwc", "GenerateAs" };
+
+    static bool Matches(string name) =>
+        Filters.Any(x => name.Contains(x, StringComparison.OrdinalIgnoreCase));
+
+    static void Main() {
+        var asm = typeof(Microsoft.AnalysisServices.AdomdClient.AdomdConnection).Assembly;
+        Console.WriteLine("ASSEMBLY " + asm.GetName().Name + " " + asm.GetName().Version);
+
+        const BindingFlags ALL = BindingFlags.Public | BindingFlags.NonPublic
+                               | BindingFlags.Instance | BindingFlags.Static;
+
+        // 1. Find GetMwcToken and report its signature — the return type (or an
+        //    out/local) names the contract we must satisfy.
+        foreach (var t in asm.GetTypes()) {
+            MethodInfo[] ms;
+            try { ms = t.GetMethods(ALL); } catch { continue; }
+            foreach (var m in ms) {
+                if (!Matches(m.Name)) continue;
+                Console.WriteLine($"METHOD {t.FullName}::{m.Name}");
+                Console.WriteLine($"  returns {m.ReturnType.FullName}");
+                foreach (var p in m.GetParameters())
+                    Console.WriteLine($"  param  {p.ParameterType.FullName} {p.Name}"
+                                      + (p.IsOut ? " [out]" : ""));
+            }
+        }
+
+        // 2. Dump every [DataContract] whose name suggests the token exchange.
+        //    Member names come from [DataMember(Name=...)], which is what
+        //    DataContractJsonSerializer matches on.
+        Console.WriteLine("---- candidate contracts ----");
+        foreach (var t in asm.GetTypes()) {
+            if (t.GetCustomAttribute<DataContractAttribute>() == null) continue;
+            var n = t.FullName ?? "";
+            if (!Matches(n)) continue;
+            Console.WriteLine("CONTRACT " + n);
+            foreach (var f in t.GetFields(ALL)) {
+                var dm = f.GetCustomAttribute<DataMemberAttribute>();
+                if (dm != null)
+                    Console.WriteLine($"    field  {dm.Name ?? f.Name} : {f.FieldType.Name}");
+            }
+            foreach (var p in t.GetProperties(ALL)) {
+                var dm = p.GetCustomAttribute<DataMemberAttribute>();
+                if (dm != null)
+                    Console.WriteLine($"    prop   {dm.Name ?? p.Name} : {p.PropertyType.Name}");
+            }
+            if (t.IsEnum)
+                Console.WriteLine("    enum values: " + string.Join(" | ", Enum.GetNames(t)));
+        }
+    }
+}

--- a/e2e/xmla/contract/README.md
+++ b/e2e/xmla/contract/README.md
@@ -1,0 +1,33 @@
+# Reading ADOMD.NET's contracts instead of guessing them
+
+The client deserialises with `DataContractJsonSerializer`, so the JSON member
+names it will match are declared on concrete types inside the shipped
+assembly — `[DataMember(Name=…)]`. They are **readable**, not searchable.
+
+That matters because guessing them is expensive and quietly misleading.
+`docs/32-xmla-plan.md` records four screens spent on the routing reply's shape,
+one of which produced a conclusion that survived a round before being
+disproved; a single assembly read then retired the whole line of enquiry and
+showed the payload was a bare array with two of five members never sent.
+
+It has since paid twice. The same read settled `generateastoken`'s response as
+`MWCToken { Token }` in one run, and — as a check on the method itself — the
+`MWCASTokenRequest` it dumped matches the request body captured on the wire in
+screen 8, field for field.
+
+## Run it
+
+```bash
+python3 e2e/xmla/contract/run.py            # everything token-related
+python3 e2e/xmla/contract/run.py Rowset     # any substring of a type name
+```
+
+Prints, for each matching `[DataContract]`, the member names the client
+matches on — and for any method whose name matches, its return type, which is
+what names the contract to look for.
+
+## When to reach for this
+
+Before screening a payload shape. A screen is the right tool when the client's
+behaviour is the unknown; it is the wrong tool when the answer is written down
+in an assembly you already have.

--- a/e2e/xmla/contract/contract.csproj
+++ b/e2e/xmla/contract/contract.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <AssemblyName>contract</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.*" />
+  </ItemGroup>
+</Project>

--- a/e2e/xmla/contract/run.py
+++ b/e2e/xmla/contract/run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Read ADOMD.NET's declared JSON contracts.
+
+The client matches JSON members against `[DataMember(Name=…)]` on types in the
+shipped assembly, so the names are readable rather than guessable. See
+README.md for why this beats screening a shape.
+"""
+import os
+import shutil
+import subprocess
+import sys
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+SDK_IMAGE = "mcr.microsoft.com/dotnet/sdk:8.0"
+
+if not shutil.which("docker"):
+    sys.exit("docker is not on PATH; the assembly read needs the .NET 8 SDK image")
+
+filt = sys.argv[1] if len(sys.argv) > 1 else ""
+# Mount read-only and build inside the container, the way e2e/xmla/run.py
+# does: a writable mount leaves bin/ and obj/ (including a 1 MB DLL) in the
+# working tree, which is how they nearly got committed.
+sys.exit(subprocess.run([
+    "docker", "run", "--rm", "--platform", "linux/amd64",
+    "-v", f"{DIR}:/src:ro", "-w", "/work",
+    "-e", f"CONTRACT_FILTER={filt}",
+    SDK_IMAGE, "sh", "-c",
+    "set -e; cp -r /src/. /work/; dotnet run --nologo",
+]).returncode)

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -130,6 +130,15 @@ ANSWER_ROUTING = False
 # the regression witness for the first-call contract, and answering everywhere
 # would destroy the thing it pins.
 ANSWER_TOKEN = False
+# Screen 11: answer /webapi/clusterResolve. Screen 10 discovered the call and
+# the contract reader named its reply —
+# `ASAzureUtility+PowerBIClusterResolutionResult` declares FixedClusterUri,
+# DynamicClusterUri, NewTenantId, RuleDescription, TTLSeconds.
+#
+# This is the steering hook that has been open since screen 5: the client ASKS
+# which cluster to use, so a URI naming our host AND PORT should bring the XMLA
+# call back to the listener instead of to :443.
+ANSWER_CLUSTER = False
 WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 
 # CANDIDATE ROUTING SHAPES, screened one per request.
@@ -386,6 +395,24 @@ class Capture(http.server.BaseHTTPRequestHandler):
 
     def do_POST(self):
         self._record()
+        if ANSWER_CLUSTER and self.path.startswith("/webapi/clusterResolve"):
+            # Both URIs name the listener's own host:port. If the client
+            # honours them, its next request is the first XMLA/SOAP envelope
+            # this project has seen; if it still dials 443, the cluster reply
+            # is not what steers it and that is equally worth knowing.
+            target = f"https://{CONTAINER_HOST}:{PORT}"
+            b = json.dumps({
+                "FixedClusterUri": target, "DynamicClusterUri": target,
+                "NewTenantId": None, "RuleDescription": "emulator",
+                "TTLSeconds": 3600,
+            }).encode()
+            print(f"    -> answering 200 clusterResolve -> {target}", flush=True)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(b)))
+            self.end_headers()
+            self.wfile.write(b)
+            return
         if ANSWER_TOKEN and self.path.startswith("/metadata/v201606/generateastoken"):
             # {"Token": "<string>"} — the contract, read from the assembly.
             # The value is ours to mint: the client carries it into whatever it
@@ -548,6 +575,48 @@ log(f"TLS capture listener on :{PORT}")
 
 target = f"{CONTAINER_HOST}:{PORT}"
 log(f"running ADOMD.NET against {target} (linux/amd64, {SDK_IMAGE})")
+FORWARDER = "xmla-e2e-443"
+
+
+def start_443_forwarder():
+    """Publish host port 443 and pipe it to the capture listener.
+
+    Screen 9: once the token is accepted the client opens its XMLA connection
+    to the routing host on **443**, discarding the port in the Data Source —
+    `capacityUri` carried `:18446` and was dialled at `:443` anyway. So the
+    endpoint address is derived, and nothing in the reply redirects it.
+
+    The harness cannot bind 443 itself (a privileged port; the Python process
+    is not root), but the Docker daemon can publish it without sudo. socat is a
+    plain TCP pipe, so TLS still terminates at the capture listener with the
+    same self-signed cert the client already trusts — this adds a door, not a
+    man in the middle.
+
+    Returns True when the door is open; False (with a reason logged) when it is
+    not, so the caller can degrade rather than hang.
+    """
+    subprocess.run(["docker", "rm", "-f", FORWARDER],
+                   capture_output=True, text=True)
+    proc = subprocess.run([
+        "docker", "run", "-d", "--rm", "--name", FORWARDER,
+        "--add-host", f"{CONTAINER_HOST}:host-gateway",
+        "-p", "443:443", "alpine/socat",
+        "TCP-LISTEN:443,fork,reuseaddr", f"TCP:{CONTAINER_HOST}:{PORT}",
+    ], capture_output=True, text=True)
+    if proc.returncode:
+        err = (proc.stderr or "").strip()
+        log(f"NOTE: could not publish 443 ({err.splitlines()[-1] if err else '?'}).")
+        log("      The client dials 443 after the token, so anything past it "
+            "will show connection-refused rather than a captured request.")
+        return False
+    log("443 forwarder up: the client's post-token connection now reaches the listener")
+    return True
+
+
+def stop_443_forwarder():
+    subprocess.run(["docker", "rm", "-f", FORWARDER], capture_output=True, text=True)
+
+
 def run_probe():
     """One ADOMD.NET run against the listener. Identical both phases — only the
     listener's behaviour differs, so any change in what the client does is
@@ -624,12 +693,15 @@ if FAILURES:
 # ---------------------------------------------------------------------------
 phase1 = [(r["method"], r["path"]) for r in REQUESTS]
 
+FORWARDING_443 = start_443_forwarder()
+
 ANSWER_ROUTING = True
 # Screen 9: with the routing reply accepted, answer the token too. Everything
 # past it still gets the SOAP fault, so the FIRST request the client makes
 # carrying an accepted token is captured and then refused — which is the
 # recording nobody in this project has ever had.
 ANSWER_TOKEN = True
+ANSWER_CLUSTER = True
 
 # ONE PROBE RUN PER SHAPE. Screen 5 established that an accepted reply is
 # cached for the life of the client process, so a second shape in the same run
@@ -646,6 +718,7 @@ for SHAPE_INDEX, (label, *_) in enumerate(_shapes("")):
         proc2 = run_probe()
     except subprocess.TimeoutExpired:
         srv.shutdown()
+        stop_443_forwarder()
         raise SystemExit(f"FAILED: the phase-0 probe for {label} did not finish "
                          f"within 15 minutes")
     if not any(ln.startswith("CASE ") for ln in proc2.stdout.splitlines()):
@@ -654,6 +727,7 @@ for SHAPE_INDEX, (label, *_) in enumerate(_shapes("")):
         # harness has seen before. Abort on the FIRST one: the alternative is
         # N containers producing N identical non-results.
         srv.shutdown()
+        stop_443_forwarder()
         raise SystemExit(
             f"FAILED: the phase-0 probe for {label} reported no CASE line, so it "
             f"never reached a connection (exit {proc2.returncode}).\n"
@@ -670,6 +744,7 @@ for SHAPE_INDEX, (label, *_) in enumerate(_shapes("")):
     with LOCK:
         runs.append((label, [dict(r) for r in REQUESTS], proc2.stdout))
 srv.shutdown()
+stop_443_forwarder()
 
 for label, reqs, out in runs:
     phase2 = [(r["method"], r["path"]) for r in reqs]

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -57,6 +57,26 @@ import threading
 
 DIR = os.path.dirname(os.path.abspath(__file__))
 WORK = os.path.join(tempfile.gettempdir(), "xmla-e2e")
+
+
+def _clear_stale_bind_targets():
+    """Remove cert.pem/key.pem if anything left DIRECTORIES in their place.
+
+    Docker creates a directory when a bind mount's source does not exist, and
+    a directory mounted where the probe expects a file makes
+    `update-ca-certificates` fail with `sed: can't read …` — an error naming
+    neither the cert nor the mount, which cost a run to trace.
+
+    **This is a guard, not a diagnosis.** The main body already rmtree's WORK
+    on every run, so a leftover should not survive into one; how a directory
+    came to be there has not been established. Cleaning it is cheap and the
+    failure mode is opaque, so the guard earns its place either way — but if
+    this fires, the cause is still open.
+    """
+    for name in ("cert.pem", "key.pem"):
+        path = os.path.join(WORK, name)
+        if os.path.isdir(path):
+            shutil.rmtree(path, ignore_errors=True)
 # 18080 was the ad-hoc choice while this was a one-off; it is already taken by
 # another suite here, and the guard below caught the collision on first run.
 PORT = int(os.environ.get("XMLA_PORT", "18446"))
@@ -339,6 +359,23 @@ def _shapes_screen5(host):
 
 
 SHAPE_INDEX = 0  # which shape this probe run serves; the phase-0 loop advances it
+
+# SCREEN 12 — the form of the cluster URI, one variable.
+#
+# Screen 11 sent a full URL and resolution rejected it without opening a
+# socket. If the client prefixes a scheme itself, "https://https://..." fails
+# exactly that way. These three rungs separate the possibilities; the routing
+# shape is pinned to the known-good L1 so the cluster form is the only thing
+# that varies.
+def _cluster_forms(host, port):
+    return [
+        ("full-url", f"https://{host}:{port}"),
+        ("host-port", f"{host}:{port}"),
+        ("host-only", f"{host}"),
+    ]
+
+
+CLUSTER_INDEX = 0
 SHAPE_LOG = []   # [(shape name, request path)] — which shape answered which call
 
 REQUESTS = []          # [{method, path, headers: {lower: value}, body}]
@@ -400,13 +437,13 @@ class Capture(http.server.BaseHTTPRequestHandler):
             # honours them, its next request is the first XMLA/SOAP envelope
             # this project has seen; if it still dials 443, the cluster reply
             # is not what steers it and that is equally worth knowing.
-            target = f"https://{CONTAINER_HOST}:{PORT}"
+            label, target = _cluster_forms(CONTAINER_HOST, PORT)[CLUSTER_INDEX]
             b = json.dumps({
                 "FixedClusterUri": target, "DynamicClusterUri": target,
                 "NewTenantId": None, "RuleDescription": "emulator",
                 "TTLSeconds": 3600,
             }).encode()
-            print(f"    -> answering 200 clusterResolve -> {target}", flush=True)
+            print(f"    -> answering 200 clusterResolve [{label}] -> {target}", flush=True)
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(b)))
@@ -561,6 +598,7 @@ if not shutil.which("docker"):
 
 require_free_port(PORT, "TLS capture listener")
 
+_clear_stale_bind_targets()
 shutil.rmtree(WORK, ignore_errors=True)
 os.makedirs(WORK)
 log("issuing a self-signed CA for the container's view of this host")
@@ -709,11 +747,12 @@ ANSWER_CLUSTER = True
 # cold client — the cost is one container per shape, and the alternative is
 # results that silently describe only the first.
 runs = []   # [(label, [(method, path)], stdout)]
-for SHAPE_INDEX, (label, *_) in enumerate(_shapes("")):
+SHAPE_INDEX = 0  # L1: one path segment, established as accepted by screen 7
+for CLUSTER_INDEX, (label, _target) in enumerate(_cluster_forms(CONTAINER_HOST, PORT)):
     with LOCK:
         REQUESTS.clear()
         SHAPE_LOG.clear()
-    log(f"PHASE 0 shape {SHAPE_INDEX + 1}/{len(_shapes(''))}: {label}")
+    log(f"SCREEN 12 cluster form {CLUSTER_INDEX + 1}/3: {label}")
     try:
         proc2 = run_probe()
     except subprocess.TimeoutExpired:

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -121,6 +121,15 @@ def require_free_port(port, what):
 # fact. So the suite runs the probe TWICE: once refusing (the regression
 # witness), once answering (the measurement).
 ANSWER_ROUTING = False
+# Screen 9: answer generateastoken too. The reply contract was READ off the
+# assembly rather than screened — `PbiPremiumAuthenticationHandle+MWCToken`
+# declares a single [DataMember] `Token` — so this is not a hypothesis the way
+# the routing shapes were. See e2e/xmla/contract and docs/32.
+#
+# Kept behind its own flag so the refusing control still refuses: that run is
+# the regression witness for the first-call contract, and answering everywhere
+# would destroy the thing it pins.
+ANSWER_TOKEN = False
 WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 
 # CANDIDATE ROUTING SHAPES, screened one per request.
@@ -377,6 +386,18 @@ class Capture(http.server.BaseHTTPRequestHandler):
 
     def do_POST(self):
         self._record()
+        if ANSWER_TOKEN and self.path.startswith("/metadata/v201606/generateastoken"):
+            # {"Token": "<string>"} — the contract, read from the assembly.
+            # The value is ours to mint: the client carries it into whatever it
+            # asks next, and capturing THAT is the point of answering here.
+            b = b'{"Token":"emulator-mwc-token"}'
+            print("    -> answering 200 with the MWCToken contract", flush=True)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(b)))
+            self.end_headers()
+            self.wfile.write(b)
+            return
         b = (b'<?xml version="1.0"?><soap:Envelope '
              b'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body>'
              b'<soap:Fault><faultcode>capture</faultcode>'
@@ -604,6 +625,11 @@ if FAILURES:
 phase1 = [(r["method"], r["path"]) for r in REQUESTS]
 
 ANSWER_ROUTING = True
+# Screen 9: with the routing reply accepted, answer the token too. Everything
+# past it still gets the SOAP fault, so the FIRST request the client makes
+# carrying an accepted token is captured and then refused — which is the
+# recording nobody in this project has ever had.
+ANSWER_TOKEN = True
 
 # ONE PROBE RUN PER SHAPE. Screen 5 established that an accepted reply is
 # cached for the life of the client process, so a second shape in the same run

--- a/internal/api/restpagination_selector_test.go
+++ b/internal/api/restpagination_selector_test.go
@@ -1,0 +1,45 @@
+package api
+
+import "testing"
+
+// headerSelector parses the `headers…` form of a REST connector's pagination
+// selector. It is small, pure, and entirely syntax — which is exactly the kind
+// of function where an off-by-one is invisible in review and shows up as a
+// connector reading the wrong header at runtime.
+//
+// The bracket forms carry their own trap: the length guards exist so `headers.`
+// and `headers[”]` are rejected rather than resolving to the empty header
+// name, which would match nothing and look like an absent header instead of a
+// malformed selector.
+func TestHeaderSelector(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"headers.Link", "Link", true},
+		{"headers.x-next-page", "x-next-page", true},
+		{"headers['Link']", "Link", true},
+		{`headers["Link"]`, "Link", true},
+		{"headers['x-next-page']", "x-next-page", true},
+
+		// Malformed: a name is required after the accessor.
+		{"headers.", "", false},
+		{"headers['']", "", false},
+		{`headers[""]`, "", false},
+
+		// Not a header selector at all.
+		{"headers", "", false},
+		{"headers['Link\"]", "", false}, // mismatched quotes
+		{"headers[Link]", "", false},    // unquoted
+		{"headersLink", "", false},      // no accessor
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := headerSelector(tc.in)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("headerSelector(%q) = (%q, %v), want (%q, %v)",
+					tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}

--- a/internal/purview/clienterror_test.go
+++ b/internal/purview/clienterror_test.go
@@ -1,0 +1,45 @@
+package purview
+
+import (
+	"net/http"
+	"testing"
+)
+
+// `clientError` derives its HTTP status from its Atlas code, so the two cannot
+// drift apart — they are one fact rather than two fields a handler must keep
+// in step.
+//
+// The type is deliberately 4xx-only. Server failures do not travel this way:
+// handlers write those directly (`writeAtlasErr(w, StatusInternalServerError,
+// "ATLAS-500-00-001", …)`), so an unrecognised code defaulting to 400 is the
+// design and not a gap. A first draft of this test asserted that
+// `ATLAS-500-00-001` yields 500; it yields 400, and the type name is the clue
+// that the test was wrong rather than the code.
+func TestClientErrorStatusComesFromTheCode(t *testing.T) {
+	for _, tc := range []struct {
+		code string
+		want int
+	}{
+		{"ATLAS-400-00-001", http.StatusBadRequest},
+		{"ATLAS-404-00-00A", http.StatusNotFound},
+		{"ATLAS-409-00-002", http.StatusConflict},
+
+		// Not a 4xx this type models, and not parseable at all: both fall back
+		// to 400 rather than to a zero status, which would serialise as 200.
+		{"ATLAS-500-00-001", http.StatusBadRequest},
+		{"nonsense", http.StatusBadRequest},
+		{"", http.StatusBadRequest},
+	} {
+		t.Run(tc.code, func(t *testing.T) {
+			e := &clientError{code: tc.code, message: "m"}
+			if got := e.status(); got != tc.want {
+				t.Fatalf("status of %q = %d, want %d", tc.code, got, tc.want)
+			}
+			// Error() must name the code: it is what a caller sees in a log
+			// when the response body is already gone.
+			if msg := e.Error(); msg == "" || msg == ": m" && tc.code != "" {
+				t.Fatalf("Error() = %q, which does not identify the code", msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Phase 0's last open question in `docs/32-xmla-plan.md` was `generateastoken`'s
**response** contract. The doc recommended reading it off the assembly rather
than screening it, because the earlier routing read retired four screens of
guessing in one go.

It worked again. Reflecting over `Microsoft.AnalysisServices.AdomdClient`
19.84.1.0:

```
MWCToken
    Token : string        [DataMember] ×1
```

So the emulator's reply is `{"Token":"<string>"}` — one PascalCase member, and
the token is one we mint.

**Checked against a measurement.** The same read dumped `MWCASTokenRequest`,
whose eight members match screen 8's captured wire body field for field. The
declared contract and the observed request agree, so the reflection route is
confirmed rather than trusted — the check the routing read never got.

Adds `e2e/xmla/contract` as a repeatable reader (`run.py [substring]`) so the
next contract question is one command rather than an ad-hoc container. It
mounts the source read-only and builds inside the container, the way
`e2e/xmla/run.py` does — a writable mount leaves `bin/`/`obj/` in the tree,
which is how a 1 MB DLL nearly got committed here. `.gitignore` gains the
matching rule.

**Next**, per the updated doc: serve `{"Token":"…"}` from the capture stub and
record what the client asks next. Nothing in this project has seen a request
past `generateastoken`; that recording is the first sight of XMLA/SOAP and is
what Phase 1 should be priced from.