### PR TITLE
deps: hold TypeScript at 6, where svelte-check caps it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,24 @@ updates:
         patterns: ['astro', '@astrojs/*', 'sharp']
       portal:
         patterns: ['svelte', '@sveltejs/*', 'vite']
+    ignore:
+      # TypeScript 7 is held back by svelte-check, not by us. Its version gate
+      # (bin/ts-version-check.js, still there in the current 4.7.5) throws on
+      # any major above 6 and tells you to install BOTH majors side by side
+      # under an npm alias and pass --tsgo, an experimental API. So the portal's
+      # type gate does not merely fail to type-check under TypeScript 7, it
+      # refuses to start, and every such bump arrives already red (#129).
+      #
+      # Held rather than worked around: the alternative is running the portal's
+      # only type gate through an experimental code path, which buys nothing
+      # here. Astro pulls TypeScript 7 transitively for the docs site and that
+      # is fine, because nothing points svelte-check at it.
+      #
+      # LIFT THIS when svelte-check accepts TypeScript 7 on the default path.
+      # The tell is its peerDependencies range, `^5.0.0 || ^6.0.0` today,
+      # growing a 7. Minor and patch updates keep flowing meanwhile.
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
 
   # Python: uv-managed, one lockfile at the root covering the dependency
   # groups. Dependabot reads pyproject.toml + uv.lock together.


### PR DESCRIPTION
Closes the recurring red TypeScript major bumps, of which #129 is the current one.

## What is wrong

`svelte-check` refuses to run at all under TypeScript 7. Its version gate throws before checking a single file:

```
Error: TypeScript 7 support currently requires both TypeScript 7 and TypeScript 6
installed in your project, and requires using the --tsgo or --tsgo-experimental-api flag.
```

So the portal's only type gate does not fail to type-check under TypeScript 7, it fails to start, and #129 was red on arrival.

This is not fixed by moving forward. The gate is still present in the newest `svelte-check` (4.7.5), and its declared peer range is `^5.0.0 || ^6.0.0`, which does not admit 7 either.

## Verified locally

Against `origin/main` at 674d507, portal only:

| typescript | `pnpm --filter fabric-emulator-portal check` |
|---|---|
| ~6.0.3 (main) | `COMPLETED 748 FILES 0 ERRORS` |
| 7.0.2 (#129) | throws in `bin/ts-version-check.js`, 0 files checked |

## What this does

Adds one `ignore` rule to the npm ecosystem: TypeScript major updates only. Minor and patch keep flowing, and every other npm dependency is untouched.

The comment in the file names the condition for lifting it, so this does not become a permanent pin nobody remembers the reason for: watch `svelte-check`'s peer range for a 7.

## What this deliberately does not do

The workaround `svelte-check` suggests is installing both majors side by side under an npm alias and passing `--tsgo`, an experimental API. That would route the portal's only type gate through an experimental code path to gain nothing, since nothing here needs TypeScript 7. Astro pulls TypeScript 7 transitively for the docs site already and that is fine, because nothing points `svelte-check` at it.

Once merged, #129 should be closed.