### PR TITLE
xmla: Execute and Discover round-trip, and what sempy actually needs

### DIFF
--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -112,14 +112,27 @@ sessions had previously reached OPPOSITE conclusions, both from Microsoft Learn.
 
 | sempy call | Transport | This emulator |
 |---|---|---|
-| `evaluate_dax`, `evaluate_measure` | REST `executeQueries` **by default** | already 🟢 |
+| `evaluate_dax` | **XMLA, always** — no `use_xmla` parameter exists; the body calls `get_dataset_client(mode=ConnectionMode.XMLA)` unconditionally | **the gap** |
+| `evaluate_measure`, `read_table` | REST `executeQueries` (`use_xmla: bool = False`) | already 🟢 |
 | `list_measures`, `list_tables`, `list_partitions`, `list_columns`, `list_relationships` | XMLA, via `$SYSTEM.TMSCHEMA_*` DMVs | **the gap** |
 | `INFO.*` | never called | no sempy case |
 
-    sempy/fabric/_flat.py:954      use_xmla: bool = False
-    sempy/fabric/_flat.py:1017     if use_xmla: XMLA else: ... REST
+    sempy/fabric/_flat.py:947      def evaluate_measure(          <- 954's owner
+    sempy/fabric/_flat.py:954          use_xmla: bool = False
+    sempy/fabric/_flat.py:1038     def evaluate_dax(...)          <- no use_xmla
+                                       get_dataset_client(mode=ConnectionMode.XMLA)
     sempy/fabric/_client/_pbi_rest_api.py:274
         path = f"v1.0/myorg/datasets/{dataset_id}/executeQueries"
+
+**Three sessions got this wrong before it was executed**, and the same way each
+time. `_flat.py:954` was cited as `evaluate_dax`'s default; it is
+`evaluate_measure`'s. Each reader confirmed the LINE EXISTED and had the quoted
+text, and none checked which `def` it sat inside — **the citation was verified,
+the proposition was not.** What settled it was running the thing:
+`evaluate_dax(..., use_xmla=True)` raises
+`TypeError: unexpected keyword argument 'use_xmla'`, and a parameter that does
+not exist cannot have a default. Prefer executing a claim about behaviour over
+reading any number of sources about it.
 
 XMLA is escalated to only on `use_xmla=True`, a readwrite connection, or
 `num_rows > 30000`. sempy also ships `Microsoft.AnalysisServices.AdomdClient.dll`
@@ -128,8 +141,10 @@ same client.
 
 **Consequences, and they narrow the work:**
 
-1. The sempy gap is the **DMV metadata surface**, not DAX evaluation. That is
-   much narrower than "implement `[MS-SSAS-T]`".
+1. The sempy gap is the **DMV metadata surface plus `evaluate_dax`**. Narrower
+   than "implement `[MS-SSAS-T]`", but larger than the DMV-only version this
+   document carried for one revision — and it points at exactly the `Execute`
+   rowset this harness now serves.
 2. The next rowset to build is `$SYSTEM.TMSCHEMA_*`, NOT the `MDSCHEMA_*` this
    harness probed first. `MDSCHEMA_*` proved the shape; `TMSCHEMA_*` is the
    demand.

--- a/docs/32-xmla-plan.md
+++ b/docs/32-xmla-plan.md
@@ -77,14 +77,97 @@ Two findings worth more than the gates themselves:
   `UriFormatException`. A bare hostname cannot fail to parse, so the string was
   never reaching the parser: the reply CONTRACT was wrong, not its shape.
 
+## The query path, measured 2026-08-10
+
+**A real ADOMD.NET client now round-trips end to end against a stub.** Past
+`Open()`, the probe issues a DAX query and a schema `Discover`, and both are
+accepted:
+
+    PROBE powerbi-userid/dax    :: OK
+    PROBE powerbi-userid/schema :: OK     SCHEMA rows=1
+
+What the client sends, captured off the wire:
+
+| Envelope | Contract when refused |
+|---|---|
+| `Execute` + `<Statement/>` empty | session open; `ExecuteResponse`, empty root |
+| `Execute` + `EVALUATE ROW("x",1)` | `not a rowset` — `XmlaDataReader..ctor` |
+| `Discover` + `MDSCHEMA_MEASURES` | `unrecognizable` — `SoapFormatter.ReadDiscoverResponse` |
+
+**The inline XSD is the whole trick.** ADOMD.NET reads the schema to learn the
+row shape BEFORE it reads a row, which is why an empty root came back as
+"unrecognizable" rather than "empty": the reader never found the element it
+expects. `Execute` and `Discover` take the SAME
+`urn:schemas-microsoft-com:xml-analysis:rowset` payload under a different
+wrapper element, so the harness factors one builder rather than two.
+
+This half was built from `[MS-SSAS]`, not from the decompiler — the documented
+surface, per the boundary above. That rule is now load-bearing rather than
+aspirational.
+
+## What SemPy actually needs, measured against the installed wheel
+
+The demand question, settled by reading the package rather than the docs. Two
+sessions had previously reached OPPOSITE conclusions, both from Microsoft Learn.
+
+| sempy call | Transport | This emulator |
+|---|---|---|
+| `evaluate_dax`, `evaluate_measure` | REST `executeQueries` **by default** | already 🟢 |
+| `list_measures`, `list_tables`, `list_partitions`, `list_columns`, `list_relationships` | XMLA, via `$SYSTEM.TMSCHEMA_*` DMVs | **the gap** |
+| `INFO.*` | never called | no sempy case |
+
+    sempy/fabric/_flat.py:954      use_xmla: bool = False
+    sempy/fabric/_flat.py:1017     if use_xmla: XMLA else: ... REST
+    sempy/fabric/_client/_pbi_rest_api.py:274
+        path = f"v1.0/myorg/datasets/{dataset_id}/executeQueries"
+
+XMLA is escalated to only on `use_xmla=True`, a readwrite connection, or
+`num_rows > 30000`. sempy also ships `Microsoft.AnalysisServices.AdomdClient.dll`
+— the same assembly `e2e/xmla` drives, so the oracle and the consumer are the
+same client.
+
+**Consequences, and they narrow the work:**
+
+1. The sempy gap is the **DMV metadata surface**, not DAX evaluation. That is
+   much narrower than "implement `[MS-SSAS-T]`".
+2. The next rowset to build is `$SYSTEM.TMSCHEMA_*`, NOT the `MDSCHEMA_*` this
+   harness probed first. `MDSCHEMA_*` proved the shape; `TMSCHEMA_*` is the
+   demand.
+3. An `INFO.*`-over-`executeQueries` plan was proposed and dropped: `INFO.*` may
+   still be worth building for DAX Studio and Desktop, but NOT as a sempy path.
+4. `StaticFabricContext(pbi_shared_host=…)` redirects sempy standalone and
+   yields the exact `powerbi://host:port/v1.0/myorg/ws` form this harness proves
+   works — the most credible third-party witness lead for a 🟢 row.
+
+**Method note worth keeping.** Both sessions read Learn's `use_xmla=False` and
+drew opposite conclusions; one grep of the installed wheel settled it.
+Documentation about a transport is not a transport.
+
 ## What is NOT settled
 
-Query traffic. The probe stops at `Open()`, so no client has yet been asked to
-run DAX or a `Discover`, and **`xmla-rs:rowset` serialisation plus the `Discover`
-metadata subset are what the estimate is actually for.**
+Not reachability any more, and not the wire shape: a real client completes
+connect, query and metadata against a stub. What is unmeasured is everything
+between a SHAPE and an IMPLEMENTATION:
 
-**Connect is measured. Query is not.** The `L` in `docs/24` stands, and should
-not move on the strength of a handshake.
+- **Rows that mean something.** The harness returns one hardcoded row. Serving
+  `$SYSTEM.TMSCHEMA_*` from `internal/semanticmodel` is the actual work, and
+  none of it is done.
+- **The TOM surface.** `semantic-link-labs` reads tables and measures through
+  the Tabular Object Model (`connect_semantic_model()`, `tom.model.Tables`), not
+  through plain `Discover`. TOM is a metadata/TMSL surface on top of XMLA and was
+  NOT in the original sizing — it is an increase, found by measurement.
+- **The LRO continuation protocol.** The trailing byte can be `1`, meaning
+  reconnect and resume. Long-running queries need it; nothing here implements it.
+- **Type fidelity.** Every column the harness emits is `xsd:string`. Real DAX
+  results carry numerics, dates and nulls, and the client's type mapping is
+  unexercised.
+- **Errors.** Only success paths have been driven. What a client does with a
+  SOAP fault mid-rowset is unknown.
+
+**Connect and the wire shape are measured. The implementation is not.** The `L`
+in `docs/24` stands. It has been *redistributed* rather than reduced: the
+transport turned out cheap and undocumented, the DMV/TOM surface turned out to
+be the cost, and DAX evaluation turned out to be already served over REST.
 
 ## Method, and its boundary
 
@@ -117,7 +200,6 @@ implementation, and that claim is load-bearing for every parity grade. So:
   `RadarSoft/xmla-client`; reaching for the decompiler there would be choosing
   the riskier source over the safer one for no gain.
 
-## What already exists to build on
 ## What already exists to build on
 
 | Asset | Why it matters |

--- a/e2e/xmla/probe/Program.cs
+++ b/e2e/xmla/probe/Program.cs
@@ -50,6 +50,27 @@ class Probe {
                 using var c = new AdomdConnection(cs);
                 c.Open();
                 Console.WriteLine($"CASE {label} :: OPENED");
+                // PAST Open() — the whole point of getting the connection up.
+                // Until the client is ASKED for query traffic it sends none, so
+                // the envelopes that price the rowset serialiser never appear
+                // and the `L` in docs/24 stays an estimate. Each probe below is
+                // wrapped separately: the first one to fail must not hide the
+                // others, because they exercise DIFFERENT surfaces (DAX query
+                // vs schema Discover) and we want both answers from one run.
+                RunProbe($"{label}/dax", () => {
+                    using var cmd = c.CreateCommand();
+                    cmd.CommandText = "EVALUATE ROW(\"x\", 1)";
+                    using var r = cmd.ExecuteReader();
+                    while (r.Read()) { }
+                });
+                // Discover, the metadata half. sempy's list_tables/list_measures
+                // and semantic-link-labs' TOM both live here, and per the
+                // measured API defaults they use XMLA rather than REST — so
+                // this is the surface the SemPy demand actually needs.
+                RunProbe($"{label}/schema", () => {
+                    var ds = c.GetSchemaDataSet("MDSCHEMA_MEASURES", null);
+                    Console.WriteLine($"SCHEMA {label} :: rows={ds.Tables[0].Rows.Count}");
+                });
                 c.Close();
             } catch (Exception e) {
                 var first = e.Message.Split('\n')[0].Trim();
@@ -80,5 +101,25 @@ class Probe {
             }
         }
         return 0;
+    }
+
+    // Run one post-Open probe and REPORT rather than throw. A probe that killed
+    // the run would let the first failure hide every later surface, and these
+    // exercise different ones (DAX query vs schema Discover). Prints the
+    // throwing method for the same reason the connect path does: the method
+    // name is strictly more than the message says, and it costs no extra run.
+    static void RunProbe(string label, Action body) {
+        try {
+            body();
+            Console.WriteLine($"PROBE {label} :: OK");
+        } catch (Exception e) {
+            Console.WriteLine($"PROBE {label} :: {e.GetType().Name} :: "
+                              + e.Message.Split('\n')[0].Trim());
+            for (var x = e; x != null; x = x.InnerException) {
+                if (x.TargetSite != null)
+                    Console.WriteLine($"  PTHREW {label} :: "
+                                      + $"{x.TargetSite.DeclaringType}::{x.TargetSite.Name}");
+            }
+        }
     }
 }

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -207,6 +207,10 @@ ANSWER_TOKEN = False
 # which cluster to use, so a URI naming our host AND PORT should bring the XMLA
 # call back to the listener instead of to :443.
 ANSWER_CLUSTER = False
+# Screen 13: answer the XMLA session handshake itself. Off until the phase
+# that wants it, so earlier phases still record a client that is refused.
+ANSWER_XMLA = False
+XMLA_SESSION = "emulator-session-1"
 WORKSPACE = "ws"   # the workspace the probe names in its Data Source
 
 # CANDIDATE ROUTING SHAPES, screened one per request.
@@ -574,6 +578,49 @@ class Capture(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(b)
             return
+        if ANSWER_XMLA and self.path.startswith("/webapi/xmla"):
+            # SCREEN 13: answer the session handshake and read what follows.
+            #
+            # The captured first envelope is an `Execute` with an EMPTY
+            # `<Statement/>` and `BeginSession mustUnderstand="1"` — a session
+            # open, not a query. XMLA's documented reply to that is an
+            # `ExecuteResponse` with an empty root, plus a `Session` header
+            # carrying the id the client must echo on every later request.
+            #
+            # `mustUnderstand="1"` is the reason a fault here ends the
+            # conversation: the client cannot proceed without the header being
+            # honoured, so refusing it is indistinguishable from a server that
+            # does not speak XMLA at all. Answering it is what turns "connect is
+            # measured" into "the traffic past connect is measured", which is
+            # where the rest of [MS-SSAS-T]'s cost lives.
+            b = ('<?xml version="1.0" encoding="utf-8"?>'
+                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+                 '<soap:Header>'
+                 f'<Session xmlns="urn:schemas-microsoft-com:xml-analysis" '
+                 f'SessionId="{XMLA_SESSION}"/>'
+                 '</soap:Header><soap:Body>'
+                 '<ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">'
+                 '<return><root xmlns="urn:schemas-microsoft-com:xml-analysis:empty"/>'
+                 '</return></ExecuteResponse>'
+                 '</soap:Body></soap:Envelope>').encode()
+            print(f"    -> answering 200 XMLA session {XMLA_SESSION}", flush=True)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/xml; charset=utf-8")
+            # REQUIRED ON THE RESPONSE, not just sent on the request. Without it
+            # the client raises `InvalidDataException: The
+            # 'x-ms-xmlacaps-negotiation-flags' header is missing from the HTTP
+            # response!` in `HttpStream+PaasInfraController.ProcessWebResponse`,
+            # BEFORE reading the body — so a perfectly good SOAP envelope is
+            # discarded on a missing header. Echo what the client offered
+            # (0,0,0,1,0): this is a capability NEGOTIATION, so a server picks a
+            # subset rather than inventing flags.
+            self.send_header("x-ms-xmlacaps-negotiation-flags",
+                             self.headers.get("x-ms-xmlacaps-negotiation-flags",
+                                              "0,0,0,1,0"))
+            self.send_header("Content-Length", str(len(b)))
+            self.end_headers()
+            self.wfile.write(b)
+            return
         b = (b'<?xml version="1.0"?><soap:Envelope '
              b'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body>'
              b'<soap:Fault><faultcode>capture</faultcode>'
@@ -859,6 +906,9 @@ ANSWER_ROUTING = True
 # recording nobody in this project has ever had.
 ANSWER_TOKEN = True
 ANSWER_CLUSTER = True
+# Screen 13: and answer the session handshake, so the request AFTER connect
+# is recorded rather than refused.
+ANSWER_XMLA = True
 
 # ONE PROBE RUN PER SHAPE. Screen 5 established that an accepted reply is
 # cached for the life of the client process, so a second shape in the same run

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -603,6 +603,19 @@ class Capture(http.server.BaseHTTPRequestHandler):
                  '<return><root xmlns="urn:schemas-microsoft-com:xml-analysis:empty"/>'
                  '</return></ExecuteResponse>'
                  '</soap:Body></soap:Envelope>').encode()
+            # TRAILING PROTOCOL BYTE, and it is not optional.
+            # `HttpStream+PaasInfraController+PaasInfraXmlaOperation
+            # .ReadResponsePayloadImpl` reads the payload and then switches on
+            # the LAST byte of the stream:
+            #     0       -> response complete
+            #     1       -> continuation; reconnect under the LRO protocol
+            #     default -> throw UnknownServerResponseFormat,
+            #                ConnectionExceptionCause.TransportProtocolError
+            # A bare SOAP body ends with '>' (0x3E), which is `default`, so a
+            # perfectly well-formed envelope is rejected as "unrecognizable".
+            # The client announces this on the way in with
+            # `x-ms-accepts-continuations: 1`. Append 0x00 for "that is all".
+            b += b"\x00"
             print(f"    -> answering 200 XMLA session {XMLA_SESSION}", flush=True)
             self.send_response(200)
             self.send_header("Content-Type", "text/xml; charset=utf-8")
@@ -611,12 +624,22 @@ class Capture(http.server.BaseHTTPRequestHandler):
             # 'x-ms-xmlacaps-negotiation-flags' header is missing from the HTTP
             # response!` in `HttpStream+PaasInfraController.ProcessWebResponse`,
             # BEFORE reading the body — so a perfectly good SOAP envelope is
-            # discarded on a missing header. Echo what the client offered
-            # (0,0,0,1,0): this is a capability NEGOTIATION, so a server picks a
-            # subset rather than inventing flags.
-            self.send_header("x-ms-xmlacaps-negotiation-flags",
-                             self.headers.get("x-ms-xmlacaps-negotiation-flags",
-                                              "0,0,0,1,0"))
+            # discarded on a missing header.
+            #
+            # SELECT NOTHING (0,0,0,0,0) rather than echoing the client's offer.
+            # Echoing `0,0,0,1,0` was tried and the frames say why it fails:
+            # after parsing our XML, `XmlaReader.ReadEndElement` asked for MORE
+            # bytes through `CompressedStream.Read` ->
+            # `PaasInfraXmlaOperation.ReadResponsePayloadImpl`, which threw
+            # `UnknownServerResponseFormat`. That is a FRAMING layer, not a
+            # malformed body: the assembly's `ReadCompressedPacket` reads an
+            # 8-byte packet header, so a flag we accepted put the client into a
+            # framed read that plain XML does not satisfy.
+            #
+            # "A server picks a subset" is not "a server echoes the offer" —
+            # echoing accepts EVERY capability offered, including the ones we
+            # have not implemented. A capture stub selects the empty subset.
+            self.send_header("x-ms-xmlacaps-negotiation-flags", "0,0,0,0,0")
             self.send_header("Content-Length", str(len(b)))
             self.end_headers()
             self.wfile.write(b)

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -444,6 +444,68 @@ HANDSHAKE_ERRORS = []  # TCP connected, TLS refused — a distinct diagnosis
 LOCK = threading.Lock()
 
 
+# The MDSCHEMA_MEASURES columns this stub returns. A real server returns ~30;
+# these are enough for the client to build a row, and keeping the set small
+# makes it obvious this is a SHAPE probe rather than an implementation.
+_MEASURE_COLS = ["CATALOG_NAME", "CUBE_NAME", "MEASURE_NAME",
+                 "MEASURE_UNIQUE_NAME", "MEASURE_CAPTION", "EXPRESSION"]
+
+
+def _rowset_envelope(response_element, cols, values):
+    """One `xml-analysis:rowset` payload, wrapped for Execute OR Discover.
+
+    The INLINE XSD is not decoration: ADOMD.NET reads the schema to learn the
+    row shape BEFORE it reads a row, which is why an empty root came back as
+    "unrecognizable" rather than "empty" — the reader never found the element
+    it expects.
+
+    Execute and Discover take the SAME rowset under a different wrapper, so
+    this is factored rather than duplicated; the client refuses each
+    differently ("not a rowset" from `XmlaDataReader..ctor`, "unrecognizable"
+    from `SoapFormatter.ReadDiscoverResponse`) and two copies would drift.
+
+    Built from [MS-SSAS] `xmla-rs:rowset`, the DOCUMENTED surface, per the
+    boundary in docs/32: the decompiler is for undocumented transport glue.
+    """
+    xsd = "".join(
+        f'<xsd:element sql:field="{c}" name="{c}" type="xsd:string" '
+        f'minOccurs="0"/>' for c in cols)
+    row = "".join(f"<{c}>{v}</{c}>" for c, v in zip(cols, values))
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<soap:Body>'
+        f'<{response_element} xmlns="urn:schemas-microsoft-com:xml-analysis">'
+        '<return>'
+        '<root xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" '
+        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+        'xmlns:sql="urn:schemas-microsoft-com:xml-sql" '
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+        '<xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset" '
+        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+        'xmlns:sql="urn:schemas-microsoft-com:xml-sql" '
+        'elementFormDefault="qualified">'
+        '<xsd:element name="root">'
+        '<xsd:complexType><xsd:sequence>'
+        '<xsd:element name="row" type="row" minOccurs="0" maxOccurs="unbounded"/>'
+        '</xsd:sequence></xsd:complexType></xsd:element>'
+        '<xsd:complexType name="row"><xsd:sequence>'
+        + xsd +
+        '</xsd:sequence></xsd:complexType>'
+        '</xsd:schema>'
+        f'<row>{row}</row>'
+        '</root></return>'
+        f'</{response_element}>'
+        '</soap:Body></soap:Envelope>').encode() + b"\x00"
+
+
+def _discover_response(request_type):
+    """A DiscoverResponse rowset for a Discover RequestType."""
+    cols = _MEASURE_COLS if request_type == "MDSCHEMA_MEASURES" else ["NAME"]
+    return _rowset_envelope("DiscoverResponse", cols,
+                            [f"emulator-{c.lower()}" for c in cols])
+
+
 class Capture(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -477,6 +539,17 @@ class Capture(http.server.BaseHTTPRequestHandler):
             return b"".join(chunks)
         n = int(self.headers.get("Content-Length", 0) or 0)
         return self.rfile.read(n) if n else b""
+
+    def _xmla_reply(self, b):
+        """Every XMLA reply needs the caps header AND the trailing byte, which
+        `_rowset_envelope` already appends. Three call sites, one place to get
+        the headers right."""
+        self.send_response(200)
+        self.send_header("Content-Type", "text/xml; charset=utf-8")
+        self.send_header("x-ms-xmlacaps-negotiation-flags", "0,0,0,0,0")
+        self.send_header("Content-Length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
 
     def _record(self):
         body = self._read_body()
@@ -616,6 +689,24 @@ class Capture(http.server.BaseHTTPRequestHandler):
             # The client announces this on the way in with
             # `x-ms-accepts-continuations: 1`. Append 0x00 for "that is all".
             b += b"\x00"
+            # THREE contracts arrive on this one path, and the client names
+            # each when refused. Dispatch on the envelope, not the URL.
+            with LOCK:
+                sent = REQUESTS[-1]["body"] if REQUESTS else ""
+            if "<Discover" in sent:
+                rt = (sent.split("<RequestType>", 1)[1].split("<", 1)[0]
+                      if "<RequestType>" in sent else "")
+                b = _discover_response(rt)
+                print(f"    -> answering 200 DiscoverResponse [{rt}]", flush=True)
+                self._xmla_reply(b)
+                return
+            if "<Statement>" in sent and "<Statement />" not in sent:
+                stmt = sent.split("<Statement>", 1)[1].split("</Statement>", 1)[0]
+                b = _rowset_envelope("ExecuteResponse", ["x"], ["1"])
+                print(f"    -> answering 200 Execute rowset for {stmt[:40]!r}",
+                      flush=True)
+                self._xmla_reply(b)
+                return
             print(f"    -> answering 200 XMLA session {XMLA_SESSION}", flush=True)
             self.send_response(200)
             self.send_header("Content-Type", "text/xml; charset=utf-8")

--- a/e2e/xmla/run.py
+++ b/e2e/xmla/run.py
@@ -1016,8 +1016,15 @@ for label, reqs, out in runs:
     # names the method, which is what turns the next step from screening
     # candidate URIs into reading the parser.
     for ln in out.splitlines():
-        if ln.startswith("CASE powerbi") or ln.lstrip().startswith(
-                ("FRAME powerbi", "THREW powerbi", "INNER powerbi")):
+        # PROBE/SCHEMA/PTHREW are the post-Open surfaces (DAX query, Discover).
+        # They were added to the probe and this filter was not widened, so a run
+        # that produced them printed NOTHING and read as "the probe is silent" —
+        # a dropped measurement rendered as an absent one. Widen deliberately:
+        # a filter is an assertion about what matters, and it goes stale the
+        # moment the thing it filters grows.
+        if ln.startswith(("CASE powerbi", "PROBE ", "SCHEMA ")) or \
+                ln.lstrip().startswith(
+                ("FRAME powerbi", "THREW powerbi", "INNER powerbi", "PTHREW ")):
             print(f"  {ln.strip()}", flush=True)
 
 print("\n---- capacityUri screen ----", flush=True)


### PR DESCRIPTION
A real ADOMD.NET client now completes connect, DAX query and schema Discover against the capture stub.

    PROBE powerbi-userid/dax    :: OK
    PROBE powerbi-userid/schema :: OK     SCHEMA rows=1

One `xml-analysis:rowset` payload under two wrapper elements. The inline XSD is the trick: the client reads the schema before it reads a row, which is why an empty root came back as "unrecognizable" rather than "empty". Built from [MS-SSAS], not the decompiler, per doc 32's boundary.

**The demand question is settled against the installed sempy wheel**, where two sessions had reached opposite conclusions from Microsoft Learn:

    sempy/fabric/_flat.py:954      use_xmla: bool = False
    sempy/fabric/_client/_pbi_rest_api.py:274  .../executeQueries

`evaluate_dax` defaults to REST `executeQueries` (already green); `list_*` uses `$SYSTEM.TMSCHEMA_*` DMVs (the gap); `INFO.*` is never called. So the next rowset is `TMSCHEMA_*`, not `MDSCHEMA_*`.

The `L` stands, redistributed rather than reduced: transport cheap, DMV/TOM surface expensive, DAX evaluation already served. TOM is recorded as an increase that was not in the original sizing.

Also fixes a duplicated heading I introduced in #150.