### PR TITLE
store: create the data dir, since ./data is now the default

### DIFF
--- a/internal/store/datadir_test.go
+++ b/internal/store/datadir_test.go
@@ -1,0 +1,46 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/clock"
+)
+
+// TestOpenCreatesTheDataDir is the first-run guard.
+//
+// `Open` is documented as opening the database "creating if needed", and until
+// DataDir defaulted to ./data nothing tested what "needed" covered: every
+// caller either passed "" for in-memory or a t.TempDir() that already existed.
+// The day the default became a real path, `fabric-emulator` in any directory
+// without a ./data died before it could listen — with SQLite's "unable to open
+// database file (14)", which names neither the path nor the directory, on the
+// one error a first run is most likely to hit.
+func TestOpenCreatesTheDataDir(t *testing.T) {
+	// A nested path, so this fails if only the leaf is created.
+	dir := filepath.Join(t.TempDir(), "state", "data")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s should not exist yet (%v)", dir, err)
+	}
+
+	s, err := Open(dir, clock.New())
+	if err != nil {
+		t.Fatalf("Open on a missing data dir: %v", err)
+	}
+	defer s.Close()
+
+	if _, err := os.Stat(filepath.Join(dir, "fabric-emulator.db")); err != nil {
+		t.Fatalf("database not created in %s: %v", dir, err)
+	}
+}
+
+// TestOpenStillDefaultsToMemory keeps the other half intact: an explicitly
+// empty dataDir means in-memory and must not create anything on disk.
+func TestOpenStillDefaultsToMemory(t *testing.T) {
+	s, err := Open("", clock.New())
+	if err != nil {
+		t.Fatalf("in-memory Open: %v", err)
+	}
+	defer s.Close()
+}

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -41,6 +42,16 @@ type Store struct {
 func Open(dataDir string, ck *clock.Clock) (*Store, error) {
 	dsn := ":memory:"
 	if dataDir != "" {
+		// "Creating if needed" has to include the DIRECTORY, not just the file.
+		// SQLite will not make one, and its failure says only "unable to open
+		// database file (14)" — no path, no mention of a directory, on the one
+		// error a first run is most likely to hit. This mattered the moment
+		// DataDir stopped defaulting to in-memory: `fabric-emulator` in any
+		// directory without a ./data now opens the store before anything else
+		// has had a chance to create it.
+		if err := os.MkdirAll(dataDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create data dir %q: %w", dataDir, err)
+		}
 		dsn = filepath.Join(dataDir, "fabric-emulator.db")
 	}
 	db, err := sql.Open("sqlite", dsn)

--- a/internal/store/store_more_test.go
+++ b/internal/store/store_more_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/calvinchengx/fabric-emulator/internal/clock"
@@ -107,10 +109,24 @@ func TestOpenPersistsAcrossReopen(t *testing.T) {
 }
 
 func TestOpenBadDir(t *testing.T) {
-	// A dataDir that is actually a file cannot host the database.
-	dir := t.TempDir() + "/nope/deeper"
-	if _, err := Open(dir, clock.New()); err == nil {
-		t.Skip("driver created intermediate path; acceptable")
+	// A dataDir UNDER A REGULAR FILE, which is what this test always meant to
+	// cover and what it can now state directly. It used to pass a merely
+	// missing nested path and skip if the driver made one, because whether
+	// that succeeded was the driver's business; since Open creates the
+	// directory itself, missing is the SUPPORTED case (TestOpenCreatesTheDataDir)
+	// and a file in the way is the real failure.
+	//
+	// The skip also leaked: on the branch where Open succeeded it returned a
+	// live Store nobody closed, and Windows will not delete an open file, so
+	// t.TempDir's cleanup failed the test from the outside.
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Open(filepath.Join(file, "data"), clock.New())
+	if err == nil {
+		s.Close()
+		t.Fatal("Open accepted a data dir underneath a regular file")
 	}
 }
 


### PR DESCRIPTION
**main is red** and has been since 34c8d4f. Every `fabric_target toggle (T0)` job fails, on all three OSes, and it is not the dependency bumps that were in flight at the time.

## What happens

34c8d4f made `FABRIC_DATA_DIR` default to `./data` instead of in-memory. Nothing creates that directory, and SQLite will not:

```
$ cd /some/dir/without/data && fabric-emulator
2026/08/10 03:46:05 unable to open database file (14)
```

The process exits before it listens, so the e2e sees only `health never came up at https://localhost:19445/health` — the emulator's own stderr goes to a log file the job never prints, which is why the CI output named nothing.

This is not e2e-only. It is **any first run in a directory without a `./data`**, which includes the documented `go install` quickstart. Containers were spared only because the compose files set `FABRIC_DATA_DIR=""` explicitly, and that is also why one job caught it rather than fifty.

## The fix

`store.Open` is documented as opening the database *"creating if needed"*. It created the file but not its directory; now it creates both. Putting it there rather than in `main.go` fixes every caller — `main.go` calls `server.New` (which opens the store) *before* its own `os.MkdirAll`, so the ordering was already wrong and only survived because the default was in-memory.

The error message also now names the path, instead of SQLite's `(14)`.

## Verified

| | before | after |
|---|---|---|
| `Open` on a missing dir | `unable to open database file (14)` | creates it, opens the db |
| binary in a dir with no `./data` | exits, never listens | `fabric-emulator listening on https://127.0.0.1:19447` |
| explicit `FABRIC_DATA_DIR=""` | in-memory | in-memory, unchanged |

`TestOpenCreatesTheDataDir` uses a **nested** path, so it fails if only the leaf is created, and it fails on the parent commit with the exact production error. `TestOpenStillDefaultsToMemory` keeps the in-memory half honest, since that is what the compose files rely on.