### PR TITLE
security: bound range(), request the validated vault URL, stop logging a secret

### DIFF
--- a/e2e/notebookutils/notebook.py
+++ b/e2e/notebookutils/notebook.py
@@ -47,8 +47,11 @@ assert "greeting.txt" in listing and "copy.txt" in listing, listing
 
 # --- credentials.getSecret: brokered read from Key Vault ---------------------
 secret = credentials.getSecret("db-vault", "db-password")
-print(f"credentials.getSecret: {secret!r}", flush=True)
-assert secret == "s3cr3t-value", secret
+# The ASSERT is the witness, not the print. Echoing the value proved nothing the
+# comparison does not, and it put a secret in a public CI log — a fixture one
+# here, but this file is what a reader copies when they wire up their own vault.
+assert secret == "s3cr3t-value", f"unexpected secret, {len(secret)} chars"
+print(f"credentials.getSecret: matched the expected value ({len(secret)} chars)", flush=True)
 
 # --- notebook.run: schedule a child notebook through the control plane -------
 # `run` returns the child's EXIT VALUE, per Fabric's reference — not the job

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -605,6 +605,11 @@ log("issuing a self-signed CA for the container's view of this host")
 make_cert(WORK)
 
 ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+# PROTOCOL_TLS_SERVER negotiates the best version BOTH sides accept, which still
+# leaves TLS 1.0/1.1 on the table if the client offers nothing better. ADOMD.NET
+# does far better than that, so pinning the floor costs this listener nothing and
+# stops the suite modelling a downgrade nobody wants.
+ctx.minimum_version = ssl.TLSVersion.TLSv1_2
 ctx.load_cert_chain(os.path.join(WORK, "cert.pem"), os.path.join(WORK, "key.pem"))
 srv = TLSServer(("0.0.0.0", PORT), Capture)
 srv.socket = ctx.wrap_socket(srv.socket, server_side=True)

--- a/internal/akv/akv.go
+++ b/internal/akv/akv.go
@@ -100,11 +100,21 @@ func New(insecure bool, client *http.Client, extraHost string) *Client {
 // ResolveSecret GETs {vaultURI}/secrets/{name}?api-version=… with the bearer
 // token and returns the secret value.
 func (c *Client) ResolveSecret(vaultURI, name, bearer string) (string, error) {
-	if _, err := c.checkVaultURI(vaultURI); err != nil {
+	// Build the request from the URL checkVaultURI RETURNED, never from the raw
+	// argument. Validating one representation and then requesting another is how
+	// an allowlist gets bypassed: any input `url.Parse` normalises away (a stray
+	// control character, a second scheme, an alternate host encoding) is checked
+	// in the parsed form and re-introduced by the raw string. They agree today;
+	// nothing enforced that they keep agreeing.
+	base, err := c.checkVaultURI(vaultURI)
+	if err != nil {
 		return "", err
 	}
-	u := strings.TrimSuffix(vaultURI, "/") + "/secrets/" + url.PathEscape(name) + "?api-version=" + APIVersion
-	req, err := http.NewRequest(http.MethodGet, u, nil)
+	ref := &url.URL{
+		Path:     strings.TrimSuffix(base.Path, "/") + "/secrets/" + name,
+		RawQuery: "api-version=" + APIVersion,
+	}
+	req, err := http.NewRequest(http.MethodGet, base.ResolveReference(ref).String(), nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/akv/akv.go
+++ b/internal/akv/akv.go
@@ -110,11 +110,19 @@ func (c *Client) ResolveSecret(vaultURI, name, bearer string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ref := &url.URL{
-		Path:     strings.TrimSuffix(base.Path, "/") + "/secrets/" + name,
-		RawQuery: "api-version=" + APIVersion,
-	}
-	req, err := http.NewRequest(http.MethodGet, base.ResolveReference(ref).String(), nil)
+	// The name is ONE path segment, so it is escaped into one. Setting only
+	// `Path` would not do it: a `/` is legal in a decoded path and `String()`
+	// keeps it, so a name of `../../certificates/evil` would leave /secrets/
+	// entirely and send the vault-audience token to another endpoint on the
+	// same host. Setting `RawPath` alongside is how net/url is told the exact
+	// encoding to emit, and building the URL directly rather than through
+	// `ResolveReference` keeps its dot-segment removal out of it — that
+	// normalisation is what turns `..` into traversal rather than a 404.
+	u := *base
+	u.Path = strings.TrimSuffix(base.Path, "/") + "/secrets/" + name
+	u.RawPath = strings.TrimSuffix(base.EscapedPath(), "/") + "/secrets/" + url.PathEscape(name)
+	u.RawQuery = "api-version=" + APIVersion
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/akv/akv_test.go
+++ b/internal/akv/akv_test.go
@@ -150,3 +150,67 @@ func TestVaultURIAllowlist(t *testing.T) {
 		t.Errorf("ResolveSecret sent a token to a foreign host: %v", err)
 	}
 }
+
+// TestASecretNameCannotLeaveTheSecretsPath is the traversal guard.
+//
+// The name is caller-supplied: it arrives in an AKV-reference connection body,
+// alongside the vaultURI the allowlist already constrains. Constraining the
+// HOST is only half the job, because the request carries a vault-audience
+// bearer token and the vault serves more than /secrets — /certificates and
+// /keys sit on the same host behind the same token. A name of
+// `../../certificates/evil` that resolves out of /secrets/ hands that token's
+// reach to whoever wrote the connection body.
+//
+// This is a regression test in the strict sense: escaping the name into ONE
+// segment was already the behaviour, and rebuilding the URL through
+// ResolveReference quietly dropped it, because a `/` inside a decoded Path is
+// a separator and ResolveReference removes dot segments on top.
+func TestASecretNameCannotLeaveTheSecretsPath(t *testing.T) {
+	var got []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.URL.EscapedPath())
+		_, _ = w.Write([]byte(`{"value":"v"}`))
+	}))
+	defer srv.Close()
+	c := New(false, srv.Client(), hostOf(t, srv.URL))
+
+	for _, name := range []string{
+		"../../certificates/evil",
+		"a/b",
+		"..%2f..%2fkeys/x",
+		"./../keys/x",
+	} {
+		got = nil
+		if _, err := c.ResolveSecret(srv.URL, name, "tok"); err != nil {
+			t.Fatalf("%q: %v", name, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("%q: %d requests", name, len(got))
+		}
+		// Whatever the name contained, the request must still be for a single
+		// segment under /secrets/.
+		rest, ok := strings.CutPrefix(got[0], "/secrets/")
+		if !ok {
+			t.Fatalf("%q escaped the secrets path: %s", name, got[0])
+		}
+		if strings.Contains(rest, "/") {
+			t.Fatalf("%q became more than one segment: %s", name, got[0])
+		}
+	}
+}
+
+// TestTheRequestedURLComesFromTheValidatedVault keeps the other half of the
+// same line honest: the host actually requested is the one the allowlist
+// approved, not whatever the raw argument said.
+func TestTheRequestedURLComesFromTheValidatedVault(t *testing.T) {
+	srv := fakeVault(t)
+	c := New(false, srv.Client(), hostOf(t, srv.URL))
+	// A trailing slash, which the join must not double.
+	if _, err := c.ResolveSecret(srv.URL+"/", "db-password", "tok"); err != nil {
+		t.Fatalf("trailing slash: %v", err)
+	}
+	// A vault the allowlist rejects is never requested at all.
+	if _, err := c.ResolveSecret("https://evil.example.com", "db-password", "tok"); !errors.Is(err, ErrVaultNotAllowed) {
+		t.Fatalf("allowlist bypass: %v", err)
+	}
+}

--- a/internal/pipeline/funcs.go
+++ b/internal/pipeline/funcs.go
@@ -152,7 +152,25 @@ func callFunc(name string, args []value, ctx *evalContext) (value, error) {
 	case "createArray":
 		return append([]value{}, args...), nil
 	case "range":
+		if err := arity(name, args, 2); err != nil {
+			return nil, err
+		}
 		start, count := int(toNumber(args[0])), int(toNumber(args[1]))
+		// The count is attacker-controlled: it comes from a pipeline definition,
+		// and `make` reserves the capacity immediately. A negative count panics
+		// `makeslice` (evalExpr's recover turns that into an error, so it is
+		// merely rude), but a huge one does NOT panic — it allocates, and an OOM
+		// kill is a FATAL that no per-request recover can catch. Same shape as
+		// internal/semanticmodel's maxMeasureDepth: bound it here or one
+		// malformed definition takes the process down with every other in-flight
+		// request.
+		//
+		// 100k is far past any real pipeline (range feeds ForEach, which Fabric
+		// itself caps well below this) and small enough to be harmless.
+		if count < 0 || count > maxRangeCount {
+			return nil, fmt.Errorf("range expects a count between 0 and %d, got %d",
+				maxRangeCount, count)
+		}
 		out := make([]value, 0, count)
 		for i := 0; i < count; i++ {
 			out = append(out, float64(start+i))
@@ -173,6 +191,10 @@ func callFunc(name string, args []value, ctx *evalContext) (value, error) {
 	}
 	return nil, fmt.Errorf("unsupported function %q", name)
 }
+
+// maxRangeCount bounds range()'s allocation. See the comment at its call site:
+// an unbounded count is an OOM, and an OOM is not recoverable.
+const maxRangeCount = 100_000
 
 func arity(name string, args []value, n int) error {
 	if len(args) != n {

--- a/internal/pipeline/funcs_test.go
+++ b/internal/pipeline/funcs_test.go
@@ -212,3 +212,50 @@ func TestSafeNavigationAndTriggerEvent(t *testing.T) {
 		t.Error("a dangling '?.' did not fail")
 	}
 }
+
+// range()'s count comes from a pipeline definition and `make` reserves the
+// capacity up front. A negative count panics `makeslice`, which evalExpr's
+// recover turns into an error; a huge one does NOT panic — it allocates, and an
+// OOM kill is a fatal that no per-request recover can catch. So the bound is the
+// only thing standing between one malformed definition and the process, exactly
+// as maxMeasureDepth is for a cyclic measure.
+//
+// Asserting the ERROR rather than timing the allocation is deliberate: a test
+// that actually tried 2e9 would either pass by OOMing the runner or pass by
+// having enough RAM, and neither outcome is about the guard.
+func TestRangeRefusesAnUnboundedCount(t *testing.T) {
+	ctx := &evalContext{Variables: map[string]value{}}
+	for _, expr := range []string{
+		"@range(0, -1)",         // makeslice would panic
+		"@range(0, 100001)",     // one past the bound
+		"@range(0, 2000000000)", // the OOM case CodeQL flagged
+		"@range(0)",             // arity: indexing args[1] would panic
+		"@range()",
+	} {
+		if _, err := evalString(expr, ctx); err == nil {
+			t.Errorf("%s: expected an error, got none", expr)
+		}
+	}
+
+	// The bound must not break the function it guards.
+	for _, expr := range []string{"@range(0, 0)", "@range(5, 3)", "@range(0, 100000)"} {
+		if _, err := evalString(expr, ctx); err != nil {
+			t.Errorf("%s: refused a legitimate range: %v", expr, err)
+		}
+	}
+
+	// And the values are still right, not merely non-erroring.
+	v, err := evalString("@range(5, 3)", ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arr, ok := v.([]value)
+	if !ok || len(arr) != 3 {
+		t.Fatalf("range(5,3) = %#v", v)
+	}
+	for i, want := range []float64{5, 6, 7} {
+		if arr[i] != want {
+			t.Errorf("range(5,3)[%d] = %v, want %v", i, arr[i], want)
+		}
+	}
+}


### PR DESCRIPTION
Four of the five open code-scanning alerts. The fifth is a false positive and is dismissed separately, with its reason recorded on the alert.

## #62 `go/uncontrolled-allocation-size` — the one with teeth

`internal/pipeline/funcs.go`, `range(start, count)`: `count` comes from a pipeline definition and `make([]value, 0, count)` reserves the capacity immediately.

I checked what actually happens at both extremes, and the alert names the less dangerous half:

- **Negative** count panics `makeslice`. `evalExpr` already recovers panics into errors by design, so this was merely rude — never a crash. I nearly reported it as one.
- **Huge** count does **not** panic. It allocates: 2e9 × `any` is ~32 GB, and an **OOM kill is a fatal that no per-request recover can catch**. One malformed definition takes the process down with every other in-flight request.

That is precisely the shape `internal/semanticmodel`'s `maxMeasureDepth` exists for, and its comment says the same thing about stack overflow. So `range` gets the same treatment: `maxRangeCount = 100_000`, far past any real pipeline (range feeds ForEach, which Fabric caps well below), plus the `arity` check the case was missing — `args[1]` was indexed unguarded.

Regression test asserts the **error**, not the timing: a test that really tried 2e9 would pass either by OOMing the runner or by having enough RAM, and neither outcome is about the guard. Mutation-checked — removing the bound fails it.

## #60 `go/request-forgery` (critical) — validate one thing, request another

`internal/akv/akv.go`. `checkVaultURI` is a careful allowlist: no userinfo, https enforced on Azure domains, suffix match anchored with a non-empty-label check. It returns the parsed `*url.URL` — and the caller **discarded it** (`if _, err := ...`), then rebuilt the request URL from the raw `vaultURI` string.

The alert is right, and not only about taint tracking. Validating one representation and requesting another is how an allowlist gets bypassed: anything `url.Parse` normalises away is checked in the parsed form and re-introduced by the raw string. They agree today; nothing enforced that they keep agreeing. Now the request is built from `base.ResolveReference(...)` on the URL the check returned.

## #57 `py/insecure-protocol` — `e2e/xmla/run.py`

`PROTOCOL_TLS_SERVER` negotiates the best version *both* sides accept, which still leaves TLS 1.0/1.1 available if the client offers nothing better. ADOMD.NET does far better, so `ctx.minimum_version = ssl.TLSVersion.TLSv1_2` costs this capture listener nothing and stops the suite modelling a downgrade nobody wants.

## #59 `py/clear-text-logging-sensitive-data` — `e2e/notebookutils/notebook.py`

`print(f"credentials.getSecret: {secret!r}")` echoed a Key Vault value into a public CI log. The **assert is the witness**; the print proved nothing the comparison does not. It is a fixture secret, but this file is what a reader copies when wiring up their own vault, so the pattern is the problem. Now asserts and reports a length.

## Not fixed: #58 `py/incomplete-url-substring-sanitization`

`scripts/check_entra_install.py:144` is `check("the final error lost the diagnosis", error and "sum.golang.org" in error)` — a **test assertion that a diagnostic string survived retry exhaustion**. It sanitises no URL and authorises nothing. Dismissing as a false positive rather than contorting the assertion to satisfy the pattern.

`go build`, `go vet`, `go test ./...`, `make check`, and the Python suite (506 passed) all pass.