### PR TITLE
xmla: correct the rowset writer against the measured client contract

### DIFF
--- a/.github/workflows/sempy.yml
+++ b/.github/workflows/sempy.yml
@@ -10,6 +10,13 @@ on:
                          # (05:17), because both publish host port 443 and only
                          # one can hold it at a time.
 
+# The GITHUB_TOKEN's default scope is whatever the repo grants, which is more
+# than a read-only suite needs. Every other workflow here declares this; this
+# one was modelled on xmla.yml and missed the block, which CodeQL caught as
+# `actions/missing-workflow-permissions`.
+permissions:
+  contents: read
+
 jobs:
   sempy:
     name: SemPy's wire contract on Linux

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ docs/demo/.capture/
 # .NET build output from the e2e probes (they build in-container).
 bin/
 obj/
+
+# The compiled binary, when someone builds into the repo root rather than a
+# temp dir. A `git add -A` sweeps up 30 MB of Mach-O otherwise, and it is the
+# kind of thing that lands unnoticed because nothing fails.
+/fabric-emulator
+/fabric-emulator.exe

--- a/e2e/sempy/driver.py
+++ b/e2e/sempy/driver.py
@@ -15,7 +15,6 @@ would ever issue it.
 import base64
 import json
 import os
-import time
 import traceback
 
 os.environ.setdefault("PYTHONNET_RUNTIME", "coreclr")
@@ -23,7 +22,6 @@ os.environ.setdefault("PYTHONNET_RUNTIME", "coreclr")
 HOST = os.environ["SEMPY_HOST"]
 WS = os.environ["SEMPY_WORKSPACE"]
 DATASET = os.environ["SEMPY_DATASET"]
-MARKER = os.environ["SEMPY_MARKER"]
 
 from fabric.analytics.environment.context import (          # noqa: E402
     StaticFabricContext, fabric_default_context_override)
@@ -37,36 +35,26 @@ from fabric.analytics.environment.credentials import (      # noqa: E402
     SetFabricAnalyticsDefaultTokenCredentialsGlobally)
 
 
-def _mint_jwt():
-    """A DECODABLE token. Every segment must be valid base64url.
+def _token():
+    """The bearer, minted by entra-emulator and handed in by the harness.
 
-    Three separate failures hide behind one message here, and all three report
-    `ArgumentException: The token has expired` for a token that never expired:
+    An earlier version of this driver hand-rolled a JWT because it was talking
+    to a stub. Against the EMULATOR the credential has to be real: the emulator
+    validates the issuer, so a self-signed token would prove only that our stub
+    accepted our own token.
 
-      1. an opaque string is not a JWT at all;
-      2. `alg: none` makes PyJWT raise `DecodeError`;
-      3. a SIGNATURE segment that is not valid base64url (a 21-char marker is
-         `len % 4 == 1`, undecodable at any padding) raises
-         `DecodeError: Invalid crypto padding`.
-
-    sempy catches DecodeError into `exp = 0` (`get_token_expiry_raw_timestamp`),
-    so a token that cannot be READ is indistinguishable from one that is stale.
-    Nothing verifies the signature; it only has to decode.
+    The shape still matters even when the value is real: every segment must be
+    valid base64url or sempy's `get_token_expiry_raw_timestamp` catches the
+    DecodeError into `exp = 0` and reports a live token as expired.
     """
-    def b64(d):
-        return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b"=").decode()
-
-    exp = int(time.time()) + 3600
-    head = b64({"alg": "HS256", "typ": "JWT"})
-    body = b64({"aud": "https://analysis.windows.net/powerbi/api",
-                "iss": "https://sts.windows.net/emulator/",
-                "exp": exp, "nbf": int(time.time()) - 60,
-                "upn": "e2e@emulator", "marker": MARKER})
-    sig = base64.urlsafe_b64encode(b"emulator-not-verified").rstrip(b"=").decode()
-    return f"{head}.{body}.{sig}", exp
+    tok = os.environ["SEMPY_TOKEN"]
+    payload = tok.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    exp = int(json.loads(base64.urlsafe_b64decode(payload))["exp"])
+    return tok, exp
 
 
-TOKEN, TOKEN_EXP = _mint_jwt()
+TOKEN, TOKEN_EXP = _token()
 
 
 class FakeCredential:
@@ -90,15 +78,20 @@ from sempy.fabric._utils import get_token_seconds_remaining  # noqa: E402
 _t = get_access_token().token
 _payload = _t.split(".")[1]
 _payload += "=" * (-len(_payload) % 4)
-_mine = json.loads(base64.urlsafe_b64decode(_payload)).get("marker") == MARKER
-print(f"###AUTH mine={_mine} seconds_left={get_token_seconds_remaining(_t)}", flush=True)
+_claims = json.loads(base64.urlsafe_b64decode(_payload))
+_mine = _claims.get("aud", "").startswith("https://analysis.windows.net/powerbi")
+print(f"###AUTH mine={_mine} iss={_claims.get('iss', '')[:40]} "
+      f"seconds_left={get_token_seconds_remaining(_t)}", flush=True)
 
 import sempy.fabric as fx                                   # noqa: E402
 
 CASES = [
     ("list_workspaces",    lambda: fx.list_workspaces()),
     ("list_datasets",      lambda: fx.list_datasets(workspace=WS)),
-    ("evaluate_dax",       lambda: fx.evaluate_dax(DATASET, "EVALUATE {1}", workspace=WS)),
+    # A query the SEEDED MODEL supports. `EVALUATE {1}` is a table constructor
+    # and tests the DAX grammar, not the transport — and a transport witness
+    # that fails on unsupported DAX reports the wrong thing.
+    ("evaluate_dax",       lambda: fx.evaluate_dax(DATASET, "EVALUATE 'Store'", workspace=WS)),
     ("list_measures",      lambda: fx.list_measures(DATASET, workspace=WS)),
     ("list_tables",        lambda: fx.list_tables(DATASET, workspace=WS)),
     ("list_columns",       lambda: fx.list_columns(DATASET, workspace=WS)),

--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -1,83 +1,81 @@
 #!/usr/bin/env python3
-"""e2e: Microsoft's `sempy` driven against a listener we control.
+"""e2e: Microsoft's `sempy` driven against THE EMULATOR.
 
-WHY THIS EXISTS SEPARATELY FROM `e2e/xmla`. That suite drives a hand-written
-ADOMD.NET program and answers what it demands. This one drives the library
-Fabric notebooks and `semantic-link-labs` actually use, and a real client asks
-for things a probe never does: `getDatabaseName` appears here and NOWHERE in
-`e2e/xmla`, because a probe connects with a database name it already knows.
+This is the WITNESS. Its predecessor drove sempy against a hand-written stub and
+measured what the client demands; those demands are now implemented in
+`internal/api/xmla.go` and `internal/xmla`, and unit-tested there. Keeping the
+stub too would be two copies of one contract, which is the defect this repo has
+a standing rule about — so the stub is gone and this suite proves the real
+thing.
 
-It is a CLIENT-CONTRACT oracle. The emulator implements no XMLA surface; what is
-pinned here is the exact sequence a real SemPy workload demands, so the work is
-sized against measurement rather than a specification.
+What it establishes, none of it inferred:
 
-WHAT IT ASSERTS, all measured off the wire:
+  1. sempy is redirectable at a host we name, with no Fabric runtime, capacity
+     or notebook — `StaticFabricContext(pbi_shared_host=...)` points BOTH its
+     transports (REST and `powerbi://` XMLA) at the emulator.
+  2. A REAL Microsoft client completes the whole connect sequence against the
+     emulator: routing, generateastoken, getDatabaseName, clusterResolve, the
+     :443 dial, and the XMLA session handshake.
+  3. `evaluate_dax` returns the emulator's own DAX result over XMLA.
+  4. The TOM metadata path works: one Execute carrying a <Batch> of ~35
+     <Discover RequestType=TMSCHEMA_*>, answered from the published model.
+  5. The DataFrames carry the SEEDED MODEL'S content — not merely a frame.
 
-  1. sempy is redirectable. `StaticFabricContext(pbi_shared_host=...)` points
-     BOTH transports at a host we name — the REST base and the `powerbi://`
-     XMLA endpoint — with no Fabric runtime, capacity or notebook.
-  2. The REST half round-trips: `list_workspaces` and `list_datasets` return
-     DataFrames.
-  3. `evaluate_dax` is XMLA and sends `Execute` with the DAX in a `<Statement>`.
-     It never touches `executeQueries`.
-  4. The metadata path is TWO mechanisms IN SEQUENCE: `Discover`
-     `DISCOVER_XML_METADATA` (`ObjectExpansion=ExpandObject`), then TMSCHEMA.
-     TMSCHEMA itself arrives TWO WAYS and they are easy to conflate:
-       * TOM (`list_measures`, `list_tables`) sends an `Execute` whose Command
-         is a `<Batch>` of ~35 `<Discover RequestType=TMSCHEMA_*>` elements,
-         restricted by `<DatabaseName>`. No SQL anywhere.
-       * sempy's own Python (`list_columns`, `list_partitions`,
-         `list_relationships`, `list_hierarchies`) sends SQL
-         `SELECT ... FROM $SYSTEM.TMSCHEMA_*` through `evaluate_dax`.
-     The SOAP verb is `Execute` in both cases; the GRAMMAR differs.
-  5. Nine transport gates, each named by the client's own error. They are
-     asserted individually below so that a regression names the gate that broke
-     rather than "sempy failed".
+The credential is minted by entra-emulator, because the emulator validates the
+issuer: a self-signed token would prove only that our own stub accepted our own
+token.
 
-WHAT IT DOES NOT ESTABLISH: what the `TMSCHEMA_*` rowsets must CONTAIN. The
-stub answers the Discover and stops at the first DMV, which is the
-`internal/semanticmodel` half and another session's claim.
-
-PLATFORM. This cannot run natively on macOS arm64: pythonnet finds no .NET
-runtime and `Microsoft.Fabric.SemanticLink.XmlaTools` fails to load. The whole
-driver runs in a `linux/amd64` container. A skip that reads as success is the
-failure this repo keeps producing, so `SEMPY_REQUIRE=1` turns every skip into a
-failure.
+PLATFORM. sempy's XMLA path cannot run natively on macOS arm64 (pythonnet finds
+no .NET runtime and `Microsoft.Fabric.SemanticLink.XmlaTools` will not load), so
+the client runs in a linux/amd64 container. It reaches the emulator as
+`api.fabric.microsoft.com`, which is in the emulator's own TLS SANs, via a
+docker alias and a socat publish of :443 — the client dials 443 after routing
+whatever port the Data Source named, because the endpoint address is derived.
 """
-import fcntl
-import http.server
+import base64
 import json
 import os
-import re
 import shutil
 import socket
 import ssl
 import subprocess
+import sys
 import tempfile
-import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 
 DIR = os.path.dirname(os.path.abspath(__file__))
-PORT = int(os.environ.get("SEMPY_PORT", "18447"))   # 18446 is e2e/xmla's
-HOST = "host.docker.internal"
-WS = "00000000-0000-0000-0000-000000000001"
-DATASET = "ds"
-MARKER = "sempy-e2e-marker-4c19"
-SESSION = "sempy-session-1"
-NS_ENGINE = "http://schemas.microsoft.com/analysisservices/2003/engine"
-# READ off Microsoft.AnalysisServices.Tabular.dll, not guessed: three guesses
-# gave three different rejections.
-NS_COMPAT = "http://schemas.microsoft.com/analysisservices/2010/engine/200"
+REPO = os.path.dirname(os.path.dirname(DIR))
+FIX = os.path.join(REPO, "e2e", "semantic-model", "fixtures")
+sys.path.insert(0, os.path.join(REPO, "e2e"))
+from entra_install import module_version  # noqa: E402
+
+WORK = tempfile.mkdtemp(prefix="sempy-e2e-")
+ENTRA_PORT = os.environ.get("ENTRA_PORT", "18543")
+FABRIC_PORT = os.environ.get("FABRIC_PORT", "19543")
+TENANT = "6f89cf12-978b-4d23-ac18-9ef0c127cf87"
+CLIENT_ID = "00d88624-f0d7-46f6-a641-6232c2608928"
+CLIENT_SECRET = "daemon-app-secret"
+ENTRA = f"https://localhost:{ENTRA_PORT}"
+FABRIC = f"https://127.0.0.1:{FABRIC_PORT}"
+PBI_AUDIENCE = "https://analysis.windows.net/powerbi/api"
+# In the emulator's TLS SANs, so the container can validate the chain without
+# any product change. Also what other e2e suites alias.
+CLIENT_HOST = "api.fabric.microsoft.com"
 FORWARDER = "sempy-e2e-443"
-RUN_LOCK = os.path.join(tempfile.gettempdir(), "sempy-e2e.lock")
+EXE = ".exe" if os.name == "nt" else ""
 REQUIRED = os.environ.get("SEMPY_REQUIRE") == "1"
 
-REQS = []
-LOCK = threading.Lock()
-_lock_fd = None
+_CTX = ssl.create_default_context()
+_CTX.check_hostname = False
+_CTX.verify_mode = ssl.CERT_NONE
+procs = []
 
 
-def log(msg):
-    print(f"==> {msg}", flush=True)
+def log(m):
+    print(f"==> {m}", flush=True)
 
 
 def skip_or_fail(reason):
@@ -87,574 +85,269 @@ def skip_or_fail(reason):
     raise SystemExit(0)
 
 
-def require_sole_run():
-    """One run at a time: the work dir, the forwarder name and 443 are exclusive.
+def http(method, url, body=None, token=None, form=False):
+    headers, data = {}, None
+    if body is not None:
+        if form:
+            data = urllib.parse.urlencode(body).encode()
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        else:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, context=_CTX, timeout=30) as r:
+        raw = r.read()
+        # LOWERCASED keys: `dict(r.headers)` preserves the canonical case Go
+        # sends (`X-Ms-Operation-Id`), so a lowercase lookup silently misses and
+        # an async create looks synchronous — which then polls
+        # `/operations/None` and 404s, naming a route rather than the real
+        # mistake.
+        hdrs = {k.lower(): v for k, v in r.headers.items()}
+        return r.status, hdrs, (json.loads(raw) if raw else {})
 
-    Same defect `e2e/xmla` hit — a second invocation's setup dismantles a live
-    run — and the same fix. A distinct lock file and container name from that
-    suite, so the two never destroy each other.
-    """
-    global _lock_fd
-    _lock_fd = open(RUN_LOCK, "w")
-    try:
-        fcntl.flock(_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        raise SystemExit(
-            "another e2e/sempy run holds the lock; it cannot share its 443 "
-            f"forwarder or work dir.\n  Wait, or clear a crashed one: rm {RUN_LOCK}")
 
-
-def require_free_port(port):
+def require_free_port(port, what):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.settimeout(0.5)
         if s.connect_ex(("127.0.0.1", int(port))) == 0:
             raise SystemExit(
-                f"port {port} is in use, so this harness cannot capture.\n"
-                f"  Free it or override: SEMPY_PORT=<free> python3 e2e/sempy/run.py")
+                f"port {port} is in use, so this harness cannot start its own {what};\n"
+                f"  a health check would pass against the OTHER service and every token\n"
+                f"  would carry the wrong issuer.\n"
+                f"  Free it, or: ENTRA_PORT=<free> FABRIC_PORT=<free> python3 {__file__}")
 
 
-def rowset(response_element, cols, values):
-    """One `xml-analysis:rowset`, for Execute OR Discover.
+def wait_healthy(url, deadline=90):
+    end = time.time() + deadline
+    while time.time() < end:
+        try:
+            with urllib.request.urlopen(url, context=_CTX, timeout=2) as r:
+                if r.status == 200:
+                    return
+        except OSError:
+            pass
+        time.sleep(0.2)
+    raise RuntimeError(f"health never came up at {url}")
 
-    THE INLINE XSD IS LOAD-BEARING: the client reads the schema before it reads
-    a row, so an envelope without it fails as "unrecognizable" rather than
-    "empty". Built from [MS-SSAS] `xmla-rs:rowset`, the documented surface.
+
+def start(name, cmd, env):
+    """Spawn from WORK, not the caller's cwd.
+
+    `entra-emulator` may resolve through a goenv shim, and goenv picks its Go
+    version FROM THE CURRENT DIRECTORY — so the same binary on the same PATH
+    runs from /tmp and fails from the repo with
+    `goenv: entra-emulator: command not found`. A launched service should not
+    depend on where its launcher happened to be standing.
     """
-    xsd = "".join(
-        f'<xsd:element sql:field="{c}" name="{c}" type="xsd:string" minOccurs="0"/>'
-        for c in cols)
-    row = "".join(f"<{c}>{v}</{c}>" for c, v in zip(cols, values))
-    return (
-        '<?xml version="1.0" encoding="utf-8"?>'
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
-        '<soap:Body>'
-        f'<{response_element} xmlns="urn:schemas-microsoft-com:xml-analysis">'
-        '<return>'
-        '<root xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" '
-        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
-        'xmlns:sql="urn:schemas-microsoft-com:xml-sql" '
-        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
-        '<xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset" '
-        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
-        'xmlns:sql="urn:schemas-microsoft-com:xml-sql" elementFormDefault="qualified">'
-        '<xsd:element name="root"><xsd:complexType><xsd:sequence>'
-        '<xsd:element name="row" type="row" minOccurs="0" maxOccurs="unbounded"/>'
-        '</xsd:sequence></xsd:complexType></xsd:element>'
-        '<xsd:complexType name="row"><xsd:sequence>' + xsd +
-        '</xsd:sequence></xsd:complexType></xsd:schema>'
-        f'<row>{row}</row>'
-        '</root></return>'
-        f'</{response_element}>'
-        '</soap:Body></soap:Envelope>').encode() + b"\x00"
+    fh = open(os.path.join(WORK, name + ".log"), "w")
+    procs.append((name, subprocess.Popen(cmd, env=env, cwd=WORK,
+                                         stdout=fh, stderr=subprocess.STDOUT), fh))
 
 
-def assl(database_scoped):
-    """ASSL for DISCOVER_XML_METADATA, embedded as XML rather than escaped.
+def dump_logs(tail=25):
+    """Show the services' own logs on failure.
 
-    Root depends on the RestrictionList: `<DatabaseID>` present means the client
-    is reading a `Tabular.Database`, absent means a `Tabular.Server`. The wrong
-    root fails as `Unexpected root 'Server' ... when trying to read
-    '...Tabular.Database'`.
-
-    Two contract details read off `Microsoft.AnalysisServices.Tabular.dll`:
-      * `CompatibilityLevel` is XmlElement in NS_COMPAT, NOT the 2003 engine
-        namespace and NOT `.../200/200`. Below 1200 the client refuses the
-        database as non-tabular.
-      * `Model` is `XmlIgnore` — it must NOT appear; the tabular model does not
-        travel on this path.
+    Without this the harness reports the CLIENT's error and hides the server's,
+    so an emulator 401 reads as a client problem. The logs live in a temp dir
+    the harness alone knows.
     """
-    db = (f"<Database xmlns='{NS_ENGINE}'><Name>{DATASET}</Name><ID>{DATASET}</ID>"
-          f"<ddl200:CompatibilityLevel xmlns:ddl200='{NS_COMPAT}'>1567"
-          "</ddl200:CompatibilityLevel>"
-          "<LastUpdate>2026-08-10T00:00:00Z</LastUpdate></Database>")
-    if database_scoped:
-        return db
-    return (f"<Server xmlns='{NS_ENGINE}'><Name>ws</Name><ID>ws</ID>"
-            f"<Databases><Database><Name>{DATASET}</Name><ID>{DATASET}</ID>"
-            "<LastUpdate>2026-08-10T00:00:00Z</LastUpdate></Database></Databases>"
-            "</Server>")
+    for name in ("fabric", "entra"):
+        path = os.path.join(WORK, name + ".log")
+        if not os.path.exists(path):
+            continue
+        with open(path) as fh:
+            lines = fh.read().splitlines()[-tail:]
+        if lines:
+            print(f"\n---- {name} log (last {len(lines)}) ----", flush=True)
+            for ln in lines:
+                print("  " + ln, flush=True)
 
 
-
-# TOM asks for the whole TMSCHEMA catalogue in ONE Execute whose Command is a
-# <Batch> of ~35 <Discover> elements. The response is a `multipleresults`
-# envelope holding one <root> per request, IN ORDER.
-# Columns are the SCALAR properties of each TOM type, read off
-# Microsoft.AnalysisServices.Tabular.dll. TOM reads them from the rowset BY
-# NAME and says which one is missing — `ArgumentException: Column 'Culture'
-# does not belong to table Model` — so the type's own property list is the
-# column contract. `ID` and the parent FK are added because the rowsets are
-# relational where the objects are nested.
-_MODEL = ["Name", "Description", "StorageLocation", "DefaultMode",
-          "DefaultDataView", "Culture", "Collation", "ModifiedTime",
-          "StructureModifiedTime", "DefaultPowerBIDataSourceVersion",
-          "ForceUniqueNames", "DiscourageImplicitMeasures",
-          "DiscourageReportMeasures", "DataSourceVariablesOverrideBehavior",
-          "DataSourceDefaultMaxConnections", "SourceQueryCulture",
-          "DiscourageCompositeModels", "DisableAutoExists",
-          "MaxParallelismPerRefresh", "MaxParallelismPerQuery"]
-_TABLE = ["Name", "DataCategory", "Description", "IsHidden", "ModifiedTime",
-          "StructureModifiedTime", "ShowAsVariationsOnly", "IsPrivate",
-          "AlternateSourcePrecedence", "ExcludeFromModelRefresh", "LineageTag",
-          "SourceLineageTag", "SystemManaged",
-          "ExcludeFromAutomaticAggregations"]
-_COLUMN = ["ExplicitName", "SourceColumn", "DataCategory", "Description",
-           "IsHidden", "State", "IsUnique", "IsKey", "IsNullable", "Alignment",
-           "TableDetailPosition", "IsDefaultLabel", "IsDefaultImage",
-           "SummarizeBy", "Type", "FormatString", "IsAvailableInMDX",
-           "ModifiedTime", "StructureModifiedTime", "RefreshedTime",
-           "KeepUniqueRows", "DisplayOrdinal", "ErrorMessage",
-           "SourceProviderType", "DisplayFolder", "EncodingHint", "LineageTag",
-           "SourceLineageTag", "ExplicitDataType", "IsDataTypeInferred"]
-_MEASURE = ["Name", "Description", "DataType", "Expression", "FormatString",
-            "IsHidden", "State", "ModifiedTime", "StructureModifiedTime",
-            "IsSimpleMeasure", "ErrorMessage", "DisplayFolder", "DataCategory",
-            "LineageTag", "SourceLineageTag"]
-_PARTITION = ["Name", "Description", "State", "Mode", "DataView",
-              "ModifiedTime", "RefreshedTime", "ErrorMessage",
-              "RetainDataTillForceCalculate", "Type"]
+def cleanup():
+    subprocess.run(["docker", "rm", "-f", FORWARDER], capture_output=True)
+    for name, p, fh in procs:
+        p.terminate()
+        try:
+            p.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            p.kill()
+        fh.close()
 
 
-
-# XSD TYPE PER COLUMN, from each TOM property's CLR type. Declaring everything
-# `xsd:string` gets the NAMES accepted and then fails as
-# `InvalidCastException: Unable to cast System.String to System.UInt64` — the
-# rowset's inline schema is a type contract, not just a column list.
-# IDs and foreign keys are UInt64; enums cross the wire as their integer value.
-_CLR = {
-    "ModifiedTime": "DateTime", "StructureModifiedTime": "DateTime",
-    "RefreshedTime": "DateTime",
-    "DefaultMode": "enum", "DefaultDataView": "enum", "State": "enum",
-    "Alignment": "enum", "SummarizeBy": "enum", "Type": "enum",
-    "EncodingHint": "enum", "DataType": "enum", "Mode": "enum",
-    "DataView": "enum", "SourceType": "enum", "ObjectType": "enum",
-    "DefaultPowerBIDataSourceVersion": "enum",
-    "DataSourceVariablesOverrideBehavior": "enum",
-    # `ExplicitDataType` is the ENUM on Column (`DataType` is derived from
-    # it). Typed as a string it arrives empty and `Enum.Parse("")` throws
-    # `Must specify valid information for parsing` — an argument error with
-    # no column named, which the stack trace resolves in one read.
-    "ExplicitDataType": "enum",
-    "ForceUniqueNames": "Boolean", "DiscourageImplicitMeasures": "Boolean",
-    "DiscourageReportMeasures": "Boolean", "DiscourageCompositeModels": "Boolean",
-    "IsHidden": "Boolean", "ShowAsVariationsOnly": "Boolean",
-    "IsPrivate": "Boolean", "ExcludeFromModelRefresh": "Boolean",
-    "SystemManaged": "Boolean", "ExcludeFromAutomaticAggregations": "Boolean",
-    "IsUnique": "Boolean", "IsKey": "Boolean", "IsNullable": "Boolean",
-    "IsDefaultLabel": "Boolean", "IsDefaultImage": "Boolean",
-    "IsAvailableInMDX": "Boolean", "KeepUniqueRows": "Boolean",
-    "IsDataTypeInferred": "Boolean", "IsSimpleMeasure": "Boolean",
-    "RetainDataTillForceCalculate": "Boolean", "IsRemoved": "Boolean",
-    "DataSourceDefaultMaxConnections": "Int32", "DisableAutoExists": "Int32",
-    "MaxParallelismPerRefresh": "Int32", "MaxParallelismPerQuery": "Int32",
-    "AlternateSourcePrecedence": "Int32", "TableDetailPosition": "Int32",
-    "DisplayOrdinal": "Int32",
-}
-_XSD = {"DateTime": "xsd:dateTime", "Boolean": "xsd:boolean",
-        "Int32": "xsd:int", "enum": "xsd:int", "UInt64": "xsd:unsignedLong",
-        "String": "xsd:string"}
-# ENUM VALUES ARE NOT FREE: 0 is not a member of several of these, and the
-# client says so — `The value '0' is unexpected for type 'ColumnType'`. Values
-# read off the assembly: ColumnType.Data=1, ObjectState.Ready=1,
-# DataType.String=2, AggregateFunction.Default=1, Alignment.Default=1,
-# PartitionSourceType.M=4. ModeType.Import and DataViewType.Full ARE 0, so a
-# blanket "use 1" would be wrong the other way.
-_ENUM_DEFAULT = {
-    "Type": "1", "State": "1", "DataType": "2", "SummarizeBy": "1",
-    "Alignment": "1", "SourceType": "4", "Mode": "0", "DataView": "0",
-    "ObjectType": "1", "EncodingHint": "0", "DefaultMode": "0",
-    "DefaultDataView": "0", "DefaultPowerBIDataSourceVersion": "0",
-    "DataSourceVariablesOverrideBehavior": "0",
-    "ExplicitDataType": "2",
-}
-_DEFAULT = {"xsd:dateTime": "2026-08-10T00:00:00", "xsd:boolean": "false",
-            "xsd:int": "0", "xsd:long": "1", "xsd:unsignedLong": "0",
-            "xsd:string": ""}
-
-
-def _xsd_type(col):
-    if col == "Version":
-        # `xsd:long`, NOT unsignedLong. `DdlUtil.GetVersionFromDataTable` does
-        # `Utils.Verify(obj is long)` on row 0 — an ASSERTION, so an
-        # unsignedLong parses fine, fails the type test, and surfaces as
-        # `TomInternalException: An internal error has occured` with no field
-        # named. The only error in this investigation that did not name itself,
-        # and it was one xsd type.
-        return "xsd:long"
-    if col == "ID" or col.endswith("ID"):
-        return "xsd:unsignedLong"
-    return _XSD[_CLR.get(col, "String")]
-
-def _row(cols, overrides):
-    return [overrides.get(c, _ENUM_DEFAULT.get(c, _DEFAULT[_xsd_type(c)]))
-            for c in cols]
-
-
-# OBJECT IDs ARE GLOBAL across the model, not per-rowset: reusing 1 gives
-# `TomInternalException ... Details: Duplicate object ID 1, first in
-# 'Tabular.Model', another one in ...`. Parent FKs must point at the parent's
-# global id, so the Column/Measure/Partition rows carry TableID = the Table's.
-POPULATED = {
-    "TMSCHEMA_MODEL": (["ID"] + _MODEL,
-                       [_row(["ID"] + _MODEL,
-                             {"ID": "1", "Name": "Model", "Culture": "en-US"})]),
-    "TMSCHEMA_TABLES": (["ID", "ModelID"] + _TABLE,
-                        [_row(["ID", "ModelID"] + _TABLE,
-                              {"ID": "2", "ModelID": "1", "Name": "Sales"})]),
-    "TMSCHEMA_COLUMNS": (["ID", "TableID"] + _COLUMN,
-                         [_row(["ID", "TableID"] + _COLUMN,
-                               {"ID": "3", "TableID": "2",
-                                "ExplicitName": "Amount"})]),
-    "TMSCHEMA_MEASURES": (["ID", "TableID"] + _MEASURE,
-                          [_row(["ID", "TableID"] + _MEASURE,
-                                {"ID": "4", "TableID": "2", "Name": "Total",
-                                 "Expression": "SUM(Sales[Amount])"})]),
-    "TMSCHEMA_PARTITIONS": (["ID", "TableID"] + _PARTITION,
-                            [_row(["ID", "TableID"] + _PARTITION,
-                                  {"ID": "5", "TableID": "2", "Name": "p1"})]),
-}
-# `AmoDataAdapter.AdjustTableNames` renames the DataSet's tables from
-# `XmlaDataReader.RowsetNames`, and each entry is literally
-# `xmlReader.GetAttribute("name")` on <root>. Omit the attribute and every name
-# is null, nothing is renamed, and `DdlUtil.ObtainModelTable`'s
-# `dataSet.Tables["Model"]` is null — reported as "failed to discover the state
-# of the model", a message about the MODEL for a defect in ROOT NAMING.
-ROOT_NAMES = {
-    "TMSCHEMA_MODEL": "Model", "TMSCHEMA_TABLES": "Table",
-    "TMSCHEMA_COLUMNS": "Column", "TMSCHEMA_MEASURES": "Measure",
-    "TMSCHEMA_PARTITIONS": "Partition", "TMSCHEMA_RELATIONSHIPS": "Relationship",
-    "TMSCHEMA_HIERARCHIES": "Hierarchy",
-}
-
-
-def _root(request_type):
-    # EVERY rowset must yield a DataTable: `AdjustTableNames` bails out
-    # entirely if `RowsetNames.Count != dataSet.Tables.Count`, so a
-    # column-less root that Fill skips silently breaks the naming for ALL
-    # 35 — and the failure surfaces as "Tables['Model'] is null".
-    cols, rows = POPULATED.get(request_type, (["ID", "Name"], []))
-    # EVERY TMSCHEMA rowset carries a `Version` column — the client refuses one
-    # without it: `ResponseFormatException: The rowset is missing a Version
-    # column`. It is the metadata version TOM tracks state with, which is why
-    # its absence reads as a malformed ROWSET rather than a missing field.
-    if "Version" not in cols:
-        cols = list(cols) + ["Version"]
-        rows = [list(r) + ["1"] for r in rows]
-    name = ROOT_NAMES.get(request_type,
-                          request_type.replace("TMSCHEMA_", "").title())
-    xsd = "".join(
-        f'<xsd:element sql:field="{c}" name="{c}" type="{_xsd_type(c)}" '
-        'minOccurs="0"/>'
-        for c in cols)
-    body = "".join("<row>" + "".join(f"<{c}>{v}</{c}>" for c, v in zip(cols, r))
-                   + "</row>" for r in rows)
-    return (
-        f'<root name="{name}" xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" '
-        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
-        'xmlns:sql="urn:schemas-microsoft-com:xml-sql">'
-        '<xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset" '
-        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
-        'xmlns:sql="urn:schemas-microsoft-com:xml-sql" elementFormDefault="qualified">'
-        '<xsd:element name="root"><xsd:complexType><xsd:sequence>'
-        '<xsd:element name="row" type="row" minOccurs="0" maxOccurs="unbounded"/>'
-        '</xsd:sequence></xsd:complexType></xsd:element>'
-        '<xsd:complexType name="row"><xsd:sequence>' + xsd +
-        '</xsd:sequence></xsd:complexType></xsd:schema>' + body + '</root>')
-
-
-def batch_response(request_types):
-    """One <root> per <Discover>, in request order.
-
-    The container namespace is NOT a suffix on the xml-analysis URN family;
-    bi-shared-docs `results-element-xmla.md` gives a different scheme entirely.
-    A wrong one is refused at the envelope before anything inside is read.
-    """
-    return (
-        '<?xml version="1.0" encoding="utf-8"?>'
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
-        '<soap:Body>'
-        '<ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">'
-        '<return><results xmlns="http://schemas.microsoft.com/analysisservices'
-        '/2003/xmla-multipleresults">'
-        + "".join(_root(rt) for rt in request_types) +
-        '</results></return></ExecuteResponse>'
-        '</soap:Body></soap:Envelope>').encode() + b"\x00"
-
-
-class Capture(http.server.BaseHTTPRequestHandler):
-    protocol_version = "HTTP/1.1"
-
-    def _body(self):
-        # XMLA arrives chunked with no Content-Length. Reading Content-Length
-        # alone records the envelope as empty, which reads as "the client sent
-        # nothing" — an absent measurement rendered as a negative observation.
-        if "chunked" in (self.headers.get("Transfer-Encoding", "") or "").lower():
-            out = []
-            while True:
-                line = self.rfile.readline().strip()
-                if not line:
-                    continue
-                n = int(line.split(b";")[0], 16)
-                if n == 0:
-                    self.rfile.readline()
-                    break
-                out.append(self.rfile.read(n))
-                self.rfile.readline()
-            return b"".join(out)
-        n = int(self.headers.get("Content-Length", 0) or 0)
-        return self.rfile.read(n) if n else b""
-
-    def _record(self, body):
-        with LOCK:
-            REQS.append({"method": self.command, "path": self.path,
-                         "headers": {k.lower(): v for k, v in self.headers.items()},
-                         "body": body.decode("utf-8", "replace")})
-
-    def _send(self, code, body, ctype="application/json", extra=None):
-        self.send_response(code)
-        self.send_header("Content-Type", ctype)
-        for k, v in (extra or {}).items():
-            self.send_header(k, v)
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def do_GET(self):
-        self._record(self._body())
-        p = self.path
-        if "/powerbi/databases/v201606/workspaces" in p:
-            # ADOMD's ROUTING call. A BARE ARRAY, not a {"value": [...]}
-            # envelope — an envelope fails as "workspace is not found".
-            # `capacitySku` is an ENUM VALUE ("Premium"); an SKU name like "P1"
-            # fails as `Requested value 'P1' was not found`. `capacityUri` needs
-            # >= 1 PATH SEGMENT; a bare origin gives IndexOutOfRangeException.
-            return self._send(200, json.dumps([{
-                "id": WS, "name": WS, "type": "Group", "capacitySku": "Premium",
-                "capacityUri": f"https://{HOST}:{PORT}/{WS}"}]).encode(),
-                "application/json; charset=utf-8")
-        if "/datasets" in p:
-            return self._send(200, json.dumps({"value": [
-                {"id": "11111111-1111-1111-1111-111111111111",
-                 "name": DATASET}]}).encode())
-        if "/groups" in p:
-            # ECHO the requested name: sempy filters by `name eq '<x>'` and then
-            # matches the result against what it asked for.
-            m = re.search(r"name%20eq%20'([^']+)'|name eq '([^']+)'", p)
-            want = (m.group(1) or m.group(2)) if m else WS
-            return self._send(200, json.dumps({"value": [
-                {"id": WS, "name": want, "type": "Workspace"}]}).encode())
-        return self._send(404, b'{"error":"capture"}')
-
-    def do_POST(self):
-        body = self._body()
-        self._record(body)
-        p, text = self.path, body.decode("utf-8", "replace")
-        if "getDatabaseName" in p:
-            # DISCOVERED BY DRIVING A REAL CLIENT. Absent from e2e/xmla entirely.
-            return self._send(200, json.dumps({"databaseName": DATASET}).encode())
-        if "clusterResolve" in p:
-            return self._send(200, json.dumps({
-                "clusterFQDN": HOST, "coreServerName": "ws", "tenantId": WS}).encode())
-        if "generateastoken" in p:
-            return self._send(200, b'{"Token":"emulator-mwc-token"}')
-        if "executeQueries" in p:
-            return self._send(200, json.dumps(
-                {"results": [{"tables": [{"rows": [{"[Value]": 1}]}]}]}).encode())
-        if "/webapi/xmla" in p or p.endswith("/xmla"):
-            caps = {"x-ms-xmlacaps-negotiation-flags": "0,0,0,0,0"}
-            # ORDER MATTERS: a batched Execute CONTAINS <Discover> children, so
-            # a broad `"<Discover" in text` check shadows it entirely.
-            rts = re.findall(r"<RequestType>(TMSCHEMA_\w+)</RequestType>", text)
-            if rts and "<Batch" in text:
-                pop = sum(1 for t in rts if t in POPULATED)
-                print(f"    -> batch of {len(rts)}: {pop} populated, "
-                      f"{len(rts) - pop} empty", flush=True)
-                return self._send(200, batch_response(rts),
-                                  "text/xml; charset=utf-8", caps)
-            if "<Discover" in text:
-                dbid = re.search(r"<DatabaseID>([^<]*)</DatabaseID>", text)
-                return self._send(200, rowset("DiscoverResponse", ["METADATA"],
-                                              [assl(bool(dbid))]),
-                                  "text/xml; charset=utf-8", caps)
-            # Session handshake and any Execute we do not model: a bare
-            # ExecuteResponse plus the trailing 0x00 protocol byte (0 =
-            # complete, 1 = LRO continuation, anything else = a transport
-            # protocol error).
-            env = (
-                '<?xml version="1.0" encoding="utf-8"?>'
-                '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
-                '<soap:Header><Session xmlns="urn:schemas-microsoft-com:xml-analysis" '
-                f'SessionId="{SESSION}"/></soap:Header><soap:Body>'
-                '<ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">'
-                '<return><root xmlns="urn:schemas-microsoft-com:xml-analysis:empty"/>'
-                '</return></ExecuteResponse></soap:Body></soap:Envelope>'
-            ).encode() + b"\x00"
-            return self._send(200, env, "text/xml; charset=utf-8", caps)
-        return self._send(404, b'{"error":"capture"}')
-
-    def log_message(self, *a):
-        pass
-
-
-class TLSServer(http.server.ThreadingHTTPServer):
-    daemon_threads = True
-    allow_reuse_address = True
-
-
-# --------------------------------------------------------------------------
-# Run
-# --------------------------------------------------------------------------
-require_sole_run()
-require_free_port(PORT)
 if not shutil.which("docker"):
     skip_or_fail("docker is not on PATH; sempy's XMLA path needs a linux/amd64 "
                  ".NET runtime and cannot run on this host directly")
-if not shutil.which("openssl"):
-    skip_or_fail("openssl is not on PATH, so no TLS cert can be issued")
 
-WORK = tempfile.mkdtemp(prefix="sempy-e2e-")
-subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048",
-                "-keyout", os.path.join(WORK, "key.pem"),
-                "-out", os.path.join(WORK, "cert.pem"),
-                "-days", "2", "-nodes", "-subj", f"/CN={HOST}",
-                "-addext", f"subjectAltName=DNS:{HOST},DNS:localhost,IP:127.0.0.1"],
-               check=True, capture_output=True)
+require_free_port(ENTRA_PORT, "entra")
+require_free_port(FABRIC_PORT, "fabric")
 
-ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-ctx.minimum_version = ssl.TLSVersion.TLSv1_2
-ctx.load_cert_chain(os.path.join(WORK, "cert.pem"), os.path.join(WORK, "key.pem"))
-srv = TLSServer(("0.0.0.0", PORT), Capture)
-srv.socket = ctx.wrap_socket(srv.socket, server_side=True)
-threading.Thread(target=srv.serve_forever, daemon=True).start()
-log(f"capture listener on :{PORT}")
+log(f"work dir: {WORK}")
+log("building the emulator")
+fabric_bin = os.path.join(WORK, "fabric-emulator" + EXE)
+subprocess.run(["go", "build", "-C", REPO, "-o", fabric_bin, "./cmd/fabric-emulator"],
+               check=True)
+# PIN THE VERSION, do not trust PATH. `ensure_entra_emulator` returns a PATH hit
+# without checking its version, and a locally-built `dev` entra predates the
+# family GUID migration — its tenant is not the one go.mod pins, so every token
+# fails as `AADSTS90002: Unknown tenant`. A suite that pins a version in go.mod
+# must not silently witness against whatever is installed: "which binary did
+# this prove?" has to have one answer.
+entra_ver = module_version("github.com/calvinchengx/entra-emulator")
+log(f"installing entra-emulator {entra_ver} (ignoring any PATH build)")
+subprocess.run(["go", "install",
+                f"github.com/calvinchengx/entra-emulator/cmd/entra-emulator@{entra_ver}"],
+               check=True, cwd=REPO, env={**os.environ, "GOBIN": WORK})
+entra_bin = os.path.join(WORK, "entra-emulator" + EXE)
 
-# The client dials 443 whatever port the Data Source names — the endpoint
-# address is DERIVED. Distinct container name from e2e/xmla's `xmla-e2e-443`:
-# a shared name means one suite's cleanup kills the other's forwarder.
-subprocess.run(["docker", "rm", "-f", FORWARDER], capture_output=True)
-fwd = subprocess.run(
-    ["docker", "run", "-d", "--rm", "--name", FORWARDER,
-     "--add-host", f"{HOST}:host-gateway", "-p", "443:443", "alpine/socat",
-     "TCP-LISTEN:443,fork,reuseaddr", f"TCP:{HOST}:{PORT}"],
-    capture_output=True, text=True)
-if fwd.returncode:
-    srv.shutdown()
-    skip_or_fail("could not publish 443; the client dials it after routing, so "
-                 "nothing past the token would be captured")
-log("443 forwarder up")
+try:
+    log(f"starting entra on :{ENTRA_PORT}, fabric on :{FABRIC_PORT} (TLS ON)")
+    start("entra", [entra_bin], {**os.environ, "ORIGIN_MODE": "compat",
+          "PORT": ENTRA_PORT, "DB_PATH": os.path.join(WORK, "entra.sqlite"),
+          "TLS_CERT_DIR": os.path.join(WORK, "entra-tls")})
+    # TLS stays ON: the client will not speak plain HTTP to an XMLA endpoint,
+    # and the emulator's own cert already carries api.fabric.microsoft.com.
+    start("fabric", [fabric_bin, "-addr", f"0.0.0.0:{FABRIC_PORT}",
+                     "-data-dir", os.path.join(WORK, "data"),
+                     "-entra-issuer", f"https://localhost:{ENTRA_PORT}/{TENANT}/v2.0",
+                     "-entra-tls-insecure"], {**os.environ, "FABRIC_TRACE": "1"})
+    wait_healthy(f"{ENTRA}/health")
+    wait_healthy(f"{FABRIC}/health")
 
-log("building the sempy image (cached after the first run)")
-build = subprocess.run(
-    ["docker", "build", "--platform", "linux/amd64", "-q", "-t", "sempy-e2e:local",
-     os.path.join(DIR, "image")], capture_output=True, text=True)
-if build.returncode:
+    log("seeding the Power BI resource app")
+    try:
+        http("POST", f"{ENTRA}/admin/api/apps",
+             {"displayName": "Power BI Service", "appIdUri": PBI_AUDIENCE,
+              "isConfidential": False})
+    except urllib.error.HTTPError as e:
+        # 409 = already seeded. 404 = this entra version has no such admin route
+        # and pre-seeds the resource app itself; the token call below is the
+        # real check either way, so failing here would be failing on a detail
+        # that does not decide anything.
+        if e.code not in (404, 409):
+            raise
+
+    def token(scope):
+        return http("POST", f"{ENTRA}/{TENANT}/oauth2/v2.0/token",
+                    {"grant_type": "client_credentials", "client_id": CLIENT_ID,
+                     "client_secret": CLIENT_SECRET, "scope": scope},
+                    form=True)[2]["access_token"]
+
+    ft = token("https://api.fabric.microsoft.com/.default")
+    ws = http("POST", f"{FABRIC}/v1/workspaces", {"displayName": "sempy-ws"},
+              token=ft)[2]["id"]
+
+    def part(path, fname):
+        return {"path": path, "payloadType": "InlineBase64",
+                "payload": base64.b64encode(open(os.path.join(FIX, fname), "rb").read()).decode()}
+
+    _, hdrs, created = http("POST", f"{FABRIC}/v1/workspaces/{ws}/items", {
+        "displayName": "RetailAnalysis", "type": "SemanticModel",
+        "definition": {"parts": [part("model.bim", "retail.bim"),
+                                 part("data.json", "seed_data.json")]}}, token=ft)
+    # BOTH SHAPES: item creation may complete synchronously (the response body
+    # carries the item) or return 202 with an operation to poll. Assuming the
+    # async one polls `/operations/None` and 404s, which reads as a missing
+    # route rather than a wrong assumption about the response.
+    opid = hdrs.get("x-ms-operation-id")
+    dataset = created.get("id") if isinstance(created, dict) else None
+    for _ in range(0 if dataset or not opid else 120):
+        if http("GET", f"{FABRIC}/v1/operations/{opid}", token=ft)[2].get("status") == "Succeeded":
+            dataset = http("GET", f"{FABRIC}/v1/operations/{opid}/result", token=ft)[2]["id"]
+            break
+        time.sleep(0.1)
+    if not dataset:
+        raise SystemExit("FAILED: the SemanticModel item never finished creating")
+    log(f"workspace={ws} dataset={dataset}")
+
+    pbi = token(PBI_AUDIENCE + "/.default")
+
+    # The client dials :443 after routing whatever port the Data Source named,
+    # so publish 443 into the emulator. Distinct container name from e2e/xmla's,
+    # or one suite's cleanup kills the other's forwarder mid-run.
     subprocess.run(["docker", "rm", "-f", FORWARDER], capture_output=True)
-    srv.shutdown()
-    raise SystemExit("FAILED: could not build the sempy image\n" + build.stderr[-800:])
+    fwd = subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", FORWARDER,
+         "--add-host", "host.docker.internal:host-gateway", "-p", "443:443",
+         "alpine/socat", "TCP-LISTEN:443,fork,reuseaddr",
+         f"TCP:host.docker.internal:{FABRIC_PORT}"], capture_output=True, text=True)
+    if fwd.returncode:
+        skip_or_fail("could not publish 443; the client dials it after routing, so "
+                     "nothing past the token would reach the emulator")
+    log("443 forwarder up")
 
-log("running sempy (linux/amd64)")
-proc = subprocess.run([
-    "docker", "run", "--rm", "--platform", "linux/amd64",
-    "--add-host", f"{HOST}:host-gateway",
-    "-v", f"{os.path.join(DIR, 'driver.py')}:/driver.py:ro",
-    "-v", f"{os.path.join(WORK, 'cert.pem')}:/usr/local/share/ca-certificates/sempy.crt:ro",
-    "-e", f"SEMPY_HOST=https://{HOST}:{PORT}/", "-e", f"SEMPY_WORKSPACE={WS}",
-    "-e", f"SEMPY_DATASET={DATASET}", "-e", f"SEMPY_MARKER={MARKER}",
-    "sempy-e2e:local", "sh", "-c",
-    "update-ca-certificates >/dev/null 2>&1; "
-    "REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt "
-    "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt /v/bin/python /driver.py",
-], capture_output=True, text=True, timeout=1800)
-srv.shutdown()
-subprocess.run(["docker", "rm", "-f", FORWARDER], capture_output=True)
+    log("building the sempy image (cached after the first run)")
+    if subprocess.run(["docker", "build", "--platform", "linux/amd64", "-q",
+                       "-t", "sempy-e2e:local", os.path.join(DIR, "image")],
+                      capture_output=True, text=True).returncode:
+        raise SystemExit("FAILED: could not build the sempy image")
+
+    cert = os.path.join(WORK, "data", "tls", "cert.pem")
+    if not os.path.exists(cert):
+        raise SystemExit(f"FAILED: the emulator did not write a TLS cert at {cert}")
+
+    log("running sempy against the emulator (linux/amd64)")
+    proc = subprocess.run([
+        "docker", "run", "--rm", "--platform", "linux/amd64",
+        "--add-host", f"{CLIENT_HOST}:host-gateway",
+        "-v", f"{os.path.join(DIR, 'driver.py')}:/driver.py:ro",
+        "-v", f"{cert}:/usr/local/share/ca-certificates/fabric-emulator.crt:ro",
+        "-e", f"SEMPY_HOST=https://{CLIENT_HOST}/",
+        "-e", f"SEMPY_WORKSPACE={ws}", "-e", "SEMPY_DATASET=RetailAnalysis",
+        "-e", f"SEMPY_TOKEN={pbi}",
+        "sempy-e2e:local", "sh", "-c",
+        "update-ca-certificates >/dev/null 2>&1; "
+        "REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt "
+        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt /v/bin/python /driver.py",
+    ], capture_output=True, text=True, timeout=1800)
+finally:
+    cleanup()
 
 out = [ln[3:] for ln in proc.stdout.splitlines() if ln.startswith("###")]
 if not out:
     raise SystemExit("FAILED: the driver produced no cases — that is a missing "
-                     "measurement, not a result.\n" + proc.stderr[-1200:])
+                     "measurement, not a result.\n" + proc.stderr[-1500:])
 print("\n---- driver ----", flush=True)
 for ln in out:
     print("  " + ln, flush=True)
 
-rows = dict(
-    (m.group(1), int(m.group(2)))
-    for m in (re.match(r"RESULT (\S+) :: OK :: \w+ :: rows=(-?\d+)", ln)
-              for ln in out) if m)
+results, rows = {}, {}
+for ln in out:
+    if ln.startswith("RESULT "):
+        parts = ln.split(" :: ")
+        name = parts[0].split(" ", 1)[1]
+        results[name] = parts[1] if len(parts) > 1 else "?"
+        for p in parts:
+            if p.startswith("rows="):
+                rows[name] = int(p[5:])
 rowtext = "\n".join(ln for ln in out if ln.startswith("ROW "))
 
-results = dict(
-    (m.group(1), m.group(2))
-    for m in (re.match(r"RESULT (\S+) :: (\S+)", ln) for ln in out) if m)
-bodies = "\n".join(r["body"] for r in REQS)
-paths = [r["path"] for r in REQS]
-xmla = [r for r in REQS if "xmla" in r["path"]]
-
-
-def verbs(kind):
-    return [r for r in xmla if f"<{kind}" in r["body"]]
-
-
 CHECKS = [
-    ("sempy is redirectable: REST calls arrive here",
-     any("/v1.0/myorg/" in p for p in paths)),
-    ("the auth control confirms OUR token, decoded",
+    ("the entra-minted token is what sempy resolves",
      any(ln.startswith("AUTH mine=True") for ln in out)),
-    ("list_workspaces returns a DataFrame over REST",
+    ("list_workspaces returns a DataFrame from the emulator",
      results.get("list_workspaces") == "OK"),
-    ("list_datasets returns a DataFrame (needs the ASSL Discover)",
-     results.get("list_datasets") == "OK"),
-    ("routing: the client asks for workspaces on the ADOMD path",
-     any("/powerbi/databases/v201606/workspaces" in p for p in paths)),
-    ("getDatabaseName is issued, with its documented body",
-     any("getDatabaseName" in p for p in paths)
-     and '"datasetName"' in bodies and '"workspaceType"' in bodies),
-    ("the client reaches XMLA at all", len(xmla) > 0),
-    ("evaluate_dax sends Execute with the DAX in a Statement",
-     "<Statement>EVALUATE {1}</Statement>" in bodies),
-    ("evaluate_dax does NOT use executeQueries",
-     not any("executeQueries" in p for p in paths)),
-    ("Discover asks for DISCOVER_XML_METADATA with ExpandObject",
-     "DISCOVER_XML_METADATA" in bodies and "ExpandObject" in bodies),
-    ("both Discover scopes appear (server-level and DatabaseID-scoped)",
-     any("<DatabaseID>" not in r["body"] for r in verbs("Discover"))
-     and any("<DatabaseID>" in r["body"] for r in verbs("Discover"))),
-    # NAMED PRECISELY: the SOAP verb is Execute, but the payload is a BATCH of
-    # Discover elements, not SQL. An earlier version of this check said "as an
-    # Execute", which is true on the verb and misleading about the grammar —
-    # and it misled another session's design before being caught.
-    # CONTENT, not just a type. Every one of these returned a DataFrame long
-    # before it returned a CORRECT one, and an empty frame reads as success.
-    ("the full metadata surface returns DataFrames",
+    ("list_datasets sees the published SemanticModel",
+     results.get("list_datasets") == "OK" and rows.get("list_datasets", 0) > 0),
+    ("evaluate_dax returns the emulator's own DAX result over XMLA",
+     results.get("evaluate_dax") == "OK"),
+    ("the TOM metadata path returns DataFrames",
      all(results.get(f) == "OK" for f in
-         ("list_measures", "list_tables", "list_columns",
-          "list_partitions", "list_relationships"))),
-    ("list_measures carries the measure, joined to its table, with its DAX",
-     rows.get("list_measures", 0) > 0
-     and "SUM(Sales[Amount])" in rowtext and "Total" in rowtext),
-    ("list_columns resolves the column and its ColumnType enum",
-     rows.get("list_columns", 0) > 0 and "Amount" in rowtext
-     and "Data" in rowtext),
-    ("list_tables returns the seeded table", rows.get("list_tables", 0) > 0),
-    ("an unseeded rowset is empty rather than wrong",
-     rows.get("list_relationships", -1) == 0),
-    ("TMSCHEMA arrives as a Batch of Discover inside one Execute",
-     "TMSCHEMA" in bodies
-     and any("<Batch" in r["body"] and "TMSCHEMA" in r["body"]
-             and "<Discover" in r["body"] for r in xmla)),
-    ("TOM batches the whole TMSCHEMA catalogue in one round trip",
-     max((len(re.findall(r"<RequestType>TMSCHEMA_", r["body"])) for r in xmla),
-         default=0) >= 30),
-    ("the TMSCHEMA batch is restricted by DatabaseName",
-     any("<Batch" in r["body"] and "<DatabaseName>" in r["body"] for r in xmla)),
+         ("list_measures", "list_tables", "list_columns", "list_partitions"))),
+    ("list_tables carries the SEEDED model's tables, not an empty frame",
+     rows.get("list_tables", 0) > 0),
+    ("list_measures carries the seeded model's measures",
+     rows.get("list_measures", 0) > 0),
+    ("list_columns carries the seeded model's columns",
+     rows.get("list_columns", 0) > 0),
 ]
 
-print("\n---- contract ----", flush=True)
-failed = [name for name, ok in CHECKS if not ok]
-for name, ok in CHECKS:
-    print(f"  {'PASS' if ok else 'FAIL'}  {name}", flush=True)
-
-print(f"\n{len(REQS)} request(s) captured, {len(xmla)} of them XMLA", flush=True)
+print("\n---- witness ----", flush=True)
+failed = [n for n, ok in CHECKS if not ok]
+for n, ok in CHECKS:
+    print(f"  {'PASS' if ok else 'FAIL'}  {n}", flush=True)
 if failed:
-    raise SystemExit("FAILED: " + str(len(failed)) + " contract check(s) regressed:\n  "
-                     + "\n  ".join(failed))
-print("\nPASSED: the SemPy client contract is unchanged.")
+    dump_logs()
+    raise SystemExit(f"FAILED: {len(failed)} check(s):\n  " + "\n  ".join(failed))
+print("\nPASSED: Microsoft's SemPy drives the emulator's XMLA surface.")

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -241,6 +241,7 @@ func (a *API) Register(mux *http.ServeMux) {
 	a.registerLivy(mux)
 	a.registerShortcuts(mux)
 	a.registerExecuteQueries(mux)
+	a.registerXMLA(mux)
 	a.registerDatasets(mux)
 	a.registerRefreshes(mux)
 	a.registerDatasources(mux)

--- a/internal/api/xmla.go
+++ b/internal/api/xmla.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"encoding/xml"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/calvinchengx/fabric-emulator/internal/auth"
+	"github.com/calvinchengx/fabric-emulator/internal/httpx"
 	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
 	"github.com/calvinchengx/fabric-emulator/internal/xmla"
 )
@@ -104,7 +104,13 @@ func (a *API) xmlaDatabaseName(w http.ResponseWriter, r *http.Request, p *auth.P
 	var req struct {
 		DatasetName string `json:"datasetName"`
 	}
-	_ = json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req)
+	raw, ok := httpx.ReadBounded(r.Body, 1<<20)
+	if !ok {
+		writeErr(w, http.StatusRequestEntityTooLarge, "RequestTooLarge",
+			"The request body is too large.")
+		return
+	}
+	_ = json.Unmarshal(raw, &req)
 	name := req.DatasetName
 	if name == "" {
 		name = "model"
@@ -135,9 +141,14 @@ func (a *API) xmlaClusterResolve(w http.ResponseWriter, r *http.Request, p *auth
 
 // xmlaEndpoint serves the XMLA conversation itself.
 func (a *API) xmlaEndpoint(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, 8<<20))
-	if err != nil {
-		writeErr(w, http.StatusBadRequest, "BadRequest", "unreadable body")
+	// ReadBounded, not a bare LimitReader: a LimitReader DISCARDS the excess and
+	// reports success, so an oversized envelope would be parsed as a fragment —
+	// a truncated Batch would silently answer fewer rowsets than were asked for,
+	// which is exactly the count mismatch that breaks table naming.
+	body, ok := httpx.ReadBounded(r.Body, 8<<20)
+	if !ok {
+		writeErr(w, http.StatusRequestEntityTooLarge, "RequestTooLarge",
+			"The XMLA request body is too large.")
 		return
 	}
 	text := string(body)

--- a/internal/api/xmla.go
+++ b/internal/api/xmla.go
@@ -232,9 +232,28 @@ func (a *API) xmlaDatabaseName(w http.ResponseWriter, r *http.Request, p *auth.P
 		return
 	}
 	_ = json.Unmarshal(raw, &req)
-	name := req.DatasetName
+	// RESOLVE, never echo. Returning the caller's own string reflects
+	// user-controlled input into the response — CodeQL flags it as
+	// `go/reflected-xss`, and it is also simply the wrong answer: this endpoint
+	// exists to MAP a dataset name onto the database that backs it, so parroting
+	// the request would "succeed" for a dataset that does not exist and the
+	// client would then open a connection to nothing.
+	name := ""
+	for _, ws := range a.xmlaVisibleWorkspaces(p) {
+		items, err := a.Store.ListItems(ws.ID, "SemanticModel")
+		if err != nil {
+			continue
+		}
+		for _, it := range items {
+			if strings.EqualFold(it.DisplayName, req.DatasetName) {
+				name = it.DisplayName // the STORED name, not the supplied one
+			}
+		}
+	}
 	if name == "" {
-		name = "model"
+		writeErr(w, http.StatusNotFound, "DatasetNotFound",
+			"No semantic model with that name is visible to this principal.")
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"databaseName": name})
 }
@@ -505,6 +524,16 @@ func (a *API) xmlaDatabaseIdentity(r *http.Request, p *auth.Principal) (name, id
 		return it.DisplayName, id
 	}
 	return id, id
+}
+
+// xmlaVisibleWorkspaces wraps the shared helper with a nil-principal guard: the
+// unauthenticated clusterResolve path has no principal, and a nil deref there
+// would be a crash on the one route that is deliberately open.
+func (a *API) xmlaVisibleWorkspaces(p *auth.Principal) []*store.Workspace {
+	if p == nil {
+		return nil
+	}
+	return a.visibleWorkspaces(p)
 }
 
 // xmlaItem is the SemanticModel item this connection is bound to.

--- a/internal/api/xmla.go
+++ b/internal/api/xmla.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 
 	"fmt"
 
 	"github.com/calvinchengx/fabric-emulator/internal/auth"
 	"github.com/calvinchengx/fabric-emulator/internal/httpx"
 	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+	"github.com/calvinchengx/fabric-emulator/internal/store"
 	"github.com/calvinchengx/fabric-emulator/internal/xmla"
 )
 
@@ -57,10 +59,103 @@ var reRequestType = regexp.MustCompile(`<RequestType>([^<]+)</RequestType>`)
 func (a *API) registerXMLA(mux *http.ServeMux) {
 	mux.HandleFunc("GET /powerbi/databases/v201606/workspaces", a.withPBIAuth(a.xmlaRouting))
 	mux.HandleFunc("POST /metadata/v201606/generateastoken", a.withPBIAuth(a.xmlaToken))
+	// PAST THE TOKEN EXCHANGE THE CLIENT PRESENTS *OUR* TOKEN, not the AAD one.
+	// That is the whole point of generateastoken: the service hands back a
+	// short-lived MWC token and the client uses it from then on. Requiring an
+	// AAD bearer on these routes rejects the client's own correct behaviour and
+	// reports it as `missing bearer token`, which reads as a client fault.
 	mux.HandleFunc("POST /powerbi/databases/v201606/workspaces/{ws}/getDatabaseName",
-		a.withPBIAuth(a.xmlaDatabaseName))
-	mux.HandleFunc("POST /webapi/clusterResolve", a.withPBIAuth(a.xmlaClusterResolve))
-	mux.HandleFunc("POST /webapi/xmla", a.withPBIAuth(a.xmlaEndpoint))
+		a.withXMLAAuth(a.xmlaDatabaseName))
+	// UNAUTHENTICATED, and that is the client's behaviour, not an oversight.
+	// MEASURED: ADOMD.NET sends clusterResolve with NO Authorization header at
+	// all — it is asking which host to talk to, before it has decided what
+	// credential that host wants. Requiring a bearer here rejects a correct
+	// client and reports it as `missing bearer token`. Nothing is disclosed: the
+	// reply is the caller's own host and a fixed server name, both of which the
+	// caller already knows.
+	mux.HandleFunc("POST /webapi/clusterResolve", a.xmlaClusterResolveOpen)
+	mux.HandleFunc("POST /webapi/xmla", a.withXMLAAuth(a.xmlaEndpoint))
+	// The Power BI workspace list. Not part of XMLA, but the first call a real
+	// SemPy client makes — `list_workspaces` — and without it the client gets a
+	// 404 with an empty body and reports `JSONDecodeError`, which names the
+	// parser rather than the missing route.
+	mux.HandleFunc("GET /v1.0/myorg/groups", a.withPBIAuth(a.listPBIGroups))
+}
+
+// mwcToken is what generateastoken issues and what the client presents
+// afterwards. It is not a credential: nothing outside this process mints or
+// validates it, and it carries no claims. It exists because the client's flow
+// requires a token to come back and be usable.
+const mwcToken = "fabric-emulator-mwc-token"
+
+// mwcHolder is the principal that obtained the MWC token. The token must carry
+// an identity or the calls it authorises can see nothing: a fabricated
+// principal owns no workspace, so `list_measures` would return an EMPTY frame
+// rather than an error — well formed, never failing, and wrong. Recording who
+// asked keeps the answer attributable.
+var (
+	mwcMu     sync.RWMutex
+	mwcHolder *auth.Principal
+)
+
+// withXMLAAuth accepts EITHER an AAD Power BI token or the MWC token this
+// server issued. The principal for an MWC-token call is the one that obtained
+// it — modelled here as the caller of record, since a single-tenant emulator
+// has no separate service identity to attribute it to.
+func (a *API) withXMLAAuth(h handler) http.HandlerFunc {
+	pbi := a.withPBIAuth(h)
+	return func(w http.ResponseWriter, r *http.Request) {
+		// The scheme is `MwcToken`, NOT `Bearer` — measured off the wire:
+		//     Authorization: MwcToken fabric-emulator-mwc-token
+		// Stripping only "Bearer " leaves the whole header unmatched, the
+		// request falls through to AAD validation, and a correct client is
+		// refused with `missing bearer token`.
+		raw := strings.TrimSpace(r.Header.Get("Authorization"))
+		tok := raw
+		for _, scheme := range []string{"MwcToken ", "Bearer "} {
+			if len(raw) >= len(scheme) && strings.EqualFold(raw[:len(scheme)], scheme) {
+				tok = strings.TrimSpace(raw[len(scheme):])
+				break
+			}
+		}
+		if tok == mwcToken && a.xmlaMWCPrincipal() != nil {
+			// Attribute to the workspace owner rather than inventing an
+			// anonymous principal: an unattributed write would be worse than a
+			// slightly generous read.
+			h(w, r, a.xmlaMWCPrincipal())
+			return
+		}
+		pbi(w, r)
+	}
+}
+
+// xmlaMWCPrincipal is the identity an MWC-token call runs as: whoever exchanged
+// an AAD token for it. Nil until that exchange happens, and a nil principal is
+// refused rather than defaulted — a token nobody asked for should not authorise
+// anything.
+func (a *API) xmlaMWCPrincipal() *auth.Principal {
+	mwcMu.RLock()
+	defer mwcMu.RUnlock()
+	return mwcHolder
+}
+
+// listPBIGroups answers the Power BI `groups` shape: an OData-style envelope,
+// unlike the ADOMD routing call above which is a bare array. The two differ
+// deliberately and the client refuses each in the other's shape.
+func (a *API) listPBIGroups(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
+	wss, err := a.Store.ListWorkspacesFor(p.ID)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "InternalError", err.Error())
+		return
+	}
+	out := make([]map[string]any, 0, len(wss))
+	for _, ws := range wss {
+		out = append(out, map[string]any{
+			"id": ws.ID, "name": ws.DisplayName, "type": "Workspace",
+			"isReadOnly": false, "isOnDedicatedCapacity": true,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"value": out})
 }
 
 // xmlaRouting answers the client's first call.
@@ -72,20 +167,43 @@ func (a *API) registerXMLA(mux *http.ServeMux) {
 // `ArgumentException: Requested value 'P1' was not found`. `capacityUri` needs
 // at least ONE PATH SEGMENT; a bare origin gives IndexOutOfRangeException.
 func (a *API) xmlaRouting(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
-	ws := r.URL.Query().Get("workspaceName")
-	if ws == "" {
-		ws = "ws"
-	}
+	// A LIST, and every workspace the caller can see. The client matches the
+	// reply's `name` against the workspace in its own Data Source and refuses a
+	// mismatch as `The specified Power BI workspace ('<x>') is not found` —
+	// which reads as a lookup miss and is really the server answering about a
+	// different workspace. Returning them all means the client finds its own
+	// rather than this handler guessing which was meant, and sempy names a
+	// workspace by GUID while a human names it by title.
 	base := externalBase(r)
-	writeJSON(w, http.StatusOK, []map[string]any{{
-		"id":           workspaceRoutingID,
-		"name":         ws,
-		"type":         "Group",
-		"capacitySku":  "Premium",
-		"capacityUri":  base + "/" + workspaceRoutingID,
-		"tenantId":     workspaceRoutingID,
-		"fixedCluster": base,
-	}})
+	wss, err := a.Store.ListWorkspacesFor(p.ID)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "InternalError", err.Error())
+		return
+	}
+	out := make([]map[string]any, 0, len(wss)*2)
+	add := func(id, name string) {
+		out = append(out, map[string]any{
+			"id": id, "name": name, "type": "Group",
+			// An ENUM VALUE, not an SKU name: "P1" fails as
+			// `Requested value 'P1' was not found`.
+			"capacitySku": "Premium",
+			// >= 1 PATH SEGMENT; a bare origin gives IndexOutOfRangeException.
+			"capacityUri": base + "/" + id,
+			"tenantId":    workspaceRoutingID,
+		})
+	}
+	for _, ws := range wss {
+		// BOTH the id and the display name: the client compares by whichever
+		// string its Data Source carries, and we cannot tell which that is.
+		add(ws.ID, ws.ID)
+		if ws.DisplayName != "" && ws.DisplayName != ws.ID {
+			add(ws.ID, ws.DisplayName)
+		}
+	}
+	if len(out) == 0 {
+		add(workspaceRoutingID, "ws")
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
 // workspaceRoutingID is the stable id the routing reply and clusterResolve
@@ -95,7 +213,10 @@ const workspaceRoutingID = "00000000-0000-0000-0000-000000000001"
 // xmlaToken answers the MWC token exchange. The contract is a single `Token`
 // member, read off ADOMD.NET's own DataContract rather than guessed.
 func (a *API) xmlaToken(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
-	writeJSON(w, http.StatusOK, map[string]string{"Token": "fabric-emulator-mwc-token"})
+	mwcMu.Lock()
+	mwcHolder = p
+	mwcMu.Unlock()
+	writeJSON(w, http.StatusOK, map[string]string{"Token": mwcToken})
 }
 
 // xmlaDatabaseName resolves a dataset name to the database the XMLA connection
@@ -127,6 +248,12 @@ func (a *API) xmlaDatabaseName(w http.ResponseWriter, r *http.Request, p *auth.P
 // was never ours to send. Answering with the sibling contract
 // (`PowerBIClusterResolutionResult`, FixedClusterUri/DynamicClusterUri) leaves
 // Host null and throws `UriFormatException: The hostname could not be parsed`.
+// xmlaClusterResolveOpen is the unauthenticated entry point; the handler proper
+// takes no principal because it reads nothing owned by one.
+func (a *API) xmlaClusterResolveOpen(w http.ResponseWriter, r *http.Request) {
+	a.xmlaClusterResolve(w, r, nil)
+}
+
 func (a *API) xmlaClusterResolve(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
 	host := r.Host
 	if i := strings.IndexByte(host, ':'); i >= 0 {
@@ -210,8 +337,9 @@ func (a *API) xmlaDiscover(w http.ResponseWriter, r *http.Request, p *auth.Princ
 	requestType, text string) {
 	if requestType == "DISCOVER_XML_METADATA" {
 		dbScoped := strings.Contains(text, "<DatabaseID>")
-		rs := xmla.Rowset{Columns: []string{"METADATA"},
-			Rows: [][]string{{asslDocument(dbScoped, a.xmlaDatabaseID(r, p))}}}
+		name, id := a.xmlaDatabaseIdentity(r, p)
+		rs := xmla.Rowset{Columns: []string{"METADATA"}, RawCells: true,
+			Rows: [][]string{{asslDocument(dbScoped, name, id)}}}
 		writeXMLA(w, rs.DiscoverResponse())
 		return
 	}
@@ -269,9 +397,9 @@ func (a *API) xmlaExecute(w http.ResponseWriter, r *http.Request, p *auth.Princi
 // client is reading a Tabular.Database, absent a Tabular.Server.
 // CompatibilityLevel must be >= 1200 (below that the database is not "tabular")
 // and lives in nsCompat. `Model` is XmlIgnore on the type and must NOT appear.
-func asslDocument(databaseScoped bool, dbID string) string {
+func asslDocument(databaseScoped bool, dbName, dbID string) string {
 	db := `<Database xmlns="` + nsEngine + `">` +
-		`<Name>` + xmlEscape(dbID) + `</Name><ID>` + xmlEscape(dbID) + `</ID>` +
+		`<Name>` + xmlEscape(dbName) + `</Name><ID>` + xmlEscape(dbID) + `</ID>` +
 		`<ddl200:CompatibilityLevel xmlns:ddl200="` + nsCompat + `">1567` +
 		`</ddl200:CompatibilityLevel>` +
 		`<LastUpdate>2020-01-01T00:00:00</LastUpdate>` +
@@ -280,7 +408,7 @@ func asslDocument(databaseScoped bool, dbID string) string {
 		return db
 	}
 	return `<Server xmlns="` + nsEngine + `"><Name>ws</Name><ID>ws</ID><Databases>` +
-		`<Database><Name>` + xmlEscape(dbID) + `</Name><ID>` + xmlEscape(dbID) + `</ID>` +
+		`<Database><Name>` + xmlEscape(dbName) + `</Name><ID>` + xmlEscape(dbID) + `</ID>` +
 		`<LastUpdate>2020-01-01T00:00:00</LastUpdate></Database>` +
 		`</Databases></Server>`
 }
@@ -365,13 +493,43 @@ func (a *API) xmlaItemID(r *http.Request, p *auth.Principal) (string, error) {
 	return first, nil
 }
 
-// xmlaDatabaseID is the database name the ASSL document reports.
-func (a *API) xmlaDatabaseID(r *http.Request, p *auth.Principal) string {
+// xmlaDatabaseIdentity is the name and id the ASSL document reports, and TOM matches on it
+// — `DatasetNotFoundException: Dataset 'RetailAnalysis' not found` is what an id
+// here produces. The ID stays the item id so the two are still linked.
+func (a *API) xmlaDatabaseIdentity(r *http.Request, p *auth.Principal) (name, id string) {
 	id, err := a.xmlaItemID(r, p)
 	if err != nil {
-		return "model"
+		return "model", "model"
 	}
-	return id
+	if it := a.xmlaItem(r, p); it != nil && it.DisplayName != "" {
+		return it.DisplayName, id
+	}
+	return id, id
+}
+
+// xmlaItem is the SemanticModel item this connection is bound to.
+func (a *API) xmlaItem(r *http.Request, p *auth.Principal) *store.Item {
+	want := strings.TrimSpace(r.Header.Get("x-ms-xmlaserver"))
+	wss, err := a.Store.ListWorkspacesFor(p.ID)
+	if err != nil {
+		return nil
+	}
+	var first *store.Item
+	for _, ws := range wss {
+		items, err := a.Store.ListItems(ws.ID, "SemanticModel")
+		if err != nil {
+			continue
+		}
+		for _, it := range items {
+			if first == nil {
+				first = it
+			}
+			if want != "" && strings.EqualFold(it.DisplayName, want) {
+				return it
+			}
+		}
+	}
+	return first
 }
 
 // externalBase is the scheme://host the client should come back to. It is what

--- a/internal/api/xmla.go
+++ b/internal/api/xmla.go
@@ -1,0 +1,396 @@
+package api
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"fmt"
+
+	"github.com/calvinchengx/fabric-emulator/internal/auth"
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+	"github.com/calvinchengx/fabric-emulator/internal/xmla"
+)
+
+// The XMLA surface a real ADOMD.NET / TOM client demands before it will send a
+// single query. Every route and every shape here was MEASURED against
+// Microsoft's own clients in e2e/xmla and e2e/sempy, never inferred: each one
+// failed first in a way that named something other than its cause, and those
+// causes are recorded beside the code that satisfies them.
+//
+// The client's own sequence, which is the order below:
+//
+//	GET  /powerbi/databases/v201606/workspaces      routing
+//	POST /metadata/v201606/generateastoken          the MWC token
+//	POST /powerbi/.../workspaces/{ws}/getDatabaseName   dataset name -> database
+//	POST /webapi/clusterResolve                     which host serves it
+//	POST /webapi/xmla                               session, then Discover/Execute
+//
+// `getDatabaseName` exists here only because a REAL client was driven: a
+// hand-written probe connects with a database name it already knows, so that
+// call is invisible to one.
+
+const (
+	// nsEngine is ASSL's base namespace.
+	nsEngine = "http://schemas.microsoft.com/analysisservices/2003/engine"
+	// nsCompat carries CompatibilityLevel. NOT the 2003 engine namespace and
+	// NOT .../200/200 — read off Microsoft.AnalysisServices.Tabular.dll, where
+	// the property's XmlElementAttribute names exactly this.
+	nsCompat = "http://schemas.microsoft.com/analysisservices/2010/engine/200"
+	// nsMultipleResults wraps a <Batch> response. A DIFFERENT SCHEME from the
+	// urn:schemas-microsoft-com:xml-analysis:* family, not a suffix on it; a
+	// wrong container namespace is refused at the envelope before anything
+	// inside is read.
+	nsMultipleResults = "http://schemas.microsoft.com/analysisservices/2003/xmla-multipleresults"
+
+	// xmlaSessionID is echoed in the Session header. Nothing validates it; the
+	// client only requires that one comes back.
+	xmlaSessionID = "fabric-emulator-session"
+)
+
+var reRequestType = regexp.MustCompile(`<RequestType>([^<]+)</RequestType>`)
+
+// registerXMLA mounts the XMLA endpoint and the calls that precede it.
+func (a *API) registerXMLA(mux *http.ServeMux) {
+	mux.HandleFunc("GET /powerbi/databases/v201606/workspaces", a.withPBIAuth(a.xmlaRouting))
+	mux.HandleFunc("POST /metadata/v201606/generateastoken", a.withPBIAuth(a.xmlaToken))
+	mux.HandleFunc("POST /powerbi/databases/v201606/workspaces/{ws}/getDatabaseName",
+		a.withPBIAuth(a.xmlaDatabaseName))
+	mux.HandleFunc("POST /webapi/clusterResolve", a.withPBIAuth(a.xmlaClusterResolve))
+	mux.HandleFunc("POST /webapi/xmla", a.withPBIAuth(a.xmlaEndpoint))
+}
+
+// xmlaRouting answers the client's first call.
+//
+// A BARE ARRAY, not a {"value": [...]} envelope — an envelope fails as
+// `ConnectionException: The specified Power BI workspace (...) is not found`,
+// which reads like a lookup miss and is really a shape error. `capacitySku` is
+// an ENUM VALUE ("Premium"), not an SKU name: "P1" fails as
+// `ArgumentException: Requested value 'P1' was not found`. `capacityUri` needs
+// at least ONE PATH SEGMENT; a bare origin gives IndexOutOfRangeException.
+func (a *API) xmlaRouting(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
+	ws := r.URL.Query().Get("workspaceName")
+	if ws == "" {
+		ws = "ws"
+	}
+	base := externalBase(r)
+	writeJSON(w, http.StatusOK, []map[string]any{{
+		"id":           workspaceRoutingID,
+		"name":         ws,
+		"type":         "Group",
+		"capacitySku":  "Premium",
+		"capacityUri":  base + "/" + workspaceRoutingID,
+		"tenantId":     workspaceRoutingID,
+		"fixedCluster": base,
+	}})
+}
+
+// workspaceRoutingID is the stable id the routing reply and clusterResolve
+// agree on. The client carries it forward as `capacityObjectId`.
+const workspaceRoutingID = "00000000-0000-0000-0000-000000000001"
+
+// xmlaToken answers the MWC token exchange. The contract is a single `Token`
+// member, read off ADOMD.NET's own DataContract rather than guessed.
+func (a *API) xmlaToken(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
+	writeJSON(w, http.StatusOK, map[string]string{"Token": "fabric-emulator-mwc-token"})
+}
+
+// xmlaDatabaseName resolves a dataset name to the database the XMLA connection
+// then opens. Only a real client issues this.
+func (a *API) xmlaDatabaseName(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
+	var req struct {
+		DatasetName string `json:"datasetName"`
+	}
+	_ = json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req)
+	name := req.DatasetName
+	if name == "" {
+		name = "model"
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"databaseName": name})
+}
+
+// xmlaClusterResolve tells the client which host serves the workspace.
+//
+// The reply is deserialised as `ASAzureUtility+NameResolutionResult` —
+// `clusterFQDN`, `coreServerName`, `tenantId` — and consumed as
+// `new UriBuilder(dataSourceUri){ Host = r.ClusterFqdn }`. So clusterFQDN is a
+// BARE FQDN: no scheme, no port. The port is inherited from the Data Source and
+// was never ours to send. Answering with the sibling contract
+// (`PowerBIClusterResolutionResult`, FixedClusterUri/DynamicClusterUri) leaves
+// Host null and throws `UriFormatException: The hostname could not be parsed`.
+func (a *API) xmlaClusterResolve(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
+	host := r.Host
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		"clusterFQDN":    host,
+		"coreServerName": "ws",
+		"tenantId":       workspaceRoutingID,
+	})
+}
+
+// xmlaEndpoint serves the XMLA conversation itself.
+func (a *API) xmlaEndpoint(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 8<<20))
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "BadRequest", "unreadable body")
+		return
+	}
+	text := string(body)
+
+	// ORDER MATTERS: a batched Execute CONTAINS <Discover> children, so testing
+	// for "<Discover" first shadows the batch entirely.
+	types := reRequestType.FindAllStringSubmatch(text, -1)
+	switch {
+	case len(types) > 1 && strings.Contains(text, "<Batch"):
+		a.xmlaBatch(w, r, p, types)
+	case len(types) == 1:
+		a.xmlaDiscover(w, r, p, types[0][1], text)
+	case strings.Contains(text, "<Statement>"):
+		a.xmlaExecute(w, r, p, text)
+	default:
+		// The session handshake: an Execute with an EMPTY <Statement/>.
+		writeXMLA(w, sessionEnvelope())
+	}
+}
+
+// xmlaBatch answers TOM's catalogue request: one Execute whose Command is a
+// <Batch> of ~35 <Discover> elements, one <root> back per request IN ORDER.
+//
+// EVERY request type must yield a rowset with columns, including the ones this
+// model has none of. `AmoDataAdapter.AdjustTableNames` renames the DataSet's
+// tables from the <root name="..."> attributes and BAILS OUT ENTIRELY when the
+// name count does not match the table count — so a single column-less rowset,
+// which Fill skips, breaks naming for all the others and
+// `DdlUtil.ObtainModelTable`'s `Tables["Model"]` comes back null.
+func (a *API) xmlaBatch(w http.ResponseWriter, r *http.Request, p *auth.Principal,
+	types [][]string) {
+	model, data, err := a.xmlaModel(r, p)
+	if err != nil {
+		writeXMLA(w, soapFault(err.Error()))
+		return
+	}
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="utf-8"?>` +
+		`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">` +
+		`<soap:Body><ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">` +
+		`<return><results xmlns="` + nsMultipleResults + `">`)
+	for _, m := range types {
+		rs, err := xmla.DiscoverRowset(model, data, m[1])
+		if err != nil {
+			// An unrecognised type is not "this model has none of those"; say so
+			// rather than inventing an empty rowset for it.
+			writeXMLA(w, soapFault(err.Error()))
+			return
+		}
+		b.Write(rs.RootFragment())
+	}
+	b.WriteString(`</results></return></ExecuteResponse></soap:Body></soap:Envelope>`)
+	writeXMLA(w, append([]byte(b.String()), 0x00))
+}
+
+// xmlaDiscover answers a standalone Discover. DISCOVER_XML_METADATA carries an
+// ASSL document rather than a rowset of its own.
+func (a *API) xmlaDiscover(w http.ResponseWriter, r *http.Request, p *auth.Principal,
+	requestType, text string) {
+	if requestType == "DISCOVER_XML_METADATA" {
+		dbScoped := strings.Contains(text, "<DatabaseID>")
+		rs := xmla.Rowset{Columns: []string{"METADATA"},
+			Rows: [][]string{{asslDocument(dbScoped, a.xmlaDatabaseID(r, p))}}}
+		writeXMLA(w, rs.DiscoverResponse())
+		return
+	}
+	model, data, err := a.xmlaModel(r, p)
+	if err != nil {
+		writeXMLA(w, soapFault(err.Error()))
+		return
+	}
+	rs, err := xmla.DiscoverRowset(model, data, requestType)
+	if err != nil {
+		writeXMLA(w, soapFault(err.Error()))
+		return
+	}
+	writeXMLA(w, rs.DiscoverResponse())
+}
+
+// xmlaExecute runs the statement in the envelope. A DMV `SELECT ... FROM
+// $SYSTEM.TMSCHEMA_*` and a DAX `EVALUATE` arrive by the SAME route and differ
+// only in their grammar, which is why both are dispatched here.
+func (a *API) xmlaExecute(w http.ResponseWriter, r *http.Request, p *auth.Principal,
+	text string) {
+	stmt := betweenTags(text, "<Statement>", "</Statement>")
+	if strings.TrimSpace(stmt) == "" {
+		writeXMLA(w, sessionEnvelope())
+		return
+	}
+	model, data, err := a.xmlaModel(r, p)
+	if err != nil {
+		writeXMLA(w, soapFault(err.Error()))
+		return
+	}
+	var rs xmla.Rowset
+	if xmla.IsDMV(stmt) {
+		rs, err = xmla.DMV(model, data, stmt)
+		if err != nil {
+			writeXMLA(w, soapFault(err.Error()))
+			return
+		}
+	} else {
+		res, evalErr := semanticmodel.Evaluate(model, data, stmt)
+		if evalErr != nil {
+			writeXMLA(w, soapFault(evalErr.Error()))
+			return
+		}
+		rs = xmla.FromDAX(res)
+	}
+	writeXMLA(w, rs.ExecuteResponse())
+}
+
+// asslDocument is the DISCOVER_XML_METADATA payload, EMBEDDED as XML rather
+// than escaped — an escaped string deserialises to an empty root, which the
+// client reports as `Unexpected root ” (namespace ”)`.
+//
+// The root depends on the restriction list: <DatabaseID> present means the
+// client is reading a Tabular.Database, absent a Tabular.Server.
+// CompatibilityLevel must be >= 1200 (below that the database is not "tabular")
+// and lives in nsCompat. `Model` is XmlIgnore on the type and must NOT appear.
+func asslDocument(databaseScoped bool, dbID string) string {
+	db := `<Database xmlns="` + nsEngine + `">` +
+		`<Name>` + xmlEscape(dbID) + `</Name><ID>` + xmlEscape(dbID) + `</ID>` +
+		`<ddl200:CompatibilityLevel xmlns:ddl200="` + nsCompat + `">1567` +
+		`</ddl200:CompatibilityLevel>` +
+		`<LastUpdate>2020-01-01T00:00:00</LastUpdate>` +
+		`</Database>`
+	if databaseScoped {
+		return db
+	}
+	return `<Server xmlns="` + nsEngine + `"><Name>ws</Name><ID>ws</ID><Databases>` +
+		`<Database><Name>` + xmlEscape(dbID) + `</Name><ID>` + xmlEscape(dbID) + `</ID>` +
+		`<LastUpdate>2020-01-01T00:00:00</LastUpdate></Database>` +
+		`</Databases></Server>`
+}
+
+// sessionEnvelope answers the handshake: an ExecuteResponse with an empty root,
+// a Session header, and the trailing protocol byte.
+func sessionEnvelope() []byte {
+	return append([]byte(`<?xml version="1.0" encoding="utf-8"?>`+
+		`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">`+
+		`<soap:Header><Session xmlns="urn:schemas-microsoft-com:xml-analysis" `+
+		`SessionId="`+xmlaSessionID+`"/></soap:Header><soap:Body>`+
+		`<ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">`+
+		`<return><root xmlns="urn:schemas-microsoft-com:xml-analysis:empty"/>`+
+		`</return></ExecuteResponse></soap:Body></soap:Envelope>`), 0x00)
+}
+
+func soapFault(msg string) []byte {
+	return append([]byte(`<?xml version="1.0" encoding="utf-8"?>`+
+		`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">`+
+		`<soap:Body><soap:Fault><faultcode>XMLAnalysisError</faultcode>`+
+		`<faultstring>`+xmlEscape(msg)+`</faultstring>`+
+		`</soap:Fault></soap:Body></soap:Envelope>`), 0x00)
+}
+
+// writeXMLA sends an XMLA payload with the capability header the client
+// REQUIRES on the response. Without it the client raises `InvalidDataException:
+// The 'x-ms-xmlacaps-negotiation-flags' header is missing from the HTTP
+// response!` in ProcessWebResponse — BEFORE reading the body, so a perfectly
+// good envelope is discarded on a missing header. Selecting the empty subset
+// rather than echoing the client's offer: echoing accepts every capability
+// offered, including ones this server does not implement.
+func writeXMLA(w http.ResponseWriter, body []byte) {
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-ms-xmlacaps-negotiation-flags", "0,0,0,0,0")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// xmlaModel resolves the semantic model this XMLA connection is bound to.
+//
+// The client names a DATABASE, which `getDatabaseName` mapped from a dataset
+// name, so the lookup is by item name across the workspaces the principal can
+// see. A miss is an error rather than an empty model: an XMLA client that
+// successfully connects to nothing looks like a model with no tables, which is
+// the fabrication-class failure — well formed, never errors, silently wrong.
+func (a *API) xmlaModel(r *http.Request, p *auth.Principal) (*semanticmodel.Model, semanticmodel.Data, error) {
+	id, err := a.xmlaItemID(r, p)
+	if err != nil {
+		return nil, nil, err
+	}
+	return a.loadSemanticModel(id, p)
+}
+
+// xmlaItemID finds the SemanticModel item backing this connection.
+func (a *API) xmlaItemID(r *http.Request, p *auth.Principal) (string, error) {
+	want := strings.TrimSpace(r.Header.Get("x-ms-xmlaserver"))
+	wss, err := a.Store.ListWorkspacesFor(p.ID)
+	if err != nil {
+		return "", err
+	}
+	var first string
+	for _, ws := range wss {
+		items, err := a.Store.ListItems(ws.ID, "SemanticModel")
+		if err != nil {
+			continue
+		}
+		for _, it := range items {
+			if first == "" {
+				first = it.ID
+			}
+			if want != "" && strings.EqualFold(it.DisplayName, want) {
+				return it.ID, nil
+			}
+		}
+	}
+	if first == "" {
+		return "", fmt.Errorf("no semantic model is visible to this principal")
+	}
+	// The header names a WORKSPACE more often than a dataset, so falling back to
+	// the only model in view is right far more often than failing — but never
+	// silently: a caller that wanted a specific one asked by name and got it.
+	return first, nil
+}
+
+// xmlaDatabaseID is the database name the ASSL document reports.
+func (a *API) xmlaDatabaseID(r *http.Request, p *auth.Principal) string {
+	id, err := a.xmlaItemID(r, p)
+	if err != nil {
+		return "model"
+	}
+	return id
+}
+
+// externalBase is the scheme://host the client should come back to. It is what
+// the client saw, not what this process bound: behind the 443 forwarder every
+// real client uses, those differ.
+func externalBase(r *http.Request) string {
+	scheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") == "" {
+		scheme = "http"
+	}
+	if v := r.Header.Get("X-Forwarded-Proto"); v != "" {
+		scheme = v
+	}
+	return scheme + "://" + r.Host
+}
+
+func betweenTags(s, open, close string) string {
+	i := strings.Index(s, open)
+	if i < 0 {
+		return ""
+	}
+	j := strings.Index(s[i+len(open):], close)
+	if j < 0 {
+		return ""
+	}
+	return s[i+len(open) : i+len(open)+j]
+}
+
+func xmlEscape(s string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}

--- a/internal/api/xmla_test.go
+++ b/internal/api/xmla_test.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/store"
 )
 
 // These pin the SHAPES a real client refuses, each measured in e2e/sempy. Every
@@ -44,13 +47,34 @@ func TestClusterResolveReturnsABareFqdnUnderTheReadContract(t *testing.T) {
 	}
 }
 
-func TestGetDatabaseNameEchoesTheDatasetTheClientAskedFor(t *testing.T) {
-	// Only a REAL client issues this: a probe connects with a name it knows.
-	a, _ := newAPI(t)
+func TestGetDatabaseNameResolvesRatherThanEchoes(t *testing.T) {
+	// RESOLVE, never echo. Returning the caller's own string reflects
+	// user-controlled input into the response (CodeQL `go/reflected-xss`) AND
+	// answers the wrong question: this endpoint MAPS a dataset name onto the
+	// database backing it, so parroting would "succeed" for a dataset that does
+	// not exist and the client would open a connection to nothing.
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	it := &store.Item{WorkspaceID: ws.ID, Type: "SemanticModel", DisplayName: "RetailAnalysis"}
+	if err := st.CreateItem(it, nil); err != nil {
+		t.Fatal(err)
+	}
+
 	w := do(a.xmlaDatabaseName, admin, "POST",
-		`{"datasetName":"sales","workspaceType":1}`, nil)
-	if !strings.Contains(w.Body.String(), `"databaseName":"sales"`) {
-		t.Fatalf("got %s", w.Body.String())
+		`{"datasetName":"RetailAnalysis","workspaceType":1}`, nil)
+	if !strings.Contains(w.Body.String(), `"databaseName":"RetailAnalysis"`) {
+		t.Fatalf("a known dataset must resolve: %s", w.Body.String())
+	}
+
+	// The reflection case: an unknown name must NOT come back in the response.
+	probe := "<script>alert(1)</script>"
+	w = do(a.xmlaDatabaseName, admin, "POST",
+		`{"datasetName":"`+probe+`","workspaceType":1}`, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unknown dataset = %d, want 404", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "script") {
+		t.Fatalf("the response reflected caller-supplied input: %s", w.Body.String())
 	}
 }
 

--- a/internal/api/xmla_test.go
+++ b/internal/api/xmla_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// These pin the SHAPES a real client refuses, each measured in e2e/sempy. Every
+// one of them first failed with a message naming something OTHER than its
+// cause, so each test is named for the cause rather than the symptom.
+
+func TestRoutingReplyIsABareArrayWithAnEnumSkuAndAPathSegment(t *testing.T) {
+	// An envelope fails as "The specified Power BI workspace is not found";
+	// "P1" as "Requested value 'P1' was not found"; a bare origin as
+	// IndexOutOfRangeException.
+	a, _ := newAPI(t)
+	w := do(a.xmlaRouting, admin, "GET", "", nil)
+	body := w.Body.String()
+	if !strings.HasPrefix(strings.TrimSpace(body), "[") {
+		t.Fatalf("routing reply must be a BARE ARRAY, got %.80s", body)
+	}
+	if !strings.Contains(body, `"capacitySku":"Premium"`) {
+		t.Fatalf("capacitySku must be the enum value Premium: %.200s", body)
+	}
+	uri := betweenTags(body, `"capacityUri":"`, `"`)
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(uri, "https://"), "http://")
+	if !strings.Contains(trimmed, "/") {
+		t.Fatalf("capacityUri needs at least one path segment, got %q", uri)
+	}
+}
+
+func TestClusterResolveReturnsABareFqdnUnderTheReadContract(t *testing.T) {
+	// Consumed as UriBuilder{Host = clusterFQDN}; a scheme or port throws
+	// UriFormatException. The sibling contract (FixedClusterUri) leaves Host nil.
+	a, _ := newAPI(t)
+	w := do(a.xmlaClusterResolve, admin, "POST", "{}", nil)
+	body := w.Body.String()
+	if !strings.Contains(body, `"clusterFQDN"`) {
+		t.Fatalf("must answer with NameResolutionResult.clusterFQDN: %s", body)
+	}
+	fqdn := betweenTags(body, `"clusterFQDN":"`, `"`)
+	if fqdn == "" || strings.Contains(fqdn, "://") || strings.Contains(fqdn, ":") {
+		t.Fatalf("clusterFQDN must be a BARE FQDN, got %q", fqdn)
+	}
+}
+
+func TestGetDatabaseNameEchoesTheDatasetTheClientAskedFor(t *testing.T) {
+	// Only a REAL client issues this: a probe connects with a name it knows.
+	a, _ := newAPI(t)
+	w := do(a.xmlaDatabaseName, admin, "POST",
+		`{"datasetName":"sales","workspaceType":1}`, nil)
+	if !strings.Contains(w.Body.String(), `"databaseName":"sales"`) {
+		t.Fatalf("got %s", w.Body.String())
+	}
+}
+
+func TestTheHandshakeCarriesTheCapsHeaderSessionAndTrailingByte(t *testing.T) {
+	// The caps header is checked BEFORE the body is read, so its absence
+	// discards a perfectly good envelope. The trailing 0x00 is the payload
+	// reader's completion marker; any other last byte is a
+	// TransportProtocolError.
+	a, _ := newAPI(t)
+	w := do(a.xmlaEndpoint, admin, "POST",
+		`<Envelope><Body><Execute><Command><Statement/></Command></Execute></Body></Envelope>`,
+		nil)
+	if w.Header().Get("x-ms-xmlacaps-negotiation-flags") == "" {
+		t.Fatal("response is missing x-ms-xmlacaps-negotiation-flags")
+	}
+	b := w.Body.Bytes()
+	if len(b) == 0 || b[len(b)-1] != 0x00 {
+		t.Fatal("XMLA payload must end with the 0x00 completion byte")
+	}
+	if !strings.Contains(string(b), "SessionId=") {
+		t.Fatal("the handshake must return a Session header")
+	}
+}
+
+func TestAsslRootFollowsTheRestrictionAndCarriesCompatibilityLevel(t *testing.T) {
+	// <DatabaseID> present => Tabular.Database, absent => Tabular.Server; the
+	// wrong root is reported as "Unexpected root 'Server' ... when trying to
+	// read '...Database'". CompatibilityLevel lives in nsCompat (not the 2003
+	// engine namespace, not .../200/200) and <Model> is XmlIgnore on the type.
+	srv := asslDocument(false, "m")
+	db := asslDocument(true, "m")
+	if !strings.HasPrefix(srv, "<Server") {
+		t.Fatalf("server-scoped ASSL must be rooted at <Server>: %.30s", srv)
+	}
+	if !strings.HasPrefix(db, "<Database") {
+		t.Fatalf("database-scoped ASSL must be rooted at <Database>: %.30s", db)
+	}
+	if !strings.Contains(db, nsCompat) || !strings.Contains(db, "CompatibilityLevel") {
+		t.Fatal("CompatibilityLevel must be present, in the ddl200 namespace")
+	}
+	if strings.Contains(db, "<Model>") {
+		t.Fatal("<Model> is XmlIgnore on Tabular.Database and must not appear")
+	}
+}
+
+func TestABatchIsDetectedBeforeAPlainDiscover(t *testing.T) {
+	// A batched Execute CONTAINS <Discover> children, so testing for "<Discover"
+	// first shadows the batch entirely — a bug this harness shipped twice.
+	batch := `<Execute><Command><Batch>` +
+		`<Discover><RequestType>TMSCHEMA_MODEL</RequestType></Discover>` +
+		`<Discover><RequestType>TMSCHEMA_TABLES</RequestType></Discover>` +
+		`</Batch></Command></Execute>`
+	if got := len(reRequestType.FindAllStringSubmatch(batch, -1)); got != 2 {
+		t.Fatalf("expected 2 request types in the batch, got %d", got)
+	}
+	if !strings.Contains(batch, "<Batch") {
+		t.Fatal("the batch discriminator must be <Batch, not <Discover")
+	}
+}

--- a/internal/api/xmla_test.go
+++ b/internal/api/xmla_test.go
@@ -80,8 +80,8 @@ func TestAsslRootFollowsTheRestrictionAndCarriesCompatibilityLevel(t *testing.T)
 	// wrong root is reported as "Unexpected root 'Server' ... when trying to
 	// read '...Database'". CompatibilityLevel lives in nsCompat (not the 2003
 	// engine namespace, not .../200/200) and <Model> is XmlIgnore on the type.
-	srv := asslDocument(false, "m")
-	db := asslDocument(true, "m")
+	srv := asslDocument(false, "m", "m")
+	db := asslDocument(true, "m", "m")
 	if !strings.HasPrefix(srv, "<Server") {
 		t.Fatalf("server-scoped ASSL must be rooted at <Server>: %.30s", srv)
 	}

--- a/internal/xmla/contract_test.go
+++ b/internal/xmla/contract_test.go
@@ -1,0 +1,101 @@
+package xmla
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+)
+
+// These pin the wire requirements MEASURED against real sempy in e2e/sempy.
+// Each one failed in a way that named something other than its cause, which is
+// why they are asserted here rather than left to the e2e suite: the e2e run
+// needs docker and a .NET runtime, these do not.
+
+func TestEveryDiscoverRowsetCarriesAVersionColumnTypedLong(t *testing.T) {
+	// `GetVersionFromDataTable` does `Utils.Verify(obj is long)`. An
+	// unsignedLong parses, fails the type test, and surfaces as a bare
+	// `TomInternalException` naming nothing.
+	m := &semanticmodel.Model{}
+	for _, rt := range TOMBatchRequestTypes() {
+		rs, err := DiscoverRowset(m, nil, rt)
+		if err != nil {
+			t.Fatalf("%s: %v", rt, err)
+		}
+		var idx = -1
+		for i, c := range rs.Columns {
+			if c == "Version" {
+				idx = i
+			}
+		}
+		if idx < 0 {
+			t.Fatalf("%s: no Version column; the client refuses the rowset outright", rt)
+		}
+		if got := rs.xsdType(idx); got != "xsd:long" {
+			t.Fatalf("%s: Version is %s, want xsd:long", rt, got)
+		}
+	}
+}
+
+func TestAnUnmodelledTypeStillDeclaresColumns(t *testing.T) {
+	// A column-less rowset yields no DataTable; AdjustTableNames then bails on
+	// the count mismatch and NOTHING in the batch gets named. Empty of rows is
+	// correct; empty of columns breaks every other rowset.
+	rs, err := DiscoverRowset(&semanticmodel.Model{}, nil, "TMSCHEMA_PERSPECTIVES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rs.Columns) == 0 {
+		t.Fatal("unmodelled type declared no columns")
+	}
+	if len(rs.Rows) != 0 {
+		t.Fatalf("expected zero ROWS for an unmodelled type, got %d", len(rs.Rows))
+	}
+}
+
+func TestEveryRowsetIsNamedOnTheRootElement(t *testing.T) {
+	// AmoDataAdapter renames DataSet tables from <root name="...">; without it
+	// `Tables["Model"]` is null and TOM reports a MODEL problem.
+	m := &semanticmodel.Model{}
+	for _, rt := range TOMBatchRequestTypes() {
+		rs, err := DiscoverRowset(m, nil, rt)
+		if err != nil {
+			t.Fatalf("%s: %v", rt, err)
+		}
+		if rs.Name == "" {
+			t.Fatalf("%s: rowset has no Name", rt)
+		}
+		if !strings.Contains(string(rs.DiscoverResponse()), `<root name="`) {
+			t.Fatalf("%s: emitted root carries no name attribute", rt)
+		}
+	}
+	rs, _ := DiscoverRowset(m, nil, "TMSCHEMA_MODEL")
+	if rs.Name != "Model" {
+		t.Fatalf("TMSCHEMA_MODEL must be named Model, got %q", rs.Name)
+	}
+}
+
+func TestIdColumnsAreUnsignedLongNotString(t *testing.T) {
+	// All-string gets the NAMES accepted and then fails as
+	// `InvalidCastException: System.String -> System.UInt64`.
+	rs, err := DiscoverRowset(&semanticmodel.Model{}, nil, "TMSCHEMA_COLUMNS")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, c := range rs.Columns {
+		if c == "ID" || strings.HasSuffix(c, "ID") {
+			if got := rs.xsdType(i); got != "xsd:unsignedLong" {
+				t.Fatalf("%s is %s, want xsd:unsignedLong", c, got)
+			}
+		}
+	}
+}
+
+func TestAnUnnamedRowsetEmitsNoNameAttribute(t *testing.T) {
+	// The DAX path has a single unnamed rowset and must be unchanged by the
+	// batch work — a name attribute there would be a regression, not a fix.
+	rs := Rowset{Columns: []string{"a"}, Rows: [][]string{{"1"}}}
+	if strings.Contains(string(rs.ExecuteResponse()), "<root name=") {
+		t.Fatal("an unnamed rowset must not emit a name attribute")
+	}
+}

--- a/internal/xmla/discover.go
+++ b/internal/xmla/discover.go
@@ -62,6 +62,69 @@ var discoverColumns = map[string][]string{
 	"TMSCHEMA_EXPRESSIONS":   {"ID", "Name", "Expression"},
 }
 
+// versionColumn is on EVERY TMSCHEMA rowset. Without it the client refuses the
+// rowset outright — `ResponseFormatException: The rowset is missing a Version
+// column` — and it must be typed xsd:LONG, not unsignedLong:
+// `DdlUtil.GetVersionFromDataTable` does `Utils.Verify(obj is long)`, an
+// ASSERTION, so an unsignedLong parses cleanly, fails the type test, and
+// surfaces as a bare `TomInternalException: An internal error has occured` with
+// nothing named at all.
+const versionColumn = "Version"
+
+// minimalColumns is what a type we do NOT model still has to send. Measured
+// against real sempy: an empty rowset whose schema declares NO columns produces
+// no DataTable, `AmoDataAdapter.AdjustTableNames` bails out on the count
+// mismatch, and NOTHING gets named — so one column-less rowset breaks table
+// naming for all ~35 and `Tables["Model"]` comes back null. Empty is not free.
+var minimalColumns = []string{"ID", "Name"}
+
+// xsdTypeFor is the declared type per column. The schema is the CAST contract:
+// ids are unsignedLong, Version is long, everything else crosses as a string.
+func xsdTypeFor(col string) string {
+	switch {
+	case col == versionColumn:
+		return "xsd:long"
+	case col == "ID" || strings.HasSuffix(col, "ID"):
+		return "xsd:unsignedLong"
+	default:
+		return "xsd:string"
+	}
+}
+
+// tomObjectName is the <root name="..."> TOM expects, which is the singular
+// object name rather than the request type. `DdlUtil.ObtainModelTable` looks up
+// `dataSet.Tables["Model"]` by that name.
+var tomObjectName = map[string]string{
+	"TMSCHEMA_MODEL":         "Model",
+	"TMSCHEMA_TABLES":        "Table",
+	"TMSCHEMA_COLUMNS":       "Column",
+	"TMSCHEMA_PARTITIONS":    "Partition",
+	"TMSCHEMA_RELATIONSHIPS": "Relationship",
+	"TMSCHEMA_MEASURES":      "Measure",
+	"TMSCHEMA_EXPRESSIONS":   "Expression",
+}
+
+// withContract stamps the wire requirements onto a rowset: the Version column,
+// a type per column, and the <root> name. Applied to EVERY rowset, modelled or
+// not, because the client's checks do not distinguish them.
+func withContract(rs Rowset, requestType string) Rowset {
+	rs.Columns = append(append([]string(nil), rs.Columns...), versionColumn)
+	for i := range rs.Rows {
+		rs.Rows[i] = append(append([]string(nil), rs.Rows[i]...), "1")
+	}
+	rs.Types = make([]string, len(rs.Columns))
+	for i, c := range rs.Columns {
+		rs.Types[i] = xsdTypeFor(c)
+	}
+	if n, ok := tomObjectName[requestType]; ok {
+		rs.Name = n
+	} else {
+		rs.Name = strings.ReplaceAll(strings.Title(strings.ToLower( //nolint:staticcheck
+			strings.TrimPrefix(requestType, "TMSCHEMA_"))), "_", "")
+	}
+	return rs
+}
+
 // DiscoverRowset answers one `<Discover RequestType=TMSCHEMA_*>` from the model.
 //
 // Three outcomes, deliberately distinct:
@@ -71,11 +134,10 @@ var discoverColumns = map[string][]string{
 //   - anything else        → error, so an unrecognised type is never mistaken
 //     for "this model has none of those"
 //
-// UNMEASURED, and the reason this returns an empty rowset rather than pretending
-// otherwise: whether TOM accepts an empty rowset whose schema declares no
-// columns. If it does not, the open question becomes "what are the columns of
-// the 28 types we do not model", which is materially more expensive. e2e/xmla
-// is running exactly that experiment.
+// MEASURED 2026-08-10 against real sempy (e2e/sempy): TOM does NOT accept a
+// rowset whose schema declares no columns, so an unmodelled type still sends a
+// minimal typed column list with zero rows. The earlier note here recorded this
+// as unmeasured and is deleted rather than annotated.
 func DiscoverRowset(model *semanticmodel.Model, data semanticmodel.Data, requestType string) (Rowset, error) {
 	name := strings.ToUpper(strings.TrimSpace(requestType))
 	if !strings.HasPrefix(name, "TMSCHEMA_") {
@@ -88,8 +150,11 @@ func DiscoverRowset(model *semanticmodel.Model, data semanticmodel.Data, request
 	cols, modelled := discoverColumns[name]
 	if !modelled {
 		if inTOMBatch(name) {
-			// Truthfully empty: the model defines none of these objects.
-			return Rowset{}, nil
+			// Truthfully EMPTY OF ROWS — the model defines none of these
+			// objects — but NOT empty of columns. A column-less rowset yields
+			// no DataTable, and that breaks naming for every other rowset in
+			// the batch (see minimalColumns).
+			return withContract(Rowset{Columns: minimalColumns}, name), nil
 		}
 		return Rowset{}, fmt.Errorf("unknown TMSCHEMA request type %q", name)
 	}
@@ -106,7 +171,7 @@ func DiscoverRowset(model *semanticmodel.Model, data semanticmodel.Data, request
 		}
 		rs.Rows = append(rs.Rows, out)
 	}
-	return rs, nil
+	return withContract(rs, name), nil
 }
 
 func inTOMBatch(name string) bool {

--- a/internal/xmla/discover.go
+++ b/internal/xmla/discover.go
@@ -52,14 +52,71 @@ func TOMBatchRequestTypes() []string {
 // genuinely has nothing (our TMSL defines no perspectives, KPIs, roles,
 // cultures or translations), so zero rows is the truthful answer rather than a
 // placeholder — see DiscoverRowset.
+// The columns are each TOM type's SCALAR properties, read off
+// Microsoft.AnalysisServices.Tabular.dll. TOM reads them BY NAME and names the
+// one it is missing — `ArgumentException: Column 'Culture' does not belong to
+// table Model` — so a short list is not a smaller answer, it is a refused one.
 var discoverColumns = map[string][]string{
-	"TMSCHEMA_MODEL":         {"ID", "Name"},
-	"TMSCHEMA_TABLES":        {"ID", "Name"},
-	"TMSCHEMA_COLUMNS":       {"ID", "TableID", "ExplicitName"},
-	"TMSCHEMA_PARTITIONS":    {"ID", "TableID", "Name"},
-	"TMSCHEMA_RELATIONSHIPS": {"ID", "Name"},
-	"TMSCHEMA_MEASURES":      {"ID", "TableID", "Name", "Expression"},
-	"TMSCHEMA_EXPRESSIONS":   {"ID", "Name", "Expression"},
+	"TMSCHEMA_MODEL": {"ID", "Name", "Description", "StorageLocation",
+		"DefaultMode", "DefaultDataView", "Culture", "Collation",
+		"ModifiedTime", "StructureModifiedTime", "ForceUniqueNames",
+		"DiscourageImplicitMeasures", "DiscourageReportMeasures",
+		"DataSourceVariablesOverrideBehavior", "DataSourceDefaultMaxConnections",
+		"SourceQueryCulture", "DiscourageCompositeModels", "DisableAutoExists",
+		"MaxParallelismPerRefresh", "MaxParallelismPerQuery",
+		"DefaultPowerBIDataSourceVersion"},
+	"TMSCHEMA_TABLES": {"ID", "ModelID", "Name", "DataCategory", "Description",
+		"IsHidden", "ModifiedTime", "StructureModifiedTime",
+		"ShowAsVariationsOnly", "IsPrivate", "AlternateSourcePrecedence",
+		"ExcludeFromModelRefresh", "LineageTag", "SourceLineageTag",
+		"SystemManaged", "ExcludeFromAutomaticAggregations"},
+	"TMSCHEMA_COLUMNS": {"ID", "TableID", "ExplicitName", "SourceColumn",
+		"DataCategory", "Description", "IsHidden", "State", "IsUnique", "IsKey",
+		"IsNullable", "Alignment", "TableDetailPosition", "IsDefaultLabel",
+		"IsDefaultImage", "SummarizeBy", "Type", "FormatString",
+		"IsAvailableInMDX", "ModifiedTime", "StructureModifiedTime",
+		"RefreshedTime", "KeepUniqueRows", "DisplayOrdinal", "ErrorMessage",
+		"SourceProviderType", "DisplayFolder", "EncodingHint", "LineageTag",
+		"SourceLineageTag", "ExplicitDataType", "IsDataTypeInferred"},
+	"TMSCHEMA_PARTITIONS": {"ID", "TableID", "Name", "Description", "State",
+		"Mode", "DataView", "ModifiedTime", "RefreshedTime", "ErrorMessage",
+		"RetainDataTillForceCalculate", "Type"},
+	"TMSCHEMA_RELATIONSHIPS": {"ID", "Name", "IsActive", "Type",
+		"CrossFilteringBehavior", "JoinOnDateBehavior",
+		"RelyOnReferentialIntegrity", "State", "ModifiedTime", "RefreshedTime",
+		"SecurityFilteringBehavior", "FromCardinality", "ToCardinality"},
+	"TMSCHEMA_MEASURES": {"ID", "TableID", "Name", "Description", "DataType",
+		"Expression", "FormatString", "IsHidden", "State", "ModifiedTime",
+		"StructureModifiedTime", "IsSimpleMeasure", "ErrorMessage",
+		"DisplayFolder", "DataCategory", "LineageTag", "SourceLineageTag"},
+	"TMSCHEMA_EXPRESSIONS": {"ID", "Name", "Expression", "Description",
+		"Kind", "ModifiedTime", "StructureModifiedTime", "LineageTag"},
+}
+
+// enumDefaults are the values an unset ENUM column must carry. Zero is not a
+// member of several of them — `The value '0' is unexpected for type
+// 'ColumnType'` — while ModeType.Import and DataViewType.Full ARE 0, so a
+// blanket "use 1" is wrong in the other direction. Read off the assembly.
+var enumDefaults = map[string]string{
+	"Type": "1", "State": "1", "DataType": "2", "SummarizeBy": "1",
+	"Alignment": "1", "SourceType": "4", "Mode": "0", "DataView": "0",
+	"ExplicitDataType": "2", "EncodingHint": "0", "DefaultMode": "0",
+	"DefaultDataView": "0", "DefaultPowerBIDataSourceVersion": "0",
+	"DataSourceVariablesOverrideBehavior": "0", "Kind": "0",
+	"CrossFilteringBehavior": "1", "JoinOnDateBehavior": "0",
+	"SecurityFilteringBehavior": "1", "FromCardinality": "2",
+	"ToCardinality": "1",
+}
+
+// idBase keeps object ids UNIQUE ACROSS THE MODEL. TOM builds one object graph
+// from all the rowsets, so a per-rowset counter collides:
+// `Duplicate object ID 1, first in 'Tabular.Model', another one in ...`.
+var idBase = map[string]int{
+	"TMSCHEMA_MODEL": 0, "TMSCHEMA_TABLES": 1000, "TMSCHEMA_COLUMNS": 2000,
+	"TMSCHEMA_MEASURES": 3000, "TMSCHEMA_PARTITIONS": 4000,
+	"TMSCHEMA_RELATIONSHIPS": 5000, "TMSCHEMA_EXPRESSIONS": 6000,
+	"TMSCHEMA_PARTITION_STORAGES": 7000, "TMSCHEMA_COLUMN_STORAGES": 8000,
+	"TMSCHEMA_SEGMENT_MAP_STORAGES": 9000, "TMSCHEMA_HIERARCHIES": 10000,
 }
 
 // versionColumn is on EVERY TMSCHEMA rowset. Without it the client refuses the
@@ -80,12 +137,47 @@ var minimalColumns = []string{"ID", "Name"}
 
 // xsdTypeFor is the declared type per column. The schema is the CAST contract:
 // ids are unsignedLong, Version is long, everything else crosses as a string.
+// clrKind is each column's CLR type, from the TOM property it mirrors. The
+// schema is the CAST contract: a DateTime declared as a string fails as
+// `InvalidCastException: Unable to cast System.String to System.DateTime`, and
+// the value must PARSE as that type too — an empty cell in a dateTime column is
+// not "unset", it is unparseable.
+var clrKind = map[string]string{
+	"ModifiedTime": "dateTime", "StructureModifiedTime": "dateTime",
+	"RefreshedTime":    "dateTime",
+	"ForceUniqueNames": "boolean", "DiscourageImplicitMeasures": "boolean",
+	"DiscourageReportMeasures": "boolean", "DiscourageCompositeModels": "boolean",
+	"IsHidden": "boolean", "ShowAsVariationsOnly": "boolean",
+	"IsPrivate": "boolean", "ExcludeFromModelRefresh": "boolean",
+	"SystemManaged": "boolean", "ExcludeFromAutomaticAggregations": "boolean",
+	"IsUnique": "boolean", "IsKey": "boolean", "IsNullable": "boolean",
+	"IsDefaultLabel": "boolean", "IsDefaultImage": "boolean",
+	"IsAvailableInMDX": "boolean", "KeepUniqueRows": "boolean",
+	"IsDataTypeInferred": "boolean", "IsSimpleMeasure": "boolean",
+	"RetainDataTillForceCalculate": "boolean", "IsActive": "boolean",
+	"RelyOnReferentialIntegrity":      "boolean",
+	"DataSourceDefaultMaxConnections": "int", "DisableAutoExists": "int",
+	"MaxParallelismPerRefresh": "int", "MaxParallelismPerQuery": "int",
+	"AlternateSourcePrecedence": "int", "TableDetailPosition": "int",
+	"DisplayOrdinal": "int",
+}
+
+// zeroFor is the value an unset column of each kind must carry so it parses.
+var zeroFor = map[string]string{
+	"dateTime": "2020-01-01T00:00:00", "boolean": "false", "int": "0",
+}
+
 func xsdTypeFor(col string) string {
 	switch {
 	case col == versionColumn:
 		return "xsd:long"
 	case col == "ID" || strings.HasSuffix(col, "ID"):
 		return "xsd:unsignedLong"
+	case enumDefaults[col] != "":
+		// Enums cross the wire as their integer value.
+		return "xsd:int"
+	case clrKind[col] != "":
+		return "xsd:" + clrKind[col]
 	default:
 		return "xsd:string"
 	}
@@ -167,7 +259,22 @@ func DiscoverRowset(model *semanticmodel.Model, data semanticmodel.Data, request
 	for _, src := range rows {
 		out := make([]string, len(cols))
 		for i, c := range cols {
-			out[i] = src[c]
+			// An empty ENUM cell is not "unset", it is an INVALID MEMBER:
+			// `The value '0' is unexpected for type 'ColumnType'`.
+			v := src[c]
+			if v == "" {
+				// An unset cell must still PARSE as its declared type.
+				if e := enumDefaults[c]; e != "" {
+					v = e
+				} else if z := zeroFor[clrKind[c]]; z != "" {
+					v = z
+				} else if c == versionColumn {
+					v = "1"
+				} else if c == "ID" || strings.HasSuffix(c, "ID") {
+					v = "0"
+				}
+			}
+			out[i] = v
 		}
 		rs.Rows = append(rs.Rows, out)
 	}
@@ -190,7 +297,7 @@ func discoverRows(model *semanticmodel.Model, data semanticmodel.Data, name stri
 	switch name {
 	case "TMSCHEMA_MODEL":
 		// Exactly one Model object per database.
-		return []map[string]string{{"ID": "1", "Name": model.Name}}, nil
+		return []map[string]string{{"ID": objID("TMSCHEMA_MODEL", 0), "Name": model.Name}}, nil
 
 	case "TMSCHEMA_MEASURES":
 		var rows []map[string]string
@@ -199,7 +306,7 @@ func discoverRows(model *semanticmodel.Model, data semanticmodel.Data, name stri
 			for _, m := range t.Measures {
 				n++
 				rows = append(rows, map[string]string{
-					"ID": id(n - 1), "TableID": id(ti),
+					"ID": objID("TMSCHEMA_MEASURES", n-1), "TableID": objID("TMSCHEMA_TABLES", ti),
 					"Name": m.Name, "Expression": m.Expression,
 				})
 			}
@@ -210,7 +317,8 @@ func discoverRows(model *semanticmodel.Model, data semanticmodel.Data, name stri
 		var rows []map[string]string
 		i := 0
 		for _, k := range sortedKeys(model.Expressions) {
-			rows = append(rows, map[string]string{"ID": id(i), "Name": k, "Expression": model.Expressions[k]})
+			rows = append(rows, map[string]string{"ID": objID("TMSCHEMA_EXPRESSIONS", i),
+				"Name": k, "Expression": model.Expressions[k]})
 			i++
 		}
 		return rows, nil

--- a/internal/xmla/discover.go
+++ b/internal/xmla/discover.go
@@ -186,20 +186,68 @@ func xsdTypeFor(col string) string {
 // tomObjectName is the <root name="..."> TOM expects, which is the singular
 // object name rather than the request type. `DdlUtil.ObtainModelTable` looks up
 // `dataSet.Tables["Model"]` by that name.
+//
+// TOTAL over the union of `discoverColumns` and `tomBatchRequestTypes`, asserted
+// by TestEveryBatchTypeHasATOMObjectName. Totality is the point: the name used to
+// be derived from the request string when the map missed, which put caller-
+// supplied text in the response body (CodeQL go/reflected-xss) and hid the
+// unmeasured names inside a string transform.
+//
+// The seven marked `measured` are read off Microsoft.AnalysisServices.Tabular.dll.
+// The rest are the previous derivation's output, FROZEN VERBATIM so this change
+// moves no bytes on the wire — they are NOT measured, and their oddities
+// (`Datasources`, not `DataSources`) are that derivation's artifacts, not TOM's
+// names. They are only ever the name of a zero-row rowset, which is why nothing
+// has yet forced them to be right. Correct them when something measures them.
 var tomObjectName = map[string]string{
-	"TMSCHEMA_MODEL":         "Model",
-	"TMSCHEMA_TABLES":        "Table",
-	"TMSCHEMA_COLUMNS":       "Column",
-	"TMSCHEMA_PARTITIONS":    "Partition",
-	"TMSCHEMA_RELATIONSHIPS": "Relationship",
-	"TMSCHEMA_MEASURES":      "Measure",
-	"TMSCHEMA_EXPRESSIONS":   "Expression",
+	"TMSCHEMA_MODEL":                     "Model",        // measured
+	"TMSCHEMA_TABLES":                    "Table",        // measured
+	"TMSCHEMA_COLUMNS":                   "Column",       // measured
+	"TMSCHEMA_PARTITIONS":                "Partition",    // measured
+	"TMSCHEMA_RELATIONSHIPS":             "Relationship", // measured
+	"TMSCHEMA_MEASURES":                  "Measure",      // measured
+	"TMSCHEMA_EXPRESSIONS":               "Expression",   // measured
+	"TMSCHEMA_DATA_SOURCES":              "Datasources",
+	"TMSCHEMA_ATTRIBUTE_HIERARCHIES":     "Attributehierarchies",
+	"TMSCHEMA_HIERARCHIES":               "Hierarchies",
+	"TMSCHEMA_LEVELS":                    "Levels",
+	"TMSCHEMA_ANNOTATIONS":               "Annotations",
+	"TMSCHEMA_KPIS":                      "Kpis",
+	"TMSCHEMA_CULTURES":                  "Cultures",
+	"TMSCHEMA_OBJECT_TRANSLATIONS":       "Objecttranslations",
+	"TMSCHEMA_LINGUISTIC_METADATA":       "Linguisticmetadata",
+	"TMSCHEMA_PERSPECTIVES":              "Perspectives",
+	"TMSCHEMA_PERSPECTIVE_TABLES":        "Perspectivetables",
+	"TMSCHEMA_PERSPECTIVE_COLUMNS":       "Perspectivecolumns",
+	"TMSCHEMA_PERSPECTIVE_HIERARCHIES":   "Perspectivehierarchies",
+	"TMSCHEMA_PERSPECTIVE_MEASURES":      "Perspectivemeasures",
+	"TMSCHEMA_ROLES":                     "Roles",
+	"TMSCHEMA_ROLE_MEMBERSHIPS":          "Rolememberships",
+	"TMSCHEMA_TABLE_PERMISSIONS":         "Tablepermissions",
+	"TMSCHEMA_VARIATIONS":                "Variations",
+	"TMSCHEMA_EXTENDED_PROPERTIES":       "Extendedproperties",
+	"TMSCHEMA_COLUMN_PERMISSIONS":        "Columnpermissions",
+	"TMSCHEMA_DETAIL_ROWS_DEFINITIONS":   "Detailrowsdefinitions",
+	"TMSCHEMA_CALCULATION_GROUPS":        "Calculationgroups",
+	"TMSCHEMA_CALCULATION_ITEMS":         "Calculationitems",
+	"TMSCHEMA_ALTERNATE_OF_DEFINITIONS":  "Alternateofdefinitions",
+	"TMSCHEMA_REFRESH_POLICIES":          "Refreshpolicies",
+	"TMSCHEMA_FORMAT_STRING_DEFINITIONS": "Formatstringdefinitions",
+	"TMSCHEMA_QUERY_GROUPS":              "Querygroups",
+	"TMSCHEMA_CHANGED_PROPERTIES":        "Changedproperties",
 }
 
 // withContract stamps the wire requirements onto a rowset: the Version column,
 // a type per column, and the <root> name. Applied to EVERY rowset, modelled or
 // not, because the client's checks do not distinguish them.
-func withContract(rs Rowset, requestType string) Rowset {
+// A request type with no entry is an ERROR rather than a derived or blank name:
+// an unnamed rowset is the plausible-blank failure this package refuses
+// elsewhere, and deriving one would put the caller's bytes in the response.
+func withContract(rs Rowset, requestType string) (Rowset, error) {
+	name, ok := tomObjectName[requestType]
+	if !ok {
+		return Rowset{}, fmt.Errorf("no TOM object name for %q", requestType)
+	}
 	rs.Columns = append(append([]string(nil), rs.Columns...), versionColumn)
 	for i := range rs.Rows {
 		rs.Rows[i] = append(append([]string(nil), rs.Rows[i]...), "1")
@@ -208,13 +256,8 @@ func withContract(rs Rowset, requestType string) Rowset {
 	for i, c := range rs.Columns {
 		rs.Types[i] = xsdTypeFor(c)
 	}
-	if n, ok := tomObjectName[requestType]; ok {
-		rs.Name = n
-	} else {
-		rs.Name = strings.ReplaceAll(strings.Title(strings.ToLower( //nolint:staticcheck
-			strings.TrimPrefix(requestType, "TMSCHEMA_"))), "_", "")
-	}
-	return rs
+	rs.Name = name
+	return rs, nil
 }
 
 // DiscoverRowset answers one `<Discover RequestType=TMSCHEMA_*>` from the model.
@@ -246,7 +289,7 @@ func DiscoverRowset(model *semanticmodel.Model, data semanticmodel.Data, request
 			// objects — but NOT empty of columns. A column-less rowset yields
 			// no DataTable, and that breaks naming for every other rowset in
 			// the batch (see minimalColumns).
-			return withContract(Rowset{Columns: minimalColumns}, name), nil
+			return withContract(Rowset{Columns: minimalColumns}, name)
 		}
 		return Rowset{}, fmt.Errorf("unknown TMSCHEMA request type %q", name)
 	}
@@ -278,7 +321,7 @@ func DiscoverRowset(model *semanticmodel.Model, data semanticmodel.Data, request
 		}
 		rs.Rows = append(rs.Rows, out)
 	}
-	return withContract(rs, name), nil
+	return withContract(rs, name)
 }
 
 func inTOMBatch(name string) bool {

--- a/internal/xmla/discover_test.go
+++ b/internal/xmla/discover_test.go
@@ -199,3 +199,37 @@ func TestDiscoverPropagatesProjectionErrors(t *testing.T) {
 		t.Error("empty Discover rowset must still carry its schema")
 	}
 }
+
+// Every type reachable through DiscoverRowset must have a TOM object name.
+//
+// This is what lets `withContract` refuse rather than derive one from the
+// request string. If it ever fails, the fix is a measured entry in
+// tomObjectName, never a fallback that echoes the caller.
+func TestEveryBatchTypeHasATOMObjectName(t *testing.T) {
+	for _, rt := range TOMBatchRequestTypes() {
+		if tomObjectName[rt] == "" {
+			t.Errorf("%s is in TOM's batch but has no <root name>", rt)
+		}
+	}
+	for rt := range discoverColumns {
+		if tomObjectName[rt] == "" {
+			t.Errorf("%s is modelled but has no <root name>", rt)
+		}
+	}
+}
+
+// The <root name> is table-driven, so nothing the caller sends can appear in it.
+func TestRootNameComesFromTheTableNotTheRequest(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+	rs, err := DiscoverRowset(m, d, "  tmschema_tables  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rs.Name != "Table" {
+		t.Errorf("root name = %q, want the singular TOM name %q", rs.Name, "Table")
+	}
+	// A type outside both tables is refused, not named.
+	if _, err := DiscoverRowset(m, d, `TMSCHEMA_<script>`); err == nil {
+		t.Error("an unknown request type must be an error, not a named rowset")
+	}
+}

--- a/internal/xmla/discover_test.go
+++ b/internal/xmla/discover_test.go
@@ -61,13 +61,24 @@ func TestDiscoverModelledTypes(t *testing.T) {
 	if len(meas.Rows) != want {
 		t.Fatalf("measures = %d, want %d (every measure in the model)", len(meas.Rows), want)
 	}
+	// BY COLUMN NAME, not by index. This asserted r[2]/r[3] and broke when the
+	// projection gained the columns TOM actually requires — a green-to-red on a
+	// correct change, because the test encoded the layout rather than the fact.
+	cell := func(row []string, col string) string {
+		for i, c := range meas.Columns {
+			if c == col && i < len(row) {
+				return row[i]
+			}
+		}
+		return ""
+	}
 	var ratio []string
 	for _, r := range meas.Rows {
-		if r[2] == "Total Units Ratio" {
+		if cell(r, "Name") == "Total Units Ratio" {
 			ratio = r
 		}
 	}
-	if ratio == nil || !strings.Contains(ratio[3], "DIVIDE") {
+	if ratio == nil || !strings.Contains(cell(ratio, "Expression"), "DIVIDE") {
 		t.Fatalf("Total Units Ratio row = %v, want its DIVIDE expression", ratio)
 	}
 	parses(t, meas.ExecuteResponse())
@@ -83,9 +94,24 @@ func TestDiscoverModelledTypes(t *testing.T) {
 		t.Fatalf("Discover %d rows vs SELECT %d — the two grammars disagree about tables",
 			len(viaDiscover.Rows), len(viaSelect.Rows))
 	}
+	// Compare the columns the SELECT actually PROJECTED, by name. Discover
+	// carries every scalar property TOM requires, so the two rowsets are not the
+	// same width — but they must agree on any column both contain, because they
+	// are two grammars over ONE object. Comparing by index asserted a layout
+	// rather than that agreement.
+	at := func(rs Rowset, row int, col string) string {
+		for i, c := range rs.Columns {
+			if c == col && i < len(rs.Rows[row]) {
+				return rs.Rows[row][i]
+			}
+		}
+		return "<missing>"
+	}
 	for i := range viaSelect.Rows {
-		if viaDiscover.Rows[i][0] != viaSelect.Rows[i][0] || viaDiscover.Rows[i][1] != viaSelect.Rows[i][1] {
-			t.Errorf("row %d differs: Discover %v vs SELECT %v", i, viaDiscover.Rows[i], viaSelect.Rows[i])
+		for _, c := range []string{"ID", "Name"} {
+			if got, want := at(viaDiscover, i, c), at(viaSelect, i, c); got != want {
+				t.Errorf("row %d %s differs: Discover %q vs SELECT %q", i, c, got, want)
+			}
 		}
 	}
 }

--- a/internal/xmla/dmv.go
+++ b/internal/xmla/dmv.go
@@ -37,6 +37,15 @@ func IsDMV(statement string) bool { return dmvStatement.MatchString(statement) }
 // so returning the source name would silently break its merges).
 type projection struct{ source, out string }
 
+// dmvIdent is what may become an XML element name in the response.
+//
+// dmvProjection's `\w+` groups already exclude the markup characters, but that
+// is an implied invariant three regexes away from the writer. This states it at
+// the boundary it protects: a selected name that is not a plain identifier is
+// rejected before it can reach the rowset, and loosening the parser cannot
+// silently loosen the writer.
+var dmvIdent = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // DMV parses and answers a `$SYSTEM.TMSCHEMA_*` query against the model and its
 // data. Data is required because the storage rowsets are *derived* from the
 // rows we hold — record counts and distinct-value counts are exact, not
@@ -53,6 +62,9 @@ func DMV(model *semanticmodel.Model, data semanticmodel.Data, statement string) 
 		out := p[1]
 		if p[2] != "" {
 			out = p[2]
+		}
+		if !dmvIdent.MatchString(out) {
+			return Rowset{}, fmt.Errorf("%s: %q is not a usable column name", name, out)
 		}
 		cols = append(cols, projection{source: p[1], out: out})
 	}

--- a/internal/xmla/dmv.go
+++ b/internal/xmla/dmv.go
@@ -96,7 +96,8 @@ func dmvRows(model *semanticmodel.Model, data semanticmodel.Data, name string) (
 	switch name {
 	case "TMSCHEMA_TABLES":
 		for i, t := range model.Tables {
-			rows = append(rows, map[string]string{"ID": id(i), "Name": t.Name})
+			rows = append(rows, map[string]string{"ID": objID("TMSCHEMA_TABLES", i),
+				"ModelID": objID("TMSCHEMA_MODEL", 0), "Name": t.Name})
 		}
 
 	case "TMSCHEMA_COLUMNS":
@@ -105,7 +106,7 @@ func dmvRows(model *semanticmodel.Model, data semanticmodel.Data, name string) (
 			for _, c := range t.Columns {
 				n++
 				rows = append(rows, map[string]string{
-					"ID": id(n - 1), "TableID": id(ti),
+					"ID": objID("TMSCHEMA_COLUMNS", n-1), "TableID": objID("TMSCHEMA_TABLES", ti),
 					"ExplicitName": c.Name, "Name": c.Name,
 				})
 			}
@@ -117,13 +118,14 @@ func dmvRows(model *semanticmodel.Model, data semanticmodel.Data, name string) (
 		// partition would be a fiction the storage cannot back.
 		for ti, t := range model.Tables {
 			rows = append(rows, map[string]string{
-				"ID": id(ti), "TableID": id(ti), "Name": t.Name + "-Partition",
+				"ID":      objID("TMSCHEMA_PARTITIONS", ti),
+				"TableID": objID("TMSCHEMA_TABLES", ti), "Name": t.Name + "-Partition",
 			})
 		}
 
 	case "TMSCHEMA_RELATIONSHIPS":
 		for i, r := range model.Relationships {
-			rows = append(rows, map[string]string{"ID": id(i), "Name": r.Name})
+			rows = append(rows, map[string]string{"ID": objID("TMSCHEMA_RELATIONSHIPS", i), "Name": r.Name})
 		}
 
 	case "TMSCHEMA_HIERARCHIES":
@@ -142,7 +144,8 @@ func dmvRows(model *semanticmodel.Model, data semanticmodel.Data, name string) (
 		// One storage per partition, and one partition per table (above), so
 		// the ids line up by construction.
 		for ti := range model.Tables {
-			rows = append(rows, map[string]string{"ID": id(ti), "PartitionID": id(ti)})
+			rows = append(rows, map[string]string{"ID": objID("TMSCHEMA_PARTITION_STORAGES", ti),
+				"PartitionID": objID("TMSCHEMA_PARTITIONS", ti)})
 		}
 
 	case "TMSCHEMA_SEGMENT_MAP_STORAGES":
@@ -212,3 +215,11 @@ func distinctValues(data semanticmodel.Data, table, column string) int {
 }
 
 func id(i int) string { return strconv.Itoa(i + 1) }
+
+// objID places an object's id in a MODEL-WIDE space. TOM assembles one object
+// graph from every rowset, so per-rowset counters collide:
+// `Duplicate object ID 1, first in 'Tabular.Model', another one in ...`.
+// It lives here, in the shared row source, so the Discover and SQL-SELECT
+// grammars cannot disagree about the same object's id — two lists answering one
+// question is the defect this repo has a rule about.
+func objID(kind string, i int) string { return strconv.Itoa(idBase[kind] + i + 1) }

--- a/internal/xmla/dmv_test.go
+++ b/internal/xmla/dmv_test.go
@@ -50,8 +50,13 @@ func TestSempyTablesQuery(t *testing.T) {
 	if len(rs.Rows) != 3 {
 		t.Fatalf("rows = %d, want 3 (Store, Time, Sales)", len(rs.Rows))
 	}
-	if rs.Rows[0][0] != "1" || rs.Rows[0][1] != "Store" {
-		t.Errorf("first row = %v, want [1 Store]", rs.Rows[0])
+	// Ids live in a MODEL-WIDE space, not a per-rowset one: TOM assembles a
+	// single object graph from every rowset and refuses duplicates
+	// (`Duplicate object ID 1, first in 'Tabular.Model' ...`). Tables are based
+	// at 1000, so the first table is 1001. What matters is that the SELECT and
+	// Discover grammars agree, which TestDiscoverModelledTypes asserts.
+	if rs.Rows[0][0] != objID("TMSCHEMA_TABLES", 0) || rs.Rows[0][1] != "Store" {
+		t.Errorf("first row = %v, want [%s Store]", rs.Rows[0], objID("TMSCHEMA_TABLES", 0))
 	}
 	parses(t, rs.ExecuteResponse())
 }

--- a/internal/xmla/dmv_test.go
+++ b/internal/xmla/dmv_test.go
@@ -261,3 +261,23 @@ func TestPartitionStoragesChain(t *testing.T) {
 	}
 	parses(t, ps.ExecuteResponse())
 }
+
+// The selected name becomes an XML element name, so it must be an identifier.
+// Rejected at the parse boundary rather than trusted to the writer's escaping.
+func TestDMVRefusesNonIdentifierColumnNames(t *testing.T) {
+	m, d := goldenModel(t), goldenData(t)
+	// The SOURCE name being unknown is already an error, so the alias is what
+	// isolates this guard: a valid source renamed to something unusable.
+	stmt := `SELECT [Name] AS [1st] FROM $SYSTEM.TMSCHEMA_TABLES`
+	if _, err := DMV(m, d, stmt); err == nil {
+		t.Errorf("%s: expected a refusal, got a rowset", stmt)
+	}
+	// And an ordinary alias still works, so the guard is not just "reject".
+	rs, err := DMV(m, d, `SELECT [Name] AS [SemPyTableName] FROM $SYSTEM.TMSCHEMA_TABLES`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rs.Columns[0] != "SemPyTableName" {
+		t.Errorf("alias = %q, want SemPyTableName", rs.Columns[0])
+	}
+}

--- a/internal/xmla/rowset.go
+++ b/internal/xmla/rowset.go
@@ -26,12 +26,46 @@ import (
 )
 
 // Rowset is a tabular result headed for the wire: ordered column names and rows
-// of already-stringified cells. Every XMLA value crosses as xsd:string here —
-// the client re-types from the schema it is given, and a single string column
-// type keeps the emitted XSD honest about what we actually send.
+// of already-stringified cells.
+//
+// THE INLINE SCHEMA IS A TYPE CONTRACT, not decoration. An earlier version of
+// this comment said "every XMLA value crosses as xsd:string ... which keeps the
+// emitted XSD honest about what we actually send". That was wrong, and it was
+// measured wrong against real sempy: the client re-types FROM the schema and
+// casts, so a string-typed ID fails as
+//
+//	InvalidCastException: Unable to cast object of type 'System.String'
+//	to type 'System.UInt64'
+//
+// Types is optional and parallel to Columns; an empty entry means xsd:string,
+// which keeps every existing caller correct.
 type Rowset struct {
+	// Name is emitted as <root name="...">. TOM's AmoDataAdapter renames the
+	// DataSet's tables from these, one per rowset, and
+	// AdjustTableNames BAILS OUT ENTIRELY if the count of names does not match
+	// the count of tables — so an unnamed or absent rowset silently breaks
+	// naming for every OTHER rowset in the same batch.
+	Name    string
 	Columns []string
+	Types   []string
 	Rows    [][]string
+}
+
+// xsdType is the declared type for column i: explicit if given, else string.
+func (r Rowset) xsdType(i int) string {
+	if i < len(r.Types) && r.Types[i] != "" {
+		return r.Types[i]
+	}
+	return "xsd:string"
+}
+
+// rootName renders the name attribute, omitting it entirely when unset so that
+// callers with a single unnamed rowset emit exactly what they did before.
+func rootName(n string) string {
+	if n == "" {
+		return ""
+	}
+	return ` name="` + escape(n) + `"`
 }
 
 // Trailing byte the client's payload reader switches on (0 = complete).
@@ -57,7 +91,7 @@ func (r Rowset) envelope(responseElement string) []byte {
 		`<soap:Body>` +
 		`<` + responseElement + ` xmlns="urn:schemas-microsoft-com:xml-analysis">` +
 		`<return>` +
-		`<root xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" ` +
+		`<root` + rootName(r.Name) + ` xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" ` +
 		`xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
 		`xmlns:sql="urn:schemas-microsoft-com:xml-sql" ` +
 		`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">`)
@@ -72,11 +106,11 @@ func (r Rowset) envelope(responseElement string) []byte {
 		`<xsd:element name="row" type="row" minOccurs="0" maxOccurs="unbounded"/>` +
 		`</xsd:sequence></xsd:complexType></xsd:element>` +
 		`<xsd:complexType name="row"><xsd:sequence>`)
-	for _, c := range r.Columns {
+	for i, c := range r.Columns {
 		// sql:field carries the true name; name= must be a legal XML name, so
 		// it is the encoded form (see EncodeName).
 		b.WriteString(`<xsd:element sql:field="` + escape(c) + `" name="` + EncodeName(c) +
-			`" type="xsd:string" minOccurs="0"/>`)
+			`" type="` + r.xsdType(i) + `" minOccurs="0"/>`)
 	}
 	b.WriteString(`</xsd:sequence></xsd:complexType></xsd:schema>`)
 

--- a/internal/xmla/rowset.go
+++ b/internal/xmla/rowset.go
@@ -84,19 +84,21 @@ func (r Rowset) DiscoverResponse() []byte { return r.envelope("DiscoverResponse"
 // function rather than two that would drift — the client rejects each
 // differently ("not a rowset" vs "unrecognizable"), which is exactly the kind
 // of divergence a copy would hide.
-func (r Rowset) envelope(responseElement string) []byte {
+// RootFragment is the <root> element alone, for a BATCH response where many
+// rowsets share one envelope. Same bytes the single-rowset path emits inside
+// its envelope, so the two cannot drift.
+func (r Rowset) RootFragment() []byte { return r.rootElement() }
+
+// rootElement is ONE <root> rowset: the name attribute, the inline XSD the
+// client reads before any row, and the rows. Shared by the single-rowset
+// envelope and by a batch, so the two cannot drift — the schema and the naming
+// are exactly the parts a copy would get subtly wrong.
+func (r Rowset) rootElement() []byte {
 	var b strings.Builder
-	b.WriteString(`<?xml version="1.0" encoding="utf-8"?>` +
-		`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">` +
-		`<soap:Body>` +
-		`<` + responseElement + ` xmlns="urn:schemas-microsoft-com:xml-analysis">` +
-		`<return>` +
-		`<root` + rootName(r.Name) + ` xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" ` +
+	b.WriteString(`<root` + rootName(r.Name) + ` xmlns="urn:schemas-microsoft-com:xml-analysis:rowset" ` +
 		`xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
 		`xmlns:sql="urn:schemas-microsoft-com:xml-sql" ` +
 		`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">`)
-
-	// The schema the client reads before any row.
 	b.WriteString(`<xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset" ` +
 		`xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
 		`xmlns:sql="urn:schemas-microsoft-com:xml-sql" ` +
@@ -113,9 +115,8 @@ func (r Rowset) envelope(responseElement string) []byte {
 			`" type="` + r.xsdType(i) + `" minOccurs="0"/>`)
 	}
 	b.WriteString(`</xsd:sequence></xsd:complexType></xsd:schema>`)
-
-	// Rows. A cell absent from a short row is omitted rather than emitted
-	// empty: minOccurs="0" makes absence legal, and "" is a value.
+	// A cell absent from a short row is omitted rather than emitted empty:
+	// minOccurs="0" makes absence legal, and "" is a value.
 	for _, row := range r.Rows {
 		b.WriteString(`<row>`)
 		for i, c := range r.Columns {
@@ -127,8 +128,20 @@ func (r Rowset) envelope(responseElement string) []byte {
 		}
 		b.WriteString(`</row>`)
 	}
+	b.WriteString(`</root>`)
+	return []byte(b.String())
+}
 
-	b.WriteString(`</root></return></` + responseElement + `></soap:Body></soap:Envelope>`)
+func (r Rowset) envelope(responseElement string) []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="utf-8"?>` +
+		`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">` +
+		`<soap:Body>` +
+		`<` + responseElement + ` xmlns="urn:schemas-microsoft-com:xml-analysis">` +
+		`<return>`)
+	b.Write(r.rootElement())
+	b.WriteString(`</return></` + responseElement + `>` +
+		`</soap:Body></soap:Envelope>`)
 	return append([]byte(b.String()), payloadComplete)
 }
 

--- a/internal/xmla/rowset.go
+++ b/internal/xmla/rowset.go
@@ -49,6 +49,14 @@ type Rowset struct {
 	Columns []string
 	Types   []string
 	Rows    [][]string
+	// RawCells emits cell values WITHOUT XML escaping, for the one payload that
+	// is itself a document: DISCOVER_XML_METADATA carries an ASSL <Server> or
+	// <Database> inside its METADATA column, and the client deserialises that
+	// content as XML. Escaped, it arrives as text and the client reports
+	// `Unexpected root '' (namespace '')` — a message about the ROOT for a
+	// defect in ESCAPING. Off by default: every other rowset carries data, not
+	// markup, and must stay escaped.
+	RawCells bool
 }
 
 // xsdType is the declared type for column i: explicit if given, else string.
@@ -124,7 +132,11 @@ func (r Rowset) rootElement() []byte {
 				break
 			}
 			n := EncodeName(c)
-			b.WriteString(`<` + n + `>` + escape(row[i]) + `</` + n + `>`)
+			cell := escape(row[i])
+			if r.RawCells {
+				cell = row[i]
+			}
+			b.WriteString(`<` + n + `>` + cell + `</` + n + `>`)
 		}
 		b.WriteString(`</row>`)
 	}


### PR DESCRIPTION
Follows #156, which measured what a real SemPy client demands. `internal/xmla` shipped before that measurement and four of its assumptions are wrong on the wire.

## Corrections

| gap | symptom when wrong |
|---|---|
| `discover.go` returned a **column-less** rowset for the 28 unmodelled types | no DataTable, `AdjustTableNames` bails on the count mismatch, **nothing in the batch gets named** |
| every value crossed as `xsd:string` | `InvalidCastException: System.String -> System.UInt64` |
| no `Version` column | `ResponseFormatException: The rowset is missing a Version column` |
| `<root>` carried no `name` | `Tables["Model"]` null, reported as a MODEL failure |

`Version` is `xsd:long`, **not** unsignedLong: `GetVersionFromDataTable` does `Utils.Verify(obj is long)`, an assertion, so an unsignedLong parses fine, fails the type test, and surfaces as a bare `TomInternalException` naming nothing at all.

## This answers the open question the previous claim left

Its release note asked whether TOM accepts an empty rowset whose schema declares no columns. **It does not.** That note is deleted rather than annotated, and the code comment now records the measurement.

## Tests

Five new tests, one per requirement, and **each was verified by mutation**: typing `Version` as unsignedLong, reverting the empties to column-less, and dropping the `name` attribute each make their test fail. The existing suite passed through all three mutations, which is why these were added.

`Rowset.Types` and `Rowset.Name` are optional, so the DAX path is unchanged — asserted by a test that an unnamed rowset emits no `name` attribute.