### PR TITLE
fix(e2e): seed the tenant these suites expect

### DIFF
--- a/e2e/airflow/docker-compose.yml
+++ b/e2e/airflow/docker-compose.yml
@@ -15,6 +15,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/azurite-shortcut/docker-compose.yml
+++ b/e2e/azurite-shortcut/docker-compose.yml
@@ -14,6 +14,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/data-science-loop/docker-compose.yml
+++ b/e2e/data-science-loop/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/dbt-fabric/docker-compose.yml
+++ b/e2e/dbt-fabric/docker-compose.yml
@@ -14,6 +14,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/dbt-fabricspark/docker-compose.yml
+++ b/e2e/dbt-fabricspark/docker-compose.yml
@@ -13,6 +13,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/deployment-pipelines/docker-compose.yml
+++ b/e2e/deployment-pipelines/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     user: "0:0"                       # bind privileged :443 (authority has no port)
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       PUBLIC_ORIGIN: "https://login.microsoftonline.com"
       LOCAL_DOMAINS: "login.microsoftonline.com"
       PORT: "443"

--- a/e2e/environment/docker-compose.yml
+++ b/e2e/environment/docker-compose.yml
@@ -9,6 +9,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/external-shortcuts/docker-compose.yml
+++ b/e2e/external-shortcuts/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/fabric-cli/docker-compose.yml
+++ b/e2e/fabric-cli/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     user: "0:0"                       # bind privileged :443 (authority has no port)
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       PUBLIC_ORIGIN: "https://login.microsoftonline.com"
       LOCAL_DOMAINS: "login.microsoftonline.com"
       PORT: "443"

--- a/e2e/livy/docker-compose.yml
+++ b/e2e/livy/docker-compose.yml
@@ -9,6 +9,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/medallion/docker-compose.yml
+++ b/e2e/medallion/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     ports:
       - "8443:8443" # login / graph / discovery (JWKS)
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       PUBLIC_ORIGIN: "https://entra-emulator:8443"
     healthcheck:

--- a/e2e/notebook-driven/docker-compose.yml
+++ b/e2e/notebook-driven/docker-compose.yml
@@ -17,6 +17,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/notebook-run/docker-compose.jvm.yml
+++ b/e2e/notebook-run/docker-compose.jvm.yml
@@ -4,6 +4,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/notebook-run/docker-compose.yml
+++ b/e2e/notebook-run/docker-compose.yml
@@ -6,6 +6,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/rest-helix/docker-compose.yml
+++ b/e2e/rest-helix/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/rest-servicenow/docker-compose.yml
+++ b/e2e/rest-servicenow/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/rti/docker-compose.yml
+++ b/e2e/rti/docker-compose.yml
@@ -10,6 +10,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/s3/docker-compose.yml
+++ b/e2e/s3/docker-compose.yml
@@ -7,6 +7,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/sail/docker-compose.yml
+++ b/e2e/sail/docker-compose.yml
@@ -11,6 +11,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/salesforce/docker-compose.yml
+++ b/e2e/salesforce/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/spark-jvm/docker-compose.yml
+++ b/e2e/spark-jvm/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/spark/docker-compose.yml
+++ b/e2e/spark/docker-compose.yml
@@ -7,6 +7,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"

--- a/e2e/vscode-extension/docker-compose.yml
+++ b/e2e/vscode-extension/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   entra-emulator:
     image: ghcr.io/calvinchengx/entra-emulator:latest
     environment:
+      # entra >=v0.4.0 seeds a different tenant by default; pin the one
+      # this suite's issuer URLs name, or discovery 404s.
+      TENANT_ID: "11111111-1111-1111-1111-111111111111"
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"
       PORT: "8443"


### PR DESCRIPTION
**`main`'s containerized CI is broken right now.** This unblocks it.

### What happened
`entra-emulator` **v0.4.0** (published Aug 8, 15:35 UTC) moved its default seeded tenant:

```
11111111-1111-1111-1111-111111111111  ->  6f89cf12-978b-4d23-ac18-9ef0c127cf87
```

All 23 containerized suites here pull `ghcr.io/calvinchengx/entra-emulator:latest` **unpinned**, while 62 files still name the old tenant in their issuer URLs. So entra began seeding a tenant nothing referenced, discovery started 404ing, and the token exchange surfaced `HTTP 400` — **29 jobs red**.

The timeline pins it, and it is not any one PR's fault:

| When | What |
|---|---|
| Aug 8, 10:17 | main CI green (e96c2a7) — 22 containerized jobs, 0 fail |
| Aug 8, 15:35 | **entra v0.4.0 published to `:latest`** |
| Aug 9, 00:44 | next PR run — 29 containerized jobs fail |

### The fix
Seed `TENANT_ID` on the entra service in each compose, pinning the tenant that suite already expects. `:latest` stays free to move. Proven against the published image:

```
without TENANT_ID:  GET /11111111-.../v2.0/.well-known/openid-configuration  ->  404
with    TENANT_ID:  same URL                                                 ->  200
```

Same pattern `arm-emulator` already adopted (`fix(compose): seed the tenant arm-emulator expects`).

### Scope
23 compose files, 3 lines each. Verified every file still parses as YAML and that `TENANT_ID` landed on the **entra** service in all 23 — not on a neighbouring service.

Migrating all 62 files to the new GUID is the bigger, longer-term alternative; it can happen on its own schedule now that CI is unblocked. #118 (the yamlEscape fix) is blocked behind this and should go green once this lands.