### PR TITLE
docs: one badge row across the family, and the version it is at

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # fabric-emulator
 
+[![version](https://img.shields.io/github/v/release/calvinchengx/fabric-emulator?label=version)](https://github.com/calvinchengx/fabric-emulator/releases/latest)
 [![CI](https://github.com/calvinchengx/fabric-emulator/actions/workflows/ci.yml/badge.svg)](https://github.com/calvinchengx/fabric-emulator/actions/workflows/ci.yml)
 [![Docs](https://github.com/calvinchengx/fabric-emulator/actions/workflows/docs-site.yml/badge.svg)](https://calvinchengx.github.io/fabric-emulator/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)


### PR DESCRIPTION
Badges were inconsistent across the five emulators: apim had none at all, only arm carried CodeQL, and no repo had a version badge. Every member now leads with the same row, in the same order.

| | version | CI | Docs | CodeQL | License |
|---|:-:|:-:|:-:|:-:|:-:|
| before | — | 4 of 5 | 3 of 5 | 1 of 5 | 4 of 5 |
| after | 5 of 5 | 5 of 5 | 5 of 5 | 4 of 5 | 5 of 5 |

Repo-specific badges keep their own row below the shared one: coverage and witnesses on arm and fabric, the Flutter e2e badge on entra, which is the only member with a mobile witness.

The version badge is `img.shields.io/github/v/release`, so it tracks the latest GitHub release with no publishing step. Verified it resolves to the right value before committing rather than trusting the URL shape.

**CodeQL is 4 of 5, not 5, and that is a finding rather than an oversight.** fabric has no `codeql.yml` and its default setup reads `not-configured`, so it has no code scanning at all. It is the largest repo in the family. Adding a badge pointing at a workflow that does not exist would have been worse than the gap, so fabric keeps four badges and I have raised the real issue separately.