### PR TITLE
docs: release notes for v0.21.0

### DIFF
--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -1,0 +1,112 @@
+# v0.21.0
+
+**XMLA works.** Thirty-one commits, and the theme is a surface that this
+repository spent months calling infeasible, then deferred on cost, and has now
+implemented and proved with two of Microsoft's own clients.
+
+Also here: the Purview Data Map goes green on an independent witness, four
+code-scanning fixes, and `./data` becomes the default state directory.
+
+**One behaviour change needs configuration: see Upgrading.**
+
+---
+
+## SemPy and semantic-link-labs, over XMLA
+
+`docs/18` deferred XMLA on "native .NET, not endpoint-overridable, no CI
+oracle". Every part of that was wrong, and `e2e/xmla` disproved it by
+measurement rather than argument: ADOMD.NET runs on Linux under .NET 8, a
+`powerbi://<host>:<port>` data source sends TLS wherever you point it, a
+self-signed CA is trusted through the ordinary route, and a bearer travels in
+the connection string.
+
+What followed was a measured walk through the client's own demands, one
+recorded request at a time, rather than an implementation against a paper spec.
+The result is a surface **two independent Microsoft clients** drive in CI, and
+the point is that they read it differently:
+
+- **`sempy`** projects the DMV rowsets: `list_workspaces`, `list_datasets`,
+  `evaluate_dax`, `list_tables`, `list_measures`, `list_columns`,
+  `list_partitions`, `list_relationships`.
+- **`semantic-link-labs` 0.17.0** goes through the Tabular Object Model
+  (`connect_semantic_model`), exercising TOM's roughly 35 element `<Discover>`
+  batch and the object graph built from it.
+
+Both report the **same** seeded model: 3 tables, 6 measures, 12 columns, 3
+partitions. Neither client is modified. They reach the emulator as
+`api.fabric.microsoft.com`, and `entra-emulator` mints the token. DAX results
+declare a type per column, so callers get numeric dtypes rather than strings.
+
+**Writes work too.** `connect_semantic_model(readonly=False)` adds a measure
+and it survives a reconnect, which is the assertion that matters, because TOM
+reports `SaveChanges` as successful whenever the server answers at all.
+
+The write protocol is **not** the TMSL JSON this repository planned for. It was
+measured: TOM sends a `<Batch Transaction="true">` of `<Create>`/`<Alter>` in
+the 2014/engine namespace carrying **row deltas** in the same rowset shape the
+server emits for Discover, keyed by the object ids it handed out. A field or
+object type the emulator cannot represent is refused by name rather than
+accepted and silently dropped.
+
+Labs also needs this repository's own `notebookutils` shim, which it calls for
+every REST request. That was measured, not assumed, by watching it fail at
+`resolve_workspace_name` before XMLA was ever reached.
+
+**Scope, stated plainly:** measures, plus lineage tags and annotations on
+existing objects. MDX, the LRO continuation byte, and structural writes (new
+tables, columns, relationships, partitions, Direct Lake migration) are **not**
+implemented. The parity row and [docs/32](https://github.com/calvinchengx/fabric-emulator/blob/main/docs/32-xmla-plan.md)
+carry the detail.
+
+## Purview Data Map is green
+
+Graded on a `pyapacheatlas` witness, which is a third-party client rather than
+this repository's own reader.
+
+## Security
+
+Four code-scanning alerts, and one of them had teeth:
+
+- **An unbounded `range()`** could be driven to an out-of-memory kill, which no
+  per-request recover catches. It is bounded now.
+- **The Key Vault secret name is kept in one path segment.** Rebuilding the URL
+  through `ResolveReference` dropped the escaping, so a name like
+  `../../certificates/evil` escaped `/secrets/` and sent the vault token
+  elsewhere on the host.
+- A secret is no longer logged, and the validated vault URL is the one
+  requested.
+
+## Reliability
+
+`e2e/xmla` takes an inter-process lock, so a second run cannot dismantle a live
+one. The previous failure mode was expensive to read: one run deleted the
+shared work directory and force-removed the forwarder while another was using
+them, and the damage surfaced as a missing certificate and a connection refused
+on 443, both of which look like findings about ADOMD.NET rather than harness
+damage.
+
+## Family alignment
+
+- entra-emulator `0.6.0` and keyvault-emulator `0.7.0` across the compose files.
+- The August dependency bumps: astro, svelte, tailwind-variants,
+  `@lucide/svelte`, Playwright, and the actions group. TypeScript is held at 6,
+  which is where `svelte-check`'s version gate caps it.
+
+## Upgrading
+
+**`./data` is now the default state directory**, matching entra, arm, keyvault
+and apim. The unset / explicitly-empty distinction is the feature:
+
+| `FABRIC_DATA_DIR` | state goes to |
+|---|---|
+| unset | `./data`, created if absent |
+| explicitly empty | memory, nothing written |
+| a path | that path, created if absent |
+
+If you run the **binary** and relied on unset meaning in-memory, set it to
+empty explicitly. If you run the **image**, note it bakes
+`FABRIC_DATA_DIR=/data` for callers who mount a volume there; mount one, or
+override back to empty as this repository's compose file does, or the store
+fails to open `/data`.
+
+Nothing else on the REST or Spark surfaces changed.


### PR DESCRIPTION
Notes for the next tag, so the published body is the story rather than GoReleaser's commit list.

Thirty-one commits since v0.20.0. The headline is XMLA: implemented, and driven in CI by two independent Microsoft clients that read the surface differently (`sempy` via DMV rowsets, `semantic-link-labs` 0.17.0 via TOM), both reporting the same seeded model. Writes included, with the measured protocol stated plainly as `<Batch Transaction="true">` row deltas rather than the TMSL JSON originally planned for, and the out-of-scope list (MDX, LRO continuation byte, structural writes) named rather than left implied.

Also covers the Purview Data Map going green on a pyapacheatlas witness, the four code-scanning fixes, the `e2e/xmla` run lock, and the family bumps.

The XMLA sections follow the parity row's and the commit messages' own wording rather than paraphrasing, since that work is another session's. **Worth a read by whoever did it** before this is tagged.

Upgrading has a table for the `FABRIC_DATA_DIR` unset / explicitly-empty / path distinction, including that the image bakes `/data` while the binary defaults to `./data` — the two differ and container users need the difference.

Docs only. No code changes.