### PR TITLE
Name the evidence go-mssqldb already provides

### DIFF
--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -3,12 +3,12 @@
     "go:TestMirrorSnapshotsBaseTables": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
     "go:TestPipelineSQLActivitiesE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
     "go:TestReflectDecimalColumn": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestRefreshMirroredDatabaseE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestSQLDatabaseMirror": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestWarehouseDeltaReflectionE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestRefreshMirroredDatabaseE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestSQLDatabaseMirror": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestWarehouseDeltaReflectionE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
     "go:TestWarehouseRouter": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestWarehouseSQLServerRelayE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestWarehouseTwoSurfaces": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestWarehouseSQLServerRelayE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestWarehouseTwoSurfaces": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
     "ci:real-fabric": "AZURE_* credentials + FABRIC_TEST_WORKSPACE — needs a real Fabric tenant, so it skips on a fork and on any checkout without the secrets. Satisfied weekly by the `real-fabric` workflow (.github/workflows/real-fabric.yml), which runs the SAME conformance suite the `fabric-target` job runs against the emulator on every push. It is the differential leg: a divergence shows up as a conformance failure there."
   },
   "abfss-onelake-dfs-fabric-microsoft-com-production-paths": {
@@ -219,7 +219,7 @@
     "claim": "**Fabric SQL Database (`database/`)** — OLTP + OneLake mirror",
     "witnesses": [
       "ci:warehouse-tds",
-      "go:TestSQLDatabaseMirror"
+      "sdk:TestSQLDatabaseMirror"
     ]
   },
   "folders": {
@@ -272,7 +272,7 @@
     "claim": "`information_schema` / `sys.*` introspection",
     "witnesses": [
       "ci:warehouse-tds",
-      "go:TestWarehouseSQLServerRelayE2E"
+      "sdk:TestWarehouseSQLServerRelayE2E"
     ]
   },
   "invoke-pipeline-executepipeline": {
@@ -341,7 +341,7 @@
     "claim": "**Lakehouse SQL analytics endpoint — Delta → engine**",
     "witnesses": [
       "ci:warehouse-tds",
-      "go:TestWarehouseDeltaReflectionE2E",
+      "sdk:TestWarehouseDeltaReflectionE2E",
       "ci:medallion"
     ]
   },
@@ -400,7 +400,7 @@
     "claim": "Mirroring — Mirrored Database (`mirroring/`)",
     "witnesses": [
       "ci:warehouse-tds",
-      "go:TestRefreshMirroredDatabaseE2E",
+      "sdk:TestRefreshMirroredDatabaseE2E",
       "go:TestMirrorSnapshotsBaseTables"
     ]
   },
@@ -478,7 +478,7 @@
     "section": "Data Warehouse (`data-warehouse/`)",
     "claim": "Per-column type fidelity (real SQL types over the wire)",
     "witnesses": [
-      "go:TestResultTypeFidelity",
+      "sdk:TestResultTypeFidelity",
       "go:TestReflectDecimalColumn",
       "go:TestReflectedSQLTypesMatchFabric",
       "go:TestNestedColumnsAreOmittedNotFabricated",
@@ -495,7 +495,7 @@
     "claim": "Per-item isolation (each item = its own SQL Server database)",
     "witnesses": [
       "ci:warehouse-tds",
-      "go:TestWarehouseTwoSurfaces",
+      "sdk:TestWarehouseTwoSurfaces",
       "go:TestWarehouseRouter"
     ]
   },
@@ -533,7 +533,7 @@
     "claim": "RBAC → SQL permissions",
     "witnesses": [
       "ci:warehouse-tds",
-      "go:TestWarehouseTDSEndpointE2E"
+      "sdk:TestWarehouseTDSEndpointE2E"
     ]
   },
   "reference-run-lakehouse-rule": {
@@ -641,7 +641,7 @@
     "claim": "**T-SQL over TDS + Entra FedAuth**",
     "witnesses": [
       "ci:warehouse-tds",
-      "go:TestLogin7FedAuthCapture"
+      "sdk:TestLogin7FedAuthCapture"
     ]
   },
   "tenant-settings-get-v1-admin-tenantsettings": {

--- a/scripts/check_witnesses.py
+++ b/scripts/check_witnesses.py
@@ -17,10 +17,20 @@ Witness kinds, deliberately distinguished because they are not equal evidence:
 
   ci:<job>      a CI job driving a real external client (strongest — this is
                 what the rule in doc 24 actually asks for)
+  sdk:<Test>    a Go test in which MICROSOFT'S OWN client does the talking —
+                go-mssqldb speaking real TDS to the warehouse surface. Third
+                party evidence like ci:, but in-process rather than a packaged
+                release over a network, so it ranks below it.
   go:<Test>     a Go test: real HTTP, real signed JWTs, real RBAC, but our own
                 client rather than a third party's
   boundary:...  the claim is scoped by a documented limitation, with the reason
   TODO          not yet identified — the point of --strict
+
+sdk: is a Go kind, and every rule that says "go" below means the Go FAMILY,
+go: and sdk: alike. This matters most at the gate check: gates on Go tests are
+DETECTED by scanning the test body, never merely asserted, and moving a test to
+sdk: must not quietly buy it the weaker asserted-gate treatment. Five of the
+warehouse witnesses are declared gates, so this was not hypothetical.
 
 A witness whose NAME exists is not a witness that RAN. That gap cost real time
 twice: `TestWarehouseSQLServerRelayE2E` skips without `WAREHOUSE_MSSQL_DSN`, so
@@ -223,7 +233,7 @@ def main() -> int:
     # witness -> reason, for the gated witnesses actually credited to a claim.
     gated_used: dict[str, str] = {}
     ungated_by_key: dict[str, int] = {}
-    kinds = {"ci": 0, "go": 0, "py": 0, "boundary": 0}
+    kinds = {"ci": 0, "sdk": 0, "go": 0, "py": 0, "boundary": 0}
     # Which claims lean on each witness — a witness covering many claims is
     # where bundling hides.
     shared: dict[str, list[str]] = {}
@@ -243,13 +253,13 @@ def main() -> int:
             shared.setdefault(witness, []).append(feature)
             if kind == "ci" and name not in jobs:
                 dangling.append(f"{key} → {witness} (no such CI job)")
-            elif kind == "go" and name not in tests:
+            elif kind in ("go", "sdk") and name not in tests:
                 dangling.append(f"{key} → {witness} (no such Go test)")
             elif kind == "py" and name not in py_tests:
                 dangling.append(f"{key} → {witness} (no such Python test)")
-            if kind == "go" and name in gated_tests:
+            if kind in ("go", "sdk") and name in gated_tests:
                 gated_used[witness] = gated_tests[name]
-            elif kind != "go" and witness in declared_gates:
+            elif kind not in ("go", "sdk") and witness in declared_gates:
                 # A gate this script cannot DETECT, only accept: a CI job that
                 # skips on absent secrets is invisible to the Go body scan, and
                 # `ci:real-fabric` — the differential leg against a real tenant —
@@ -284,6 +294,7 @@ def main() -> int:
 
     print(f"supported capability claims: {len(claims)}")
     print(f"  witnessed by a real external client (ci:) : {kinds.get('ci', 0)}")
+    print(f"  witnessed by Microsoft's own clients (sdk:): {kinds.get('sdk', 0)}")
     print(f"  witnessed by our own Go tests (go:)       : {kinds.get('go', 0)}")
     print(f"  witnessed by our own Python tests (py:)   : {kinds.get('py', 0)}")
     print(f"  scoped by a documented boundary           : {kinds.get('boundary', 0)}")


### PR DESCRIPTION
Last repo in the family sweep, after arm #17, keyvault #20 and apim #5 found the same defect.

Eight warehouse and TDS witnesses drive `go-mssqldb` and `msdsn`, Microsoft's own SQL Server driver, speaking real TDS to the warehouse surface. They were filed as `go:`, whose definition reads "our own client rather than a third party's", so the report counted Microsoft's driver as ours.

Adds `sdk:` between `ci:` and `go:`:

```
witnessed by a real external client (ci:) : 69
witnessed by Microsoft's own clients (sdk:): 8
witnessed by our own Go tests (go:)       : 259   (was 267)
credited witnesses that can SKIP          : 10    (unchanged)
```

**The gate coupling was the real work here, not the relabelling.** This checker does something the siblings do not: it DETECTS gates by scanning Go test bodies, and only ACCEPTS asserted gates for non-Go kinds, with a comment stating that `kind != "go"` is load-bearing precisely so a Go witness that stopped skipping cannot slip into the asserted path. A naive `sdk:` addition would have moved five gated warehouse tests out of detection and into assertion, quietly weakening the rule.

So `sdk:` is treated as a member of the Go FAMILY everywhere that mattered: dangling-name resolution, gate detection, and the asserted-gate exclusion. The five `_gated` declaration keys move with their citations, since those are keyed by the full witness string.

Verified by diffing the checker's full output before and after: 13 changed lines, all accounted for. The five gated warehouse witnesses still report `skips via its own t.Skip`, meaning still detected rather than merely asserted, and the SKIP count stays 10 with none undeclared and none stale.

Negative controls:

- dangling name: `rbac-sql-permissions -> sdk:TestNoSuchThing (no such Go test)`
- gate key left as `go:` while its citation moved: `10, 1 UNDECLARED` plus a stale declaration, which is what proves the paired rename was required

Docs-only, no Go code touched. `--strict` exits 0.

Built in a worktree off `origin/main`; the shared checkout stayed on `fix/xmla-concurrent-runs` throughout. CLAIMS.md still carries entries naming `docs/witnesses.json` for local_5f900b3b and local_2cb98795, but the PRs those entries cite (#94, #96, #104) are all merged and fabric has no open PRs, so the holds read as stale rather than live.