### PR TITLE
build(deps): hold TypeScript at 6 until svelte-check supports 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,23 @@ updates:
         patterns: ['astro', '@astrojs/*', 'sharp']
       portal:
         patterns: ['svelte', '@sveltejs/*', 'vite']
+    ignore:
+      # TypeScript 7 is the native (Go) compiler, and svelte-check 4.x REFUSES
+      # it outright: "TypeScript 7 support currently requires both TypeScript 7
+      # and TypeScript 6 installed in your project, and requires using the
+      # --tsgo or --tsgo-experimental-api flag" (#129 failed on exactly that).
+      #
+      # Taking it would mean carrying two TypeScript installs behind an npm
+      # alias and running the portal's type check through an experimental API —
+      # and that check is not cosmetic here: `svelte-check + a new kind must not
+      # compile` is the invariant that makes an unhandled SSE event kind a build
+      # failure rather than a silently blank panel. An experimental compiler
+      # path is the wrong place for the thing that guards a whole contract.
+      #
+      # Majors only: 6.x patches still arrive. Drop this once svelte-check
+      # supports TS 7 without the dual install.
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
 
   # Python: uv-managed, one lockfile at the root covering the dependency
   # groups. Dependabot reads pyproject.toml + uv.lock together.


### PR DESCRIPTION
Closes the loop on #129, which cannot pass and should not be made to.

## Why #129 fails

`svelte-check@4.7.4` refuses TypeScript 7 outright:

> TypeScript 7 support currently requires both TypeScript 7 and TypeScript 6 installed in your project, and requires using the `--tsgo` or `--tsgo-experimental-api` flag.

TypeScript 7 is the native (Go) compiler, and svelte-check's support for it is transitional. So the bump is not a matter of fixing a type error — the checker declines to run at all.

## Why not just do what it asks

Satisfying it means carrying **two TypeScript installs** behind an npm alias and running the portal's type check through an **experimental API**. That check is not cosmetic here. The job is called `svelte-check + a new kind must not compile`, and it is the invariant that makes an unhandled SSE event kind a **build failure** instead of a silently blank panel — `scripts/check_kind_exhaustiveness.py` inserts a kind into `bus.go`, regenerates, and requires the portal to stop compiling.

Putting the thing that guards a whole contract on an experimental compiler path trades a real guarantee for a version number.

## The change

One scoped `ignore` on the npm ecosystem:

```yaml
- dependency-name: typescript
  update-types: ['version-update:semver-major']
```

**Majors only** — 6.x patches keep arriving, so security fixes are unaffected. `portal/package.json` already declares `~6.0.3`, so this makes the manifest's intent explicit to Dependabot rather than changing policy. Drop it once svelte-check supports TS 7 without the dual install.

Verified: the YAML parses, both existing groups (`docs-site`, `portal`) and all five ecosystems are intact, and `pnpm --filter fabric-emulator-portal check` reports **0 errors** on TS 6.