### PR TITLE
build(compose): the root compose defaults to the BOM, not latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@
 # both `<version>` and `latest` (see .github/workflows/release.yml).
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-latest}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.0}
     environment:
       ORIGIN_MODE: compat # single origin, path-prefixed surfaces
       PUBLIC_ORIGIN: "https://entra-emulator:8443"
@@ -54,7 +54,7 @@ services:
       retries: 10
 
   keyvault-emulator:
-    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-latest}
+    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.4.0}
     depends_on:
       entra-emulator:
         condition: service_healthy


### PR DESCRIPTION
Found while wiring these pins into `azure-emulators`' `check_family_pins.py`.

#120 pinned the 23 e2e composes, but **this one was missed** — it already used a variable, just with the wrong default:

```diff
-  entra-emulator:${ENTRA_EMULATOR_VERSION:-latest}
+  entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.0}
-  azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-latest}
+  azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.4.0}
```

So `make up` and the quickstart still pulled whatever was newest on GHCR — the same drift that took out 29 jobs on 2026-08-08. My sweep missed it because it replaced the literal `:latest` tag, and these were already `${VAR:-latest}`.

Overriding still works, so drift testing is unaffected:

```
docker compose config          ->  entra 0.4.0, keyvault 0.4.0
ENTRA_EMULATOR_VERSION=latest  ->  entra latest
```

fabric's own images (`fabric-emulator`, `-sail`, `-spark-agent`) stay on `:latest` — this repo's own artifacts, and this compose is how a reader runs them.

Needed before the `azure-emulators` checker PR can enforce this file.