### PR TITLE
chore(compose): keyvault 0.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       retries: 10
 
   keyvault-emulator:
-    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.5.0}
+    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.6.0}
     depends_on:
       entra-emulator:
         condition: service_healthy

--- a/e2e/medallion/docker-compose.yml
+++ b/e2e/medallion/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       retries: 20
 
   keyvault-emulator:
-    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.5.0}
+    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.6.0}
     depends_on:
       entra-emulator:
         condition: service_healthy


### PR DESCRIPTION
Sweeps the two composes that pin keyvault onto the release the BOM is moving to.

v0.6.0's breaking change is to keyvault's *own* compose stack, which now stands arm up and denies by default. The binary is unchanged and `-arm-url` still defaults to empty, so these composes, which never set `KV_ARM_URL`, keep the permissive behaviour they had at 0.5.0.

The azure-emulators BOM bump follows once this lands, since its gate reads consumers from main.