### PR TITLE
docs(site): escape backslashes in frontmatter titles

### DIFF
--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -68,8 +68,10 @@ function cleanTitle(h1) {
   return h1.replace(/^\d+[a-z]?\s*[—:-]\s*/i, '').trim();
 }
 
+// Backslashes must be escaped before quotes, or a title ending in one would
+// escape the closing quote and produce unparseable frontmatter.
 function yamlEscape(s) {
-  return '"' + s.replace(/"/g, '\\"') + '"';
+  return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
 }
 
 // Strip the leading H1 (Starlight renders the frontmatter title) and rewrite


### PR DESCRIPTION
Family sweep. CodeQL flagged this exact function in `arm-emulator` as `js/incomplete-sanitization` (**high**); the same copy lives here, in `azure-keyvault-emulator`, and `entra-emulator` (already fixed there).

`yamlEscape` escaped `"` but not `\`, so a doc title containing a backslash emits frontmatter that will not parse — a title *ending* in one escapes its own closing quote. Verified against `js-yaml`:

```
old    "trailing\\"   -> "trailing\"    PARSE ERROR
fixed  "trailing\\"   -> "trailing\\"   OK
old    "back\\slash"  -> "back\slash"   PARSE ERROR
fixed  "back\\slash"  -> "back\\slash"  OK
```

Backslashes are escaped before quotes; the other order double-escapes. No current doc title contains a backslash, so this is latent rather than actively broken.

### How this was made
Committed **through the GitHub API rather than the local checkout**: this clone is shared by ~28 worktrees and its working copy sits on `fix/xmla-concurrent-runs`, so switching branches or adding a worktree would have disturbed another session — and the machine's disk is currently at 100%. The file was patched from `origin/main`'s blob and `node --check`ed before upload; the working copy was left exactly as found.

I could not run the docs build locally for the same disk reason — the Docs site check here covers it.