### PR TITLE
Create the data dir before opening the database in it

### DIFF
--- a/cmd/fabric-emulator/main.go
+++ b/cmd/fabric-emulator/main.go
@@ -113,17 +113,22 @@ func run(args []string, stop <-chan struct{}, ready chan<- net.Addr) error {
 		return err
 	}
 
-	srv, err := server.New(cfg, nil)
-	if err != nil {
-		return err
-	}
-	defer srv.Close()
-
+	// BEFORE server.New, which opens the SQLite file inside this directory.
+	// SQLite does not create missing parents, so with the directory absent the
+	// open fails with "unable to open database file (14)" and the process exits
+	// before it ever listens. Every caller then sees only a health check that
+	// never came up, which is the symptom furthest from the cause.
 	if cfg.DataDir != "" {
 		if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
 			return err
 		}
 	}
+
+	srv, err := server.New(cfg, nil)
+	if err != nil {
+		return err
+	}
+	defer srv.Close()
 
 	ln, err := net.Listen("tcp", cfg.Addr)
 	if err != nil {


### PR DESCRIPTION
`main` is red. `fabric_target toggle drives the emulator profile (T0)` fails on **all three platforms** with:

```
RuntimeError: health never came up at https://localhost:19445/health
```

That is the symptom, not the cause. The emulator was exiting at startup.

**Reproduced locally**, running the binary from a clean directory exactly as the harness does, with no `FABRIC_DATA_DIR`:

```
2026/08/10 03:32:20 unable to open database file (14)
```

`34c8d4f` ("Persist to ./data by default") made an unset `FABRIC_DATA_DIR` resolve to `./data`. But `server.New` opens the SQLite file **before** the `os.MkdirAll(cfg.DataDir)` a few lines below it, and SQLite does not create missing parents. So the open fails, the process exits before it listens, and the only thing any caller can observe is a health check that never came up — the symptom furthest from the cause.

The proof it is the ordering and nothing else: pre-creating `./data` by hand and re-running the same binary gives `health=200`.

This moves the `MkdirAll` above `server.New` and says why in a comment, so it does not drift back. Verified from a clean directory: `health=200`, the process stays up, and `data/` is created containing `fabric-emulator.db` and `tls/`.

Worth noting the harness could not have told anyone this. It captures the emulator's stdout to a log file inside its work dir, which CI does not upload, so the run log shows only the timeout. Surfacing that log on failure would turn a five-minute diagnosis into a five-second one, but that is a separate change and this one is holding main red.