### PR TITLE
docs: the CodeQL badge fabric earned

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![version](https://img.shields.io/github/v/release/calvinchengx/fabric-emulator?label=version)](https://github.com/calvinchengx/fabric-emulator/releases/latest)
 [![CI](https://github.com/calvinchengx/fabric-emulator/actions/workflows/ci.yml/badge.svg)](https://github.com/calvinchengx/fabric-emulator/actions/workflows/ci.yml)
 [![Docs](https://github.com/calvinchengx/fabric-emulator/actions/workflows/docs-site.yml/badge.svg)](https://calvinchengx.github.io/fabric-emulator/)
+[![CodeQL](https://github.com/calvinchengx/fabric-emulator/actions/workflows/codeql.yml/badge.svg)](https://github.com/calvinchengx/fabric-emulator/actions/workflows/codeql.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 [![go coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fcalvinchengx.github.io%2Ffabric-emulator%2Fcoverage-go.json)](https://calvinchengx.github.io/fabric-emulator/10-testing/)


### PR DESCRIPTION
Completes the shared badge row. fabric was the one member without a CodeQL badge in #134, and my stated reason for that was wrong.

I claimed fabric had no code scanning. It does: `.github/workflows/codeql.yml` has been on `main` since `6bb976b` ("CodeQL and Dependabot, the last repo in the family without them"), scanning **four** languages — `go` with autobuild, `javascript-typescript`, `python` and `actions` — and it has already run green on main. It is a more considered setup than its siblings, scanning `python/` because that is a shipped first-party package here rather than a test driver.

Two mistakes produced the false finding, both worth naming:

- The workflow survey read the **local checkout**, which is parked on another session's `fix/xmla-concurrent-runs` and predates that commit. Every other check today deliberately read `origin/main`; this one did not.
- `code-scanning/default-setup` returning `not-configured` was read as "no scanning". It means the opposite here: advanced setup via a workflow, which is how all five repos are configured.

With this, the shared row is genuinely identical across all five: version, CI, Docs, CodeQL, License.