### PR TITLE
e2e/sempy: answer TOM's TMSCHEMA batch, and record the rowset contract

### DIFF
--- a/e2e/sempy/driver.py
+++ b/e2e/sempy/driver.py
@@ -109,7 +109,19 @@ CASES = [
 for name, fn in CASES:
     try:
         r = fn()
-        print(f"###RESULT {name} :: OK :: {type(r).__name__}", flush=True)
+        # CONTENT, not just a type. A DataFrame with zero rows reads as success
+        # and proves nothing — the failure mode this whole suite exists to avoid.
+        n = len(r) if hasattr(r, "__len__") else -1
+        cells = ""
+        try:
+            if n:
+                cells = " | ".join(str(v)[:24] for v in r.iloc[0].tolist()[:4])
+        except Exception:
+            cells = "(unreadable)"
+        print(f"###RESULT {name} :: OK :: {type(r).__name__} :: rows={n}",
+              flush=True)
+        if cells:
+            print(f"###ROW {name} :: {cells}", flush=True)
     except Exception as e:
         first = str(e).splitlines()[0][:150] if str(e).strip() else "(no message)"
         print(f"###RESULT {name} :: {type(e).__name__} :: {first}", flush=True)

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -576,6 +576,12 @@ print("\n---- driver ----", flush=True)
 for ln in out:
     print("  " + ln, flush=True)
 
+rows = dict(
+    (m.group(1), int(m.group(2)))
+    for m in (re.match(r"RESULT (\S+) :: OK :: \w+ :: rows=(-?\d+)", ln)
+              for ln in out) if m)
+rowtext = "\n".join(ln for ln in out if ln.startswith("ROW "))
+
 results = dict(
     (m.group(1), m.group(2))
     for m in (re.match(r"RESULT (\S+) :: (\S+)", ln) for ln in out) if m)
@@ -616,6 +622,21 @@ CHECKS = [
     # Discover elements, not SQL. An earlier version of this check said "as an
     # Execute", which is true on the verb and misleading about the grammar —
     # and it misled another session's design before being caught.
+    # CONTENT, not just a type. Every one of these returned a DataFrame long
+    # before it returned a CORRECT one, and an empty frame reads as success.
+    ("the full metadata surface returns DataFrames",
+     all(results.get(f) == "OK" for f in
+         ("list_measures", "list_tables", "list_columns",
+          "list_partitions", "list_relationships"))),
+    ("list_measures carries the measure, joined to its table, with its DAX",
+     rows.get("list_measures", 0) > 0
+     and "SUM(Sales[Amount])" in rowtext and "Total" in rowtext),
+    ("list_columns resolves the column and its ColumnType enum",
+     rows.get("list_columns", 0) > 0 and "Amount" in rowtext
+     and "Data" in rowtext),
+    ("list_tables returns the seeded table", rows.get("list_tables", 0) > 0),
+    ("an unseeded rowset is empty rather than wrong",
+     rows.get("list_relationships", -1) == 0),
     ("TMSCHEMA arrives as a Batch of Discover inside one Execute",
      "TMSCHEMA" in bodies
      and any("<Batch" in r["body"] and "TMSCHEMA" in r["body"]

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -248,8 +248,22 @@ _CLR = {
 _XSD = {"DateTime": "xsd:dateTime", "Boolean": "xsd:boolean",
         "Int32": "xsd:int", "enum": "xsd:int", "UInt64": "xsd:unsignedLong",
         "String": "xsd:string"}
+# ENUM VALUES ARE NOT FREE: 0 is not a member of several of these, and the
+# client says so — `The value '0' is unexpected for type 'ColumnType'`. Values
+# read off the assembly: ColumnType.Data=1, ObjectState.Ready=1,
+# DataType.String=2, AggregateFunction.Default=1, Alignment.Default=1,
+# PartitionSourceType.M=4. ModeType.Import and DataViewType.Full ARE 0, so a
+# blanket "use 1" would be wrong the other way.
+_ENUM_DEFAULT = {
+    "Type": "1", "State": "1", "DataType": "2", "SummarizeBy": "1",
+    "Alignment": "1", "SourceType": "4", "Mode": "0", "DataView": "0",
+    "ObjectType": "1", "EncodingHint": "0", "DefaultMode": "0",
+    "DefaultDataView": "0", "DefaultPowerBIDataSourceVersion": "0",
+    "DataSourceVariablesOverrideBehavior": "0",
+}
 _DEFAULT = {"xsd:dateTime": "2026-08-10T00:00:00", "xsd:boolean": "false",
-            "xsd:int": "0", "xsd:unsignedLong": "0", "xsd:string": ""}
+            "xsd:int": "0", "xsd:long": "1", "xsd:unsignedLong": "0",
+            "xsd:string": ""}
 
 
 def _xsd_type(col):
@@ -266,7 +280,8 @@ def _xsd_type(col):
     return _XSD[_CLR.get(col, "String")]
 
 def _row(cols, overrides):
-    return [overrides.get(c, _DEFAULT[_xsd_type(c)]) for c in cols]
+    return [overrides.get(c, _ENUM_DEFAULT.get(c, _DEFAULT[_xsd_type(c)]))
+            for c in cols]
 
 
 # OBJECT IDs ARE GLOBAL across the model, not per-rowset: reusing 1 gives

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -300,6 +300,13 @@ def _root(request_type):
     # column-less root that Fill skips silently breaks the naming for ALL
     # 35 — and the failure surfaces as "Tables['Model'] is null".
     cols, rows = POPULATED.get(request_type, (["ID", "Name"], []))
+    # EVERY TMSCHEMA rowset carries a `Version` column — the client refuses one
+    # without it: `ResponseFormatException: The rowset is missing a Version
+    # column`. It is the metadata version TOM tracks state with, which is why
+    # its absence reads as a malformed ROWSET rather than a missing field.
+    if "Version" not in cols:
+        cols = list(cols) + ["Version"]
+        rows = [list(r) + ["1"] for r in rows]
     name = ROOT_NAMES.get(request_type,
                           request_type.replace("TMSCHEMA_", "").title())
     xsd = "".join(

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -230,6 +230,11 @@ _CLR = {
     "DataView": "enum", "SourceType": "enum", "ObjectType": "enum",
     "DefaultPowerBIDataSourceVersion": "enum",
     "DataSourceVariablesOverrideBehavior": "enum",
+    # `ExplicitDataType` is the ENUM on Column (`DataType` is derived from
+    # it). Typed as a string it arrives empty and `Enum.Parse("")` throws
+    # `Must specify valid information for parsing` — an argument error with
+    # no column named, which the stack trace resolves in one read.
+    "ExplicitDataType": "enum",
     "ForceUniqueNames": "Boolean", "DiscourageImplicitMeasures": "Boolean",
     "DiscourageReportMeasures": "Boolean", "DiscourageCompositeModels": "Boolean",
     "IsHidden": "Boolean", "ShowAsVariationsOnly": "Boolean",
@@ -260,6 +265,7 @@ _ENUM_DEFAULT = {
     "ObjectType": "1", "EncodingHint": "0", "DefaultMode": "0",
     "DefaultDataView": "0", "DefaultPowerBIDataSourceVersion": "0",
     "DataSourceVariablesOverrideBehavior": "0",
+    "ExplicitDataType": "2",
 }
 _DEFAULT = {"xsd:dateTime": "2026-08-10T00:00:00", "xsd:boolean": "false",
             "xsd:int": "0", "xsd:long": "1", "xsd:unsignedLong": "0",

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -253,7 +253,15 @@ _DEFAULT = {"xsd:dateTime": "2026-08-10T00:00:00", "xsd:boolean": "false",
 
 
 def _xsd_type(col):
-    if col == "ID" or col.endswith("ID") or col == "Version":
+    if col == "Version":
+        # `xsd:long`, NOT unsignedLong. `DdlUtil.GetVersionFromDataTable` does
+        # `Utils.Verify(obj is long)` on row 0 — an ASSERTION, so an
+        # unsignedLong parses fine, fails the type test, and surfaces as
+        # `TomInternalException: An internal error has occured` with no field
+        # named. The only error in this investigation that did not name itself,
+        # and it was one xsd type.
+        return "xsd:long"
+    if col == "ID" or col.endswith("ID"):
         return "xsd:unsignedLong"
     return _XSD[_CLR.get(col, "String")]
 

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -175,6 +175,79 @@ def assl(database_scoped):
             "</Server>")
 
 
+
+# TOM asks for the whole TMSCHEMA catalogue in ONE Execute whose Command is a
+# <Batch> of ~35 <Discover> elements. The response is a `multipleresults`
+# envelope holding one <root> per request, IN ORDER.
+POPULATED = {
+    "TMSCHEMA_MODEL":         (["ID", "Name"], [["1", "Model"]]),
+    "TMSCHEMA_TABLES":        (["ID", "ModelID", "Name"], [["1", "1", "Sales"]]),
+    "TMSCHEMA_COLUMNS":       (["ID", "TableID", "ExplicitName", "Name"],
+                               [["1", "1", "Amount", "Amount"]]),
+    "TMSCHEMA_MEASURES":      (["ID", "TableID", "Name", "Expression"],
+                               [["1", "1", "Total", "SUM(Sales[Amount])"]]),
+    "TMSCHEMA_PARTITIONS":    (["ID", "TableID", "Name"], [["1", "1", "p1"]]),
+}
+# `AmoDataAdapter.AdjustTableNames` renames the DataSet's tables from
+# `XmlaDataReader.RowsetNames`, and each entry is literally
+# `xmlReader.GetAttribute("name")` on <root>. Omit the attribute and every name
+# is null, nothing is renamed, and `DdlUtil.ObtainModelTable`'s
+# `dataSet.Tables["Model"]` is null — reported as "failed to discover the state
+# of the model", a message about the MODEL for a defect in ROOT NAMING.
+ROOT_NAMES = {
+    "TMSCHEMA_MODEL": "Model", "TMSCHEMA_TABLES": "Table",
+    "TMSCHEMA_COLUMNS": "Column", "TMSCHEMA_MEASURES": "Measure",
+    "TMSCHEMA_PARTITIONS": "Partition", "TMSCHEMA_RELATIONSHIPS": "Relationship",
+    "TMSCHEMA_HIERARCHIES": "Hierarchy",
+}
+
+
+def _root(request_type):
+    # EVERY rowset must yield a DataTable: `AdjustTableNames` bails out
+    # entirely if `RowsetNames.Count != dataSet.Tables.Count`, so a
+    # column-less root that Fill skips silently breaks the naming for ALL
+    # 35 — and the failure surfaces as "Tables['Model'] is null".
+    cols, rows = POPULATED.get(request_type, (["ID", "Name"], []))
+    name = ROOT_NAMES.get(request_type,
+                          request_type.replace("TMSCHEMA_", "").title())
+    xsd = "".join(
+        f'<xsd:element sql:field="{c}" name="{c}" type="xsd:string" minOccurs="0"/>'
+        for c in cols)
+    body = "".join("<row>" + "".join(f"<{c}>{v}</{c}>" for c, v in zip(cols, r))
+                   + "</row>" for r in rows)
+    return (
+        f'<root name="{name}" xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" '
+        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+        'xmlns:sql="urn:schemas-microsoft-com:xml-sql">'
+        '<xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset" '
+        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+        'xmlns:sql="urn:schemas-microsoft-com:xml-sql" elementFormDefault="qualified">'
+        '<xsd:element name="root"><xsd:complexType><xsd:sequence>'
+        '<xsd:element name="row" type="row" minOccurs="0" maxOccurs="unbounded"/>'
+        '</xsd:sequence></xsd:complexType></xsd:element>'
+        '<xsd:complexType name="row"><xsd:sequence>' + xsd +
+        '</xsd:sequence></xsd:complexType></xsd:schema>' + body + '</root>')
+
+
+def batch_response(request_types):
+    """One <root> per <Discover>, in request order.
+
+    The container namespace is NOT a suffix on the xml-analysis URN family;
+    bi-shared-docs `results-element-xmla.md` gives a different scheme entirely.
+    A wrong one is refused at the envelope before anything inside is read.
+    """
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<soap:Body>'
+        '<ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">'
+        '<return><results xmlns="http://schemas.microsoft.com/analysisservices'
+        '/2003/xmla-multipleresults">'
+        + "".join(_root(rt) for rt in request_types) +
+        '</results></return></ExecuteResponse>'
+        '</soap:Body></soap:Envelope>').encode() + b"\x00"
+
+
 class Capture(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -256,6 +329,15 @@ class Capture(http.server.BaseHTTPRequestHandler):
                 {"results": [{"tables": [{"rows": [{"[Value]": 1}]}]}]}).encode())
         if "/webapi/xmla" in p or p.endswith("/xmla"):
             caps = {"x-ms-xmlacaps-negotiation-flags": "0,0,0,0,0"}
+            # ORDER MATTERS: a batched Execute CONTAINS <Discover> children, so
+            # a broad `"<Discover" in text` check shadows it entirely.
+            rts = re.findall(r"<RequestType>(TMSCHEMA_\w+)</RequestType>", text)
+            if rts and "<Batch" in text:
+                pop = sum(1 for t in rts if t in POPULATED)
+                print(f"    -> batch of {len(rts)}: {pop} populated, "
+                      f"{len(rts) - pop} empty", flush=True)
+                return self._send(200, batch_response(rts),
+                                  "text/xml; charset=utf-8", caps)
             if "<Discover" in text:
                 dbid = re.search(r"<DatabaseID>([^<]*)</DatabaseID>", text)
                 return self._send(200, rowset("DiscoverResponse", ["METADATA"],

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -215,8 +215,50 @@ _PARTITION = ["Name", "Description", "State", "Mode", "DataView",
               "RetainDataTillForceCalculate", "Type"]
 
 
+
+# XSD TYPE PER COLUMN, from each TOM property's CLR type. Declaring everything
+# `xsd:string` gets the NAMES accepted and then fails as
+# `InvalidCastException: Unable to cast System.String to System.UInt64` — the
+# rowset's inline schema is a type contract, not just a column list.
+# IDs and foreign keys are UInt64; enums cross the wire as their integer value.
+_CLR = {
+    "ModifiedTime": "DateTime", "StructureModifiedTime": "DateTime",
+    "RefreshedTime": "DateTime",
+    "DefaultMode": "enum", "DefaultDataView": "enum", "State": "enum",
+    "Alignment": "enum", "SummarizeBy": "enum", "Type": "enum",
+    "EncodingHint": "enum", "DataType": "enum", "Mode": "enum",
+    "DataView": "enum", "SourceType": "enum", "ObjectType": "enum",
+    "DefaultPowerBIDataSourceVersion": "enum",
+    "DataSourceVariablesOverrideBehavior": "enum",
+    "ForceUniqueNames": "Boolean", "DiscourageImplicitMeasures": "Boolean",
+    "DiscourageReportMeasures": "Boolean", "DiscourageCompositeModels": "Boolean",
+    "IsHidden": "Boolean", "ShowAsVariationsOnly": "Boolean",
+    "IsPrivate": "Boolean", "ExcludeFromModelRefresh": "Boolean",
+    "SystemManaged": "Boolean", "ExcludeFromAutomaticAggregations": "Boolean",
+    "IsUnique": "Boolean", "IsKey": "Boolean", "IsNullable": "Boolean",
+    "IsDefaultLabel": "Boolean", "IsDefaultImage": "Boolean",
+    "IsAvailableInMDX": "Boolean", "KeepUniqueRows": "Boolean",
+    "IsDataTypeInferred": "Boolean", "IsSimpleMeasure": "Boolean",
+    "RetainDataTillForceCalculate": "Boolean", "IsRemoved": "Boolean",
+    "DataSourceDefaultMaxConnections": "Int32", "DisableAutoExists": "Int32",
+    "MaxParallelismPerRefresh": "Int32", "MaxParallelismPerQuery": "Int32",
+    "AlternateSourcePrecedence": "Int32", "TableDetailPosition": "Int32",
+    "DisplayOrdinal": "Int32",
+}
+_XSD = {"DateTime": "xsd:dateTime", "Boolean": "xsd:boolean",
+        "Int32": "xsd:int", "enum": "xsd:int", "UInt64": "xsd:unsignedLong",
+        "String": "xsd:string"}
+_DEFAULT = {"xsd:dateTime": "2026-08-10T00:00:00", "xsd:boolean": "false",
+            "xsd:int": "0", "xsd:unsignedLong": "0", "xsd:string": ""}
+
+
+def _xsd_type(col):
+    if col == "ID" or col.endswith("ID"):
+        return "xsd:unsignedLong"
+    return _XSD[_CLR.get(col, "String")]
+
 def _row(cols, overrides):
-    return [overrides.get(c, "") for c in cols]
+    return [overrides.get(c, _DEFAULT[_xsd_type(c)]) for c in cols]
 
 
 POPULATED = {
@@ -261,7 +303,8 @@ def _root(request_type):
     name = ROOT_NAMES.get(request_type,
                           request_type.replace("TMSCHEMA_", "").title())
     xsd = "".join(
-        f'<xsd:element sql:field="{c}" name="{c}" type="xsd:string" minOccurs="0"/>'
+        f'<xsd:element sql:field="{c}" name="{c}" type="{_xsd_type(c)}" '
+        'minOccurs="0"/>'
         for c in cols)
     body = "".join("<row>" + "".join(f"<{c}>{v}</{c}>" for c, v in zip(cols, r))
                    + "</row>" for r in rows)

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -269,24 +269,28 @@ def _row(cols, overrides):
     return [overrides.get(c, _DEFAULT[_xsd_type(c)]) for c in cols]
 
 
+# OBJECT IDs ARE GLOBAL across the model, not per-rowset: reusing 1 gives
+# `TomInternalException ... Details: Duplicate object ID 1, first in
+# 'Tabular.Model', another one in ...`. Parent FKs must point at the parent's
+# global id, so the Column/Measure/Partition rows carry TableID = the Table's.
 POPULATED = {
     "TMSCHEMA_MODEL": (["ID"] + _MODEL,
                        [_row(["ID"] + _MODEL,
                              {"ID": "1", "Name": "Model", "Culture": "en-US"})]),
     "TMSCHEMA_TABLES": (["ID", "ModelID"] + _TABLE,
                         [_row(["ID", "ModelID"] + _TABLE,
-                              {"ID": "1", "ModelID": "1", "Name": "Sales"})]),
+                              {"ID": "2", "ModelID": "1", "Name": "Sales"})]),
     "TMSCHEMA_COLUMNS": (["ID", "TableID"] + _COLUMN,
                          [_row(["ID", "TableID"] + _COLUMN,
-                               {"ID": "1", "TableID": "1",
+                               {"ID": "3", "TableID": "2",
                                 "ExplicitName": "Amount"})]),
     "TMSCHEMA_MEASURES": (["ID", "TableID"] + _MEASURE,
                           [_row(["ID", "TableID"] + _MEASURE,
-                                {"ID": "1", "TableID": "1", "Name": "Total",
+                                {"ID": "4", "TableID": "2", "Name": "Total",
                                  "Expression": "SUM(Sales[Amount])"})]),
     "TMSCHEMA_PARTITIONS": (["ID", "TableID"] + _PARTITION,
                             [_row(["ID", "TableID"] + _PARTITION,
-                                  {"ID": "1", "TableID": "1", "Name": "p1"})]),
+                                  {"ID": "5", "TableID": "2", "Name": "p1"})]),
 }
 # `AmoDataAdapter.AdjustTableNames` renames the DataSet's tables from
 # `XmlaDataReader.RowsetNames`, and each entry is literally

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -253,7 +253,7 @@ _DEFAULT = {"xsd:dateTime": "2026-08-10T00:00:00", "xsd:boolean": "false",
 
 
 def _xsd_type(col):
-    if col == "ID" or col.endswith("ID"):
+    if col == "ID" or col.endswith("ID") or col == "Version":
         return "xsd:unsignedLong"
     return _XSD[_CLR.get(col, "String")]
 

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -179,14 +179,64 @@ def assl(database_scoped):
 # TOM asks for the whole TMSCHEMA catalogue in ONE Execute whose Command is a
 # <Batch> of ~35 <Discover> elements. The response is a `multipleresults`
 # envelope holding one <root> per request, IN ORDER.
+# Columns are the SCALAR properties of each TOM type, read off
+# Microsoft.AnalysisServices.Tabular.dll. TOM reads them from the rowset BY
+# NAME and says which one is missing — `ArgumentException: Column 'Culture'
+# does not belong to table Model` — so the type's own property list is the
+# column contract. `ID` and the parent FK are added because the rowsets are
+# relational where the objects are nested.
+_MODEL = ["Name", "Description", "StorageLocation", "DefaultMode",
+          "DefaultDataView", "Culture", "Collation", "ModifiedTime",
+          "StructureModifiedTime", "DefaultPowerBIDataSourceVersion",
+          "ForceUniqueNames", "DiscourageImplicitMeasures",
+          "DiscourageReportMeasures", "DataSourceVariablesOverrideBehavior",
+          "DataSourceDefaultMaxConnections", "SourceQueryCulture",
+          "DiscourageCompositeModels", "DisableAutoExists",
+          "MaxParallelismPerRefresh", "MaxParallelismPerQuery"]
+_TABLE = ["Name", "DataCategory", "Description", "IsHidden", "ModifiedTime",
+          "StructureModifiedTime", "ShowAsVariationsOnly", "IsPrivate",
+          "AlternateSourcePrecedence", "ExcludeFromModelRefresh", "LineageTag",
+          "SourceLineageTag", "SystemManaged",
+          "ExcludeFromAutomaticAggregations"]
+_COLUMN = ["ExplicitName", "SourceColumn", "DataCategory", "Description",
+           "IsHidden", "State", "IsUnique", "IsKey", "IsNullable", "Alignment",
+           "TableDetailPosition", "IsDefaultLabel", "IsDefaultImage",
+           "SummarizeBy", "Type", "FormatString", "IsAvailableInMDX",
+           "ModifiedTime", "StructureModifiedTime", "RefreshedTime",
+           "KeepUniqueRows", "DisplayOrdinal", "ErrorMessage",
+           "SourceProviderType", "DisplayFolder", "EncodingHint", "LineageTag",
+           "SourceLineageTag", "ExplicitDataType", "IsDataTypeInferred"]
+_MEASURE = ["Name", "Description", "DataType", "Expression", "FormatString",
+            "IsHidden", "State", "ModifiedTime", "StructureModifiedTime",
+            "IsSimpleMeasure", "ErrorMessage", "DisplayFolder", "DataCategory",
+            "LineageTag", "SourceLineageTag"]
+_PARTITION = ["Name", "Description", "State", "Mode", "DataView",
+              "ModifiedTime", "RefreshedTime", "ErrorMessage",
+              "RetainDataTillForceCalculate", "Type"]
+
+
+def _row(cols, overrides):
+    return [overrides.get(c, "") for c in cols]
+
+
 POPULATED = {
-    "TMSCHEMA_MODEL":         (["ID", "Name"], [["1", "Model"]]),
-    "TMSCHEMA_TABLES":        (["ID", "ModelID", "Name"], [["1", "1", "Sales"]]),
-    "TMSCHEMA_COLUMNS":       (["ID", "TableID", "ExplicitName", "Name"],
-                               [["1", "1", "Amount", "Amount"]]),
-    "TMSCHEMA_MEASURES":      (["ID", "TableID", "Name", "Expression"],
-                               [["1", "1", "Total", "SUM(Sales[Amount])"]]),
-    "TMSCHEMA_PARTITIONS":    (["ID", "TableID", "Name"], [["1", "1", "p1"]]),
+    "TMSCHEMA_MODEL": (["ID"] + _MODEL,
+                       [_row(["ID"] + _MODEL,
+                             {"ID": "1", "Name": "Model", "Culture": "en-US"})]),
+    "TMSCHEMA_TABLES": (["ID", "ModelID"] + _TABLE,
+                        [_row(["ID", "ModelID"] + _TABLE,
+                              {"ID": "1", "ModelID": "1", "Name": "Sales"})]),
+    "TMSCHEMA_COLUMNS": (["ID", "TableID"] + _COLUMN,
+                         [_row(["ID", "TableID"] + _COLUMN,
+                               {"ID": "1", "TableID": "1",
+                                "ExplicitName": "Amount"})]),
+    "TMSCHEMA_MEASURES": (["ID", "TableID"] + _MEASURE,
+                          [_row(["ID", "TableID"] + _MEASURE,
+                                {"ID": "1", "TableID": "1", "Name": "Total",
+                                 "Expression": "SUM(Sales[Amount])"})]),
+    "TMSCHEMA_PARTITIONS": (["ID", "TableID"] + _PARTITION,
+                            [_row(["ID", "TableID"] + _PARTITION,
+                                  {"ID": "1", "TableID": "1", "Name": "p1"})]),
 }
 # `AmoDataAdapter.AdjustTableNames` renames the DataSet's tables from
 # `XmlaDataReader.RowsetNames`, and each entry is literally


### PR DESCRIPTION
Continues the SemPy measurement. **Answers the 5-vs-35 question, and the answer is 35.**

## The batch-response contract, each gate named by the client's own error

1. **Container namespace** is `http://schemas.microsoft.com/analysisservices/2003/xmla-multipleresults` — a different scheme from the `urn:schemas-microsoft-com:xml-analysis:*` family, not a suffix on it. Wrong one is refused at the envelope before anything inside is read.
2. **Every `<root>` needs a `name` attribute.** `AmoDataAdapter.AdjustTableNames` renames DataSet tables from `XmlaDataReader.RowsetNames`, each entry being `xmlReader.GetAttribute("name")`. Omit it and `DdlUtil.ObtainModelTable`'s `dataSet.Tables["Model"]` is null — reported as *"failed to discover the state of the model"*, a message about the MODEL for a defect in ROOT NAMING.
3. **All 35 rowsets must yield a DataTable.** `AdjustTableNames` bails out entirely on `RowsetNames.Count != Tables.Count`, so a column-less root that `Fill` skips silently breaks naming for every one. **Empty is not free** — the 30 unused still need column lists.
4. **Column NAMES come from the TOM type's scalar properties** — `ArgumentException: Column 'Culture' does not belong to table Model`.
5. **The inline schema is a TYPE contract**, not just names: IDs are `xsd:unsignedLong`, enums `xsd:int`, timestamps `xsd:dateTime`. All-string fails as `InvalidCastException: Unable to cast System.String to System.UInt64`.
6. **Every rowset carries a `Version` column** — `ResponseFormatException: The rowset is missing a Version column`.

## Where it stops, honestly

`TomInternalException: An internal error has occured` — the first error in this entire investigation that does **not** name what it wants. The named-error technique that carried every prior gate is exhausted, so the next step needs a different one rather than more iterations.

`list_workspaces` and `list_datasets` return real DataFrames. The suite's contract checks all still pass.