### PR TITLE
docs: release notes for v0.19.0

### DIFF
--- a/docs/release-notes/v0.19.0.md
+++ b/docs/release-notes/v0.19.0.md
@@ -1,0 +1,95 @@
+# v0.19.0
+
+Forty-three commits continuing v0.18.0's theme, aimed at a narrower target:
+**work that reported success without doing any.** A Copy Job now copies. Nine
+pipeline activities that returned "Succeeded" without running now run. Spark
+jobs execute on the pool rather than being announced. The XMLA endpoint answers
+the call its clients actually make, measured against the assembly rather than
+inferred.
+
+Around that: Purview's Data Map arrives as Atlas v2, the portal reads and runs
+notebooks and browses lakehouse Delta, and the whole e2e suite is pinned to the
+family BOM so an upstream release can no longer land in CI unannounced.
+
+No breaking changes.
+
+---
+
+## Pipelines: activities that run
+
+- **Nine activity types that silently succeeded** now do the work, and the job
+  announcement that did not is issued.
+- **Databricks, Azure Batch and Azure ML** activities, and **HDInsight Spark**,
+  which terminates its protocol properly and computes through Sail.
+- **WebHook parks for real** — on the controllable clock, so a parked callback
+  is advanced rather than waited out.
+- **Delete data** and **deactivated activities** behave as documented, and the
+  WebHook is honest about what it did.
+- **The job POST returns before the pipeline finishes**, matching doc 37 §4.
+  The previous synchronous return was the kind of plausible answer that passes
+  a test and misleads a client.
+
+## Copy Job
+
+A Copy Job now copies. The **status comes from the copy**, not from the clock,
+and a refusal **names the side** that refused, deterministically — no more
+guessing which end rejected a run.
+
+## Compute and query
+
+- **Spark jobs run on the pool**, as Fabric's does.
+- **XMLA**: Phase 0 is answered and measured — the client's real call after
+  routing, with the routing answered in a second pass and the change recorded.
+  `generateastoken`'s reply contract is read **off the assembly** rather than
+  guessed.
+- **DAX and lakehouse browsing** reach the portal: read a lakehouse, preview
+  its Delta tables.
+
+## Purview, OneLake and the portal
+
+- **The Data Map's type system and entities, as Atlas v2** — Purview's real
+  shape, not an approximation.
+- **A Dataverse shortcut target** in OneLake, read-only as documented.
+- **The portal reads a notebook and runs it through the documented job**,
+  closing the Jupyter gap; the interaction-surface doctrine is written down so
+  the next surface has a rule to follow rather than a precedent to copy.
+
+## Governance and parity
+
+- **A Fabric-administrator gate on `/v1/admin`**, graded as documented.
+- **Five item types execute** where the parity row credited one; the Power BI
+  row is split, and reports get the definition routes Fabric documents.
+
+## The family
+
+- **Migrated to entra-emulator v0.4.0's seeded GUIDs.** v0.4.0 re-seeded every
+  placeholder id, and this repo named the old ones in 62 files. The tenant, the
+  daemon service principal and Alice's object id all move. Because the old
+  tenant GUID also served as an arbitrary fixture id for our *own* objects,
+  six occurrences are deliberately unchanged — they were never entra's.
+- **Every family image is pinned to the BOM**, not `:latest`. Tracking
+  `:latest` is how v0.4.0 reached this repo's CI unannounced and turned 29 jobs
+  red on an unrelated commit. Drift testing still works by overriding the
+  version variable, and now happens in `azure-emulators`' nightly job, which
+  exists for it.
+- The host-run e2e follow the same pin, through `go.mod`.
+
+## CI and hygiene
+
+- **Every job declares `timeout-minutes`**, enforced by a check — a hung job
+  used to burn the full six hours.
+- Async job polls are bounded at 30s rather than 5, `make check` runs ruff and
+  ty rather than only the invariant scripts, and the expanded target list is
+  derived from `.PHONY` instead of being maintained twice.
+- ServiceNow's Table API joins the REST connector witnesses.
+- `nanoid` is pinned past GHSA-2v37-7h3g-55p8, and the docs generator no longer
+  emits unparseable frontmatter for titles containing a backslash.
+
+## Upgrading
+
+Nothing to do in the emulator's API. If you run the compose stacks, they now
+default to the BOM's pinned images rather than `:latest`; override
+`ENTRA_EMULATOR_VERSION` or `KEYVAULT_EMULATOR_VERSION` if you were relying on
+tracking newest. If you drive this emulator against your own entra, it must be
+**v0.4.0 or later** — the seeded tenant and service principal changed, and the
+two must agree.


### PR DESCRIPTION
Notes for the v0.19.0 tag, following this repo's `docs/release-notes/vX.Y.Z.md` convention so the published body is prose rather than GoReleaser's commit list.

Drawn from the 43 non-merge commits since v0.18.0, organised by what changed for a reader. The theme continues v0.18.0's — but narrower: **work that reported success without doing any**. A Copy Job now copies; nine pipeline activities that returned "Succeeded" without running now run; Spark jobs execute on the pool; XMLA answers the call clients actually make, read off the assembly rather than inferred.

Three things I was careful about:

- **No breaking changes, stated up front.** Nothing in the emulator's API moves. The upgrade section covers the two things that *could* surprise: compose now defaults to BOM-pinned images rather than `:latest`, and driving this against your own entra requires **v0.4.0+**.
- **The GUID migration is described with its exception.** The old tenant GUID also served as an arbitrary fixture id for our own objects, so six occurrences are deliberately unchanged. Saying "migrated 62 files" without that would invite someone to "finish the job" and break unit tests.
- **The pinning entry names why**, not just what: tracking `:latest` is how entra v0.4.0 reached this repo's CI unannounced and turned 29 jobs red on an unrelated commit. That is the incident this release closes.