### PR TITLE
entra 0.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@
 # both `<version>` and `latest` (see .github/workflows/release.yml).
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat # single origin, path-prefixed surfaces
       PUBLIC_ORIGIN: "https://entra-emulator:8443"

--- a/e2e/airflow/docker-compose.yml
+++ b/e2e/airflow/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       retries: 10
 
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/azurite-shortcut/docker-compose.yml
+++ b/e2e/azurite-shortcut/docker-compose.yml
@@ -12,7 +12,7 @@
 # read genuinely exercises the SAS credential path.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/data-science-loop/docker-compose.yml
+++ b/e2e/data-science-loop/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/dbt-fabric/docker-compose.yml
+++ b/e2e/dbt-fabric/docker-compose.yml
@@ -12,7 +12,7 @@
 # (advertises ENCRYPT_NOT_SUP), so dbt connects with encrypt=false.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/dbt-fabricspark/docker-compose.yml
+++ b/e2e/dbt-fabricspark/docker-compose.yml
@@ -11,7 +11,7 @@
 # via the emu-data volume for REQUESTS_CA_BUNDLE.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/deployment-pipelines/docker-compose.yml
+++ b/e2e/deployment-pipelines/docker-compose.yml
@@ -14,7 +14,7 @@
 # api.fabric.microsoft.com.
 services:
   entra:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     user: "0:0"                       # bind privileged :443 (authority has no port)
     environment:
       PUBLIC_ORIGIN: "https://login.microsoftonline.com"

--- a/e2e/environment/docker-compose.yml
+++ b/e2e/environment/docker-compose.yml
@@ -7,7 +7,7 @@
 #   client → fabric-emulator (Livy REST, native) → spark agent (persistent SparkSession)
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/external-shortcuts/docker-compose.yml
+++ b/e2e/external-shortcuts/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/fabric-cli/docker-compose.yml
+++ b/e2e/fabric-cli/docker-compose.yml
@@ -4,7 +4,7 @@
 # (fab's FAB_API_ENDPOINT_FABRIC override points at it on :8443).
 services:
   entra:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     user: "0:0"                       # bind privileged :443 (authority has no port)
     environment:
       PUBLIC_ORIGIN: "https://login.microsoftonline.com"

--- a/e2e/livy/docker-compose.yml
+++ b/e2e/livy/docker-compose.yml
@@ -7,7 +7,7 @@
 #   client → fabric-emulator (Livy REST, native) → spark agent (persistent SparkSession)
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/medallion/docker-compose.yml
+++ b/e2e/medallion/docker-compose.yml
@@ -20,7 +20,7 @@
 # client on the host, the documented path is the tested path.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     ports:
       - "8443:8443" # login / graph / discovery (JWKS)
     environment:

--- a/e2e/notebook-driven/docker-compose.yml
+++ b/e2e/notebook-driven/docker-compose.yml
@@ -15,7 +15,7 @@
 # test would prove nothing.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/notebook-run/docker-compose.jvm.yml
+++ b/e2e/notebook-run/docker-compose.jvm.yml
@@ -2,7 +2,7 @@
 # optional Apache Spark 3.5 / Delta 3.2 Fabric Runtime 1.3 oracle.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/notebook-run/docker-compose.yml
+++ b/e2e/notebook-run/docker-compose.yml
@@ -4,7 +4,7 @@
 # reflects real execution. Plain HTTP over the container network.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/rest-helix/docker-compose.yml
+++ b/e2e/rest-helix/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/rest-servicenow/docker-compose.yml
+++ b/e2e/rest-servicenow/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/rti/docker-compose.yml
+++ b/e2e/rti/docker-compose.yml
@@ -8,7 +8,7 @@
 # is computed by the engine; the emulator only terminates the contract.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/s3/docker-compose.yml
+++ b/e2e/s3/docker-compose.yml
@@ -5,7 +5,7 @@
 # makes this a real test of the emulator's signer rather than of plain HTTP.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/sail/docker-compose.yml
+++ b/e2e/sail/docker-compose.yml
@@ -9,7 +9,7 @@
 # from process env only.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/salesforce/docker-compose.yml
+++ b/e2e/salesforce/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/spark-jvm/docker-compose.yml
+++ b/e2e/spark-jvm/docker-compose.yml
@@ -2,7 +2,7 @@
 # Delta 3.2). This is deliberately separate from the default Sail compose.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/spark/docker-compose.yml
+++ b/e2e/spark/docker-compose.yml
@@ -5,7 +5,7 @@
 # throughout for the container network.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/vscode-extension/docker-compose.yml
+++ b/e2e/vscode-extension/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.4.1}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/examples/fab-driven/.env
+++ b/examples/fab-driven/.env
@@ -15,7 +15,7 @@
 # reports the right name and the wrong bytes:
 #   docker inspect fab-driven-fabric-emulator-1 --format '{{.Image}}'
 FABRIC_EMULATOR_VERSION=0.15.1
-ENTRA_EMULATOR_VERSION=0.4.1
+ENTRA_EMULATOR_VERSION=0.6.0
 
 # Sail is LakeSail's Rust Spark-Connect server, and the agent is what the
 # emulator drives to execute a notebook. Both are published by the emulator's


### PR DESCRIPTION
Bumps this repo's entra pins from 0.4.1 to 0.6.0, ahead of the family BOM
bump in `azure-emulators` — the error-tier `pins` gate goes red the moment the
BOM moves ahead of consumers, so consumers land first.

**Two releases in one jump (0.5.0 and 0.6.0), both non-breaking.** v0.5.0 says
"nothing to do, and nothing to re-read"; v0.6.0 adds SAML 2.0 SP-initiated SSO
and fixes seven defects real clients found, all corrective rather than
contract-changing.

The one behaviour change worth naming: custom API scopes now echo
`api://<app>/<scope>` rather than the short name, which is what real clients
send. Nothing here asserts on the short form, and CI is the check.

No config change is required of this repo.