### PR TITLE
compose: keyvault 0.7.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       retries: 10
 
   keyvault-emulator:
-    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.6.0}
+    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.7.0}
     depends_on:
       entra-emulator:
         condition: service_healthy

--- a/e2e/medallion/docker-compose.yml
+++ b/e2e/medallion/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       retries: 20
 
   keyvault-emulator:
-    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.6.0}
+    image: ghcr.io/calvinchengx/azure-keyvault-emulator:${KEYVAULT_EMULATOR_VERSION:-0.7.0}
     depends_on:
       entra-emulator:
         condition: service_healthy


### PR DESCRIPTION
Bumps the keyvault image these stacks run from 0.6.0 to 0.7.0 — the root
compose and the medallion e2e, which are the two the family pins checker
watches.

**Why now:** the BOM bump in `azure-emulators` needs these pins swept first,
or `check_family_pins.py` goes red at error tier the moment it lands.

**What 0.7.0 changes for us:** the `nextLink` fix, so a Microsoft SDK pager
against the vault now survives the second page. The other two fixes (`nbf`/`exp`
on secret reads, HSM key types refused) are behaviour neither stack exercises —
no `RSA-HSM` anywhere in this repo.

**No config change needed.** 0.7.0 persists to `./data` by default, but both
composes already pin `KV_DATA_DIR: ""`, so they stay in-memory.