### PR TITLE
xmla: rowset serialiser + the five TMSCHEMA metadata DMVs

### DIFF
--- a/internal/xmla/dax.go
+++ b/internal/xmla/dax.go
@@ -1,0 +1,52 @@
+package xmla
+
+import (
+	"strconv"
+
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+)
+
+// FromDAX projects a DAX evaluation onto a Rowset.
+//
+// This is the path `sempy.evaluate_dax` takes: it is XMLA unconditionally —
+// `_flat.py:1036` accepts no `use_xmla` parameter and its body is a bare
+// `DatasetXmlaClient(...)` call — and arrives as an Execute carrying
+// `<Statement>EVALUATE …</Statement>`. It does NOT go through executeQueries,
+// which serves `evaluate_measure` and `read_table` instead.
+func FromDAX(res *semanticmodel.Result) Rowset {
+	if res == nil {
+		return Rowset{}
+	}
+	rs := Rowset{Columns: append([]string(nil), res.Columns...)}
+	for _, row := range res.Rows {
+		cells := make([]string, len(rs.Columns))
+		for i, c := range rs.Columns {
+			cells[i] = cell(row[c])
+		}
+		rs.Rows = append(rs.Rows, cells)
+	}
+	return rs
+}
+
+// cell renders one value for the wire. Blank (DAX's empty result, e.g. DIVIDE
+// by zero) is the empty string, matching how the evaluator already reports it.
+// Integral floats lose their ".0" so a row count crosses as "3", not "3.0" —
+// the client re-types from the schema, and "3.0" in an integer column is a
+// conversion the reader should never have been asked to make.
+func cell(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		if t == float64(int64(t)) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	default:
+		return ""
+	}
+}

--- a/internal/xmla/discover.go
+++ b/internal/xmla/discover.go
@@ -1,0 +1,172 @@
+package xmla
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+)
+
+// The TOM metadata path. `Microsoft.AnalysisServices.Tabular` materialises a
+// Database by sending ONE Execute whose Command is a `<Batch>` of ~35
+// `<Discover>` elements — every TMSCHEMA_* request type at once, each
+// restricted only by `<DatabaseName>`. That is a different grammar from the SQL
+// `SELECT … FROM $SYSTEM.TMSCHEMA_*` that sempy's own Python issues through
+// evaluate_dax (see dmv.go); both arrive as an Execute, which is why the two
+// were conflated once already.
+//
+// This file is the seam a batch handler calls once per <Discover>: request type
+// in, rowset out. The transport — parsing the Batch, pairing responses to
+// requests — belongs to e2e/xmla and is measured there against a real client.
+
+// tomBatchRequestTypes are the request types a real TOM client was observed to
+// ask for in a single batch. Kept as a list because "which types must be
+// answered" is a wire fact, not a modelling choice, and a handler enumerating
+// them from here cannot drift from what was captured.
+var tomBatchRequestTypes = []string{
+	"TMSCHEMA_MODEL", "TMSCHEMA_DATA_SOURCES", "TMSCHEMA_TABLES", "TMSCHEMA_COLUMNS",
+	"TMSCHEMA_ATTRIBUTE_HIERARCHIES", "TMSCHEMA_PARTITIONS", "TMSCHEMA_RELATIONSHIPS",
+	"TMSCHEMA_MEASURES", "TMSCHEMA_HIERARCHIES", "TMSCHEMA_LEVELS", "TMSCHEMA_ANNOTATIONS",
+	"TMSCHEMA_KPIS", "TMSCHEMA_CULTURES", "TMSCHEMA_OBJECT_TRANSLATIONS",
+	"TMSCHEMA_LINGUISTIC_METADATA", "TMSCHEMA_PERSPECTIVES", "TMSCHEMA_PERSPECTIVE_TABLES",
+	"TMSCHEMA_PERSPECTIVE_COLUMNS", "TMSCHEMA_PERSPECTIVE_HIERARCHIES",
+	"TMSCHEMA_PERSPECTIVE_MEASURES", "TMSCHEMA_ROLES", "TMSCHEMA_ROLE_MEMBERSHIPS",
+	"TMSCHEMA_TABLE_PERMISSIONS", "TMSCHEMA_VARIATIONS", "TMSCHEMA_EXTENDED_PROPERTIES",
+	"TMSCHEMA_EXPRESSIONS", "TMSCHEMA_COLUMN_PERMISSIONS", "TMSCHEMA_DETAIL_ROWS_DEFINITIONS",
+	"TMSCHEMA_CALCULATION_GROUPS", "TMSCHEMA_CALCULATION_ITEMS",
+	"TMSCHEMA_ALTERNATE_OF_DEFINITIONS", "TMSCHEMA_REFRESH_POLICIES",
+	"TMSCHEMA_FORMAT_STRING_DEFINITIONS", "TMSCHEMA_QUERY_GROUPS",
+	"TMSCHEMA_CHANGED_PROPERTIES",
+}
+
+// TOMBatchRequestTypes returns the captured batch, for a handler to iterate.
+func TOMBatchRequestTypes() []string {
+	return append([]string(nil), tomBatchRequestTypes...)
+}
+
+// discoverColumns are the columns emitted per request type. Unlike the sempy
+// SELECT path — where the client names the columns it wants and we project
+// them — a Discover names only the rowset, so the SHAPE is ours to declare.
+//
+// Only the types this emulator models carry columns. For the rest the model
+// genuinely has nothing (our TMSL defines no perspectives, KPIs, roles,
+// cultures or translations), so zero rows is the truthful answer rather than a
+// placeholder — see DiscoverRowset.
+var discoverColumns = map[string][]string{
+	"TMSCHEMA_MODEL":         {"ID", "Name"},
+	"TMSCHEMA_TABLES":        {"ID", "Name"},
+	"TMSCHEMA_COLUMNS":       {"ID", "TableID", "ExplicitName"},
+	"TMSCHEMA_PARTITIONS":    {"ID", "TableID", "Name"},
+	"TMSCHEMA_RELATIONSHIPS": {"ID", "Name"},
+	"TMSCHEMA_MEASURES":      {"ID", "TableID", "Name", "Expression"},
+	"TMSCHEMA_EXPRESSIONS":   {"ID", "Name", "Expression"},
+}
+
+// DiscoverRowset answers one `<Discover RequestType=TMSCHEMA_*>` from the model.
+//
+// Three outcomes, deliberately distinct:
+//   - a type we model      → populated rowset
+//   - a type in TOM's batch we do not model → EMPTY rowset, which is the true
+//     answer for these models (no perspectives, no KPIs, no roles …), not a stub
+//   - anything else        → error, so an unrecognised type is never mistaken
+//     for "this model has none of those"
+//
+// UNMEASURED, and the reason this returns an empty rowset rather than pretending
+// otherwise: whether TOM accepts an empty rowset whose schema declares no
+// columns. If it does not, the open question becomes "what are the columns of
+// the 28 types we do not model", which is materially more expensive. e2e/xmla
+// is running exactly that experiment.
+func DiscoverRowset(model *semanticmodel.Model, data semanticmodel.Data, requestType string) (Rowset, error) {
+	name := strings.ToUpper(strings.TrimSpace(requestType))
+	if !strings.HasPrefix(name, "TMSCHEMA_") {
+		return Rowset{}, fmt.Errorf("not a TMSCHEMA Discover request type: %q", requestType)
+	}
+	if model == nil {
+		return Rowset{}, fmt.Errorf("no model")
+	}
+
+	cols, modelled := discoverColumns[name]
+	if !modelled {
+		if inTOMBatch(name) {
+			// Truthfully empty: the model defines none of these objects.
+			return Rowset{}, nil
+		}
+		return Rowset{}, fmt.Errorf("unknown TMSCHEMA request type %q", name)
+	}
+
+	rs := Rowset{Columns: cols}
+	rows, err := discoverRows(model, data, name)
+	if err != nil {
+		return Rowset{}, err
+	}
+	for _, src := range rows {
+		out := make([]string, len(cols))
+		for i, c := range cols {
+			out[i] = src[c]
+		}
+		rs.Rows = append(rs.Rows, out)
+	}
+	return rs, nil
+}
+
+func inTOMBatch(name string) bool {
+	for _, t := range tomBatchRequestTypes {
+		if t == name {
+			return true
+		}
+	}
+	return false
+}
+
+// discoverRows materialises the modelled types. TABLES/COLUMNS/PARTITIONS/
+// RELATIONSHIPS reuse dmvRows so the SELECT path and the Discover path cannot
+// disagree about the same objects — one projection, two grammars.
+func discoverRows(model *semanticmodel.Model, data semanticmodel.Data, name string) ([]map[string]string, error) {
+	switch name {
+	case "TMSCHEMA_MODEL":
+		// Exactly one Model object per database.
+		return []map[string]string{{"ID": "1", "Name": model.Name}}, nil
+
+	case "TMSCHEMA_MEASURES":
+		var rows []map[string]string
+		n := 0
+		for ti, t := range model.Tables {
+			for _, m := range t.Measures {
+				n++
+				rows = append(rows, map[string]string{
+					"ID": id(n - 1), "TableID": id(ti),
+					"Name": m.Name, "Expression": m.Expression,
+				})
+			}
+		}
+		return rows, nil
+
+	case "TMSCHEMA_EXPRESSIONS":
+		var rows []map[string]string
+		i := 0
+		for _, k := range sortedKeys(model.Expressions) {
+			rows = append(rows, map[string]string{"ID": id(i), "Name": k, "Expression": model.Expressions[k]})
+			i++
+		}
+		return rows, nil
+
+	default:
+		return dmvRows(model, data, name)
+	}
+}
+
+// sortedKeys keeps Expression rows in a stable order: Go map iteration is
+// randomised, and a rowset whose row order changes between identical requests
+// is a flake generator for anything that diffs or indexes by position.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	return keys
+}

--- a/internal/xmla/discover_test.go
+++ b/internal/xmla/discover_test.go
@@ -1,0 +1,175 @@
+package xmla
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every type TOM asks for in its batch must get an answer, not an error — an
+// error on one of 35 would fail the whole materialisation.
+func TestEveryTOMBatchTypeIsAnswerable(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+	types := TOMBatchRequestTypes()
+	if len(types) != 35 {
+		t.Fatalf("captured batch has %d types, want the 35 observed on the wire", len(types))
+	}
+	populated, empty := 0, 0
+	for _, rt := range types {
+		rs, err := DiscoverRowset(m, d, rt)
+		if err != nil {
+			t.Errorf("%s: %v — every batched type must answer", rt, err)
+			continue
+		}
+		if len(rs.Rows) > 0 {
+			populated++
+		} else {
+			empty++
+		}
+		parses(t, rs.ExecuteResponse()) // every answer must be well-formed
+	}
+	if populated == 0 {
+		t.Error("no request type produced rows — the model is not reaching the wire")
+	}
+	t.Logf("TOM batch: %d populated, %d truthfully empty", populated, empty)
+}
+
+func TestDiscoverModelledTypes(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+
+	// Exactly one Model object, named from the TMSL.
+	mod, err := DiscoverRowset(m, d, "TMSCHEMA_MODEL")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mod.Rows) != 1 || mod.Rows[0][1] != "RetailAnalysis" {
+		t.Fatalf("TMSCHEMA_MODEL = %v, want one row named RetailAnalysis", mod.Rows)
+	}
+
+	// Measures carry their DAX expression — the payload that made XML escaping
+	// non-optional, since DAX routinely contains < and &.
+	meas, err := DiscoverRowset(m, d, "TMSCHEMA_MEASURES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Counted from the model, not hardcoded: the golden fixture is shared and
+	// gains measures over time, and a magic number here would fail on someone
+	// else's correct change rather than on a defect in this projection.
+	want := 0
+	for _, tb := range m.Tables {
+		want += len(tb.Measures)
+	}
+	if len(meas.Rows) != want {
+		t.Fatalf("measures = %d, want %d (every measure in the model)", len(meas.Rows), want)
+	}
+	var ratio []string
+	for _, r := range meas.Rows {
+		if r[2] == "Total Units Ratio" {
+			ratio = r
+		}
+	}
+	if ratio == nil || !strings.Contains(ratio[3], "DIVIDE") {
+		t.Fatalf("Total Units Ratio row = %v, want its DIVIDE expression", ratio)
+	}
+	parses(t, meas.ExecuteResponse())
+
+	// Tables answered through Discover must match the SELECT path exactly:
+	// one projection, two grammars.
+	viaDiscover, _ := DiscoverRowset(m, d, "TMSCHEMA_TABLES")
+	viaSelect, err := DMV(m, d, `SELECT [ID], [Name] FROM $SYSTEM.TMSCHEMA_TABLES`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(viaDiscover.Rows) != len(viaSelect.Rows) {
+		t.Fatalf("Discover %d rows vs SELECT %d — the two grammars disagree about tables",
+			len(viaDiscover.Rows), len(viaSelect.Rows))
+	}
+	for i := range viaSelect.Rows {
+		if viaDiscover.Rows[i][0] != viaSelect.Rows[i][0] || viaDiscover.Rows[i][1] != viaSelect.Rows[i][1] {
+			t.Errorf("row %d differs: Discover %v vs SELECT %v", i, viaDiscover.Rows[i], viaSelect.Rows[i])
+		}
+	}
+}
+
+// Empty must mean "the model has none", and must be distinguishable from
+// "we do not know that type" — which errors.
+func TestEmptyVersusUnknown(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+
+	rs, err := DiscoverRowset(m, d, "TMSCHEMA_PERSPECTIVES")
+	if err != nil {
+		t.Fatalf("a batched type we do not model must answer empty, not error: %v", err)
+	}
+	if len(rs.Rows) != 0 {
+		t.Error("golden model defines no perspectives; expected zero rows")
+	}
+
+	for _, bad := range []string{"TMSCHEMA_NOT_A_THING", "MDSCHEMA_MEASURES", "EVALUATE 'Store'", ""} {
+		if _, err := DiscoverRowset(m, d, bad); err == nil {
+			t.Errorf("%q should error rather than pass as 'model has none'", bad)
+		}
+	}
+	if _, err := DiscoverRowset(nil, nil, "TMSCHEMA_TABLES"); err == nil {
+		t.Error("nil model should error")
+	}
+}
+
+// Request types are matched case- and whitespace-insensitively; a batch element
+// with surrounding whitespace is otherwise a spurious failure.
+func TestRequestTypeNormalisation(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+	for _, v := range []string{"tmschema_tables", "  TMSCHEMA_TABLES  ", "TmSchema_Tables"} {
+		rs, err := DiscoverRowset(m, d, v)
+		if err != nil || len(rs.Rows) != 3 {
+			t.Errorf("DiscoverRowset(%q) = %d rows, %v", v, len(rs.Rows), err)
+		}
+	}
+}
+
+// Go randomises map iteration; an Expressions rowset whose order changes
+// between identical requests would flake anything indexing by position.
+func TestExpressionOrderIsStable(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+	if m.Expressions == nil {
+		m.Expressions = map[string]string{}
+	}
+	m.Expressions["b"] = "2"
+	m.Expressions["a"] = "1"
+	m.Expressions["c"] = "3"
+	first, err := DiscoverRowset(m, d, "TMSCHEMA_EXPRESSIONS")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		again, _ := DiscoverRowset(m, d, "TMSCHEMA_EXPRESSIONS")
+		for r := range first.Rows {
+			if first.Rows[r][1] != again.Rows[r][1] {
+				t.Fatalf("row order changed between identical requests: %v vs %v",
+					first.Rows, again.Rows)
+			}
+		}
+	}
+	if first.Rows[0][1] != "a" {
+		t.Errorf("expected stable sorted order, got %v", first.Rows)
+	}
+}
+
+// A modelled type whose projection fails must surface the error, not answer
+// empty — an empty rowset here would read as "the model has none".
+func TestDiscoverPropagatesProjectionErrors(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+	// TMSCHEMA_PARTITIONS routes through dmvRows; drive it with a model whose
+	// tables are gone so the underlying projection has nothing to answer from.
+	empty := *m
+	empty.Tables = nil
+	rs, err := DiscoverRowset(&empty, d, "TMSCHEMA_PARTITIONS")
+	if err != nil {
+		t.Fatalf("a table-less model is legitimately empty, not an error: %v", err)
+	}
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected no partitions for a table-less model, got %d", len(rs.Rows))
+	}
+	// And the schema still ships, so the client can read the shape.
+	if !strings.Contains(string(rs.ExecuteResponse()), "<xsd:schema") {
+		t.Error("empty Discover rowset must still carry its schema")
+	}
+}

--- a/internal/xmla/dmv.go
+++ b/internal/xmla/dmv.go
@@ -1,0 +1,142 @@
+package xmla
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+)
+
+// The `$SYSTEM.TMSCHEMA_*` metadata DMVs, projected from the emulator's own
+// model. These arrive as an `Execute` carrying a SQL-ish `<Statement>`, not as
+// a `Discover` — the same envelope and rowset writer as DAX `EVALUATE`, with a
+// different statement grammar. sempy issues them through `evaluate_dax`, e.g.
+//
+//	SELECT [ID] AS [SemPyTableID], [Name] AS [SemPyTableName]
+//	FROM $SYSTEM.TMSCHEMA_TABLES
+//
+// The columns implemented here are the ones sempy 0.14.2 actually selects,
+// enumerated from the installed wheel rather than from the spec: the Learn
+// pages for these rowsets are stubs, and guessing wire contracts has been
+// expensive on this workstream. A selected column we do not model is an error,
+// not an empty string — a plausible blank is how a wrong shape survives.
+
+// dmvStatement matches `SELECT <projection> FROM $SYSTEM.<NAME>`.
+var dmvStatement = regexp.MustCompile(`(?is)^\s*SELECT\s+(.+?)\s+FROM\s+\$SYSTEM\.(\w+)\s*;?\s*$`)
+
+// dmvProjection matches `[Col]` or `[Col] AS [Alias]`.
+var dmvProjection = regexp.MustCompile(`(?i)\[(\w+)\]\s*(?:AS\s*\[(\w+)\])?`)
+
+// IsDMV reports whether a statement is a `$SYSTEM.*` DMV query rather than DAX.
+func IsDMV(statement string) bool { return dmvStatement.MatchString(statement) }
+
+// projection is one selected column: its source name and the name it is
+// returned under (the alias when given — sempy joins DataFrames on the alias,
+// so returning the source name would silently break its merges).
+type projection struct{ source, out string }
+
+// DMV parses and answers a `$SYSTEM.TMSCHEMA_*` query against the model.
+func DMV(model *semanticmodel.Model, statement string) (Rowset, error) {
+	m := dmvStatement.FindStringSubmatch(statement)
+	if m == nil {
+		return Rowset{}, fmt.Errorf("not a $SYSTEM DMV statement")
+	}
+	name := strings.ToUpper(m[2])
+
+	var cols []projection
+	for _, p := range dmvProjection.FindAllStringSubmatch(m[1], -1) {
+		out := p[1]
+		if p[2] != "" {
+			out = p[2]
+		}
+		cols = append(cols, projection{source: p[1], out: out})
+	}
+	if len(cols) == 0 {
+		return Rowset{}, fmt.Errorf("%s: no columns selected (SELECT * is not supported)", name)
+	}
+
+	rows, err := dmvRows(model, name)
+	if err != nil {
+		return Rowset{}, err
+	}
+
+	rs := Rowset{}
+	for _, c := range cols {
+		rs.Columns = append(rs.Columns, c.out)
+	}
+	for _, src := range rows {
+		out := make([]string, len(cols))
+		for i, c := range cols {
+			v, ok := src[c.source]
+			if !ok {
+				return Rowset{}, fmt.Errorf("%s has no column %q", name, c.source)
+			}
+			out[i] = v
+		}
+		rs.Rows = append(rs.Rows, out)
+	}
+	return rs, nil
+}
+
+// dmvRows materialises one DMV as source-named cells. IDs are 1-based
+// declaration order: TMSCHEMA IDs are opaque integers whose only contract is
+// that they join (sempy merges partitions to tables on TableID), so stable
+// ordinals satisfy the consumer without inventing server internals.
+func dmvRows(model *semanticmodel.Model, name string) ([]map[string]string, error) {
+	if model == nil {
+		return nil, fmt.Errorf("no model")
+	}
+	var rows []map[string]string
+
+	switch name {
+	case "TMSCHEMA_TABLES":
+		for i, t := range model.Tables {
+			rows = append(rows, map[string]string{"ID": id(i), "Name": t.Name})
+		}
+
+	case "TMSCHEMA_COLUMNS":
+		n := 0
+		for ti, t := range model.Tables {
+			for _, c := range t.Columns {
+				n++
+				rows = append(rows, map[string]string{
+					"ID": id(n - 1), "TableID": id(ti),
+					"ExplicitName": c.Name, "Name": c.Name,
+				})
+			}
+		}
+
+	case "TMSCHEMA_PARTITIONS":
+		// One partition per table: the emulator stores a table's rows as a
+		// single unit (import) or one Delta entity (Direct Lake), so a second
+		// partition would be a fiction the storage cannot back.
+		for ti, t := range model.Tables {
+			rows = append(rows, map[string]string{
+				"ID": id(ti), "TableID": id(ti), "Name": t.Name + "-Partition",
+			})
+		}
+
+	case "TMSCHEMA_RELATIONSHIPS":
+		for i, r := range model.Relationships {
+			rows = append(rows, map[string]string{"ID": id(i), "Name": r.Name})
+		}
+
+	case "TMSCHEMA_HIERARCHIES":
+		// None: the model format we parse carries no hierarchies, so this is
+		// legitimately empty rather than unimplemented. An empty rowset still
+		// carries its schema, which is what the client reads first.
+
+	default:
+		if strings.HasSuffix(name, "_STORAGES") || name == "TMSCHEMA_DELTA_TABLE_METADATA_STORAGES" {
+			return nil, fmt.Errorf("%s reports VertiPaq physical storage (segment counts, "+
+				"distinct-state counts) that this emulator does not have; refusing rather "+
+				"than returning invented statistics", name)
+		}
+		return nil, fmt.Errorf("unsupported DMV %s", name)
+	}
+	return rows, nil
+}
+
+func id(i int) string { return strconv.Itoa(i + 1) }

--- a/internal/xmla/dmv.go
+++ b/internal/xmla/dmv.go
@@ -37,8 +37,11 @@ func IsDMV(statement string) bool { return dmvStatement.MatchString(statement) }
 // so returning the source name would silently break its merges).
 type projection struct{ source, out string }
 
-// DMV parses and answers a `$SYSTEM.TMSCHEMA_*` query against the model.
-func DMV(model *semanticmodel.Model, statement string) (Rowset, error) {
+// DMV parses and answers a `$SYSTEM.TMSCHEMA_*` query against the model and its
+// data. Data is required because the storage rowsets are *derived* from the
+// rows we hold — record counts and distinct-value counts are exact, not
+// estimates.
+func DMV(model *semanticmodel.Model, data semanticmodel.Data, statement string) (Rowset, error) {
 	m := dmvStatement.FindStringSubmatch(statement)
 	if m == nil {
 		return Rowset{}, fmt.Errorf("not a $SYSTEM DMV statement")
@@ -57,7 +60,7 @@ func DMV(model *semanticmodel.Model, statement string) (Rowset, error) {
 		return Rowset{}, fmt.Errorf("%s: no columns selected (SELECT * is not supported)", name)
 	}
 
-	rows, err := dmvRows(model, name)
+	rows, err := dmvRows(model, data, name)
 	if err != nil {
 		return Rowset{}, err
 	}
@@ -84,7 +87,7 @@ func DMV(model *semanticmodel.Model, statement string) (Rowset, error) {
 // declaration order: TMSCHEMA IDs are opaque integers whose only contract is
 // that they join (sempy merges partitions to tables on TableID), so stable
 // ordinals satisfy the consumer without inventing server internals.
-func dmvRows(model *semanticmodel.Model, name string) ([]map[string]string, error) {
+func dmvRows(model *semanticmodel.Model, data semanticmodel.Data, name string) ([]map[string]string, error) {
 	if model == nil {
 		return nil, fmt.Errorf("no model")
 	}
@@ -128,15 +131,84 @@ func dmvRows(model *semanticmodel.Model, name string) ([]map[string]string, erro
 		// legitimately empty rather than unimplemented. An empty rowset still
 		// carries its schema, which is what the client reads first.
 
+	// --- storage rowsets -----------------------------------------------------
+	// These are DERIVED, not invented. An earlier revision refused the whole
+	// family as "VertiPaq physical statistics we do not have"; that was too
+	// broad. Record counts and distinct-value counts are exact from the rows we
+	// already hold, and segment count follows a documented formula, so refusing
+	// them was withholding an answer we can give correctly.
+
+	case "TMSCHEMA_PARTITION_STORAGES":
+		// One storage per partition, and one partition per table (above), so
+		// the ids line up by construction.
+		for ti := range model.Tables {
+			rows = append(rows, map[string]string{"ID": id(ti), "PartitionID": id(ti)})
+		}
+
+	case "TMSCHEMA_SEGMENT_MAP_STORAGES":
+		for ti, t := range model.Tables {
+			n := len(data.Rows(t.Name))
+			rows = append(rows, map[string]string{
+				"PartitionStorageID": id(ti),
+				"RecordCount":        strconv.Itoa(n),
+				"SegmentCount":       strconv.Itoa(segmentCount(n)),
+			})
+		}
+
+	case "TMSCHEMA_COLUMN_STORAGES":
+		n := 0
+		for _, t := range model.Tables {
+			for _, c := range t.Columns {
+				n++
+				rows = append(rows, map[string]string{
+					"ColumnID":                  id(n - 1),
+					"Statistics_DistinctStates": strconv.Itoa(distinctValues(data, t.Name, c.Name)),
+				})
+			}
+		}
+
 	default:
-		if strings.HasSuffix(name, "_STORAGES") || name == "TMSCHEMA_DELTA_TABLE_METADATA_STORAGES" {
-			return nil, fmt.Errorf("%s reports VertiPaq physical storage (segment counts, "+
-				"distinct-state counts) that this emulator does not have; refusing rather "+
-				"than returning invented statistics", name)
+		if name == "TMSCHEMA_DELTA_TABLE_METADATA_STORAGES" {
+			// TableName we have; FallbackReason we do not. Direct Lake falls
+			// back to DirectQuery for specific documented causes (a SQL view,
+			// SQL-based RLS, an unprocessed table) — none of which apply to a
+			// table reading Delta here, so "no fallback" is semantically right.
+			// Its *wire encoding* is unverified, and a wrong enum reads as a
+			// real fallback reason, so this stays refused until a live client
+			// names it. Narrow refusal, not a family-wide one.
+			return nil, fmt.Errorf("%s: TableName is available but FallbackReason's "+
+				"encoding is unverified; refusing rather than guessing an enum that "+
+				"would read as a genuine fallback cause", name)
 		}
 		return nil, fmt.Errorf("unsupported DMV %s", name)
 	}
 	return rows, nil
+}
+
+// defaultSegmentRowCount is VertiPaq's documented DefaultSegmentRowCount:
+// "the number of data rows per segment … The default value is 8,388,608
+// (8*1024*1024) rows" (Analysis Services general server properties).
+const defaultSegmentRowCount = 8 * 1024 * 1024
+
+// segmentCount derives a partition's segment count from its row count. The
+// same spec states "every table partition has at least one segment of data",
+// so an empty table is 1, not 0.
+func segmentCount(rows int) int {
+	if rows <= 0 {
+		return 1
+	}
+	return (rows + defaultSegmentRowCount - 1) / defaultSegmentRowCount
+}
+
+// distinctValues counts a column's distinct values — what
+// Statistics_DistinctStates reports. Exact here, because the emulator holds
+// every row rather than a compressed dictionary to estimate from.
+func distinctValues(data semanticmodel.Data, table, column string) int {
+	seen := map[string]struct{}{}
+	for _, r := range data.Rows(table) {
+		seen[fmt.Sprint(r[column])] = struct{}{}
+	}
+	return len(seen)
 }
 
 func id(i int) string { return strconv.Itoa(i + 1) }

--- a/internal/xmla/dmv_test.go
+++ b/internal/xmla/dmv_test.go
@@ -34,7 +34,7 @@ func TestIsDMV(t *testing.T) {
 // The exact query sempy issues, alias and all — the alias is what it merges
 // DataFrames on, so returning the source name would break its joins silently.
 func TestSempyTablesQuery(t *testing.T) {
-	rs, err := DMV(goldenModel(t), `
+	rs, err := DMV(goldenModel(t), goldenData(t), `
 		SELECT
 			[ID]   AS [SemPyTableID],
 			[Name] AS [SemPyTableName]
@@ -60,11 +60,11 @@ func TestSempyTablesQuery(t *testing.T) {
 // the ids must agree across the two rowsets.
 func TestPartitionsJoinToTables(t *testing.T) {
 	m := goldenModel(t)
-	tables, err := DMV(m, `SELECT [ID] AS [SemPyTableID], [Name] FROM $SYSTEM.TMSCHEMA_TABLES`)
+	tables, err := DMV(m, goldenData(t), `SELECT [ID] AS [SemPyTableID], [Name] FROM $SYSTEM.TMSCHEMA_TABLES`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	parts, err := DMV(m, `SELECT [ID] AS [SemPyPartitionID], [TableID] AS [SemPyTableID], [Name] FROM $SYSTEM.TMSCHEMA_PARTITIONS`)
+	parts, err := DMV(m, goldenData(t), `SELECT [ID] AS [SemPyPartitionID], [TableID] AS [SemPyTableID], [Name] FROM $SYSTEM.TMSCHEMA_PARTITIONS`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestPartitionsJoinToTables(t *testing.T) {
 
 func TestColumnsAndRelationships(t *testing.T) {
 	m := goldenModel(t)
-	cols, err := DMV(m, `SELECT [ID], [TableID], [ExplicitName] FROM $SYSTEM.TMSCHEMA_COLUMNS`)
+	cols, err := DMV(m, goldenData(t), `SELECT [ID], [TableID], [ExplicitName] FROM $SYSTEM.TMSCHEMA_COLUMNS`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestColumnsAndRelationships(t *testing.T) {
 		}
 		seen[r[0]] = true
 	}
-	rels, err := DMV(m, `SELECT [ID], [Name] FROM $SYSTEM.TMSCHEMA_RELATIONSHIPS`)
+	rels, err := DMV(m, goldenData(t), `SELECT [ID], [Name] FROM $SYSTEM.TMSCHEMA_RELATIONSHIPS`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestColumnsAndRelationships(t *testing.T) {
 // An empty rowset is a legitimate answer and must still carry its schema —
 // the client reads the shape before the rows.
 func TestHierarchiesEmptyButWellFormed(t *testing.T) {
-	rs, err := DMV(goldenModel(t), `SELECT [ID], [Name], [TableID] FROM $SYSTEM.TMSCHEMA_HIERARCHIES`)
+	rs, err := DMV(goldenModel(t), goldenData(t), `SELECT [ID], [Name], [TableID] FROM $SYSTEM.TMSCHEMA_HIERARCHIES`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,23 +131,120 @@ func TestHierarchiesEmptyButWellFormed(t *testing.T) {
 func TestRefusalsAreErrors(t *testing.T) {
 	m := goldenModel(t)
 	cases := map[string]string{
-		"storage stats":  `SELECT [ColumnID], [Statistics_DistinctStates] FROM $SYSTEM.TMSCHEMA_COLUMN_STORAGES`,
 		"unknown dmv":    `SELECT [ID] FROM $SYSTEM.TMSCHEMA_NOPE`,
 		"unknown column": `SELECT [Nonexistent] FROM $SYSTEM.TMSCHEMA_TABLES`,
 		"select star":    `SELECT * FROM $SYSTEM.TMSCHEMA_TABLES`,
 		"not a dmv":      `EVALUATE 'Store'`,
 	}
 	for name, q := range cases {
-		if _, err := DMV(m, q); err == nil {
+		if _, err := DMV(m, goldenData(t), q); err == nil {
 			t.Errorf("%s: expected an error, got a rowset", name)
 		}
 	}
-	// The storage refusal should say why, not just fail.
-	_, err := DMV(m, `SELECT [ColumnID] FROM $SYSTEM.TMSCHEMA_COLUMN_STORAGES`)
-	if err == nil || !strings.Contains(err.Error(), "VertiPaq") {
-		t.Errorf("storage refusal should name the reason, got %v", err)
+	// COLUMN_STORAGES is deliberately NOT in that list any more: it is derived
+	// exactly from the rows we hold, so refusing it withheld an answer we can
+	// give. Asserted positively in TestStorageRowsetsAreDerivedExactly.
+	if _, err := DMV(m, goldenData(t), `SELECT [ColumnID] FROM $SYSTEM.TMSCHEMA_COLUMN_STORAGES`); err != nil {
+		t.Errorf("COLUMN_STORAGES is derivable and must be answered, got %v", err)
 	}
-	if _, err := DMV(nil, `SELECT [ID] FROM $SYSTEM.TMSCHEMA_TABLES`); err == nil {
+	if _, err := DMV(nil, nil, `SELECT [ID] FROM $SYSTEM.TMSCHEMA_TABLES`); err == nil {
 		t.Error("nil model should error")
 	}
+}
+
+func goldenData(t *testing.T) semanticmodel.Data {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "e2e", "semantic-model", "fixtures", "seed_data.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := semanticmodel.ParseData(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// The storage rowsets are DERIVED from rows we hold, so they must be exact —
+// this is the test that would fail if they were stubbed to 0.
+func TestStorageRowsetsAreDerivedExactly(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+
+	seg, err := DMV(m, d, `SELECT [PartitionStorageID], [RecordCount], [SegmentCount] FROM $SYSTEM.TMSCHEMA_SEGMENT_MAP_STORAGES`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sales has 8 rows in the golden fixture; one segment (far under 8,388,608).
+	var sales []string
+	for _, r := range seg.Rows {
+		if r[0] == "3" { // Sales is the third table
+			sales = r
+		}
+	}
+	if sales == nil || sales[1] != "8" || sales[2] != "1" {
+		t.Fatalf("Sales segment row = %v, want RecordCount 8 / SegmentCount 1", sales)
+	}
+
+	cs, err := DMV(m, d, `SELECT [ColumnID], [Statistics_DistinctStates] FROM $SYSTEM.TMSCHEMA_COLUMN_STORAGES`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cs.Rows) != 12 {
+		t.Fatalf("column storages = %d, want 12", len(cs.Rows))
+	}
+	// Store[Territory] is the 4th column: West, East, Central, West -> 3 distinct.
+	if cs.Rows[3][1] != "3" {
+		t.Errorf("Territory distinct states = %s, want 3", cs.Rows[3][1])
+	}
+	parses(t, cs.ExecuteResponse())
+}
+
+// The documented rule: "every table partition has at least one segment", and
+// the default is 8,388,608 rows per segment.
+func TestSegmentCountFormula(t *testing.T) {
+	cases := map[int]int{0: 1, 1: 1, 8388608: 1, 8388609: 2, 16777216: 2, 16777217: 3}
+	for rows, want := range cases {
+		if got := segmentCount(rows); got != want {
+			t.Errorf("segmentCount(%d) = %d, want %d", rows, got, want)
+		}
+	}
+}
+
+// The one that stays refused, and the refusal must name the narrow reason.
+func TestDeltaMetadataStillRefused(t *testing.T) {
+	_, err := DMV(goldenModel(t), goldenData(t),
+		`SELECT [FallbackReason], [TableName] FROM $SYSTEM.TMSCHEMA_DELTA_TABLE_METADATA_STORAGES`)
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if !strings.Contains(err.Error(), "FallbackReason") {
+		t.Errorf("refusal should name the unverified field, got %v", err)
+	}
+}
+
+// PARTITION_STORAGES joins to partitions, which join to tables — the chain
+// sempy walks to attribute segment stats back to a table name.
+func TestPartitionStoragesChain(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+	ps, err := DMV(m, d, `SELECT [ID], [PartitionID] FROM $SYSTEM.TMSCHEMA_PARTITION_STORAGES`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts, err := DMV(m, d, `SELECT [ID] FROM $SYSTEM.TMSCHEMA_PARTITIONS`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ps.Rows) != len(parts.Rows) {
+		t.Fatalf("partition storages = %d, partitions = %d; one each", len(ps.Rows), len(parts.Rows))
+	}
+	ids := map[string]bool{}
+	for _, r := range parts.Rows {
+		ids[r[0]] = true
+	}
+	for _, r := range ps.Rows {
+		if !ids[r[1]] {
+			t.Errorf("storage PartitionID %q joins to no partition", r[1])
+		}
+	}
+	parses(t, ps.ExecuteResponse())
 }

--- a/internal/xmla/dmv_test.go
+++ b/internal/xmla/dmv_test.go
@@ -1,0 +1,153 @@
+package xmla
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+)
+
+func goldenModel(t *testing.T) *semanticmodel.Model {
+	t.Helper()
+	bim, err := os.ReadFile(filepath.Join("..", "..", "e2e", "semantic-model", "fixtures", "retail.bim"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := semanticmodel.ParseTMSL(bim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func TestIsDMV(t *testing.T) {
+	if !IsDMV("SELECT [ID] FROM $SYSTEM.TMSCHEMA_TABLES") {
+		t.Error("DMV statement not recognised")
+	}
+	if IsDMV(`EVALUATE SUMMARIZECOLUMNS('Time'[FiscalYear])`) {
+		t.Error("DAX EVALUATE must not be taken for a DMV")
+	}
+}
+
+// The exact query sempy issues, alias and all — the alias is what it merges
+// DataFrames on, so returning the source name would break its joins silently.
+func TestSempyTablesQuery(t *testing.T) {
+	rs, err := DMV(goldenModel(t), `
+		SELECT
+			[ID]   AS [SemPyTableID],
+			[Name] AS [SemPyTableName]
+		FROM
+			$SYSTEM.TMSCHEMA_TABLES
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(rs.Columns, ","); got != "SemPyTableID,SemPyTableName" {
+		t.Fatalf("columns = %q; aliases must win over source names", got)
+	}
+	if len(rs.Rows) != 3 {
+		t.Fatalf("rows = %d, want 3 (Store, Time, Sales)", len(rs.Rows))
+	}
+	if rs.Rows[0][0] != "1" || rs.Rows[0][1] != "Store" {
+		t.Errorf("first row = %v, want [1 Store]", rs.Rows[0])
+	}
+	parses(t, rs.ExecuteResponse())
+}
+
+// Partitions join back to tables on TableID; sempy does exactly this merge, so
+// the ids must agree across the two rowsets.
+func TestPartitionsJoinToTables(t *testing.T) {
+	m := goldenModel(t)
+	tables, err := DMV(m, `SELECT [ID] AS [SemPyTableID], [Name] FROM $SYSTEM.TMSCHEMA_TABLES`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts, err := DMV(m, `SELECT [ID] AS [SemPyPartitionID], [TableID] AS [SemPyTableID], [Name] FROM $SYSTEM.TMSCHEMA_PARTITIONS`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tableIDs := map[string]bool{}
+	for _, r := range tables.Rows {
+		tableIDs[r[0]] = true
+	}
+	if len(parts.Rows) == 0 {
+		t.Fatal("no partitions")
+	}
+	for _, p := range parts.Rows {
+		if !tableIDs[p[1]] {
+			t.Errorf("partition TableID %q joins to no table — sempy's merge would drop it", p[1])
+		}
+	}
+}
+
+func TestColumnsAndRelationships(t *testing.T) {
+	m := goldenModel(t)
+	cols, err := DMV(m, `SELECT [ID], [TableID], [ExplicitName] FROM $SYSTEM.TMSCHEMA_COLUMNS`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Store(4) + Time(3) + Sales(5) = 12 columns in the golden model.
+	if len(cols.Rows) != 12 {
+		t.Errorf("columns = %d, want 12", len(cols.Rows))
+	}
+	// Column IDs must be unique across the whole model, not per table.
+	seen := map[string]bool{}
+	for _, r := range cols.Rows {
+		if seen[r[0]] {
+			t.Errorf("duplicate column ID %q — ids must be model-wide", r[0])
+		}
+		seen[r[0]] = true
+	}
+	rels, err := DMV(m, `SELECT [ID], [Name] FROM $SYSTEM.TMSCHEMA_RELATIONSHIPS`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rels.Rows) != 2 {
+		t.Errorf("relationships = %d, want 2", len(rels.Rows))
+	}
+}
+
+// An empty rowset is a legitimate answer and must still carry its schema —
+// the client reads the shape before the rows.
+func TestHierarchiesEmptyButWellFormed(t *testing.T) {
+	rs, err := DMV(goldenModel(t), `SELECT [ID], [Name], [TableID] FROM $SYSTEM.TMSCHEMA_HIERARCHIES`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rs.Rows) != 0 {
+		t.Errorf("expected no hierarchies, got %d", len(rs.Rows))
+	}
+	payload := rs.ExecuteResponse()
+	parses(t, payload)
+	if !strings.Contains(string(payload), "<xsd:schema") {
+		t.Error("an empty DMV rowset must still emit its schema")
+	}
+}
+
+// Refusals must be refusals. A blank or zero here would look like a real
+// answer and survive indefinitely.
+func TestRefusalsAreErrors(t *testing.T) {
+	m := goldenModel(t)
+	cases := map[string]string{
+		"storage stats":  `SELECT [ColumnID], [Statistics_DistinctStates] FROM $SYSTEM.TMSCHEMA_COLUMN_STORAGES`,
+		"unknown dmv":    `SELECT [ID] FROM $SYSTEM.TMSCHEMA_NOPE`,
+		"unknown column": `SELECT [Nonexistent] FROM $SYSTEM.TMSCHEMA_TABLES`,
+		"select star":    `SELECT * FROM $SYSTEM.TMSCHEMA_TABLES`,
+		"not a dmv":      `EVALUATE 'Store'`,
+	}
+	for name, q := range cases {
+		if _, err := DMV(m, q); err == nil {
+			t.Errorf("%s: expected an error, got a rowset", name)
+		}
+	}
+	// The storage refusal should say why, not just fail.
+	_, err := DMV(m, `SELECT [ColumnID] FROM $SYSTEM.TMSCHEMA_COLUMN_STORAGES`)
+	if err == nil || !strings.Contains(err.Error(), "VertiPaq") {
+		t.Errorf("storage refusal should name the reason, got %v", err)
+	}
+	if _, err := DMV(nil, `SELECT [ID] FROM $SYSTEM.TMSCHEMA_TABLES`); err == nil {
+		t.Error("nil model should error")
+	}
+}

--- a/internal/xmla/dmv_test.go
+++ b/internal/xmla/dmv_test.go
@@ -88,9 +88,13 @@ func TestColumnsAndRelationships(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Store(4) + Time(3) + Sales(5) = 12 columns in the golden model.
-	if len(cols.Rows) != 12 {
-		t.Errorf("columns = %d, want 12", len(cols.Rows))
+	// Counted from the model: the golden fixture is shared and grows.
+	wantCols := 0
+	for _, tb := range m.Tables {
+		wantCols += len(tb.Columns)
+	}
+	if len(cols.Rows) != wantCols {
+		t.Errorf("columns = %d, want %d (every column in the model)", len(cols.Rows), wantCols)
 	}
 	// Column IDs must be unique across the whole model, not per table.
 	seen := map[string]bool{}
@@ -104,8 +108,8 @@ func TestColumnsAndRelationships(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rels.Rows) != 2 {
-		t.Errorf("relationships = %d, want 2", len(rels.Rows))
+	if len(rels.Rows) != len(m.Relationships) {
+		t.Errorf("relationships = %d, want %d", len(rels.Rows), len(m.Relationships))
 	}
 }
 
@@ -189,8 +193,12 @@ func TestStorageRowsetsAreDerivedExactly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cs.Rows) != 12 {
-		t.Fatalf("column storages = %d, want 12", len(cs.Rows))
+	wantCS := 0
+	for _, tb := range m.Tables {
+		wantCS += len(tb.Columns)
+	}
+	if len(cs.Rows) != wantCS {
+		t.Fatalf("column storages = %d, want %d (one per column)", len(cs.Rows), wantCS)
 	}
 	// Store[Territory] is the 4th column: West, East, Central, West -> 3 distinct.
 	if cs.Rows[3][1] != "3" {

--- a/internal/xmla/name.go
+++ b/internal/xmla/name.go
@@ -1,0 +1,65 @@
+package xmla
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// EncodeName renders a column name as a legal XML element name using XMLA's
+// documented `_xHHHH_` escape.
+//
+// This is not a nicety. A DAX result's columns are `Time[FiscalYear]` and
+// `[TotalUnits]`, and `[`/`]` are illegal in XML names — emitting them raw
+// produces a payload that is not well-formed XML at all, which a client
+// reports as a parse failure rather than as a bad column. XMLA's answer
+// ([MS-SSAS] rowset naming) is to replace each invalid character with the
+// four-hex-digit UCS-2 form: the classic example is `Order Details` →
+// `Order_x0020_Details`, and here `Time[FiscalYear]` →
+// `Time_x005B_FiscalYear_x005D_`.
+//
+// The true name is not lost: the schema carries it verbatim in `sql:field`,
+// so a client can map back without decoding.
+func EncodeName(s string) string {
+	if s == "" {
+		return "_x0020_" // an empty element name is not legal; encode a space
+	}
+	var b strings.Builder
+	for i, r := range s {
+		switch {
+		// A literal underscore that could start an escape must itself be
+		// escaped, or `a_x0020_b` would decode to something the source never
+		// contained. Encoding every `_` is the unambiguous choice.
+		case r == '_':
+			b.WriteString("_x005F_")
+		case i == 0 && !isNameStart(r):
+			writeEscape(&b, r)
+		case i > 0 && !isNameChar(r):
+			writeEscape(&b, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func writeEscape(b *strings.Builder, r rune) {
+	// UCS-2 form; runes beyond the BMP are emitted as their surrogate pair.
+	if r > 0xFFFF {
+		r -= 0x10000
+		fmt.Fprintf(b, "_x%04X__x%04X_", 0xD800+(r>>10), 0xDC00+(r&0x3FF))
+		return
+	}
+	fmt.Fprintf(b, "_x%04X_", r)
+}
+
+// isNameStart reports whether r may begin an XML name (underscore excluded
+// here deliberately — EncodeName escapes it unconditionally).
+func isNameStart(r rune) bool {
+	return r == ':' || unicode.IsLetter(r)
+}
+
+// isNameChar reports whether r may appear after the first character.
+func isNameChar(r rune) bool {
+	return isNameStart(r) || unicode.IsDigit(r) || r == '-' || r == '.' || r == 0xB7
+}

--- a/internal/xmla/rowset.go
+++ b/internal/xmla/rowset.go
@@ -1,0 +1,109 @@
+// Package xmla serialises results onto the XMLA wire: the
+// `urn:schemas-microsoft-com:xml-analysis:rowset` payload that Microsoft's own
+// ADOMD.NET client consumes, wrapped for either Execute or Discover.
+//
+// Scope note: this package is the *serialisation* half of XMLA. The transport —
+// routing, the session handshake, clusterResolve, the four connect gates — is
+// e2e/xmla's, and is measured there against a real ADOMD.NET client rather than
+// guessed. What lives here is the projection from the emulator's own model
+// (internal/semanticmodel) onto rowsets, which is why it holds no HTTP.
+//
+// The envelope shape below is not read off the XSD; it is the shape a real
+// ADOMD.NET client has been observed to ACCEPT (e2e/xmla, PR #152). Two details
+// are load-bearing and neither is obvious from the spec:
+//
+//   - The inline XSD is mandatory. The client reads the schema to learn the row
+//     shape BEFORE it reads any row, so a rowset without it is rejected as
+//     "unrecognizable" rather than as empty.
+//   - The payload ends with a trailing 0x00 byte. ReadResponsePayloadImpl
+//     switches on the final byte: 0 = complete, 1 = LRO continuation, anything
+//     else = TransportProtocolError.
+package xmla
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+// Rowset is a tabular result headed for the wire: ordered column names and rows
+// of already-stringified cells. Every XMLA value crosses as xsd:string here —
+// the client re-types from the schema it is given, and a single string column
+// type keeps the emitted XSD honest about what we actually send.
+type Rowset struct {
+	Columns []string
+	Rows    [][]string
+}
+
+// Trailing byte the client's payload reader switches on (0 = complete).
+const payloadComplete = 0x00
+
+// ExecuteResponse wraps the rowset as a response to an Execute — a DAX
+// `EVALUATE` or a `$SYSTEM.TMSCHEMA_*` DMV query, which arrive by the same
+// route and differ only in the statement.
+func (r Rowset) ExecuteResponse() []byte { return r.envelope("ExecuteResponse") }
+
+// DiscoverResponse wraps the same rowset as a response to a Discover.
+func (r Rowset) DiscoverResponse() []byte { return r.envelope("DiscoverResponse") }
+
+// envelope emits the SOAP envelope, the inline XSD and the rows. Execute and
+// Discover take an identical rowset under a different wrapper, so this is one
+// function rather than two that would drift — the client rejects each
+// differently ("not a rowset" vs "unrecognizable"), which is exactly the kind
+// of divergence a copy would hide.
+func (r Rowset) envelope(responseElement string) []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="utf-8"?>` +
+		`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">` +
+		`<soap:Body>` +
+		`<` + responseElement + ` xmlns="urn:schemas-microsoft-com:xml-analysis">` +
+		`<return>` +
+		`<root xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" ` +
+		`xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
+		`xmlns:sql="urn:schemas-microsoft-com:xml-sql" ` +
+		`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">`)
+
+	// The schema the client reads before any row.
+	b.WriteString(`<xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset" ` +
+		`xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
+		`xmlns:sql="urn:schemas-microsoft-com:xml-sql" ` +
+		`elementFormDefault="qualified">` +
+		`<xsd:element name="root">` +
+		`<xsd:complexType><xsd:sequence>` +
+		`<xsd:element name="row" type="row" minOccurs="0" maxOccurs="unbounded"/>` +
+		`</xsd:sequence></xsd:complexType></xsd:element>` +
+		`<xsd:complexType name="row"><xsd:sequence>`)
+	for _, c := range r.Columns {
+		// sql:field carries the true name; name= must be a legal XML name, so
+		// it is the encoded form (see EncodeName).
+		b.WriteString(`<xsd:element sql:field="` + escape(c) + `" name="` + EncodeName(c) +
+			`" type="xsd:string" minOccurs="0"/>`)
+	}
+	b.WriteString(`</xsd:sequence></xsd:complexType></xsd:schema>`)
+
+	// Rows. A cell absent from a short row is omitted rather than emitted
+	// empty: minOccurs="0" makes absence legal, and "" is a value.
+	for _, row := range r.Rows {
+		b.WriteString(`<row>`)
+		for i, c := range r.Columns {
+			if i >= len(row) {
+				break
+			}
+			n := EncodeName(c)
+			b.WriteString(`<` + n + `>` + escape(row[i]) + `</` + n + `>`)
+		}
+		b.WriteString(`</row>`)
+	}
+
+	b.WriteString(`</root></return></` + responseElement + `></soap:Body></soap:Envelope>`)
+	return append([]byte(b.String()), payloadComplete)
+}
+
+// escape XML-escapes text. Not optional here: DAX measure expressions are
+// routine rowset payloads and routinely contain <, > and &, so an unescaped
+// writer produces malformed XML on ordinary model content rather than on
+// adversarial input.
+func escape(s string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}

--- a/internal/xmla/rowset_test.go
+++ b/internal/xmla/rowset_test.go
@@ -1,0 +1,223 @@
+package xmla
+
+import (
+	"bytes"
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+)
+
+// parses asserts the payload is well-formed XML once the trailing marker byte
+// is removed — the check that catches an unescaped value, which is otherwise
+// invisible until a real client rejects it.
+func parses(t *testing.T, payload []byte) {
+	t.Helper()
+	if len(payload) == 0 || payload[len(payload)-1] != payloadComplete {
+		t.Fatalf("payload must end with the 0x00 completion byte")
+	}
+	dec := xml.NewDecoder(bytes.NewReader(payload[:len(payload)-1]))
+	for {
+		_, err := dec.Token()
+		if err != nil {
+			if err.Error() == "EOF" {
+				return
+			}
+			t.Fatalf("payload is not well-formed XML: %v", err)
+		}
+	}
+}
+
+func TestEnvelopeShape(t *testing.T) {
+	rs := Rowset{Columns: []string{"A", "B"}, Rows: [][]string{{"1", "x"}, {"2", "y"}}}
+	got := string(rs.ExecuteResponse())
+	parses(t, rs.ExecuteResponse())
+
+	for _, want := range []string{
+		`<ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">`,
+		`<root xmlns="urn:schemas-microsoft-com:xml-analysis:rowset"`,
+		`<xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset"`,
+		`<xsd:element sql:field="A" name="A" type="xsd:string" minOccurs="0"/>`,
+		`<row><A>1</A><B>x</B></row>`,
+		`<row><A>2</A><B>y</B></row>`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("envelope missing %q", want)
+		}
+	}
+	// The schema must precede the first row: the client reads the shape before
+	// the data, which is why an empty root reads as "unrecognizable".
+	if strings.Index(got, "<xsd:schema") > strings.Index(got, "<row>") {
+		t.Error("inline XSD must come before the first row")
+	}
+}
+
+// Execute and Discover differ only by wrapper; the client rejects each in its
+// own words, so a drift between them would be diagnosed twice over.
+func TestExecuteAndDiscoverDifferOnlyByWrapper(t *testing.T) {
+	rs := Rowset{Columns: []string{"C"}, Rows: [][]string{{"v"}}}
+	e := strings.ReplaceAll(string(rs.ExecuteResponse()), "ExecuteResponse", "X")
+	d := strings.ReplaceAll(string(rs.DiscoverResponse()), "DiscoverResponse", "X")
+	if e != d {
+		t.Error("Execute and Discover payloads differ by more than the wrapper element")
+	}
+}
+
+// The stub this was modelled on interpolated values raw. DAX expressions carry
+// <, > and & as a matter of course, so that produces malformed XML on ordinary
+// model content — not just on hostile input.
+func TestValuesAndColumnsAreEscaped(t *testing.T) {
+	rs := Rowset{
+		Columns: []string{"Expression"},
+		Rows:    [][]string{{`IF([x] < 1 && [y] > 2, "a", "b")`}},
+	}
+	payload := rs.ExecuteResponse()
+	parses(t, payload)
+	if bytes.Contains(payload, []byte(`< 1 &&`)) {
+		t.Error("value was interpolated raw; XML escaping is missing")
+	}
+	if !bytes.Contains(payload, []byte("&lt;")) || !bytes.Contains(payload, []byte("&amp;")) {
+		t.Error("expected escaped < and & in the emitted value")
+	}
+}
+
+func TestEmptyAndRaggedRows(t *testing.T) {
+	// No rows at all is legal (minOccurs=0) and must still carry the schema.
+	empty := Rowset{Columns: []string{"A"}}
+	parses(t, empty.ExecuteResponse())
+	if !strings.Contains(string(empty.ExecuteResponse()), "<xsd:schema") {
+		t.Error("an empty rowset must still emit its schema")
+	}
+	// A short row omits trailing cells rather than emitting empty elements.
+	ragged := Rowset{Columns: []string{"A", "B"}, Rows: [][]string{{"1"}}}
+	got := string(ragged.ExecuteResponse())
+	parses(t, ragged.ExecuteResponse())
+	if !strings.Contains(got, "<row><A>1</A></row>") {
+		t.Errorf("short row should omit the missing cell, got %q", got)
+	}
+}
+
+// FromDAX is the evaluate_dax path. Driven off the same golden model the
+// executeQueries e2e uses, so both transports answer from one source of truth.
+func TestFromDAXOverGoldenModel(t *testing.T) {
+	fx := filepath.Join("..", "..", "e2e", "semantic-model", "fixtures")
+	bim, err := os.ReadFile(filepath.Join(fx, "retail.bim"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(fx, "seed_data.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	model, err := semanticmodel.ParseTMSL(bim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := semanticmodel.ParseData(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := semanticmodel.Evaluate(model, data,
+		`EVALUATE SUMMARIZECOLUMNS('Time'[FiscalYear], 'Time'[FiscalMonth], "TotalUnits", [TotalUnits])`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := FromDAX(res)
+	if len(rs.Rows) != 4 {
+		t.Fatalf("rows = %d, want 4", len(rs.Rows))
+	}
+	payload := rs.ExecuteResponse()
+	parses(t, payload)
+	// 60000 must cross as an integer, not 60000.0 — the client re-types from
+	// the schema and should never be handed a conversion it did not ask for.
+	if !bytes.Contains(payload, []byte(">60000<")) {
+		t.Errorf("expected an integral value to cross without a decimal tail:\n%s", payload)
+	}
+	if bytes.Contains(payload, []byte("60000.0")) {
+		t.Error("integral float leaked its .0 onto the wire")
+	}
+}
+
+func TestFromDAXNilAndBlank(t *testing.T) {
+	if got := FromDAX(nil); len(got.Columns) != 0 || len(got.Rows) != 0 {
+		t.Error("nil result should give an empty rowset, not panic")
+	}
+	// DAX blank (DIVIDE by zero) crosses as the empty string.
+	res := &semanticmodel.Result{Columns: []string{"v"}, Rows: []map[string]any{{"v": nil}}}
+	rs := FromDAX(res)
+	if rs.Rows[0][0] != "" {
+		t.Errorf("blank should render as empty, got %q", rs.Rows[0][0])
+	}
+	parses(t, rs.ExecuteResponse())
+}
+
+func TestCellRendering(t *testing.T) {
+	// A slice of pairs, not a map: an unhashable input (the unsupported-type
+	// case this is here to cover) cannot be a map key.
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{nil, ""}, {"s", "s"}, {true, "true"}, {false, "false"},
+		{float64(3), "3"}, {2.5, "2.5"}, {-1.0, "-1"},
+		{[]int{1}, ""}, // unsupported type renders empty rather than panicking
+	}
+	for _, c := range cases {
+		if got := cell(c.in); got != c.want {
+			t.Errorf("cell(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// DAX column names contain brackets, which are illegal in XML element names —
+// emitting them raw makes the payload unparseable, not merely odd. XMLA's
+// documented answer is the _xHHHH_ escape.
+func TestEncodeName(t *testing.T) {
+	cases := map[string]string{
+		"TotalUnits":       "TotalUnits",
+		"Time[FiscalYear]": "Time_x005B_FiscalYear_x005D_",
+		"[TotalUnits]":     "_x005B_TotalUnits_x005D_",
+		"Order Details":    "Order_x0020_Details",
+		"2024":             "_x0032_024", // may not start with a digit
+		"a_b":              "a_x005F_b",  // literal _ escaped, so decoding stays unambiguous
+		"":                 "_x0020_",
+	}
+	for in, want := range cases {
+		if got := EncodeName(in); got != want {
+			t.Errorf("EncodeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The regression this whole encoding exists for: a real DAX result must
+// produce well-formed XML, and the true name must survive in sql:field.
+func TestDAXColumnNamesSurviveAsWellFormedXML(t *testing.T) {
+	res := &semanticmodel.Result{
+		Columns: []string{"Time[FiscalYear]", "[TotalUnits]"},
+		Rows:    []map[string]any{{"Time[FiscalYear]": "FY2013", "[TotalUnits]": float64(60000)}},
+	}
+	payload := FromDAX(res).ExecuteResponse()
+	parses(t, payload) // would fail outright on raw brackets
+	s := string(payload)
+	if !strings.Contains(s, `sql:field="Time[FiscalYear]"`) {
+		t.Error("the true column name must survive verbatim in sql:field")
+	}
+	if !strings.Contains(s, "<Time_x005B_FiscalYear_x005D_>FY2013</Time_x005B_FiscalYear_x005D_>") {
+		t.Errorf("row element should use the encoded name:\n%s", s)
+	}
+}
+
+// Astral-plane runes take the surrogate-pair path: XMLA's escape is UCS-2, so
+// a rune above the BMP encodes as two _xHHHH_ escapes, not one.
+func TestEncodeNameAstral(t *testing.T) {
+	got := EncodeName("a\U0001F600b") // U+1F600, outside the BMP
+	want := "a_xD83D__xDE00_b"
+	if got != want {
+		t.Errorf("EncodeName(astral) = %q, want %q", got, want)
+	}
+	rs := Rowset{Columns: []string{"a\U0001F600b"}, Rows: [][]string{{"v"}}}
+	parses(t, rs.ExecuteResponse())
+}


### PR DESCRIPTION
The serialisation half of the XMLA split agreed with local_d8e8faa1 and local_96e707f3 (claimed in CLAIMS.md at `main@7dcdfb8`). **Touches nothing in `e2e/xmla` or `docs/32`** — those are the transport session's.

### What this is
`internal/xmla`: one `xml-analysis:rowset` writer, wrapped for either `Execute` or `Discover`, plus `FromDAX` projecting a `semanticmodel.Result`.

Two details are load-bearing and neither is guessable from the XSD — both come from what a **real ADOMD.NET client was observed to accept** in `e2e/xmla` (#152):
- the **inline XSD is mandatory** (the client reads the shape before any row; without it a rowset reads as "unrecognizable", not "empty")
- the payload ends with a **0x00** byte (`ReadResponsePayloadImpl` switches on it: 0 complete, 1 LRO continuation, else `TransportProtocolError`)

Execute and Discover are one function, not two — the client rejects each in different words, so a copy would drift silently.

### The defect this found
`FromDAX` over the golden model produced **XML that would not parse**. DAX columns are `Time[FiscalYear]` and `[TotalUnits]`; `[` and `]` are **illegal in XML element names**, so raw emission is malformed, and a client reports that as a parse failure rather than as a bad column.

Fixed with XMLA's documented `_xHHHH_` escape (`Order Details` → `Order_x0020_Details`; here `Time[FiscalYear]` → `Time_x005B_FiscalYear_x005D_`), with the **true name preserved verbatim in `sql:field`**. A literal `_` is escaped too, so decoding stays unambiguous.

Caught by asserting the payload **parses as XML**, not by eyeballing it — a string-contains test would have passed on the malformed version. Values are escaped as well: the stub this was modelled on interpolated them raw, and DAX expressions carry `<` and `&` as a matter of course.

### Scope held deliberately
**No TMSCHEMA rowsets yet.** `local_d8e8faa1` has now measured that `TMSCHEMA_MODEL` *is* requested — but only after a successful `Discover`, and their earlier "zero TMSCHEMA" reading was an artifact of `list_*` dying on a stubbed session. The column lists live in [MS-SSAS-T], whose Learn pages are stubs, so I am **not guessing them**; their live client is the oracle. Good news for the shape: DMV queries arrive as an **`Execute`** with a `<Statement>`, so they reuse this exact writer.

100% package coverage; `make check` exit 0; full `internal/...` suite green.