### PR TITLE
examples: resolve the target through fabric-target, and enforce it

### DIFF
--- a/.github/workflows/real-fabric.yml
+++ b/.github/workflows/real-fabric.yml
@@ -78,6 +78,26 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: uv run --frozen --group fabric-target python e2e/notebook-run/real_fabric.py
+      # THE EXAMPLE'S OWN CODE against real Fabric — the other half of T3 in
+      # e2e/fabric-target/run.py, which runs this same step with
+      # FABRIC_TARGET=emulator. Until both legs existed, "the same code runs
+      # against real Fabric" was true of the conformance suite and unproven of
+      # anything a reader would actually copy: the four medallion examples
+      # hardcoded the seeded principal, so the toggle never reached them.
+      #
+      # provision.py only touches the control plane, so it needs no Spark, SQL
+      # Server or vault — the whole resolver path with none of the sidecars.
+      - name: An example's own provisioning against real Fabric
+        if: steps.gate.outputs.run == 'true'
+        working-directory: examples/medallion-pyspark
+        env:
+          FABRIC_TARGET: real
+          FABRIC_WORKSPACE: ${{ secrets.FABRIC_TEST_WORKSPACE }}
+          WORKSPACE_NAME: ${{ secrets.FABRIC_TEST_WORKSPACE }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: uv run --frozen python provision.py
       # Oracle capture, on demand only. Several activities are blocked on one
       # thing — nobody has captured the wire `type` and `typeProperties` shape
       # Fabric actually sends — and this turns that capture into a button.

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_witnesses.py --strict
 	@$(PY) scripts/check_govern_types.py
 	@$(PY) scripts/check_example_parity.py
+	@$(PY) scripts/check_example_portability.py
 	@$(PY) scripts/check_conformance.py
 	@$(PY) scripts/check_arch_services.py
 	@$(PY) scripts/check_docs_sidebar.py

--- a/docs/21-real-fabric-toggle.md
+++ b/docs/21-real-fabric-toggle.md
@@ -22,6 +22,12 @@ So the toggle is not an emulation feature; it is **one resolver** that turns a
 target name into a coherent set of endpoints + credentials, plus guardrails
 for the places the two worlds genuinely differ.
 
+Where your artifacts persist — definition parts, the `{name}.{type}/` +
+`.platform` source format, and the hard line that OneLake data is never in Git —
+is [docs/46](46-artifact-persistence.md). This document resolves *where to talk*;
+that one says *what you are storing*, and both have to hold for a run to be
+portable.
+
 ## The contract
 
 One switch: `FABRIC_TARGET=emulator | real` (default `emulator`).

--- a/docs/46-artifact-persistence.md
+++ b/docs/46-artifact-persistence.md
@@ -83,6 +83,83 @@ ingest.DataPipeline/
 Invalid, leading, or trailing characters in a display name are replaced by their
 HTML number; if the name is unavailable the `logicalId` is used instead.
 
+## The two addresses a definition needs at runtime: compute, and SQL
+
+A definition is portable. What it *runs on* and what it *queries through* are
+assigned by the service, and this is where an example stops being portable
+without noticing — everything above can be perfect while a step still dials
+`localhost:1433`.
+
+### Spark: you do not get a pool, you get a job
+
+There is no Spark endpoint on Fabric to connect to from outside. Spark lives
+inside the service and the unit of work is a **submitted job**, not a session you
+attach to:
+
+| | What it is | Who picks the compute |
+|---|---|---|
+| **Starter pool** | Microsoft-managed pre-warmed Medium nodes, the workspace default. Best-effort: when warm capacity exists a session starts in seconds, otherwise it falls back to on-demand provisioning and takes longer. Node ceilings are per capacity SKU (F2 → 1 node, F64 → 16, F2048 → 200). | workspace Spark settings |
+| **Custom pool** | Your node family, size and autoscale. A *custom live pool* keeps clusters warm on a schedule you control, so sessions start in about 5 seconds inside that window and environment libraries are already installed. | an **Environment** attached to the item or workspace |
+| **Environment** | The Spark runtime + libraries + pool selection, as a first-class item. This is the only handle you get on "which pool", and it is passed by id. | you, per item or per job |
+
+Two ways to submit:
+
+1. **Run the notebook item** — `POST /v1/workspaces/{ws}/notebooks/{id}/jobs/instances?jobType=RunNotebook`,
+   which takes parameters, a session/compute configuration, an environment, and a
+   default lakehouse. This is the portable one: the emulator accepts the same
+   call, so `run_job(notebook_id, "RunNotebook")` works on both targets.
+2. **The Livy API** — `POST /v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/{sessions|batches}`.
+   Sessions are interactive and keep state across statements (idle-terminated
+   after 20 minutes); batches are one application per submission. A session runs
+   on the workspace's starter pool unless you pass
+   `conf: {"spark.fabric.environmentDetails": "{\"id\": \"<environmentId>\"}"}`.
+   Beyond the usual Fabric scopes this needs `Lakehouse.Execute.All` plus the
+   `Code.Access*` family (`Code.AccessFabric.All` and `Code.AccessStorage.All`
+   are required; Key Vault, ADLS, Kusto and SQL are opt-in scopes).
+
+The consequence for this repo: the emulator has no pool, so it parses a notebook
+into cells, records a `Pending` run, and waits for an engine (Sail over Spark
+Connect) to execute them and report back. That engine is scaffolding for the
+missing half of the target. A step that drives Spark Connect **directly** is
+emulator-only by construction, which is why `silver.py` and `star_silver.py`
+refuse under `real` and name the two submission routes above, while `engine.py`
+skips: Fabric runs the queued notebook itself.
+
+### SQL: the address is per-item and only the API knows it
+
+Both SQL surfaces are assigned by the service at creation time. Ask the item, on
+the **typed** route (the generic `/items/{id}` answers the generic record):
+
+| Surface | Where the address lives | Writable |
+|---|---|---|
+| Warehouse | `GET /warehouses/{id}` → `properties.connectionString` | yes |
+| Lakehouse SQL analytics endpoint | `GET /lakehouses/{id}` → `properties.sqlEndpointProperties.connectionString` | **no**, read-only over the Delta tables |
+
+Both look like `<opaque>-<opaque>.datawarehouse.fabric.microsoft.com` on port
+1433, with TLS required. Three things that bite:
+
+- **`provisioningStatus`** on the lakehouse endpoint is `InProgress` until it is
+  `Success`. It is provisioned asynchronously, so a client that reads the
+  connection string and dials immediately can be early.
+- **The database is the DISPLAY NAME**, and the workspace is encoded in the
+  server name. This is why the emulator accepts *either* the item id or the
+  display name (`internal/server/warehouse.go`): the id is the only addressing
+  that works when one host serves every workspace.
+- **The analytics endpoint lags the lakehouse.** Metadata sync is normally under
+  a minute but is not instant, so a table Spark just wrote can be briefly absent
+  from T-SQL. `POST /v1/workspaces/{ws}/sqlEndpoints/{sqlEndpointId}/refreshMetadata`
+  forces the sync rather than waiting for the background one. **The emulator does
+  not implement that endpoint**, and does not report the endpoint's `id` either —
+  it has no separate `SQLEndpoint` item and reflects on connect, so there is
+  nothing to sync. Code that needs the refresh must be written against real
+  Fabric, and will 404 locally.
+
+`examples/contoso-fixtures/common.py:sql_endpoint()` is the portable form:
+discover the address, use the item id locally and the display name on real
+Fabric, TLS on real and off against the emulator's FedAuth-without-TLS front.
+`TDS_SERVER` remains only as an override, because the emulator advertises the
+port it *listens* on rather than the one Docker published.
+
 ## Why ids are never hardcoded
 
 Ids cannot match across targets — a workspace GUID in the emulator has no
@@ -93,9 +170,9 @@ not an emulator concession; it is the only thing that can work.
 ## How this is enforced
 
 - **`scripts/check_example_portability.py`** (in `make check`) fails when an
-  example hardcodes the seeded principal or a `localhost` endpoint outside the
-  resolver, when the resolver stops consuming `fabric-target`, or when a
-  definition part uses a path that is not Fabric's.
+  example hardcodes the seeded principal, a `localhost` control-plane endpoint or
+  a SQL host outside the resolver, when the resolver stops consuming
+  `fabric-target`, or when a definition part uses a path that is not Fabric's.
 - **`python/tests/test_check_example_portability.py`** proves the gate fails on
   each of those, *and* that it does not fire on a OneLake shortcut target or on
   installed dependencies — the false positives its first version produced.
@@ -122,6 +199,14 @@ A contract you copy is a contract you get wrong. Consume `fabric-target`.
 - [CI/CD for pipelines in Data Factory](https://learn.microsoft.com/en-us/fabric/data-factory/cicd-pipelines) · [Pipeline REST API](https://learn.microsoft.com/en-us/fabric/data-factory/pipeline-rest-api)
 - [Lakehouse Git integration and deployment pipelines](https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-git-deployment-pipelines) — the tables-and-`Files/` exclusion
 - [Notebook source control and deployment](https://learn.microsoft.com/en-us/fabric/data-engineering/notebook-source-control-deployment)
+
+Compute and SQL endpoints:
+
+- [Run On Demand Notebook](https://learn.microsoft.com/en-us/rest/api/fabric/notebook/background-jobs/run-on-demand-notebook) · [Notebook public API](https://learn.microsoft.com/en-us/fabric/data-engineering/notebook-public-api)
+- [Livy API overview](https://learn.microsoft.com/en-us/fabric/data-engineering/api-livy-overview) · [Livy sessions](https://learn.microsoft.com/en-us/fabric/data-engineering/get-started-api-livy-session) — the URL pattern, the `Code.*` scopes, and the Environment override
+- [Configure starter pools](https://learn.microsoft.com/en-us/fabric/data-engineering/configure-starter-pools) — best-effort warm capacity, per-SKU node ceilings
+- [Get Lakehouse](https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/items/get-lakehouse) · [Get Warehouse](https://learn.microsoft.com/en-us/rest/api/fabric/warehouse/items/get-warehouse) — where the connection strings live
+- [SQL analytics endpoint metadata sync](https://learn.microsoft.com/en-us/fabric/data-engineering/sql-analytics-endpoint-metadata-sync) — the lag, and `refreshMetadata`
 
 **One caution on that Git source-code-format page**: its "item definition files"
 section lists only six item types and **omits data pipelines**, even though the

--- a/docs/46-artifact-persistence.md
+++ b/docs/46-artifact-persistence.md
@@ -1,0 +1,130 @@
+# 46 — Where a data engineer's artifacts actually live
+
+**Status: enforced** (`scripts/check_example_portability.py`, in `make check`).
+
+This is the contract that makes [docs/21](21-real-fabric-toggle.md)'s one-flag
+toggle *mean* something. The toggle resolves endpoints and credentials; this
+document says what your artifacts **are** and where they **persist** — because a
+pipeline that runs against both targets while persisting its work in a shape real
+Fabric would refuse has parity in the demo and none in production.
+
+Verified against Microsoft's own documentation, not inferred from the emulator.
+
+## Two stores, and the line between them
+
+| | Definitions (item source) | Data |
+|---|---|---|
+| Lives in | the **workspace** metadata store | **OneLake** |
+| Reached by | `getDefinition` / `updateDefinition` | ADLS/Blob APIs, Spark, TDS |
+| In Git? | **yes**, when the workspace is connected | **never** |
+| Overwritten by a deployment? | yes, that is the point | **no, never** |
+
+The second row of the last column is the one people get wrong. Fabric's own
+documentation is explicit: tables (Delta and non-Delta) and folders under
+`Files/` **aren't tracked or versioned in Git**, and Git and deployment
+operations never overwrite them. Your notebook *code* is versioned; the lakehouse
+*tables it writes* are not. A CI/CD pipeline moves definitions between
+workspaces — it does not move data, and a design that assumes otherwise will
+silently lose it or silently keep stale copies.
+
+## Definitions are base64 parts
+
+`getDefinition` returns, and `updateDefinition` accepts, a list of parts:
+
+```json
+{"definition": {"parts": [
+  {"path": "notebook-content.py", "payload": "<base64>", "payloadType": "InlineBase64"},
+  {"path": ".platform",           "payload": "<base64>", "payloadType": "InlineBase64"}
+]}}
+```
+
+The `path` values are **Fabric's, not ours**. Inventing one produces an item the
+emulator will happily store — it keeps parts verbatim by design — and real Fabric
+will reject. That asymmetry is why this is a gate and not a guideline.
+
+| Item | Parts |
+|---|---|
+| Notebook | `notebook-content.py` (or `notebook-content.ipynb` with `?format=ipynb`) |
+| Data pipeline | `pipeline-content.json` |
+| Semantic model | `definition.pbism` + `definition/` TMDL files |
+| Report | `definition.pbir` + `report.json` |
+| *every* item | `.platform` |
+
+## `.platform`, and the identity that survives a rename
+
+```json
+{
+  "version": "2.0",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "config": {"logicalId": "e553e3b0-0260-4141-a42a-70a24872f88d"},
+  "metadata": {"type": "Notebook", "displayName": "silver", "description": "..."}
+}
+```
+
+`logicalId` is the load-bearing field: a cross-workspace identifier linking an
+item to its source-control representation, stable across renames and directory
+moves. **Do not change it.** Version 1 split this into `item.metadata.json` +
+`item.config.json`; a directory must carry one form or the other, never both.
+
+## The Git layout
+
+One directory per item, named `{display name}.{public facing type}`, containing
+the definition files plus `.platform`:
+
+```
+silver.Notebook/
+  notebook-content.py
+  .platform
+ingest.DataPipeline/
+  pipeline-content.json
+  .platform
+```
+
+Invalid, leading, or trailing characters in a display name are replaced by their
+HTML number; if the name is unavailable the `logicalId` is used instead.
+
+## Why ids are never hardcoded
+
+Ids cannot match across targets — a workspace GUID in the emulator has no
+relationship to one in your tenant. So everything durable is addressed **by
+name** and resolved to a GUID per target, at startup, by the resolver. This is
+not an emulator concession; it is the only thing that can work.
+
+## How this is enforced
+
+- **`scripts/check_example_portability.py`** (in `make check`) fails when an
+  example hardcodes the seeded principal or a `localhost` endpoint outside the
+  resolver, when the resolver stops consuming `fabric-target`, or when a
+  definition part uses a path that is not Fabric's.
+- **`python/tests/test_check_example_portability.py`** proves the gate fails on
+  each of those, *and* that it does not fire on a OneLake shortcut target or on
+  installed dependencies — the false positives its first version produced.
+- **`examples/contoso-fixtures/common.py`** is the single resolver for all four
+  medallion examples. It consumes `fabric-target`; it does not restate it.
+
+## The failure this prevents, from the field
+
+`contoso-data-platform` restated the target contract locally while
+`fabric-target` was unpublished, and the restatement drifted: it resolved the
+real target to an Entra client-credentials flow requiring `AZURE_CLIENT_SECRET`.
+That meant `az login` did not work, a managed identity did not work, and the
+platform **could not have run inside a Fabric notebook at all** — a notebook has
+no client secret to give. It looked correct and passed its own tests, because its
+tests ran against the emulator.
+
+A contract you copy is a contract you get wrong. Consume `fabric-target`.
+
+## Sources
+
+- [Overview of item definitions](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/item-definition-overview)
+- [Notebook definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/notebook-definition) · [Get Notebook Definition](https://learn.microsoft.com/en-us/rest/api/fabric/notebook/items/get-notebook-definition)
+- [Git source code format](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/source-code-format) — directory naming, `.platform`, `logicalId`
+- [CI/CD for pipelines in Data Factory](https://learn.microsoft.com/en-us/fabric/data-factory/cicd-pipelines) · [Pipeline REST API](https://learn.microsoft.com/en-us/fabric/data-factory/pipeline-rest-api)
+- [Lakehouse Git integration and deployment pipelines](https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-git-deployment-pipelines) — the tables-and-`Files/` exclusion
+- [Notebook source control and deployment](https://learn.microsoft.com/en-us/fabric/data-engineering/notebook-source-control-deployment)
+
+**One caution on that Git source-code-format page**: its "item definition files"
+section lists only six item types and **omits data pipelines**, even though the
+Data Factory CI/CD docs document pipeline Git integration and
+`pipeline-content.json`. Treat it as authoritative on layout and `.platform`, not
+as an inventory of what Git supports.

--- a/e2e/fabric-target/run.py
+++ b/e2e/fabric-target/run.py
@@ -127,6 +127,30 @@ try:
         [sys.executable, "-m", "pytest", "-m", "target", "-q",
          os.path.join(REPO, "python", "fabric-target", "conformance")],
         check=True, env={**env, "FABRIC_WORKSPACE": "target-e2e"})
+
+    # T3: A USER'S OWN EXAMPLE through the toggle, not just the contract.
+    #
+    # The conformance suite proves `fabric-target` resolves correctly. It does
+    # not prove that the code a reader copies goes through it — and for a long
+    # while it did not: the four medallion examples hardcoded the seeded
+    # principal and localhost defaults, so `docs/21`'s toggle never reached
+    # them and nothing noticed, because the emulator went on passing.
+    #
+    # provision.py is the right step to run here: it touches only the control
+    # plane (workspace, lakehouse, warehouse, workspace identity), so it needs
+    # no Spark, SQL Server or vault sidecar, while still exercising the whole
+    # resolver path — target() -> credential -> session -> item create.
+    #
+    # The real leg is the SAME step with FABRIC_TARGET=real, in
+    # .github/workflows/real-fabric.yml, secret-gated. That is what makes "one
+    # flag" a measurement rather than a design intention.
+    example = os.path.join(REPO, "examples", "medallion-pyspark")
+    log("running examples/medallion-pyspark/provision.py under FABRIC_TARGET=emulator")
+    subprocess.run(
+        ["uv", "run", "--frozen", "python", "provision.py"],
+        check=True, cwd=example,
+        env={**env, "WORKSPACE_NAME": "target-e2e-example",
+             "PIPELINE_STATE": os.path.join(WORK, "example-state.json")})
     log("PASS")
 finally:
     for p in procs:

--- a/e2e/medallion/run.py
+++ b/e2e/medallion/run.py
@@ -42,7 +42,10 @@ ENDPOINTS = {
     "ENTRA_URL": "https://localhost:8443",
     "KV_URL": "https://localhost:8444",
     "FABRIC_REST_URL": "https://localhost:9443",
-    "TDS_SERVER": "localhost,1433",
+    # TDS_SERVER is deliberately NOT set: unset means the example discovers the
+    # SQL address from the item's own properties, which is the only form that can
+    # work against real Fabric. Setting it here would leave that path unexercised
+    # by every CI run while looking covered.
     "SPARK_REMOTE": "sc://localhost:50051",
     "KV_INTERNAL_URL": "https://keyvault-emulator:8444",
 }
@@ -93,10 +96,18 @@ def run(example=EXAMPLE, label="medallion", profiles=()):
             #
             # Run inside the example's project so it borrows that example's
             # state and token helpers — the same route the tutorial documents.
+            # The probe gets TDS_SERVER explicitly, and the EXAMPLE does not. It
+            # is harness tooling rather than tutorial code: it dials the SQL
+            # endpoint to check a type mapping, with no state.json of its own to
+            # discover an item from. The example must discover its address (the
+            # only form that works on real Fabric); the probe would gain nothing
+            # from it and would only make this suite unable to prove the
+            # discovery path is exercised.
             rc = subprocess.run(
                 ["uv", "run", "--project", example, "python",
                  os.path.join(REPO, "e2e", "type-map", "probe.py")],
-                cwd=example, env={**os.environ, **ENDPOINTS}).returncode
+                cwd=example,
+                env={**os.environ, **ENDPOINTS, "TDS_SERVER": "localhost,1433"}).returncode
             if rc != 0:
                 print("\n==== type-map probe FAILED ====", file=sys.stderr)
         if rc != 0:

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,13 +52,48 @@ cd ~/mine && uv sync && uv run python pipeline.py`. And its dependencies
 (pandas, dbt, pyodbc, …) never enter the emulator's own dependency graph, which
 stays about building and testing the emulator.
 
-**Examples do not share helper modules.** Each one carries its own `common.py`
-even where that duplicates another. Copy-paste independence is the property that
-makes an example useful; DRY across examples would trade it away for nothing a
-reader benefits from.
+**The four medallion examples share one fixture package, and only that.** They
+import `contoso-fixtures` for the seeded source-system generators and the target
+resolver (`common.py`). That is a deliberate exception to copy-paste
+independence, for a reason specific to these four: the comparison between them
+asserts they produce *identical* silver, and two copies of a seeded generator
+that drifted by a single RNG draw would compare two different datasets while both
+still passed their own assertions. One generator makes that failure impossible
+rather than merely unlikely. Everything else — every line of pipeline code, the
+`pyproject.toml`, the lockfile, `definitions/` — each example owns.
+
+**The target is resolved in exactly one file.** `contoso-fixtures/common.py`
+turns `FABRIC_TARGET=emulator|real` into endpoints and a credential, through the
+published `fabric-target` package. No step branches on which target is active;
+they hold display *names* and receive resolved values, because item ids can never
+match across targets. See [docs/21](../docs/21-real-fabric-toggle.md).
 
 **Every example is executable end to end and asserts its own results.** An
 example that merely *looks* right is a liability — these fail loudly instead.
+
+## Your items are files, in Fabric's layout
+
+Each example keeps its Notebook and DataPipeline definitions on disk, one
+directory per item:
+
+```
+definitions/
+  bronze-orders.Notebook/     .platform  notebook-content.py
+  bronze-ingest.DataPipeline/ .platform  pipeline-content.json
+```
+
+`{display name}.{public facing type}` with the definition files plus
+`.platform` is exactly what Fabric's Git integration writes when you connect a
+real workspace to Azure DevOps or GitHub — so what an example commits is what
+your repository holds in production, and the filenames (`notebook-content.py`,
+`pipeline-content.json`) are the ones `updateDefinition` accepts. Ids that differ
+per workspace are `{{TOKENS}}` substituted at deploy, the way Microsoft's
+`fabric-cicd` uses a `find_replace` parameter file.
+
+Definitions are versioned. The Delta tables they write live in OneLake and are
+never in Git, and no deployment overwrites them.
+[docs/46](../docs/46-artifact-persistence.md) is the contract, with a Microsoft
+documentation link behind each claim.
 
 ## Where the fidelity proof lives — and it is not here
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -95,6 +95,32 @@ never in Git, and no deployment overwrites them.
 [docs/46](../docs/46-artifact-persistence.md) is the contract, with a Microsoft
 documentation link behind each claim.
 
+## Secrets, and where the compute lives
+
+**Secrets are read the way a notebook reads them.** `extract_load.py` calls
+`notebookutils.credentials.getSecret(vault_uri, "contoso-pos-api-key")` — the
+brokered path, where the workspace identity mints a vault-audience token and the
+secret never appears in the notebook, a parameter, or a pipeline definition. It
+works outside Fabric because this repo ships a working `notebookutils`
+(`python/notebookutils/`): entra-emulator under `emulator`,
+`DefaultAzureCredential` under `real`. Reading Key Vault's REST API directly
+would reach the same secret and teach a shape that cannot move into a notebook.
+
+`secret.py` covers the other half: the secret is stored in the vault and bound to
+Fabric as an **AzureKeyVaultReference** connection, which Fabric resolves
+server-side — so the connection's read shape never contains the value, and the
+example asserts that.
+
+**Compute and SQL addresses are discovered, never configured.** The SQL endpoint
+of a warehouse or a lakehouse is assigned per item by the service, so every step
+asks for it (`common.sql_endpoint()`) instead of naming a host; the enforcement
+gate fails a step that names one. Spark is the honest limit: Fabric exposes no
+Spark endpoint to dial, so `silver.py` refuses under `real` and names the two
+real routes (submit the notebook item, or the Livy API), while `engine.py` skips
+because Fabric runs the queued notebook on its own pool. That whole story,
+including starter versus custom pools and the analytics-endpoint sync lag, is in
+[docs/46](../docs/46-artifact-persistence.md).
+
 ## Where the fidelity proof lives — and it is not here
 
 These four show what the emulator **does**. They do not show it is **right**,

--- a/examples/contoso-fixtures-advanced/uv.lock
+++ b/examples/contoso-fixtures-advanced/uv.lock
@@ -1,0 +1,198 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "contoso-fixtures"
+version = "0.1.0"
+source = { editable = "../contoso-fixtures" }
+dependencies = [
+    { name = "fabric-emulator-notebookutils" },
+    { name = "fabric-target" },
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fabric-emulator-notebookutils", editable = "../../python" },
+    { name = "fabric-target", editable = "../../python/fabric-target" },
+    { name = "requests", specifier = ">=2.32,<3" },
+]
+
+[[package]]
+name = "contoso-fixtures-advanced"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "contoso-fixtures" },
+    { name = "pyarrow" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "contoso-fixtures", editable = "../contoso-fixtures" },
+    { name = "pyarrow", specifier = ">=18,<24" },
+]
+
+[[package]]
+name = "fabric-emulator-notebookutils"
+version = "0.1.0"
+source = { editable = "../../python" }
+
+[[package]]
+name = "fabric-target"
+version = "0.1.0"
+source = { editable = "../../python/fabric-target" }
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-identity", marker = "extra == 'real'", specifier = ">=1.17" },
+    { name = "requests", marker = "extra == 'sessions'", specifier = ">=2.31" },
+]
+provides-extras = ["real", "sessions"]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -163,6 +163,53 @@ def load():
 # into cells and records a Pending run, then an ENGINE executes those cells and
 # reports back. That split is why these helpers exist.
 
+DEFINITIONS = pathlib.Path(os.environ.get("DEFINITIONS", HERE / "definitions"))
+
+
+def create_item_from_definition(folder, display_name=None, **substitutions):
+    """Create an item from an on-disk definition folder in Fabric's SOURCE FORMAT.
+
+    `definitions/<display name>.<Type>/` holding the item's definition files plus
+    `.platform` is exactly what Fabric's Git integration writes and what
+    `fabric-cicd` deploys, so what is committed here is what a real repository
+    committed (docs/46-artifact-persistence.md). The alternative — building the
+    body in a Python string — models the API and not the artefact, and teaches a
+    layout no CI/CD tool would recognise.
+
+    WHY THERE IS A SUBSTITUTION STEP. A definition names the workspace, lakehouse
+    and upstream items it reads by GUID, and those do not exist until provisioning
+    has run. So the committed files carry `{{TOKENS}}` and the deploy substitutes
+    them. That is not a local workaround: Microsoft's own fabric-cicd ships a
+    `find_replace` parameter file for the same reason, because one definition has
+    to land in dev, test and prod with different ids.
+
+    The item TYPE comes from the folder name, as it does in Git, so a definition
+    cannot be deployed as the wrong type by a typo at the call site.
+    """
+    folder_path = DEFINITIONS / folder
+    assert folder_path.is_dir(), f"no definition folder {folder_path}"
+    name, _, item_type = folder.rpartition(".")
+    assert name and item_type, (
+        f"definition folder {folder!r} must be named '<display name>.<Type>', "
+        f"the layout Fabric's Git integration uses")
+
+    parts = {}
+    for path in sorted(folder_path.rglob("*")):
+        if not path.is_file():
+            continue
+        text = path.read_text()
+        for token, value in substitutions.items():
+            text = text.replace("{{" + token + "}}", str(value))
+        # A surviving placeholder would deploy cleanly and fail much later as a
+        # Spark error about a workspace literally named {{WORKSPACE_ID}}.
+        assert "{{" not in text, (
+            f"unsubstituted placeholder in {path.relative_to(folder_path)}: "
+            f"{text[text.index('{{'):][:40]!r}")
+        parts[str(path.relative_to(folder_path)).replace(os.sep, "/")] = text
+
+    return create_item(display_name or name, item_type, parts)
+
+
 def create_item(display_name, item_type, parts):
     """Create an item with a definition, resolving the LRO if the create is async."""
     import base64

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -206,8 +206,9 @@ def tables_uri():
 
 # An item's SQL endpoint, as the API reports it. The collection segment is the
 # typed route Fabric documents the property on — the generic /items/{id} answers
-# the generic record there, so reading the address off it works here and returns
-# nothing against real Fabric (internal/api/kql.go).
+# the generic record there, so reading the address off it can work against a
+# development stack and return nothing on real Fabric
+# (docs/46-artifact-persistence.md).
 _SQL_COLLECTION = {"Warehouse": "warehouses", "SQLDatabase": "sqlDatabases",
                    "Lakehouse": "lakehouses"}
 SqlTarget = collections.namedtuple("SqlTarget", "server database encrypt")
@@ -238,11 +239,11 @@ def sql_endpoint(item_id):
       Lakehouse                -> properties.sqlEndpointProperties.connectionString
                                   (its read-only SQL analytics endpoint)
 
-    The DATABASE NAME differs by target and that is real, not an emulator
-    shortcut. Fabric addresses a database by DISPLAY NAME and encodes the
-    workspace in the server name; the emulator serves one host for every
-    workspace, so it addresses by item id (internal/server/warehouse.go accepts
-    both). Resolving it here is what keeps the branch out of the steps.
+    The DATABASE NAME differs by target and that is real, not a local shortcut.
+    Fabric addresses a database by DISPLAY NAME and encodes the workspace in the
+    server name; a development stack serves one host for every workspace, so
+    there it is addressed by item id — both spellings are accepted locally.
+    Resolving it here is what keeps the branch out of the steps.
 
     Cached per item: the callers are retry loops waiting for a database to come
     online, and an endpoint does not move between attempts.

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -38,7 +38,20 @@ _T = target()
 # cannot quietly authenticate as a dev daemon against production.
 ENTRA = _T.entra_url
 FABRIC = _T.api_root[: -len("/v1")] if _T.api_root.endswith("/v1") else _T.api_root
-KV = _T.vault_url or "https://localhost:8444"
+# NO FALLBACK. Under `emulator` fabric-target already defaults this to the local
+# vault; under `real` it is None unless FABRIC_VAULT_URL/AZURE_KEY_VAULT_URL is
+# set, and `or "https://localhost:8444"` would have pointed a PRODUCTION run at
+# the emulator's vault — silently, since the resolver is exempt from the gate's
+# localhost rule. Every medallion example stores a source credential in Key Vault
+# (step 2), so a missing vault under real is always a misconfiguration: refuse
+# here, where the cause is legible, rather than at a 404 later.
+if _T.is_real and not _T.vault_url:
+    raise SystemExit(
+        "FABRIC_TARGET=real needs a vault: set FABRIC_VAULT_URL (or "
+        "AZURE_KEY_VAULT_URL) to your Key Vault URI. These examples store the "
+        "source API key there and resolve it through an AKV reference, exactly "
+        "as they do locally.")
+KV = _T.vault_url
 TENANT = _T.tenant
 
 # Local policy, not target policy (see the module docstring).
@@ -88,13 +101,27 @@ def log(msg):
 def ensure_app(app_id_uri, name):
     """Register a non-default audience in entra (409 = already there).
 
-    EMULATOR ONLY, and refused rather than silently skipped under `real`: this
-    POSTs entra-emulator's admin API, which has no counterpart in Entra ID. A
-    real tenant's app registrations are an administrator's act, not a pipeline
-    step, so a run that reaches here against real Fabric is misconfigured and
-    should say so at the call rather than fail later somewhere stranger.
+    SKIPPED under `real`, not refused — and the distinction matters.
+
+    This is emulator-only SETUP, not an emulator-only FEATURE. It POSTs
+    entra-emulator's admin API to make an audience issuable; in a real tenant the
+    audiences these examples ask for (storage, vault, SQL, Power BI) are Microsoft
+    first-party resources that already exist, so the POSTCONDITION is already
+    true and there is nothing to do. Refusing here would turn "no setup needed"
+    into "this step cannot run", which is what it did at first — and it blocked
+    four of the eleven steps from ever being portable.
+
+    Contrast `_emulator/clock`: advancing time is a CAPABILITY with no real
+    counterpart, so a caller that needs it is asking for something production
+    cannot give. That one must refuse (see contoso-data-platform's
+    platform/schedule.py, which asserts clock_is_controllable).
+
+    The rule: if the target already satisfies the postcondition, skip; if the
+    target cannot satisfy it at all, refuse.
     """
-    _T.emulator_only("entra-emulator admin app registration (ensure_app)")
+    if _T.is_real:
+        log(f"skipping ensure_app({app_id_uri}) — a real tenant already issues it")
+        return
     r = _RAW.post(f"{ENTRA}/admin/api/apps",
                json={"displayName": name, "appIdUri": app_id_uri, "isConfidential": False})
     assert r.status_code in (200, 201, 409), f"seed {app_id_uri}: {r.status_code} {r.text}"

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -21,17 +21,25 @@ Artifacts are persisted the way real Fabric persists them — definition parts
 with Fabric's own paths (`notebook-content.py`, `pipeline-content.json`). See
 docs/46-artifact-persistence.md.
 """
+import collections
 import json
 import os
 import pathlib
 
 import requests
 import urllib3
-from fabric_target import target
+from fabric_target import apply_notebook_env, target
 
 urllib3.disable_warnings()  # the family serves self-signed TLS
 
 _T = target()
+
+# The notebook runtime context, from the SAME resolved target. Steps that use
+# `notebookutils` (the brokered path a Fabric notebook actually takes) would
+# otherwise read the shim's own defaults — a different entra port, TLS
+# verification on against the family's self-signed certs — and disagree with the
+# control-plane calls in the same process. Anything already exported wins.
+apply_notebook_env(_T)
 
 # Resolved per target, never hardcoded. In real mode `fabric-target` refuses the
 # emulator's seeded principal BY VALUE, so a shell left over from a local run
@@ -54,8 +62,13 @@ if _T.is_real and not _T.vault_url:
 KV = _T.vault_url
 TENANT = _T.tenant
 
-# Local policy, not target policy (see the module docstring).
-TDS_SERVER = os.environ.get("TDS_SERVER", "localhost,1433")
+# Local policy, not target policy (see the module docstring). UNSET means
+# "ask the API", which is the portable path — see sql_endpoint(). It stays
+# overridable because the emulator advertises the port it LISTENS on, not the
+# port Docker published it to, so an isolated stack with a remapped port
+# (`11533:1433`) is the one case discovery gets wrong. Fabric has no such
+# distinction, which is why this is an override and not a parameter.
+TDS_SERVER = os.environ.get("TDS_SERVER")
 KV_INTERNAL = os.environ.get("KV_INTERNAL_URL", "https://keyvault-emulator:8444")
 SPARK_REMOTE = os.environ.get("SPARK_REMOTE", "sc://localhost:50051")
 # OpenMetadata, the governance sidecar the advanced examples catalog into. Local
@@ -127,6 +140,40 @@ def ensure_app(app_id_uri, name):
     assert r.status_code in (200, 201, 409), f"seed {app_id_uri}: {r.status_code} {r.text}"
 
 
+def skip_on_real(step, because):
+    """Exit 0 under `real`: there is nothing for this step to do there.
+
+    The step-level form of ensure_app's skip, and it covers two cases that share
+    one answer. Either real Fabric reaches the postcondition itself (it runs the
+    notebook on its own pool, so the local engine has no job), or the step drives
+    a companion service that Fabric simply has no endpoint for (OpenMetadata;
+    Purview is a different integration, not a different URL). Both times the work
+    the pipeline needs is not missing, so failing would be a lie — it exits
+    successfully and says why.
+
+    Contrast only_the_emulator_can, for a step whose OUTPUT the pipeline does
+    need and cannot get.
+    """
+    if _T.is_real:
+        log(f"skipping {step}: {because}")
+        raise SystemExit(0)
+
+
+def only_the_emulator_can(step, because, instead):
+    """Refuse under `real`, naming the mechanism real Fabric uses instead.
+
+    For a step that depends on a CAPABILITY the emulator adds for local
+    development and real Fabric does not expose. The refusal is the honest
+    answer, and `instead` is what makes it actionable rather than a dead end:
+    the portable form exists, it is just a different shape.
+    """
+    if _T.is_real:
+        raise SystemExit(
+            f"{step} cannot run against real Fabric.\n"
+            f"  why:     {because}\n"
+            f"  instead: {instead}")
+
+
 def token(audience):
     """A bearer for `audience`, from whichever credential the target resolved:
     the seeded daemon locally, DefaultAzureCredential (env SP, managed identity,
@@ -157,20 +204,108 @@ def tables_uri():
     return f"az://{st['workspace']}/{st['lakehouse']}/Tables"
 
 
-def tds_connect(database, token_value=None, timeout=60):
-    """FedAuth over TDS: the pre-minted Azure-SQL token rides in
-    SQL_COPT_SS_ACCESS_TOKEN (1256) — the exact injection dbt-fabric performs, so
-    the ODBC driver never runs MSAL. Encrypt=no because the TDS front terminates
-    FedAuth without TLS (it advertises ENCRYPT_NOT_SUP)."""
+# An item's SQL endpoint, as the API reports it. The collection segment is the
+# typed route Fabric documents the property on — the generic /items/{id} answers
+# the generic record there, so reading the address off it works here and returns
+# nothing against real Fabric (internal/api/kql.go).
+_SQL_COLLECTION = {"Warehouse": "warehouses", "SQLDatabase": "sqlDatabases",
+                   "Lakehouse": "lakehouses"}
+SqlTarget = collections.namedtuple("SqlTarget", "server database encrypt")
+_SQL_CACHE = {}
+
+
+def _odbc_server(connection_string):
+    """`host:port` (what the emulator advertises) -> `host,port` (what the SQL
+    Server ODBC driver wants). A real Fabric connection string is a bare FQDN on
+    the default port and passes through untouched; an IPv6 literal keeps its
+    brackets, so only a trailing numeric port is rewritten."""
+    host, sep, port = connection_string.rpartition(":")
+    if sep and port.isdigit():
+        return f"{host},{port}"
+    return connection_string
+
+
+def sql_endpoint(item_id):
+    """Where to dial for `item_id`'s SQL endpoint, and as what database.
+
+    THIS IS THE PORTABLE FORM, and the reason is not convenience. On real Fabric
+    the SQL address is per-workspace and assigned by the service: nothing outside
+    it can know the host, so any example that hardcodes one is emulator-only by
+    construction, however carefully everything else is resolved. Both targets
+    answer the same documented question instead:
+
+      Warehouse / SQL database -> properties.connectionString
+      Lakehouse                -> properties.sqlEndpointProperties.connectionString
+                                  (its read-only SQL analytics endpoint)
+
+    The DATABASE NAME differs by target and that is real, not an emulator
+    shortcut. Fabric addresses a database by DISPLAY NAME and encodes the
+    workspace in the server name; the emulator serves one host for every
+    workspace, so it addresses by item id (internal/server/warehouse.go accepts
+    both). Resolving it here is what keeps the branch out of the steps.
+
+    Cached per item: the callers are retry loops waiting for a database to come
+    online, and an endpoint does not move between attempts.
+    """
+    if item_id in _SQL_CACHE:
+        return _SQL_CACHE[item_id]
+    st = load()
+    H = fabric_headers()
+    base = f"{FABRIC}/v1/workspaces/{st['workspace']}"
+    r = S.get(f"{base}/items/{item_id}", headers=H)
+    r.raise_for_status()
+    item = r.json()
+    collection = _SQL_COLLECTION.get(item["type"])
+    assert collection, f"item {item['displayName']!r} is a {item['type']}, which has no SQL endpoint"
+
+    server = TDS_SERVER
+    if not server:
+        r = S.get(f"{base}/{collection}/{item_id}", headers=H)
+        r.raise_for_status()
+        props = r.json().get("properties") or {}
+        if item["type"] == "Lakehouse":
+            ep = props.get("sqlEndpointProperties") or {}
+            # Real Fabric provisions the analytics endpoint asynchronously, so a
+            # status that is not Success is a wait-or-fail, not a missing feature.
+            # Saying which beats a connection timeout that names nothing. Only
+            # when the property is THERE, though: absent means this build serves
+            # no SQL at all, which the no-endpoint branch below explains better.
+            if ep:
+                assert ep.get("provisioningStatus") == "Success", (
+                    f"the SQL analytics endpoint of {item['displayName']!r} is "
+                    f"{ep['provisioningStatus']}; it cannot be queried yet")
+            server = ep.get("connectionString")
+        else:
+            server = props.get("connectionString")
+        assert server, (
+            f"{item['type']} {item['displayName']!r} advertises no SQL endpoint. "
+            f"Locally that means the stack runs without its SQL sidecar; set "
+            f"TDS_SERVER to override.")
+        server = _odbc_server(server)
+
+    _SQL_CACHE[item_id] = SqlTarget(
+        server=server,
+        database=item["displayName"] if _T.is_real else item_id,
+        # Real Fabric's endpoint requires TLS. The emulator's TDS front
+        # terminates FedAuth without it (it advertises ENCRYPT_NOT_SUP).
+        encrypt=_T.is_real)
+    return _SQL_CACHE[item_id]
+
+
+def tds_connect(item_id, token_value=None, timeout=60):
+    """FedAuth over TDS to an item's SQL endpoint: the pre-minted Azure-SQL token
+    rides in SQL_COPT_SS_ACCESS_TOKEN (1256) — the exact injection dbt-fabric
+    performs, so the ODBC driver never runs MSAL."""
     import struct
 
     import pyodbc
 
+    t = sql_endpoint(item_id)
     enc = (token_value or token(SQL_AUD)).encode("utf-16-le")
     return pyodbc.connect(
         "DRIVER={ODBC Driver 18 for SQL Server};"
-        f"SERVER={TDS_SERVER};Database={database};"
-        "Encrypt=no;TrustServerCertificate=yes",
+        f"SERVER={t.server};Database={t.database};"
+        f"Encrypt={'yes' if t.encrypt else 'no'};TrustServerCertificate=yes",
         attrs_before={1256: struct.pack("<i", len(enc)) + enc}, timeout=timeout)
 
 

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -1,12 +1,25 @@
-"""Endpoints, tokens, and shared state for the medallion example.
+"""Endpoints, tokens, and shared state for the medallion examples.
 
-Every hop authenticates against entra-emulator with the seeded daemon service
-principal — the same trust relationships as production Azure.
+**The target is resolved here and nowhere else.** `FABRIC_TARGET=emulator|real`
+(default `emulator`) picks the whole coherent set — API root, token authority,
+credential, OneLake, vault, TLS — through the published `fabric-target`
+contract. No step branches on which target is active; they hold display NAMES
+and receive endpoints, because ids can never match across targets
+(docs/21-real-fabric-toggle.md).
 
-Endpoints default to the local developer stack (`docker compose up`, self-signed
-TLS on localhost) and are overridable by environment variable, so the same code
-runs unchanged inside a container against compose service names. That is how
-`e2e/medallion` drives this example in CI.
+This file is the CONSUMER half. It does not restate the contract: contoso-data-platform
+did that while `fabric-target` was unpublished and the restatement drifted into
+requiring a client secret, which broke `az login`, managed identity, and running
+inside a Fabric notebook. A contract you copy is a contract you get wrong.
+
+What stays local policy, because it is genuinely this example's choice rather
+than the toggle's: who plays the Spark pool (`SPARK_REMOTE`), the TDS endpoint,
+and which address the *emulator* must use to reach the vault it resolves
+server-side (`KV_INTERNAL`).
+
+Artifacts are persisted the way real Fabric persists them — definition parts
+with Fabric's own paths (`notebook-content.py`, `pipeline-content.json`). See
+docs/46-artifact-persistence.md.
 """
 import json
 import os
@@ -14,30 +27,29 @@ import pathlib
 
 import requests
 import urllib3
+from fabric_target import target
 
 urllib3.disable_warnings()  # the family serves self-signed TLS
 
-TENANT = "6f89cf12-978b-4d23-ac18-9ef0c127cf87"
-CLIENT_ID = "00d88624-f0d7-46f6-a641-6232c2608928"  # seeded daemon SP
-CLIENT_SECRET = "daemon-app-secret"  # intentionally public dev value
+_T = target()
 
-ENTRA = os.environ.get("ENTRA_URL", "https://localhost:8443")
-KV = os.environ.get("KV_URL", "https://localhost:8444")
-FABRIC = os.environ.get("FABRIC_REST_URL", "https://localhost:9443")
+# Resolved per target, never hardcoded. In real mode `fabric-target` refuses the
+# emulator's seeded principal BY VALUE, so a shell left over from a local run
+# cannot quietly authenticate as a dev daemon against production.
+ENTRA = _T.entra_url
+FABRIC = _T.api_root[: -len("/v1")] if _T.api_root.endswith("/v1") else _T.api_root
+KV = _T.vault_url or "https://localhost:8444"
+TENANT = _T.tenant
+
+# Local policy, not target policy (see the module docstring).
 TDS_SERVER = os.environ.get("TDS_SERVER", "localhost,1433")
-# Fabric resolves an AKV reference server-side, so the vault URI it stores must
-# be reachable from the *emulator*, which is not always where you are. Running
-# these steps on your machine against `docker compose up`, `localhost:8444` is
-# the vault as *you* reach it — the emulator container cannot follow it back
-# out. So the default is the compose service name, which is correct whether the
-# step runs on the host or in a container alongside it. Override for any other
-# topology (the CI harness points it at plain HTTP; a bare-metal vault at your
-# own address).
 KV_INTERNAL = os.environ.get("KV_INTERNAL_URL", "https://keyvault-emulator:8444")
-
-# The Spark engine engine.py drives the queued notebook run onto. Default is
-# Sail as `docker compose up` publishes it; the CI harness uses the service name.
 SPARK_REMOTE = os.environ.get("SPARK_REMOTE", "sc://localhost:50051")
+# OpenMetadata, the governance sidecar the advanced examples catalog into. Local
+# policy for the same reason: it is a companion service, not a Fabric surface, so
+# the toggle has nothing to say about it. Real Fabric's counterpart is Purview,
+# which is a different integration rather than a different endpoint.
+OM_URL = os.environ.get("OM_URL", "http://localhost:8585")
 
 FABRIC_AUD = "https://api.fabric.microsoft.com"
 STORAGE_AUD = "https://storage.azure.com"
@@ -45,8 +57,15 @@ SQL_AUD = "https://database.windows.net"
 VAULT_AUD = "https://vault.azure.net"
 PBI_AUD = "https://analysis.windows.net/powerbi/api"
 
-S = requests.Session()
-S.verify = False
+S = _T.session()
+
+# entra-emulator's own endpoints (the admin API, the token endpoint) must NOT
+# carry a Fabric bearer: `S` injects one on every request, which is correct for
+# the control plane and meaningless to the authority issuing the token. So the
+# few calls that talk to the issuer use a plain session with the target's TLS
+# mode, not the authenticated one.
+_RAW = requests.Session()
+_RAW.verify = _T.tls_verify
 
 # Anchored on the CALLING example's directory, not on this file's. This module
 # is shared by both medallion examples, so `HERE` would resolve to the fixture
@@ -67,18 +86,25 @@ def log(msg):
 
 
 def ensure_app(app_id_uri, name):
-    """Register a non-default audience in entra (409 = already there)."""
-    r = S.post(f"{ENTRA}/admin/api/apps",
+    """Register a non-default audience in entra (409 = already there).
+
+    EMULATOR ONLY, and refused rather than silently skipped under `real`: this
+    POSTs entra-emulator's admin API, which has no counterpart in Entra ID. A
+    real tenant's app registrations are an administrator's act, not a pipeline
+    step, so a run that reaches here against real Fabric is misconfigured and
+    should say so at the call rather than fail later somewhere stranger.
+    """
+    _T.emulator_only("entra-emulator admin app registration (ensure_app)")
+    r = _RAW.post(f"{ENTRA}/admin/api/apps",
                json={"displayName": name, "appIdUri": app_id_uri, "isConfidential": False})
     assert r.status_code in (200, 201, 409), f"seed {app_id_uri}: {r.status_code} {r.text}"
 
 
 def token(audience):
-    r = S.post(f"{ENTRA}/{TENANT}/oauth2/v2.0/token", data={
-        "grant_type": "client_credentials", "client_id": CLIENT_ID,
-        "client_secret": CLIENT_SECRET, "scope": audience + "/.default"})
-    r.raise_for_status()
-    return r.json()["access_token"]
+    """A bearer for `audience`, from whichever credential the target resolved:
+    the seeded daemon locally, DefaultAzureCredential (env SP, managed identity,
+    or a developer's `az login`) under real."""
+    return _T.credential.get_token(audience + "/.default").token
 
 
 def fabric_headers():
@@ -90,9 +116,9 @@ def storage_options():
     opts = {
         "azure_storage_account_name": "onelake",
         "azure_storage_token": token(STORAGE_AUD),
-        "azure_endpoint": f"{FABRIC}/onelake",
+        "azure_endpoint": f"{_T.onelake_url}/onelake",
     }
-    if FABRIC.startswith("http://"):
+    if _T.onelake_url.startswith("http://"):
         opts["azure_allow_http"] = "true"
     else:
         opts["azure_allow_invalid_certificates"] = "true"

--- a/examples/contoso-fixtures/pyproject.toml
+++ b/examples/contoso-fixtures/pyproject.toml
@@ -18,6 +18,10 @@ description = "Shared source-system fixture and emulator plumbing for the medall
 requires-python = ">=3.12"
 dependencies = [
     "requests>=2.32,<3",
+    # The target contract, consumed rather than restated. Published from the
+    # emulator's release workflow; `make fixtures` installs it alongside these
+    # generators. See docs/21-real-fabric-toggle.md and the common.py docstring.
+    "fabric-target",
 ]
 
 # Flat modules, not a package namespace: the examples are tutorial code, and
@@ -29,3 +33,6 @@ py-modules = ["common", "source_system"]
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
+
+[tool.uv.sources]
+fabric-target = { path = "../../python/fabric-target", editable = true }

--- a/examples/contoso-fixtures/pyproject.toml
+++ b/examples/contoso-fixtures/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     # emulator's release workflow; `make fixtures` installs it alongside these
     # generators. See docs/21-real-fabric-toggle.md and the common.py docstring.
     "fabric-target",
+    # The notebook surface itself. Real Fabric preinstalls `notebookutils` in
+    # the runtime; outside it, this shim IS that runtime, so a step can fetch a
+    # secret the way a notebook does (credentials.getSecret) instead of the way
+    # a service client does. Same code either way, which is the point.
+    "fabric-emulator-notebookutils",
 ]
 
 # Flat modules, not a package namespace: the examples are tutorial code, and
@@ -36,3 +41,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv.sources]
 fabric-target = { path = "../../python/fabric-target", editable = true }
+fabric-emulator-notebookutils = { path = "../../python", editable = true }

--- a/examples/contoso-fixtures/uv.lock
+++ b/examples/contoso-fixtures/uv.lock
@@ -1,0 +1,140 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "contoso-fixtures"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fabric-emulator-notebookutils" },
+    { name = "fabric-target" },
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fabric-emulator-notebookutils", editable = "../../python" },
+    { name = "fabric-target", editable = "../../python/fabric-target" },
+    { name = "requests", specifier = ">=2.32,<3" },
+]
+
+[[package]]
+name = "fabric-emulator-notebookutils"
+version = "0.1.0"
+source = { editable = "../../python" }
+
+[[package]]
+name = "fabric-target"
+version = "0.1.0"
+source = { editable = "../../python/fabric-target" }
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-identity", marker = "extra == 'real'", specifier = ">=1.17" },
+    { name = "requests", marker = "extra == 'sessions'", specifier = ">=2.31" },
+]
+provides-extras = ["real", "sessions"]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/examples/fab-driven/uv.lock
+++ b/examples/fab-driven/uv.lock
@@ -135,11 +135,17 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-emulator-notebookutils" },
+    { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32,<3" }]
+requires-dist = [
+    { name = "fabric-emulator-notebookutils", editable = "../../python" },
+    { name = "fabric-target", editable = "../../python/fabric-target" },
+    { name = "requests", specifier = ">=2.32,<3" },
+]
 
 [[package]]
 name = "deltalake"
@@ -197,6 +203,23 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.3,<10" }]
+
+[[package]]
+name = "fabric-emulator-notebookutils"
+version = "0.1.0"
+source = { editable = "../../python" }
+
+[[package]]
+name = "fabric-target"
+version = "0.1.0"
+source = { editable = "../../python/fabric-target" }
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-identity", marker = "extra == 'real'", specifier = ">=1.17" },
+    { name = "requests", marker = "extra == 'sessions'", specifier = ">=2.31" },
+]
+provides-extras = ["real", "sessions"]
 
 [[package]]
 name = "idna"

--- a/examples/medallion-advanced-dbt-fabricspark/README.md
+++ b/examples/medallion-advanced-dbt-fabricspark/README.md
@@ -46,6 +46,14 @@ The silver assertions are the **same oracle**, not a relaxed one — the same
 PySpark example asserts against. Two engines asked for the same transform must
 produce the same answer, or comparing them measures nothing.
 
+## Where your items live: `definitions/`
+
+Unchanged from the sibling, and worth reading there:
+[`../medallion-pyspark#where-your-items-live-definitions`](../medallion-pyspark/README.md#where-your-items-live-definitions).
+Bronze deploys from committed files in Fabric's own source format —
+`{display name}.{public facing type}/` with `.platform` — which is the layout
+Fabric's Git integration writes. Only **silver** differs in this example.
+
 ## The dbt project
 
 ```

--- a/examples/medallion-advanced-dbt-fabricspark/bronze.py
+++ b/examples/medallion-advanced-dbt-fabricspark/bronze.py
@@ -19,56 +19,34 @@ that terminal state, exactly as a Fabric pipeline does. `engine.py` still shows
 the other half of the contract — the `notebookRunResult` callback an external
 engine uses.
 """
-import json
 
 import source_system as src
-from common import activity_runs, create_item, load, log, run_job, save
+from common import activity_runs, create_item_from_definition, load, log, run_job, save
 
 st = load()
 lake, ws = st["lakehouse"], st["workspace"]
 landing_dir = f"landing/contoso_pos/{st['landing_date']}"
 
-# The notebook a Fabric author would write for the semi-structured feed: read
-# landing with Spark, write Delta straight to OneLake.
-NOTEBOOK = f'''# Fabric notebook source
+# The items are deployed from `definitions/`, which holds them in Fabric's own
+# SOURCE FORMAT — `<display name>.<Type>/` with the definition files and
+# `.platform`, exactly what Git integration writes and fabric-cicd deploys
+# (docs/46-artifact-persistence.md). The committed files carry {{TOKENS}} because
+# a definition names the workspace and lakehouse it reads by GUID and those do
+# not exist until provision.py has run; substituting at deploy is what
+# fabric-cicd's own find_replace parameter file is for.
+nb = create_item_from_definition(
+    "bronze-orders.Notebook",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, LANDING_DATE=st["landing_date"])
 
-# CELL ********************
-
-from pyspark.sql.functions import lit
-
-# ABFS addresses OneLake by its full account host, exactly as a Fabric
-# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
-landing = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Files/{landing_dir}/orders.jsonl"
-bronze = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Tables/bronze_orders"
-
-orders = spark.read.json(landing).withColumn("_landing_date", lit("{st['landing_date']}"))
-orders.write.format("delta").mode("overwrite").save(bronze)
-print("bronze_orders rows:", orders.count())
-'''
-
-nb = create_item("bronze-orders", "Notebook", {"notebook-content.py": NOTEBOOK})
-
-# One pipeline, two activities — the shape a real medallion ingest takes.
-# Built as a dict and serialised, not string-templated: a pipeline definition is
-# nested JSON, and hand-escaping braces is how you get PipelineDefinitionInvalid.
-lakehouse = {"linkedService": {"properties": {
-    "type": "Lakehouse",
-    "typeProperties": {"workspaceId": ws, "artifactId": lake}}}}
-
-definition = {"properties": {"activities": [
-    {"name": "IngestCustomers", "type": "Copy", "typeProperties": {
-        "source": {"type": "DelimitedTextSource", "rootFolder": "Files",
-                   "folderPath": landing_dir, "fileName": "customers.csv",
-                   "datasetSettings": lakehouse},
-        "sink": {"type": "LakehouseTableSink", "tableActionOption": "Overwrite",
-                 "table": "bronze_customers",
-                 "datasetSettings": lakehouse}}},
-    {"name": "IngestOrders", "type": "TridentNotebook", "typeProperties": {
-        "notebookId": nb}},
-]}}
-
-pl = create_item("bronze-ingest", "DataPipeline",
-                 {"pipeline-content.json": json.dumps(definition)})
+# The same, for the pipeline: one Copy activity for the structured feed and a
+# TridentNotebook activity for the semi-structured one. NOTEBOOK_ID is a
+# placeholder because the notebook above only just acquired its id — the ordinary
+# case in a real deployment, where items reference each other by GUID.
+pl = create_item_from_definition(
+    "bronze-ingest.DataPipeline",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, NOTEBOOK_ID=nb)
 jid, status = run_job(pl, "Pipeline")
 assert status == "Completed", f"bronze pipeline: {status}"
 

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/.platform
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "DataPipeline",
+    "displayName": "bronze-ingest",
+    "description": "One pipeline, two activities: a Copy for the structured feed and a notebook for the semi-structured one."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "c4a9e77b-31d8-4e02-8f16-5b7a2c9d0e44"
+  }
+}

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -1,0 +1,52 @@
+{
+  "properties": {
+    "activities": [
+      {
+        "name": "IngestCustomers",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "DelimitedTextSource",
+            "rootFolder": "Files",
+            "folderPath": "{{LANDING_DIR}}",
+            "fileName": "customers.csv",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_customers",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestOrders",
+        "type": "TridentNotebook",
+        "typeProperties": {
+          "notebookId": "{{NOTEBOOK_ID}}"
+        }
+      }
+    ]
+  }
+}

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-orders.Notebook/.platform
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-orders.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "bronze-orders",
+    "description": "Reads the semi-structured POS feed from landing and writes Delta to the lakehouse."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "6b1f0d2a-7c3e-4a58-9d61-0f2e4b8c1a37"
+  }
+}

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-orders.Notebook/notebook-content.py
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-orders.Notebook/notebook-content.py
@@ -1,0 +1,14 @@
+# Fabric notebook source
+
+# CELL ********************
+
+from pyspark.sql.functions import lit
+
+# ABFS addresses OneLake by its full account host, exactly as a Fabric
+# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
+landing = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Files/{{LANDING_DIR}}/orders.jsonl"
+bronze = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables/bronze_orders"
+
+orders = spark.read.json(landing).withColumn("_landing_date", lit("{{LANDING_DATE}}"))
+orders.write.format("delta").mode("overwrite").save(bronze)
+print("bronze_orders rows:", orders.count())

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/erp-reference-ingest.DataPipeline/.platform
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/erp-reference-ingest.DataPipeline/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "DataPipeline",
+    "displayName": "erp-reference-ingest",
+    "description": "Three Parquet Copy activities: ERP changes, FX rates, product hierarchy."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "9d2c6f41-8ab0-4d17-b3e5-72c8149af6b2"
+  }
+}

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/erp-reference-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/erp-reference-ingest.DataPipeline/pipeline-content.json
@@ -1,0 +1,123 @@
+{
+  "properties": {
+    "activities": [
+      {
+        "name": "IngestErpChanges",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "ParquetSource",
+            "rootFolder": "Files",
+            "folderPath": "{{ERP_DIR}}",
+            "fileName": "changes.parquet",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_erp_changes",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestFxRates",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "ParquetSource",
+            "rootFolder": "Files",
+            "folderPath": "{{REF_DIR}}",
+            "fileName": "fx_rates.parquet",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_fx_rates",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestProductHierarchy",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "ParquetSource",
+            "rootFolder": "Files",
+            "folderPath": "{{REF_DIR}}",
+            "fileName": "product_hierarchy.parquet",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_product_hierarchy",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/examples/medallion-advanced-dbt-fabricspark/engine.py
+++ b/examples/medallion-advanced-dbt-fabricspark/engine.py
@@ -15,7 +15,18 @@ import io
 import time
 from contextlib import redirect_stdout
 
-from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log
+from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log, skip_on_real
+
+# Real Fabric HAS a Spark pool, so there is nothing for this step to do there.
+# Its notebook activity runs on the workspace's starter pool (or a custom pool
+# selected through an Environment) and reports its own outcome; the emulator has
+# no pool, which is exactly why it parses the notebook, records a Pending run,
+# and waits for an engine to execute the cells and report back. The step is
+# scaffolding for the missing half of the target, not part of the pipeline.
+skip_on_real(
+    "the notebook engine",
+    "Fabric runs the queued notebook on its own Spark pool and reports the run "
+    "itself, so there is no external engine to attach")
 
 st = load()
 jid, nb = st["orders_job"], st["orders_notebook"]

--- a/examples/medallion-advanced-dbt-fabricspark/erp_bronze.py
+++ b/examples/medallion-advanced-dbt-fabricspark/erp_bronze.py
@@ -11,41 +11,23 @@ events with their capture sequence, still out of order where the connector
 delivered them that way. Turning that into a dimension with history is 24's
 job, and 24 has to do it from what actually arrived.
 """
-import json
 
 import erp_system as erp
 import reference_data as ref
-from common import activity_runs, create_item, load, log, run_job, save
+from common import activity_runs, create_item_from_definition, load, log, run_job, save
 
 st = load()
 lake, ws = st["lakehouse"], st["workspace"]
 erp_dir = f"landing/contoso_erp/{st['erp_landing_date']}"
 ref_dir = f"landing/reference/{st['erp_landing_date']}"
 
-lakehouse = {"linkedService": {"properties": {
-    "type": "Lakehouse",
-    "typeProperties": {"workspaceId": ws, "artifactId": lake}}}}
-
-
-def copy_activity(name, folder, filename, table):
-    """A Copy whose source is Parquet rather than delimited text."""
-    return {"name": name, "type": "Copy", "typeProperties": {
-        "source": {"type": "ParquetSource", "rootFolder": "Files",
-                   "folderPath": folder, "fileName": filename,
-                   "datasetSettings": lakehouse},
-        "sink": {"type": "LakehouseTableSink", "tableActionOption": "Overwrite",
-                 "table": table, "datasetSettings": lakehouse}}}
-
-
-definition = {"properties": {"activities": [
-    copy_activity("IngestErpChanges", erp_dir, "changes.parquet", "bronze_erp_changes"),
-    copy_activity("IngestFxRates", ref_dir, "fx_rates.parquet", "bronze_fx_rates"),
-    copy_activity("IngestProductHierarchy", ref_dir, "product_hierarchy.parquet",
-                  "bronze_product_hierarchy"),
-]}}
-
-pl = create_item("erp-reference-ingest", "DataPipeline",
-                 {"pipeline-content.json": json.dumps(definition)})
+# Deployed from `definitions/erp-reference-ingest.DataPipeline/` in Fabric's own
+# source format (docs/46-artifact-persistence.md). Three Parquet Copy activities
+# rather than one delimited-text one; the folder paths are placeholders because
+# they carry the landing date, which is state, not source.
+pl = create_item_from_definition(
+    "erp-reference-ingest.DataPipeline",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake, ERP_DIR=erp_dir, REF_DIR=ref_dir)
 jid, status = run_job(pl, "Pipeline")
 assert status == "Completed", f"erp/reference pipeline: {status}"
 

--- a/examples/medallion-advanced-dbt-fabricspark/extract_load.py
+++ b/examples/medallion-advanced-dbt-fabricspark/extract_load.py
@@ -1,15 +1,26 @@
-"""Fetch the API key from Key Vault (as notebookutils.credentials.getSecret
-does), pull the vendor export, and land it verbatim in OneLake."""
+"""Fetch the API key from Key Vault as a Fabric notebook does, pull the vendor
+export, and land it verbatim in OneLake.
+
+`notebookutils.credentials.getSecret` is the BROKERED path, and it is the one a
+notebook has: inside Fabric the workspace identity mints a vault-audience token
+and the secret never appears in the notebook, a parameter, or a pipeline
+definition. Calling Key Vault's REST API with a token minted here reaches the
+same secret and teaches the wrong lesson, because that code cannot move into a
+notebook unchanged. The shim makes this exact call work outside Fabric too
+(python/notebookutils/credentials.py): entra-emulator under `emulator`,
+DefaultAzureCredential under `real`.
+
+The vault is passed as a URI, which is also the real signature — Fabric accepts
+either a vault name or its URI, and only the URI can name the emulator's vault.
+"""
 import datetime
 
+import notebookutils
 import source_system as src
 from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
 
-vt = token(VAULT_AUD)
-r = S.get(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",
-          headers={"Authorization": "Bearer " + vt})
-r.raise_for_status()
-api_key = r.json()["value"]
+ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
+api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-advanced-dbt-fabricspark/gold.py
+++ b/examples/medallion-advanced-dbt-fabricspark/gold.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 
 import source_system as src
-from common import GOLD_PROJECT, SQL_AUD, TDS_SERVER, load, log, tds_connect, token
+from common import GOLD_PROJECT, SQL_AUD, load, log, sql_endpoint, tds_connect, token
 
 st = load()
 sql_tok = token(SQL_AUD)
@@ -30,8 +30,11 @@ for _ in range(40):
 else:
     raise SystemExit(f"warehouse warmup failed: {last}")
 
-# The token is pre-minted, so dbt never runs MSAL. encrypt=false matches the TDS
-# front, which terminates FedAuth without TLS.
+# The token is pre-minted, so dbt never runs MSAL. Server, database and encrypt
+# all come from the resolver: on real Fabric the address is per-workspace and only
+# the API knows it, so a pinned host is emulator-only by construction (docs/46).
+wh = sql_endpoint(st["warehouse"])
+lake_db = sql_endpoint(st["lakehouse"]).database
 with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     f.write(f"""contoso_gold:
   target: dev
@@ -39,18 +42,18 @@ with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     dev:
       type: fabric
       driver: "ODBC Driver 18 for SQL Server"
-      server: "{TDS_SERVER}"
-      database: "{st['warehouse']}"
+      server: "{wh.server}"
+      database: "{wh.database}"
       schema: "dbo"
       authentication: "ActiveDirectoryAccessToken"
       access_token: "{sql_tok}"
       access_token_expires_on: 0
-      encrypt: false
+      encrypt: {'true' if wh.encrypt else 'false'}
       trust_cert: true
       threads: 1
 """)
 
-env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakehouse"]}
+env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": lake_db}
 t0 = time.time()
 rc = subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 build_secs = time.time() - t0

--- a/examples/medallion-advanced-dbt-fabricspark/gold_star.py
+++ b/examples/medallion-advanced-dbt-fabricspark/gold_star.py
@@ -17,11 +17,17 @@ import time
 
 import source_system as src
 import web_store as web
-from common import SQL_AUD, TDS_SERVER, load, log, tds_connect, token
+from common import SQL_AUD, load, log, sql_endpoint, tds_connect, token
 
 st = load()
 sql_tok = token(SQL_AUD)
 PROJECT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gold_star")
+
+# Server, database and encrypt all come from the resolver: on real Fabric the
+# address is per-workspace and only the API knows it, so a pinned host is
+# emulator-only by construction (docs/46-artifact-persistence.md).
+wh = sql_endpoint(st["warehouse"])
+lake_db = sql_endpoint(st["lakehouse"]).database
 
 with open(os.path.join(PROJECT, "profiles.yml"), "w") as f:
     f.write(f"""contoso_gold_star:
@@ -30,18 +36,18 @@ with open(os.path.join(PROJECT, "profiles.yml"), "w") as f:
     dev:
       type: fabric
       driver: "ODBC Driver 18 for SQL Server"
-      server: "{TDS_SERVER}"
-      database: "{st['warehouse']}"
+      server: "{wh.server}"
+      database: "{wh.database}"
       schema: "dbo"
       authentication: "ActiveDirectoryAccessToken"
       access_token: "{sql_tok}"
       access_token_expires_on: 0
-      encrypt: false
+      encrypt: {'true' if wh.encrypt else 'false'}
       trust_cert: true
       threads: 1
 """)
 
-env = {**os.environ, "DBT_PROFILES_DIR": PROJECT, "LAKEHOUSE_ID": st["lakehouse"]}
+env = {**os.environ, "DBT_PROFILES_DIR": PROJECT, "LAKEHOUSE_ID": lake_db}
 t0 = time.time()
 rc = subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=PROJECT, env=env).returncode
 build_secs = time.time() - t0

--- a/examples/medallion-advanced-dbt-fabricspark/govern.py
+++ b/examples/medallion-advanced-dbt-fabricspark/govern.py
@@ -31,7 +31,18 @@ import os
 
 import requests
 import yaml
-from common import FABRIC, OM_URL, S, fabric_headers, load, log
+from common import FABRIC, OM_URL, S, fabric_headers, load, log, skip_on_real
+
+# OpenMetadata is a companion service, not a Fabric surface, and the lineage this
+# step reads is the emulator's own recorded flow graph. Fabric's counterpart is
+# Purview: a different integration with a different model, not the same call to a
+# different host. Skipping rather than refusing because the catalog is optional
+# here by design (see the module docstring) and the medallion is complete without it.
+skip_on_real(
+    "the OpenMetadata catalog step",
+    "OpenMetadata has no Fabric endpoint to resolve to, and the lineage it "
+    "publishes comes from the emulator's flow graph. Purview is the real "
+    "counterpart, and a different integration")
 
 # Local policy, resolved centrally — see common.OM_URL.
 OM = OM_URL

--- a/examples/medallion-advanced-dbt-fabricspark/govern.py
+++ b/examples/medallion-advanced-dbt-fabricspark/govern.py
@@ -31,9 +31,10 @@ import os
 
 import requests
 import yaml
-from common import FABRIC, S, fabric_headers, load, log
+from common import FABRIC, OM_URL, S, fabric_headers, load, log
 
-OM = os.environ.get("OM_URL", "http://localhost:8585")
+# Local policy, resolved centrally — see common.OM_URL.
+OM = OM_URL
 HERE = os.path.dirname(os.path.abspath(__file__))
 CONTRACTS = os.path.join(HERE, "contracts")
 

--- a/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
@@ -42,4 +42,7 @@ contoso-fixtures = { path = "../contoso-fixtures", editable = true }
 # The target contract, resolved from the repo rather than PyPI so an example run
 # from a checkout uses the same code the emulator publishes.
 fabric-target = { path = "../../python/fabric-target", editable = true }
+# The notebookutils shim, from the same checkout: contoso-fixtures depends on it
+# so a step can read a secret the way a Fabric notebook does.
+fabric-emulator-notebookutils = { path = "../../python", editable = true }
 contoso-fixtures-advanced = { path = "../contoso-fixtures-advanced", editable = true }

--- a/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
@@ -39,4 +39,7 @@ package = false
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }
+# The target contract, resolved from the repo rather than PyPI so an example run
+# from a checkout uses the same code the emulator publishes.
+fabric-target = { path = "../../python/fabric-target", editable = true }
 contoso-fixtures-advanced = { path = "../contoso-fixtures-advanced", editable = true }

--- a/examples/medallion-advanced-dbt-fabricspark/star_silver.py
+++ b/examples/medallion-advanced-dbt-fabricspark/star_silver.py
@@ -27,7 +27,24 @@ than saying so.
 import erp_system as erp
 import source_system as src
 import web_store as web
-from common import SPARK_REMOTE, load, log, report_lineage
+from common import SPARK_REMOTE, load, log, only_the_emulator_can, report_lineage
+
+# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
+# portability line falls. Real Fabric does not expose a Spark endpoint to dial
+# from outside: its compute runs the notebook. So this transform is portable only
+# once it LIVES in a notebook definition, which is a rewrite of where the code
+# sits rather than of what it does.
+only_the_emulator_can(
+    "driving Spark directly over Spark Connect",
+    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
+            "the service, on the workspace's starter pool or a custom pool chosen "
+            "through an Environment",
+    instead="move this transform into a Notebook definition under definitions/ and "
+            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
+            "accept; the Livy API "
+            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
+            "is the other route on real Fabric")
+
 
 st = load()
 assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"

--- a/examples/medallion-advanced-dbt-fabricspark/uv.lock
+++ b/examples/medallion-advanced-dbt-fabricspark/uv.lock
@@ -467,11 +467,15 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32,<3" }]
+requires-dist = [
+    { name = "fabric-target", editable = "../../python/fabric-target" },
+    { name = "requests", specifier = ">=2.32,<3" },
+]
 
 [[package]]
 name = "contoso-fixtures-advanced"
@@ -821,6 +825,18 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-target"
+version = "0.1.0"
+source = { editable = "../../python/fabric-target" }
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-identity", marker = "extra == 'real'", specifier = ">=1.17" },
+    { name = "requests", marker = "extra == 'sessions'", specifier = ">=2.31" },
+]
+provides-extras = ["real", "sessions"]
 
 [[package]]
 name = "fastjsonschema"

--- a/examples/medallion-advanced-dbt-fabricspark/uv.lock
+++ b/examples/medallion-advanced-dbt-fabricspark/uv.lock
@@ -467,12 +467,14 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-emulator-notebookutils" },
     { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fabric-emulator-notebookutils", editable = "../../python" },
     { name = "fabric-target", editable = "../../python/fabric-target" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
@@ -825,6 +827,11 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-emulator-notebookutils"
+version = "0.1.0"
+source = { editable = "../../python" }
 
 [[package]]
 name = "fabric-target"

--- a/examples/medallion-advanced-pyspark/README.md
+++ b/examples/medallion-advanced-pyspark/README.md
@@ -147,6 +147,69 @@ ERP↔Web share nothing at all. Identity is therefore a **graph** — an ERP acc
 reaches a web account only by travelling through POS — which is the whole reason
 this example exists alongside the single-source one.
 
+## Where your items live: `definitions/`
+
+The notebook and the pipelines are **not** built as strings in Python. They are
+committed files, in the layout Microsoft Fabric itself uses:
+
+```
+definitions/
+  bronze-orders.Notebook/
+    .platform                 ← item metadata: type, display name, logicalId
+    notebook-content.py       ← the notebook, as Fabric stores it
+  bronze-ingest.DataPipeline/
+    .platform
+    pipeline-content.json     ← the activities
+```
+
+**This is the same layout Fabric's Git integration writes.** Connect a real
+workspace to Azure DevOps or GitHub and Fabric produces exactly this: one
+directory per item named `{display name}.{public facing type}`, holding the
+item's definition files plus a `.platform`. So the directory above is what your
+repository looks like in production — not an emulator convention you would have
+to unlearn.
+
+Three things follow from that, and they are the point of the example:
+
+**The filenames are Fabric's.** `notebook-content.py` for a Notebook,
+`pipeline-content.json` for a DataPipeline. These become the `path` values in
+the definition parts that `updateDefinition` accepts. Invent a filename and the
+emulator will store it happily — it keeps parts verbatim by design — while real
+Fabric refuses. Copy these names.
+
+**`.platform` carries the identity.** Its `logicalId` is the cross-workspace
+identifier that ties this item to its source-control representation and survives
+renames and moves. It is how one branch can deploy to dev, test and prod and have
+Fabric recognise the same item in each. Do not edit it.
+
+**`{{TOKENS}}` are how ids travel.** A pipeline names the workspace and lakehouse
+it reads by GUID, and those GUIDs differ in every workspace:
+
+```json
+"typeProperties": {"workspaceId": "{{WORKSPACE_ID}}", "artifactId": "{{LAKEHOUSE_ID}}"}
+```
+
+So the committed file is a template and the deploy substitutes. That is not a
+local shortcut — Microsoft's own [`fabric-cicd`](https://learn.microsoft.com/en-us/fabric/cicd/tutorial-fabric-cicd-azure-devops)
+ships a `find_replace` parameter file for the same reason. `bronze.py` deploys
+with one call:
+
+```python
+nb = create_item_from_definition(
+    "bronze-orders.Notebook",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, LANDING_DATE=st["landing_date"])
+```
+
+The item **type comes from the folder name**, as it does in Git, and any
+placeholder left unsubstituted is an error at deploy rather than a Spark failure
+ten minutes later about a workspace literally named `{{WORKSPACE_ID}}`.
+
+What is *not* in `definitions/` is your data. Definitions are versioned; the
+Delta tables they write live in OneLake and are never in Git, and no deployment
+overwrites them. [docs/46](../../docs/46-artifact-persistence.md) is the full
+contract, with links to Microsoft's documentation for each claim.
+
 ## The steps
 
 `pipeline.py` runs them in order and stops at the first failure. The basic track

--- a/examples/medallion-advanced-pyspark/bronze.py
+++ b/examples/medallion-advanced-pyspark/bronze.py
@@ -19,56 +19,34 @@ that terminal state, exactly as a Fabric pipeline does. `engine.py` still shows
 the other half of the contract — the `notebookRunResult` callback an external
 engine uses.
 """
-import json
 
 import source_system as src
-from common import activity_runs, create_item, load, log, run_job, save
+from common import activity_runs, create_item_from_definition, load, log, run_job, save
 
 st = load()
 lake, ws = st["lakehouse"], st["workspace"]
 landing_dir = f"landing/contoso_pos/{st['landing_date']}"
 
-# The notebook a Fabric author would write for the semi-structured feed: read
-# landing with Spark, write Delta straight to OneLake.
-NOTEBOOK = f'''# Fabric notebook source
+# The items are deployed from `definitions/`, which holds them in Fabric's own
+# SOURCE FORMAT — `<display name>.<Type>/` with the definition files and
+# `.platform`, exactly what Git integration writes and fabric-cicd deploys
+# (docs/46-artifact-persistence.md). The committed files carry {{TOKENS}} because
+# a definition names the workspace and lakehouse it reads by GUID and those do
+# not exist until provision.py has run; substituting at deploy is what
+# fabric-cicd's own find_replace parameter file is for.
+nb = create_item_from_definition(
+    "bronze-orders.Notebook",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, LANDING_DATE=st["landing_date"])
 
-# CELL ********************
-
-from pyspark.sql.functions import lit
-
-# ABFS addresses OneLake by its full account host, exactly as a Fabric
-# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
-landing = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Files/{landing_dir}/orders.jsonl"
-bronze = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Tables/bronze_orders"
-
-orders = spark.read.json(landing).withColumn("_landing_date", lit("{st['landing_date']}"))
-orders.write.format("delta").mode("overwrite").save(bronze)
-print("bronze_orders rows:", orders.count())
-'''
-
-nb = create_item("bronze-orders", "Notebook", {"notebook-content.py": NOTEBOOK})
-
-# One pipeline, two activities — the shape a real medallion ingest takes.
-# Built as a dict and serialised, not string-templated: a pipeline definition is
-# nested JSON, and hand-escaping braces is how you get PipelineDefinitionInvalid.
-lakehouse = {"linkedService": {"properties": {
-    "type": "Lakehouse",
-    "typeProperties": {"workspaceId": ws, "artifactId": lake}}}}
-
-definition = {"properties": {"activities": [
-    {"name": "IngestCustomers", "type": "Copy", "typeProperties": {
-        "source": {"type": "DelimitedTextSource", "rootFolder": "Files",
-                   "folderPath": landing_dir, "fileName": "customers.csv",
-                   "datasetSettings": lakehouse},
-        "sink": {"type": "LakehouseTableSink", "tableActionOption": "Overwrite",
-                 "table": "bronze_customers",
-                 "datasetSettings": lakehouse}}},
-    {"name": "IngestOrders", "type": "TridentNotebook", "typeProperties": {
-        "notebookId": nb}},
-]}}
-
-pl = create_item("bronze-ingest", "DataPipeline",
-                 {"pipeline-content.json": json.dumps(definition)})
+# The same, for the pipeline: one Copy activity for the structured feed and a
+# TridentNotebook activity for the semi-structured one. NOTEBOOK_ID is a
+# placeholder because the notebook above only just acquired its id — the ordinary
+# case in a real deployment, where items reference each other by GUID.
+pl = create_item_from_definition(
+    "bronze-ingest.DataPipeline",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, NOTEBOOK_ID=nb)
 jid, status = run_job(pl, "Pipeline")
 assert status == "Completed", f"bronze pipeline: {status}"
 

--- a/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/.platform
+++ b/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "DataPipeline",
+    "displayName": "bronze-ingest",
+    "description": "One pipeline, two activities: a Copy for the structured feed and a notebook for the semi-structured one."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "c4a9e77b-31d8-4e02-8f16-5b7a2c9d0e44"
+  }
+}

--- a/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -1,0 +1,52 @@
+{
+  "properties": {
+    "activities": [
+      {
+        "name": "IngestCustomers",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "DelimitedTextSource",
+            "rootFolder": "Files",
+            "folderPath": "{{LANDING_DIR}}",
+            "fileName": "customers.csv",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_customers",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestOrders",
+        "type": "TridentNotebook",
+        "typeProperties": {
+          "notebookId": "{{NOTEBOOK_ID}}"
+        }
+      }
+    ]
+  }
+}

--- a/examples/medallion-advanced-pyspark/definitions/bronze-orders.Notebook/.platform
+++ b/examples/medallion-advanced-pyspark/definitions/bronze-orders.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "bronze-orders",
+    "description": "Reads the semi-structured POS feed from landing and writes Delta to the lakehouse."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "6b1f0d2a-7c3e-4a58-9d61-0f2e4b8c1a37"
+  }
+}

--- a/examples/medallion-advanced-pyspark/definitions/bronze-orders.Notebook/notebook-content.py
+++ b/examples/medallion-advanced-pyspark/definitions/bronze-orders.Notebook/notebook-content.py
@@ -1,0 +1,14 @@
+# Fabric notebook source
+
+# CELL ********************
+
+from pyspark.sql.functions import lit
+
+# ABFS addresses OneLake by its full account host, exactly as a Fabric
+# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
+landing = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Files/{{LANDING_DIR}}/orders.jsonl"
+bronze = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables/bronze_orders"
+
+orders = spark.read.json(landing).withColumn("_landing_date", lit("{{LANDING_DATE}}"))
+orders.write.format("delta").mode("overwrite").save(bronze)
+print("bronze_orders rows:", orders.count())

--- a/examples/medallion-advanced-pyspark/definitions/erp-reference-ingest.DataPipeline/.platform
+++ b/examples/medallion-advanced-pyspark/definitions/erp-reference-ingest.DataPipeline/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "DataPipeline",
+    "displayName": "erp-reference-ingest",
+    "description": "Three Parquet Copy activities: ERP changes, FX rates, product hierarchy."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "9d2c6f41-8ab0-4d17-b3e5-72c8149af6b2"
+  }
+}

--- a/examples/medallion-advanced-pyspark/definitions/erp-reference-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-pyspark/definitions/erp-reference-ingest.DataPipeline/pipeline-content.json
@@ -1,0 +1,123 @@
+{
+  "properties": {
+    "activities": [
+      {
+        "name": "IngestErpChanges",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "ParquetSource",
+            "rootFolder": "Files",
+            "folderPath": "{{ERP_DIR}}",
+            "fileName": "changes.parquet",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_erp_changes",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestFxRates",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "ParquetSource",
+            "rootFolder": "Files",
+            "folderPath": "{{REF_DIR}}",
+            "fileName": "fx_rates.parquet",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_fx_rates",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestProductHierarchy",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "ParquetSource",
+            "rootFolder": "Files",
+            "folderPath": "{{REF_DIR}}",
+            "fileName": "product_hierarchy.parquet",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_product_hierarchy",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/examples/medallion-advanced-pyspark/engine.py
+++ b/examples/medallion-advanced-pyspark/engine.py
@@ -15,7 +15,18 @@ import io
 import time
 from contextlib import redirect_stdout
 
-from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log
+from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log, skip_on_real
+
+# Real Fabric HAS a Spark pool, so there is nothing for this step to do there.
+# Its notebook activity runs on the workspace's starter pool (or a custom pool
+# selected through an Environment) and reports its own outcome; the emulator has
+# no pool, which is exactly why it parses the notebook, records a Pending run,
+# and waits for an engine to execute the cells and report back. The step is
+# scaffolding for the missing half of the target, not part of the pipeline.
+skip_on_real(
+    "the notebook engine",
+    "Fabric runs the queued notebook on its own Spark pool and reports the run "
+    "itself, so there is no external engine to attach")
 
 st = load()
 jid, nb = st["orders_job"], st["orders_notebook"]

--- a/examples/medallion-advanced-pyspark/erp_bronze.py
+++ b/examples/medallion-advanced-pyspark/erp_bronze.py
@@ -11,41 +11,23 @@ events with their capture sequence, still out of order where the connector
 delivered them that way. Turning that into a dimension with history is 24's
 job, and 24 has to do it from what actually arrived.
 """
-import json
 
 import erp_system as erp
 import reference_data as ref
-from common import activity_runs, create_item, load, log, run_job, save
+from common import activity_runs, create_item_from_definition, load, log, run_job, save
 
 st = load()
 lake, ws = st["lakehouse"], st["workspace"]
 erp_dir = f"landing/contoso_erp/{st['erp_landing_date']}"
 ref_dir = f"landing/reference/{st['erp_landing_date']}"
 
-lakehouse = {"linkedService": {"properties": {
-    "type": "Lakehouse",
-    "typeProperties": {"workspaceId": ws, "artifactId": lake}}}}
-
-
-def copy_activity(name, folder, filename, table):
-    """A Copy whose source is Parquet rather than delimited text."""
-    return {"name": name, "type": "Copy", "typeProperties": {
-        "source": {"type": "ParquetSource", "rootFolder": "Files",
-                   "folderPath": folder, "fileName": filename,
-                   "datasetSettings": lakehouse},
-        "sink": {"type": "LakehouseTableSink", "tableActionOption": "Overwrite",
-                 "table": table, "datasetSettings": lakehouse}}}
-
-
-definition = {"properties": {"activities": [
-    copy_activity("IngestErpChanges", erp_dir, "changes.parquet", "bronze_erp_changes"),
-    copy_activity("IngestFxRates", ref_dir, "fx_rates.parquet", "bronze_fx_rates"),
-    copy_activity("IngestProductHierarchy", ref_dir, "product_hierarchy.parquet",
-                  "bronze_product_hierarchy"),
-]}}
-
-pl = create_item("erp-reference-ingest", "DataPipeline",
-                 {"pipeline-content.json": json.dumps(definition)})
+# Deployed from `definitions/erp-reference-ingest.DataPipeline/` in Fabric's own
+# source format (docs/46-artifact-persistence.md). Three Parquet Copy activities
+# rather than one delimited-text one; the folder paths are placeholders because
+# they carry the landing date, which is state, not source.
+pl = create_item_from_definition(
+    "erp-reference-ingest.DataPipeline",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake, ERP_DIR=erp_dir, REF_DIR=ref_dir)
 jid, status = run_job(pl, "Pipeline")
 assert status == "Completed", f"erp/reference pipeline: {status}"
 

--- a/examples/medallion-advanced-pyspark/extract_load.py
+++ b/examples/medallion-advanced-pyspark/extract_load.py
@@ -1,15 +1,26 @@
-"""Fetch the API key from Key Vault (as notebookutils.credentials.getSecret
-does), pull the vendor export, and land it verbatim in OneLake."""
+"""Fetch the API key from Key Vault as a Fabric notebook does, pull the vendor
+export, and land it verbatim in OneLake.
+
+`notebookutils.credentials.getSecret` is the BROKERED path, and it is the one a
+notebook has: inside Fabric the workspace identity mints a vault-audience token
+and the secret never appears in the notebook, a parameter, or a pipeline
+definition. Calling Key Vault's REST API with a token minted here reaches the
+same secret and teaches the wrong lesson, because that code cannot move into a
+notebook unchanged. The shim makes this exact call work outside Fabric too
+(python/notebookutils/credentials.py): entra-emulator under `emulator`,
+DefaultAzureCredential under `real`.
+
+The vault is passed as a URI, which is also the real signature — Fabric accepts
+either a vault name or its URI, and only the URI can name the emulator's vault.
+"""
 import datetime
 
+import notebookutils
 import source_system as src
 from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
 
-vt = token(VAULT_AUD)
-r = S.get(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",
-          headers={"Authorization": "Bearer " + vt})
-r.raise_for_status()
-api_key = r.json()["value"]
+ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
+api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-advanced-pyspark/gold.py
+++ b/examples/medallion-advanced-pyspark/gold.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 
 import source_system as src
-from common import GOLD_PROJECT, SQL_AUD, TDS_SERVER, load, log, tds_connect, token
+from common import GOLD_PROJECT, SQL_AUD, load, log, sql_endpoint, tds_connect, token
 
 st = load()
 sql_tok = token(SQL_AUD)
@@ -30,8 +30,11 @@ for _ in range(40):
 else:
     raise SystemExit(f"warehouse warmup failed: {last}")
 
-# The token is pre-minted, so dbt never runs MSAL. encrypt=false matches the TDS
-# front, which terminates FedAuth without TLS.
+# The token is pre-minted, so dbt never runs MSAL. Server, database and encrypt
+# all come from the resolver: on real Fabric the address is per-workspace and only
+# the API knows it, so a pinned host is emulator-only by construction (docs/46).
+wh = sql_endpoint(st["warehouse"])
+lake_db = sql_endpoint(st["lakehouse"]).database
 with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     f.write(f"""contoso_gold:
   target: dev
@@ -39,18 +42,18 @@ with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     dev:
       type: fabric
       driver: "ODBC Driver 18 for SQL Server"
-      server: "{TDS_SERVER}"
-      database: "{st['warehouse']}"
+      server: "{wh.server}"
+      database: "{wh.database}"
       schema: "dbo"
       authentication: "ActiveDirectoryAccessToken"
       access_token: "{sql_tok}"
       access_token_expires_on: 0
-      encrypt: false
+      encrypt: {'true' if wh.encrypt else 'false'}
       trust_cert: true
       threads: 1
 """)
 
-env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakehouse"]}
+env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": lake_db}
 t0 = time.time()
 rc = subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 build_secs = time.time() - t0

--- a/examples/medallion-advanced-pyspark/gold_star.py
+++ b/examples/medallion-advanced-pyspark/gold_star.py
@@ -17,11 +17,17 @@ import time
 
 import source_system as src
 import web_store as web
-from common import SQL_AUD, TDS_SERVER, load, log, tds_connect, token
+from common import SQL_AUD, load, log, sql_endpoint, tds_connect, token
 
 st = load()
 sql_tok = token(SQL_AUD)
 PROJECT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gold_star")
+
+# Server, database and encrypt all come from the resolver: on real Fabric the
+# address is per-workspace and only the API knows it, so a pinned host is
+# emulator-only by construction (docs/46-artifact-persistence.md).
+wh = sql_endpoint(st["warehouse"])
+lake_db = sql_endpoint(st["lakehouse"]).database
 
 with open(os.path.join(PROJECT, "profiles.yml"), "w") as f:
     f.write(f"""contoso_gold_star:
@@ -30,18 +36,18 @@ with open(os.path.join(PROJECT, "profiles.yml"), "w") as f:
     dev:
       type: fabric
       driver: "ODBC Driver 18 for SQL Server"
-      server: "{TDS_SERVER}"
-      database: "{st['warehouse']}"
+      server: "{wh.server}"
+      database: "{wh.database}"
       schema: "dbo"
       authentication: "ActiveDirectoryAccessToken"
       access_token: "{sql_tok}"
       access_token_expires_on: 0
-      encrypt: false
+      encrypt: {'true' if wh.encrypt else 'false'}
       trust_cert: true
       threads: 1
 """)
 
-env = {**os.environ, "DBT_PROFILES_DIR": PROJECT, "LAKEHOUSE_ID": st["lakehouse"]}
+env = {**os.environ, "DBT_PROFILES_DIR": PROJECT, "LAKEHOUSE_ID": lake_db}
 t0 = time.time()
 rc = subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=PROJECT, env=env).returncode
 build_secs = time.time() - t0

--- a/examples/medallion-advanced-pyspark/govern.py
+++ b/examples/medallion-advanced-pyspark/govern.py
@@ -31,7 +31,18 @@ import os
 
 import requests
 import yaml
-from common import FABRIC, OM_URL, S, fabric_headers, load, log
+from common import FABRIC, OM_URL, S, fabric_headers, load, log, skip_on_real
+
+# OpenMetadata is a companion service, not a Fabric surface, and the lineage this
+# step reads is the emulator's own recorded flow graph. Fabric's counterpart is
+# Purview: a different integration with a different model, not the same call to a
+# different host. Skipping rather than refusing because the catalog is optional
+# here by design (see the module docstring) and the medallion is complete without it.
+skip_on_real(
+    "the OpenMetadata catalog step",
+    "OpenMetadata has no Fabric endpoint to resolve to, and the lineage it "
+    "publishes comes from the emulator's flow graph. Purview is the real "
+    "counterpart, and a different integration")
 
 # Local policy, resolved centrally — see common.OM_URL.
 OM = OM_URL

--- a/examples/medallion-advanced-pyspark/govern.py
+++ b/examples/medallion-advanced-pyspark/govern.py
@@ -31,9 +31,10 @@ import os
 
 import requests
 import yaml
-from common import FABRIC, S, fabric_headers, load, log
+from common import FABRIC, OM_URL, S, fabric_headers, load, log
 
-OM = os.environ.get("OM_URL", "http://localhost:8585")
+# Local policy, resolved centrally — see common.OM_URL.
+OM = OM_URL
 HERE = os.path.dirname(os.path.abspath(__file__))
 CONTRACTS = os.path.join(HERE, "contracts")
 

--- a/examples/medallion-advanced-pyspark/pyproject.toml
+++ b/examples/medallion-advanced-pyspark/pyproject.toml
@@ -38,4 +38,7 @@ package = false
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }
+# The target contract, resolved from the repo rather than PyPI so an example run
+# from a checkout uses the same code the emulator publishes.
+fabric-target = { path = "../../python/fabric-target", editable = true }
 contoso-fixtures-advanced = { path = "../contoso-fixtures-advanced", editable = true }

--- a/examples/medallion-advanced-pyspark/pyproject.toml
+++ b/examples/medallion-advanced-pyspark/pyproject.toml
@@ -41,4 +41,7 @@ contoso-fixtures = { path = "../contoso-fixtures", editable = true }
 # The target contract, resolved from the repo rather than PyPI so an example run
 # from a checkout uses the same code the emulator publishes.
 fabric-target = { path = "../../python/fabric-target", editable = true }
+# The notebookutils shim, from the same checkout: contoso-fixtures depends on it
+# so a step can read a secret the way a Fabric notebook does.
+fabric-emulator-notebookutils = { path = "../../python", editable = true }
 contoso-fixtures-advanced = { path = "../contoso-fixtures-advanced", editable = true }

--- a/examples/medallion-advanced-pyspark/silver.py
+++ b/examples/medallion-advanced-pyspark/silver.py
@@ -19,7 +19,23 @@ needs would be the wrong place to do it: silver is the conformed customer-360,
 and the star's dimensions are a projection of it, not the other way round.
 """
 import source_system as src
-from common import SPARK_REMOTE, load, log, report_lineage
+from common import SPARK_REMOTE, load, log, only_the_emulator_can, report_lineage
+
+# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
+# portability line falls. Real Fabric does not expose a Spark endpoint to dial
+# from outside: its compute runs the notebook. So this transform is portable only
+# once it LIVES in a notebook definition, which is a rewrite of where the code
+# sits rather than of what it does.
+only_the_emulator_can(
+    "driving Spark directly over Spark Connect",
+    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
+            "the service, on the workspace's starter pool or a custom pool chosen "
+            "through an Environment",
+    instead="move this transform into a Notebook definition under definitions/ and "
+            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
+            "accept; the Livy API "
+            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
+            "is the other route on real Fabric")
 
 st = load()
 assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"

--- a/examples/medallion-advanced-pyspark/star_silver.py
+++ b/examples/medallion-advanced-pyspark/star_silver.py
@@ -27,7 +27,24 @@ than saying so.
 import erp_system as erp
 import source_system as src
 import web_store as web
-from common import SPARK_REMOTE, load, log, report_lineage
+from common import SPARK_REMOTE, load, log, only_the_emulator_can, report_lineage
+
+# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
+# portability line falls. Real Fabric does not expose a Spark endpoint to dial
+# from outside: its compute runs the notebook. So this transform is portable only
+# once it LIVES in a notebook definition, which is a rewrite of where the code
+# sits rather than of what it does.
+only_the_emulator_can(
+    "driving Spark directly over Spark Connect",
+    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
+            "the service, on the workspace's starter pool or a custom pool chosen "
+            "through an Environment",
+    instead="move this transform into a Notebook definition under definitions/ and "
+            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
+            "accept; the Livy API "
+            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
+            "is the other route on real Fabric")
+
 
 st = load()
 assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"

--- a/examples/medallion-advanced-pyspark/uv.lock
+++ b/examples/medallion-advanced-pyspark/uv.lock
@@ -467,12 +467,14 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-emulator-notebookutils" },
     { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fabric-emulator-notebookutils", editable = "../../python" },
     { name = "fabric-target", editable = "../../python/fabric-target" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
@@ -806,6 +808,11 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-emulator-notebookutils"
+version = "0.1.0"
+source = { editable = "../../python" }
 
 [[package]]
 name = "fabric-target"

--- a/examples/medallion-advanced-pyspark/uv.lock
+++ b/examples/medallion-advanced-pyspark/uv.lock
@@ -467,11 +467,15 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32,<3" }]
+requires-dist = [
+    { name = "fabric-target", editable = "../../python/fabric-target" },
+    { name = "requests", specifier = ">=2.32,<3" },
+]
 
 [[package]]
 name = "contoso-fixtures-advanced"
@@ -802,6 +806,18 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-target"
+version = "0.1.0"
+source = { editable = "../../python/fabric-target" }
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-identity", marker = "extra == 'real'", specifier = ">=1.17" },
+    { name = "requests", marker = "extra == 'sessions'", specifier = ">=2.31" },
+]
+provides-extras = ["real", "sessions"]
 
 [[package]]
 name = "fastjsonschema"

--- a/examples/medallion-dbt-fabricspark/README.md
+++ b/examples/medallion-dbt-fabricspark/README.md
@@ -63,6 +63,14 @@ uv sync --frozen && uv run python pipeline.py
 Running this example alone is fine — `compare.py` skips with a nudge rather than
 failing. See the caveat about that skip below.
 
+## Where your items live: `definitions/`
+
+Unchanged from the sibling, and worth reading there:
+[`../medallion-pyspark#where-your-items-live-definitions`](../medallion-pyspark/README.md#where-your-items-live-definitions).
+Bronze deploys from committed files in Fabric's own source format —
+`{display name}.{public facing type}/` with `.platform` — which is the layout
+Fabric's Git integration writes. Only **silver** differs in this example.
+
 ## The comparison
 
 `compare.py` reads the `silver_summary.json` each example writes and reports

--- a/examples/medallion-dbt-fabricspark/bronze.py
+++ b/examples/medallion-dbt-fabricspark/bronze.py
@@ -19,56 +19,34 @@ that terminal state, exactly as a Fabric pipeline does. `engine.py` still shows
 the other half of the contract — the `notebookRunResult` callback an external
 engine uses.
 """
-import json
 
 import source_system as src
-from common import activity_runs, create_item, load, log, run_job, save
+from common import activity_runs, create_item_from_definition, load, log, run_job, save
 
 st = load()
 lake, ws = st["lakehouse"], st["workspace"]
 landing_dir = f"landing/contoso_pos/{st['landing_date']}"
 
-# The notebook a Fabric author would write for the semi-structured feed: read
-# landing with Spark, write Delta straight to OneLake.
-NOTEBOOK = f'''# Fabric notebook source
+# The items are deployed from `definitions/`, which holds them in Fabric's own
+# SOURCE FORMAT — `<display name>.<Type>/` with the definition files and
+# `.platform`, exactly what Git integration writes and fabric-cicd deploys
+# (docs/46-artifact-persistence.md). The committed files carry {{TOKENS}} because
+# a definition names the workspace and lakehouse it reads by GUID and those do
+# not exist until provision.py has run; substituting at deploy is what
+# fabric-cicd's own find_replace parameter file is for.
+nb = create_item_from_definition(
+    "bronze-orders.Notebook",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, LANDING_DATE=st["landing_date"])
 
-# CELL ********************
-
-from pyspark.sql.functions import lit
-
-# ABFS addresses OneLake by its full account host, exactly as a Fabric
-# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
-landing = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Files/{landing_dir}/orders.jsonl"
-bronze = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Tables/bronze_orders"
-
-orders = spark.read.json(landing).withColumn("_landing_date", lit("{st['landing_date']}"))
-orders.write.format("delta").mode("overwrite").save(bronze)
-print("bronze_orders rows:", orders.count())
-'''
-
-nb = create_item("bronze-orders", "Notebook", {"notebook-content.py": NOTEBOOK})
-
-# One pipeline, two activities — the shape a real medallion ingest takes.
-# Built as a dict and serialised, not string-templated: a pipeline definition is
-# nested JSON, and hand-escaping braces is how you get PipelineDefinitionInvalid.
-lakehouse = {"linkedService": {"properties": {
-    "type": "Lakehouse",
-    "typeProperties": {"workspaceId": ws, "artifactId": lake}}}}
-
-definition = {"properties": {"activities": [
-    {"name": "IngestCustomers", "type": "Copy", "typeProperties": {
-        "source": {"type": "DelimitedTextSource", "rootFolder": "Files",
-                   "folderPath": landing_dir, "fileName": "customers.csv",
-                   "datasetSettings": lakehouse},
-        "sink": {"type": "LakehouseTableSink", "tableActionOption": "Overwrite",
-                 "table": "bronze_customers",
-                 "datasetSettings": lakehouse}}},
-    {"name": "IngestOrders", "type": "TridentNotebook", "typeProperties": {
-        "notebookId": nb}},
-]}}
-
-pl = create_item("bronze-ingest", "DataPipeline",
-                 {"pipeline-content.json": json.dumps(definition)})
+# The same, for the pipeline: one Copy activity for the structured feed and a
+# TridentNotebook activity for the semi-structured one. NOTEBOOK_ID is a
+# placeholder because the notebook above only just acquired its id — the ordinary
+# case in a real deployment, where items reference each other by GUID.
+pl = create_item_from_definition(
+    "bronze-ingest.DataPipeline",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, NOTEBOOK_ID=nb)
 jid, status = run_job(pl, "Pipeline")
 assert status == "Completed", f"bronze pipeline: {status}"
 

--- a/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/.platform
+++ b/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "DataPipeline",
+    "displayName": "bronze-ingest",
+    "description": "One pipeline, two activities: a Copy for the structured feed and a notebook for the semi-structured one."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "c4a9e77b-31d8-4e02-8f16-5b7a2c9d0e44"
+  }
+}

--- a/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -1,0 +1,52 @@
+{
+  "properties": {
+    "activities": [
+      {
+        "name": "IngestCustomers",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "DelimitedTextSource",
+            "rootFolder": "Files",
+            "folderPath": "{{LANDING_DIR}}",
+            "fileName": "customers.csv",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_customers",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestOrders",
+        "type": "TridentNotebook",
+        "typeProperties": {
+          "notebookId": "{{NOTEBOOK_ID}}"
+        }
+      }
+    ]
+  }
+}

--- a/examples/medallion-dbt-fabricspark/definitions/bronze-orders.Notebook/.platform
+++ b/examples/medallion-dbt-fabricspark/definitions/bronze-orders.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "bronze-orders",
+    "description": "Reads the semi-structured POS feed from landing and writes Delta to the lakehouse."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "6b1f0d2a-7c3e-4a58-9d61-0f2e4b8c1a37"
+  }
+}

--- a/examples/medallion-dbt-fabricspark/definitions/bronze-orders.Notebook/notebook-content.py
+++ b/examples/medallion-dbt-fabricspark/definitions/bronze-orders.Notebook/notebook-content.py
@@ -1,0 +1,14 @@
+# Fabric notebook source
+
+# CELL ********************
+
+from pyspark.sql.functions import lit
+
+# ABFS addresses OneLake by its full account host, exactly as a Fabric
+# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
+landing = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Files/{{LANDING_DIR}}/orders.jsonl"
+bronze = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables/bronze_orders"
+
+orders = spark.read.json(landing).withColumn("_landing_date", lit("{{LANDING_DATE}}"))
+orders.write.format("delta").mode("overwrite").save(bronze)
+print("bronze_orders rows:", orders.count())

--- a/examples/medallion-dbt-fabricspark/engine.py
+++ b/examples/medallion-dbt-fabricspark/engine.py
@@ -15,7 +15,18 @@ import io
 import time
 from contextlib import redirect_stdout
 
-from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log
+from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log, skip_on_real
+
+# Real Fabric HAS a Spark pool, so there is nothing for this step to do there.
+# Its notebook activity runs on the workspace's starter pool (or a custom pool
+# selected through an Environment) and reports its own outcome; the emulator has
+# no pool, which is exactly why it parses the notebook, records a Pending run,
+# and waits for an engine to execute the cells and report back. The step is
+# scaffolding for the missing half of the target, not part of the pipeline.
+skip_on_real(
+    "the notebook engine",
+    "Fabric runs the queued notebook on its own Spark pool and reports the run "
+    "itself, so there is no external engine to attach")
 
 st = load()
 jid, nb = st["orders_job"], st["orders_notebook"]

--- a/examples/medallion-dbt-fabricspark/extract_load.py
+++ b/examples/medallion-dbt-fabricspark/extract_load.py
@@ -1,15 +1,26 @@
-"""Fetch the API key from Key Vault (as notebookutils.credentials.getSecret
-does), pull the vendor export, and land it verbatim in OneLake."""
+"""Fetch the API key from Key Vault as a Fabric notebook does, pull the vendor
+export, and land it verbatim in OneLake.
+
+`notebookutils.credentials.getSecret` is the BROKERED path, and it is the one a
+notebook has: inside Fabric the workspace identity mints a vault-audience token
+and the secret never appears in the notebook, a parameter, or a pipeline
+definition. Calling Key Vault's REST API with a token minted here reaches the
+same secret and teaches the wrong lesson, because that code cannot move into a
+notebook unchanged. The shim makes this exact call work outside Fabric too
+(python/notebookutils/credentials.py): entra-emulator under `emulator`,
+DefaultAzureCredential under `real`.
+
+The vault is passed as a URI, which is also the real signature — Fabric accepts
+either a vault name or its URI, and only the URI can name the emulator's vault.
+"""
 import datetime
 
+import notebookutils
 import source_system as src
 from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
 
-vt = token(VAULT_AUD)
-r = S.get(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",
-          headers={"Authorization": "Bearer " + vt})
-r.raise_for_status()
-api_key = r.json()["value"]
+ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
+api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-dbt-fabricspark/gold.py
+++ b/examples/medallion-dbt-fabricspark/gold.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 
 import source_system as src
-from common import GOLD_PROJECT, SQL_AUD, TDS_SERVER, load, log, tds_connect, token
+from common import GOLD_PROJECT, SQL_AUD, load, log, sql_endpoint, tds_connect, token
 
 st = load()
 sql_tok = token(SQL_AUD)
@@ -30,8 +30,11 @@ for _ in range(40):
 else:
     raise SystemExit(f"warehouse warmup failed: {last}")
 
-# The token is pre-minted, so dbt never runs MSAL. encrypt=false matches the TDS
-# front, which terminates FedAuth without TLS.
+# The token is pre-minted, so dbt never runs MSAL. Server, database and encrypt
+# all come from the resolver: on real Fabric the address is per-workspace and only
+# the API knows it, so a pinned host is emulator-only by construction (docs/46).
+wh = sql_endpoint(st["warehouse"])
+lake_db = sql_endpoint(st["lakehouse"]).database
 with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     f.write(f"""contoso_gold:
   target: dev
@@ -39,18 +42,18 @@ with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     dev:
       type: fabric
       driver: "ODBC Driver 18 for SQL Server"
-      server: "{TDS_SERVER}"
-      database: "{st['warehouse']}"
+      server: "{wh.server}"
+      database: "{wh.database}"
       schema: "dbo"
       authentication: "ActiveDirectoryAccessToken"
       access_token: "{sql_tok}"
       access_token_expires_on: 0
-      encrypt: false
+      encrypt: {'true' if wh.encrypt else 'false'}
       trust_cert: true
       threads: 1
 """)
 
-env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakehouse"]}
+env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": lake_db}
 t0 = time.time()
 rc = subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 build_secs = time.time() - t0

--- a/examples/medallion-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-dbt-fabricspark/pyproject.toml
@@ -31,3 +31,6 @@ contoso-fixtures = { path = "../contoso-fixtures", editable = true }
 # The target contract, resolved from the repo rather than PyPI so an example run
 # from a checkout uses the same code the emulator publishes.
 fabric-target = { path = "../../python/fabric-target", editable = true }
+# The notebookutils shim, from the same checkout: contoso-fixtures depends on it
+# so a step can read a secret the way a Fabric notebook does.
+fabric-emulator-notebookutils = { path = "../../python", editable = true }

--- a/examples/medallion-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-dbt-fabricspark/pyproject.toml
@@ -28,3 +28,6 @@ package = false
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }
+# The target contract, resolved from the repo rather than PyPI so an example run
+# from a checkout uses the same code the emulator publishes.
+fabric-target = { path = "../../python/fabric-target", editable = true }

--- a/examples/medallion-dbt-fabricspark/uv.lock
+++ b/examples/medallion-dbt-fabricspark/uv.lock
@@ -314,11 +314,15 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32,<3" }]
+requires-dist = [
+    { name = "fabric-target", editable = "../../python/fabric-target" },
+    { name = "requests", specifier = ">=2.32,<3" },
+]
 
 [[package]]
 name = "cryptography"
@@ -599,6 +603,18 @@ requires-dist = [
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-target"
+version = "0.1.0"
+source = { editable = "../../python/fabric-target" }
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-identity", marker = "extra == 'real'", specifier = ">=1.17" },
+    { name = "requests", marker = "extra == 'sessions'", specifier = ">=2.31" },
+]
+provides-extras = ["real", "sessions"]
 
 [[package]]
 name = "googleapis-common-protos"

--- a/examples/medallion-dbt-fabricspark/uv.lock
+++ b/examples/medallion-dbt-fabricspark/uv.lock
@@ -314,12 +314,14 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-emulator-notebookutils" },
     { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fabric-emulator-notebookutils", editable = "../../python" },
     { name = "fabric-target", editable = "../../python/fabric-target" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
@@ -603,6 +605,11 @@ requires-dist = [
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-emulator-notebookutils"
+version = "0.1.0"
+source = { editable = "../../python" }
 
 [[package]]
 name = "fabric-target"

--- a/examples/medallion-pyspark/README.md
+++ b/examples/medallion-pyspark/README.md
@@ -237,7 +237,7 @@ at compose service names over plain HTTP:
 | `ENTRA_URL` | `https://localhost:8443` |
 | `KV_URL` | `https://localhost:8444` |
 | `FABRIC_REST_URL` | `https://localhost:9443` |
-| `TDS_SERVER` | `localhost,1433` |
+| `TDS_SERVER` | *unset* — the SQL address is **discovered** from the item (`properties.connectionString`, or `sqlEndpointProperties.connectionString` for the lakehouse endpoint), which is the only form that also works on real Fabric. Set it only for a stack whose SQL port is remapped, since the emulator advertises the port it listens on |
 | `KV_INTERNAL_URL` | `https://keyvault-emulator:8444` — the vault URI **Fabric** resolves, so it must be reachable from the emulator, not from you. That is why it is a service name and not `localhost` even when you run these steps on your machine |
 | `SPARK_REMOTE` | `sc://localhost:50051` — the Spark engine `engine.py` drives the notebook run onto (Sail, as the root compose publishes it) |
 | `PIPELINE_STATE` | `./state.json` |

--- a/examples/medallion-pyspark/README.md
+++ b/examples/medallion-pyspark/README.md
@@ -143,6 +143,69 @@ uv run python pipeline.py     # the basic pipeline, then 20+
 the basic track cannot drift out from under the advanced one.
 [`e2e/medallion-advanced`](../../e2e/medallion-advanced/) runs it in CI.
 
+## Where your items live: `definitions/`
+
+The notebook and the pipelines are **not** built as strings in Python. They are
+committed files, in the layout Microsoft Fabric itself uses:
+
+```
+definitions/
+  bronze-orders.Notebook/
+    .platform                 ← item metadata: type, display name, logicalId
+    notebook-content.py       ← the notebook, as Fabric stores it
+  bronze-ingest.DataPipeline/
+    .platform
+    pipeline-content.json     ← the activities
+```
+
+**This is the same layout Fabric's Git integration writes.** Connect a real
+workspace to Azure DevOps or GitHub and Fabric produces exactly this: one
+directory per item named `{display name}.{public facing type}`, holding the
+item's definition files plus a `.platform`. So the directory above is what your
+repository looks like in production — not an emulator convention you would have
+to unlearn.
+
+Three things follow from that, and they are the point of the example:
+
+**The filenames are Fabric's.** `notebook-content.py` for a Notebook,
+`pipeline-content.json` for a DataPipeline. These become the `path` values in
+the definition parts that `updateDefinition` accepts. Invent a filename and the
+emulator will store it happily — it keeps parts verbatim by design — while real
+Fabric refuses. Copy these names.
+
+**`.platform` carries the identity.** Its `logicalId` is the cross-workspace
+identifier that ties this item to its source-control representation and survives
+renames and moves. It is how one branch can deploy to dev, test and prod and have
+Fabric recognise the same item in each. Do not edit it.
+
+**`{{TOKENS}}` are how ids travel.** A pipeline names the workspace and lakehouse
+it reads by GUID, and those GUIDs differ in every workspace:
+
+```json
+"typeProperties": {"workspaceId": "{{WORKSPACE_ID}}", "artifactId": "{{LAKEHOUSE_ID}}"}
+```
+
+So the committed file is a template and the deploy substitutes. That is not a
+local shortcut — Microsoft's own [`fabric-cicd`](https://learn.microsoft.com/en-us/fabric/cicd/tutorial-fabric-cicd-azure-devops)
+ships a `find_replace` parameter file for the same reason. `bronze.py` deploys
+with one call:
+
+```python
+nb = create_item_from_definition(
+    "bronze-orders.Notebook",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, LANDING_DATE=st["landing_date"])
+```
+
+The item **type comes from the folder name**, as it does in Git, and any
+placeholder left unsubstituted is an error at deploy rather than a Spark failure
+ten minutes later about a workspace literally named `{{WORKSPACE_ID}}`.
+
+What is *not* in `definitions/` is your data. Definitions are versioned; the
+Delta tables they write live in OneLake and are never in Git, and no deployment
+overwrites them. [docs/46](../../docs/46-artifact-persistence.md) is the full
+contract, with links to Microsoft's documentation for each claim.
+
 ## Files
 
 - `common.py` — endpoints, tokens for all five audiences, the TDS connector, state
@@ -159,6 +222,8 @@ the basic track cannot drift out from under the advanced one.
 - `contracts/` — ODCS v3.1.0 data contracts over the layers; see
   [docs/30](../../docs/30-odcs-data-contracts.md)
 - `gold/` — the dbt project (models, sources, schema tests, singular tests)
+- `definitions/` — your items in Fabric's own source format, one directory
+  per item; see the section above
 - `state.json` — written by `provision.py`, read by everything after it
 
 ## Configuration

--- a/examples/medallion-pyspark/bronze.py
+++ b/examples/medallion-pyspark/bronze.py
@@ -19,56 +19,34 @@ that terminal state, exactly as a Fabric pipeline does. `engine.py` still shows
 the other half of the contract — the `notebookRunResult` callback an external
 engine uses.
 """
-import json
 
 import source_system as src
-from common import activity_runs, create_item, load, log, run_job, save
+from common import activity_runs, create_item_from_definition, load, log, run_job, save
 
 st = load()
 lake, ws = st["lakehouse"], st["workspace"]
 landing_dir = f"landing/contoso_pos/{st['landing_date']}"
 
-# The notebook a Fabric author would write for the semi-structured feed: read
-# landing with Spark, write Delta straight to OneLake.
-NOTEBOOK = f'''# Fabric notebook source
+# The items are deployed from `definitions/`, which holds them in Fabric's own
+# SOURCE FORMAT — `<display name>.<Type>/` with the definition files and
+# `.platform`, exactly what Git integration writes and fabric-cicd deploys
+# (docs/46-artifact-persistence.md). The committed files carry {{TOKENS}} because
+# a definition names the workspace and lakehouse it reads by GUID and those do
+# not exist until provision.py has run; substituting at deploy is what
+# fabric-cicd's own find_replace parameter file is for.
+nb = create_item_from_definition(
+    "bronze-orders.Notebook",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, LANDING_DATE=st["landing_date"])
 
-# CELL ********************
-
-from pyspark.sql.functions import lit
-
-# ABFS addresses OneLake by its full account host, exactly as a Fabric
-# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
-landing = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Files/{landing_dir}/orders.jsonl"
-bronze = "abfs://{ws}@onelake.dfs.fabric.microsoft.com/{lake}/Tables/bronze_orders"
-
-orders = spark.read.json(landing).withColumn("_landing_date", lit("{st['landing_date']}"))
-orders.write.format("delta").mode("overwrite").save(bronze)
-print("bronze_orders rows:", orders.count())
-'''
-
-nb = create_item("bronze-orders", "Notebook", {"notebook-content.py": NOTEBOOK})
-
-# One pipeline, two activities — the shape a real medallion ingest takes.
-# Built as a dict and serialised, not string-templated: a pipeline definition is
-# nested JSON, and hand-escaping braces is how you get PipelineDefinitionInvalid.
-lakehouse = {"linkedService": {"properties": {
-    "type": "Lakehouse",
-    "typeProperties": {"workspaceId": ws, "artifactId": lake}}}}
-
-definition = {"properties": {"activities": [
-    {"name": "IngestCustomers", "type": "Copy", "typeProperties": {
-        "source": {"type": "DelimitedTextSource", "rootFolder": "Files",
-                   "folderPath": landing_dir, "fileName": "customers.csv",
-                   "datasetSettings": lakehouse},
-        "sink": {"type": "LakehouseTableSink", "tableActionOption": "Overwrite",
-                 "table": "bronze_customers",
-                 "datasetSettings": lakehouse}}},
-    {"name": "IngestOrders", "type": "TridentNotebook", "typeProperties": {
-        "notebookId": nb}},
-]}}
-
-pl = create_item("bronze-ingest", "DataPipeline",
-                 {"pipeline-content.json": json.dumps(definition)})
+# The same, for the pipeline: one Copy activity for the structured feed and a
+# TridentNotebook activity for the semi-structured one. NOTEBOOK_ID is a
+# placeholder because the notebook above only just acquired its id — the ordinary
+# case in a real deployment, where items reference each other by GUID.
+pl = create_item_from_definition(
+    "bronze-ingest.DataPipeline",
+    WORKSPACE_ID=ws, LAKEHOUSE_ID=lake,
+    LANDING_DIR=landing_dir, NOTEBOOK_ID=nb)
 jid, status = run_job(pl, "Pipeline")
 assert status == "Completed", f"bronze pipeline: {status}"
 

--- a/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/.platform
+++ b/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "DataPipeline",
+    "displayName": "bronze-ingest",
+    "description": "One pipeline, two activities: a Copy for the structured feed and a notebook for the semi-structured one."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "c4a9e77b-31d8-4e02-8f16-5b7a2c9d0e44"
+  }
+}

--- a/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -1,0 +1,52 @@
+{
+  "properties": {
+    "activities": [
+      {
+        "name": "IngestCustomers",
+        "type": "Copy",
+        "typeProperties": {
+          "source": {
+            "type": "DelimitedTextSource",
+            "rootFolder": "Files",
+            "folderPath": "{{LANDING_DIR}}",
+            "fileName": "customers.csv",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          },
+          "sink": {
+            "type": "LakehouseTableSink",
+            "tableActionOption": "Overwrite",
+            "table": "bronze_customers",
+            "datasetSettings": {
+              "linkedService": {
+                "properties": {
+                  "type": "Lakehouse",
+                  "typeProperties": {
+                    "workspaceId": "{{WORKSPACE_ID}}",
+                    "artifactId": "{{LAKEHOUSE_ID}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "IngestOrders",
+        "type": "TridentNotebook",
+        "typeProperties": {
+          "notebookId": "{{NOTEBOOK_ID}}"
+        }
+      }
+    ]
+  }
+}

--- a/examples/medallion-pyspark/definitions/bronze-orders.Notebook/.platform
+++ b/examples/medallion-pyspark/definitions/bronze-orders.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "bronze-orders",
+    "description": "Reads the semi-structured POS feed from landing and writes Delta to the lakehouse."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "6b1f0d2a-7c3e-4a58-9d61-0f2e4b8c1a37"
+  }
+}

--- a/examples/medallion-pyspark/definitions/bronze-orders.Notebook/notebook-content.py
+++ b/examples/medallion-pyspark/definitions/bronze-orders.Notebook/notebook-content.py
@@ -1,0 +1,14 @@
+# Fabric notebook source
+
+# CELL ********************
+
+from pyspark.sql.functions import lit
+
+# ABFS addresses OneLake by its full account host, exactly as a Fabric
+# notebook does: abfs://<workspace>@onelake.dfs.fabric.microsoft.com/<item>/...
+landing = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Files/{{LANDING_DIR}}/orders.jsonl"
+bronze = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables/bronze_orders"
+
+orders = spark.read.json(landing).withColumn("_landing_date", lit("{{LANDING_DATE}}"))
+orders.write.format("delta").mode("overwrite").save(bronze)
+print("bronze_orders rows:", orders.count())

--- a/examples/medallion-pyspark/engine.py
+++ b/examples/medallion-pyspark/engine.py
@@ -15,7 +15,18 @@ import io
 import time
 from contextlib import redirect_stdout
 
-from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log
+from common import FABRIC, SPARK_REMOTE, S, fabric_headers, load, log, skip_on_real
+
+# Real Fabric HAS a Spark pool, so there is nothing for this step to do there.
+# Its notebook activity runs on the workspace's starter pool (or a custom pool
+# selected through an Environment) and reports its own outcome; the emulator has
+# no pool, which is exactly why it parses the notebook, records a Pending run,
+# and waits for an engine to execute the cells and report back. The step is
+# scaffolding for the missing half of the target, not part of the pipeline.
+skip_on_real(
+    "the notebook engine",
+    "Fabric runs the queued notebook on its own Spark pool and reports the run "
+    "itself, so there is no external engine to attach")
 
 st = load()
 jid, nb = st["orders_job"], st["orders_notebook"]

--- a/examples/medallion-pyspark/extract_load.py
+++ b/examples/medallion-pyspark/extract_load.py
@@ -1,15 +1,26 @@
-"""Fetch the API key from Key Vault (as notebookutils.credentials.getSecret
-does), pull the vendor export, and land it verbatim in OneLake."""
+"""Fetch the API key from Key Vault as a Fabric notebook does, pull the vendor
+export, and land it verbatim in OneLake.
+
+`notebookutils.credentials.getSecret` is the BROKERED path, and it is the one a
+notebook has: inside Fabric the workspace identity mints a vault-audience token
+and the secret never appears in the notebook, a parameter, or a pipeline
+definition. Calling Key Vault's REST API with a token minted here reaches the
+same secret and teaches the wrong lesson, because that code cannot move into a
+notebook unchanged. The shim makes this exact call work outside Fabric too
+(python/notebookutils/credentials.py): entra-emulator under `emulator`,
+DefaultAzureCredential under `real`.
+
+The vault is passed as a URI, which is also the real signature — Fabric accepts
+either a vault name or its URI, and only the URI can name the emulator's vault.
+"""
 import datetime
 
+import notebookutils
 import source_system as src
 from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
 
-vt = token(VAULT_AUD)
-r = S.get(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",
-          headers={"Authorization": "Bearer " + vt})
-r.raise_for_status()
-api_key = r.json()["value"]
+ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
+api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-pyspark/gold.py
+++ b/examples/medallion-pyspark/gold.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 
 import source_system as src
-from common import GOLD_PROJECT, SQL_AUD, TDS_SERVER, load, log, tds_connect, token
+from common import GOLD_PROJECT, SQL_AUD, load, log, sql_endpoint, tds_connect, token
 
 st = load()
 sql_tok = token(SQL_AUD)
@@ -30,8 +30,11 @@ for _ in range(40):
 else:
     raise SystemExit(f"warehouse warmup failed: {last}")
 
-# The token is pre-minted, so dbt never runs MSAL. encrypt=false matches the TDS
-# front, which terminates FedAuth without TLS.
+# The token is pre-minted, so dbt never runs MSAL. Server, database and encrypt
+# all come from the resolver: on real Fabric the address is per-workspace and only
+# the API knows it, so a pinned host is emulator-only by construction (docs/46).
+wh = sql_endpoint(st["warehouse"])
+lake_db = sql_endpoint(st["lakehouse"]).database
 with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     f.write(f"""contoso_gold:
   target: dev
@@ -39,18 +42,18 @@ with open(os.path.join(GOLD_PROJECT, "profiles.yml"), "w") as f:
     dev:
       type: fabric
       driver: "ODBC Driver 18 for SQL Server"
-      server: "{TDS_SERVER}"
-      database: "{st['warehouse']}"
+      server: "{wh.server}"
+      database: "{wh.database}"
       schema: "dbo"
       authentication: "ActiveDirectoryAccessToken"
       access_token: "{sql_tok}"
       access_token_expires_on: 0
-      encrypt: false
+      encrypt: {'true' if wh.encrypt else 'false'}
       trust_cert: true
       threads: 1
 """)
 
-env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakehouse"]}
+env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": lake_db}
 t0 = time.time()
 rc = subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 build_secs = time.time() - t0

--- a/examples/medallion-pyspark/pyproject.toml
+++ b/examples/medallion-pyspark/pyproject.toml
@@ -32,3 +32,6 @@ contoso-fixtures = { path = "../contoso-fixtures", editable = true }
 # The target contract, resolved from the repo rather than PyPI so an example run
 # from a checkout uses the same code the emulator publishes.
 fabric-target = { path = "../../python/fabric-target", editable = true }
+# The notebookutils shim, from the same checkout: contoso-fixtures depends on it
+# so a step can read a secret the way a Fabric notebook does.
+fabric-emulator-notebookutils = { path = "../../python", editable = true }

--- a/examples/medallion-pyspark/pyproject.toml
+++ b/examples/medallion-pyspark/pyproject.toml
@@ -29,3 +29,6 @@ package = false
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }
+# The target contract, resolved from the repo rather than PyPI so an example run
+# from a checkout uses the same code the emulator publishes.
+fabric-target = { path = "../../python/fabric-target", editable = true }

--- a/examples/medallion-pyspark/silver.py
+++ b/examples/medallion-pyspark/silver.py
@@ -19,7 +19,24 @@ needs would be the wrong place to do it: silver is the conformed customer-360,
 and the star's dimensions are a projection of it, not the other way round.
 """
 import source_system as src
-from common import SPARK_REMOTE, load, log
+from common import SPARK_REMOTE, load, log, only_the_emulator_can
+
+# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
+# portability line falls. Real Fabric does not expose a Spark endpoint to dial
+# from outside: its compute runs the notebook. So this transform is portable only
+# once it LIVES in a notebook definition, which is a rewrite of where the code
+# sits rather than of what it does.
+only_the_emulator_can(
+    "driving Spark directly over Spark Connect",
+    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
+            "the service, on the workspace's starter pool or a custom pool chosen "
+            "through an Environment",
+    instead="move this transform into a Notebook definition under definitions/ and "
+            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
+            "accept; the Livy API "
+            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
+            "is the other route on real Fabric")
+
 
 st = load()
 assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"

--- a/examples/medallion-pyspark/uv.lock
+++ b/examples/medallion-pyspark/uv.lock
@@ -314,11 +314,15 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32,<3" }]
+requires-dist = [
+    { name = "fabric-target", editable = "../../python/fabric-target" },
+    { name = "requests", specifier = ">=2.32,<3" },
+]
 
 [[package]]
 name = "cryptography"
@@ -580,6 +584,18 @@ requires-dist = [
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-target"
+version = "0.1.0"
+source = { editable = "../../python/fabric-target" }
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-identity", marker = "extra == 'real'", specifier = ">=1.17" },
+    { name = "requests", marker = "extra == 'sessions'", specifier = ">=2.31" },
+]
+provides-extras = ["real", "sessions"]
 
 [[package]]
 name = "googleapis-common-protos"

--- a/examples/medallion-pyspark/uv.lock
+++ b/examples/medallion-pyspark/uv.lock
@@ -314,12 +314,14 @@ name = "contoso-fixtures"
 version = "0.1.0"
 source = { editable = "../contoso-fixtures" }
 dependencies = [
+    { name = "fabric-emulator-notebookutils" },
     { name = "fabric-target" },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fabric-emulator-notebookutils", editable = "../../python" },
     { name = "fabric-target", editable = "../../python/fabric-target" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
@@ -584,6 +586,11 @@ requires-dist = [
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+
+[[package]]
+name = "fabric-emulator-notebookutils"
+version = "0.1.0"
+source = { editable = "../../python" }
 
 [[package]]
 name = "fabric-target"

--- a/internal/api/kql.go
+++ b/internal/api/kql.go
@@ -431,6 +431,31 @@ func (a *API) typedItemProperties(r *http.Request, it *store.Item) map[string]an
 			return map[string]any{"connectionString": cs}
 		}
 		return nil
+	case "Lakehouse":
+		// The SQL analytics endpoint: the read-only T-SQL surface over the
+		// lakehouse's Delta tables. It is the same TDS listener a Warehouse
+		// uses — the emulator routes by item and makes a Lakehouse read-only
+		// (internal/server/warehouse.go) — but it is a DIFFERENT property, and
+		// real Fabric names it differently, so it is reported under the name
+		// real Fabric reports it under.
+		//
+		// `id` IS DELIBERATELY ABSENT. On real Fabric the analytics endpoint is
+		// its own SQLEndpoint item with its own GUID; the emulator has no such
+		// item and routes the endpoint by the lakehouse id. Reporting the
+		// lakehouse id under that name would invite a consumer to use it as a
+		// database name, which works here and fails on real Fabric. Leaving it
+		// out fails the other way round: locally, loudly, before it ships.
+		if cs := a.warehouseConnectionString(r); cs != "" {
+			return map[string]any{"sqlEndpointProperties": map[string]any{
+				"connectionString": cs,
+				// The emulator provisions the endpoint on first connect, so it
+				// is never pending from the caller's point of view. Real Fabric
+				// can answer InProgress, which a client must handle: hence a
+				// status field at all rather than an implied one.
+				"provisioningStatus": "Success",
+			}}
+		}
+		return nil
 	case "Eventhouse":
 		base := kustoBaseURI(r, it.WorkspaceID, it.ID)
 		ids := []string{}

--- a/internal/api/sql_endpoint_discovery_test.go
+++ b/internal/api/sql_endpoint_discovery_test.go
@@ -1,0 +1,119 @@
+package api
+
+// A lakehouse's SQL analytics endpoint, discovered the way real Fabric documents.
+//
+// WHY THIS MATTERS BEYOND ONE PROPERTY. An example that dials a configured host
+// (`TDS_SERVER=localhost,1433`) cannot run against real Fabric, where the address
+// is per-workspace and only the API knows it. The portable form is to ask the
+// item — `GET /lakehouses/{id}` -> properties.sqlEndpointProperties.connectionString
+// for the analytics endpoint, `GET /warehouses/{id}` -> properties.connectionString
+// for a warehouse. The warehouse half already worked (warehouse_endpoint.go); the
+// lakehouse half returned nothing, so the four medallion examples had no
+// discoverable address for the surface reflect.py connects to.
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+)
+
+// typedItemBody drives the typed route's handler with a fake principal, as the
+// rest of this suite does, and returns its decoded body.
+func typedItemBody(t *testing.T, a *API, host, wid, iid, itemType string) (int, map[string]any) {
+	t.Helper()
+	r := httptest.NewRequest("GET", "/x", nil)
+	r.Host = host
+	r.SetPathValue("wid", wid)
+	r.SetPathValue("iid", iid)
+	w := httptest.NewRecorder()
+	a.typedGet(itemType)(w, r, admin)
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	return w.Code, body
+}
+
+func seedItem(t *testing.T, st *store.Store, wsID, itemType, name string) *store.Item {
+	t.Helper()
+	it := &store.Item{WorkspaceID: wsID, Type: itemType, DisplayName: name}
+	if err := st.CreateItem(it, nil); err != nil {
+		t.Fatal(err)
+	}
+	return it
+}
+
+func TestLakehouseAdvertisesItsSQLAnalyticsEndpoint(t *testing.T) {
+	a, st := newAPI(t)
+	a.SQLEndpointPort = "1433"
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+
+	code, body := typedItemBody(t, a, "localhost:9443", ws.ID, lake.ID, "Lakehouse")
+	if code != 200 {
+		t.Fatalf("GET /lakehouses/{id} = %d %v", code, body)
+	}
+	props, ok := body["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("no properties on a lakehouse with a SQL endpoint: %v", body)
+	}
+	ep, ok := props["sqlEndpointProperties"].(map[string]any)
+	if !ok {
+		t.Fatalf("no sqlEndpointProperties: %v", props)
+	}
+	if ep["connectionString"] != "localhost:1433" {
+		t.Errorf("connectionString = %v, want localhost:1433", ep["connectionString"])
+	}
+	if ep["provisioningStatus"] != "Success" {
+		t.Errorf("provisioningStatus = %v, want Success", ep["provisioningStatus"])
+	}
+	// See kql.go: on real Fabric the analytics endpoint is a separate SQLEndpoint
+	// item with its own GUID. Reporting the lakehouse id under that name would
+	// invite a consumer to use it as a database name, which works here and fails
+	// on real Fabric. Absent fails the other way round: locally, before it ships.
+	if _, present := ep["id"]; present {
+		t.Errorf("sqlEndpointProperties.id is present (%v): the emulator has no "+
+			"SQLEndpoint item, so any value here would be a different id than real "+
+			"Fabric's", ep["id"])
+	}
+	// Two surfaces, two property names. A lakehouse never carries the Warehouse
+	// one (TestOnlyAWarehouseGetsAConnectionString covers the generic route).
+	if cs, present := props["connectionString"]; present {
+		t.Errorf("a lakehouse advertised a warehouse connectionString: %v", cs)
+	}
+}
+
+// The address is echoed from the request for the same reason a warehouse's is:
+// the caller's own host is by definition reachable from where the caller stands.
+func TestLakehouseEndpointIsDialableFromWhereverTheCallerIs(t *testing.T) {
+	a, st := newAPI(t)
+	a.SQLEndpointPort = "1433"
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+
+	for host, want := range map[string]string{
+		"fabric-emulator:9443": "fabric-emulator:1433",
+		"localhost:19543":      "localhost:1433",
+	} {
+		_, body := typedItemBody(t, a, host, ws.ID, lake.ID, "Lakehouse")
+		props, _ := body["properties"].(map[string]any)
+		ep, _ := props["sqlEndpointProperties"].(map[string]any)
+		if ep["connectionString"] != want {
+			t.Errorf("Host %q -> %v, want %q", host, ep["connectionString"], want)
+		}
+	}
+}
+
+// The contract-only stack (no sqlserver sidecar) is supported: say nothing rather
+// than advertise an endpoint that is not listening.
+func TestLakehouseSaysNothingWithoutASQLEndpoint(t *testing.T) {
+	a, st := newAPI(t)
+	a.SQLEndpointPort = "" // FABRIC_SQL_TDS_ADDR unset
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+
+	_, body := typedItemBody(t, a, "localhost:9443", ws.ID, lake.ID, "Lakehouse")
+	if props, ok := body["properties"]; ok {
+		t.Fatalf("a lakehouse with no SQL endpoint advertised properties: %v", props)
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ test = [
     # because a developer machine usually has pyyaml lying around and CI does
     # not — which is exactly how it passed locally and broke on the runner.
     "pyyaml>=6,<7",
+    # test_example_sql_endpoint.py imports the EXAMPLES' resolver
+    # (examples/contoso-fixtures/common.py) to test the SQL-endpoint discovery
+    # its real branch takes, which no local e2e can reach. That module imports
+    # requests, and the same trap as pyyaml above caught this one: it passed in a
+    # developer .venv carrying requests from another group and failed in a clean
+    # environment. Verified with UV_PROJECT_ENVIRONMENT pointed at an empty dir.
+    "requests>=2.32,<3",
 ]
 lint = [
     "ruff>=0.14,<0.16",

--- a/python/fabric-target/fabric_target/__init__.py
+++ b/python/fabric-target/fabric_target/__init__.py
@@ -279,6 +279,93 @@ class Target:
             f"({len(r.json().get('value', []))} visible)")
 
 
+def notebook_env(t=None):
+    """The NOTEBOOKUTILS_* runtime context for a target, as (name, value) pairs.
+
+    Real Fabric injects a notebook's runtime context — workspace, endpoints,
+    identity — into the kernel. The shim cannot inject into an arbitrary kernel,
+    so it reads that context from the environment (python/notebookutils/_config.py).
+    Which means SOMETHING has to put it there, and if every caller writes its own
+    set, the shim and the resolver can disagree about which entra a token comes
+    from while both look right. This is the one definition: `python -m
+    fabric_target env` prints it for a shell, `apply_notebook_env` applies it
+    in-process, and both are this function.
+
+    Real mode emits NO credential: `credentials.getToken` falls through to
+    DefaultAzureCredential, which is what lets the same notebook run under
+    `az login`, a managed identity, or inside real Fabric.
+    """
+    t = t or target()
+    e = [("FABRIC_TARGET", t.name)]
+    if t.is_emulator:
+        e += [
+            ("NOTEBOOKUTILS_FABRIC_URL", t.api_root.removesuffix("/v1")),
+            ("NOTEBOOKUTILS_ONELAKE_URL", t.onelake_url),
+            ("NOTEBOOKUTILS_ENTRA_URL", t.entra_url),
+            ("NOTEBOOKUTILS_TENANT", t.tenant),
+            ("NOTEBOOKUTILS_CLIENT_ID",
+             _env_any(("FABRIC_CLIENT_ID", "AZURE_CLIENT_ID"), SEED_CLIENT_ID)),
+            ("NOTEBOOKUTILS_CLIENT_SECRET",
+             _env_any(("FABRIC_CLIENT_SECRET", "AZURE_CLIENT_SECRET"),
+                      SEED_CLIENT_SECRET)),
+            ("NOTEBOOKUTILS_VAULT_URL", t.vault_url),
+            ("NOTEBOOKUTILS_INSECURE", "1"),
+        ]
+    else:
+        e += [
+            ("NOTEBOOKUTILS_FABRIC_URL", "https://api.fabric.microsoft.com"),
+            ("NOTEBOOKUTILS_ONELAKE_URL", t.onelake_url),
+            ("NOTEBOOKUTILS_ENTRA_URL", t.entra_url),
+            ("NOTEBOOKUTILS_TENANT", t.tenant),
+            ("NOTEBOOKUTILS_INSECURE", "0"),
+            # az-login-friendly auth hints for env-driven tools:
+            ("AZCOPY_AUTO_LOGIN_TYPE", "AZCLI"),
+        ]
+        if t.vault_url:
+            e.append(("NOTEBOOKUTILS_VAULT_URL", t.vault_url))
+    return e
+
+
+def apply_notebook_env(t=None, override=False):
+    """Put `notebook_env` into os.environ, so notebookutils in THIS process
+    resolves against the same target the caller resolved.
+
+    Without this, a script that uses both the control plane and
+    `notebookutils.credentials.getSecret` gets its Fabric calls from the target
+    and its notebook tokens from the shim's own defaults — two answers to one
+    question, agreeing only by luck.
+
+    An explicit NOTEBOOKUTILS_* already in the environment WINS by default:
+    `eval "$(python -m fabric_target env ...)"` and a compose file are both
+    deliberate, and silently overwriting them would make the toggle unpredictable
+    for the case it exists to serve. Returns what it set.
+    """
+    applied = {}
+    for k, v in notebook_env(t):
+        if v is None:
+            continue
+        if override or not os.environ.get(k):
+            os.environ[k] = v
+            applied[k] = v
+    if applied:
+        _config_reset()
+    return applied
+
+
+def _config_reset():
+    """Drop notebookutils' cached runtime profile, if the shim is importable.
+
+    _config caches Config on first use; applying the environment after something
+    already called getSecret would otherwise have no effect. Absent shim is fine
+    — fabric-target does not depend on it.
+    """
+    try:
+        from notebookutils._config import reset
+    except ImportError:
+        return
+    reset()
+
+
 _cached = None
 
 

--- a/python/fabric-target/fabric_target/__main__.py
+++ b/python/fabric-target/fabric_target/__main__.py
@@ -12,38 +12,7 @@ user already controls.
 import shlex
 import sys
 
-from . import SEED_CLIENT_ID, SEED_CLIENT_SECRET, Target, TargetError, _env, _env_any
-
-
-def _lines(t):
-    e = [("FABRIC_TARGET", t.name)]
-    if t.is_emulator:
-        e += [
-            ("NOTEBOOKUTILS_FABRIC_URL", t.api_root.removesuffix("/v1")),
-            ("NOTEBOOKUTILS_ONELAKE_URL", t.onelake_url),
-            ("NOTEBOOKUTILS_ENTRA_URL", t.entra_url),
-            ("NOTEBOOKUTILS_TENANT", t.tenant),
-            ("NOTEBOOKUTILS_CLIENT_ID",
-             _env_any(("FABRIC_CLIENT_ID", "AZURE_CLIENT_ID"), SEED_CLIENT_ID)),
-            ("NOTEBOOKUTILS_CLIENT_SECRET",
-             _env_any(("FABRIC_CLIENT_SECRET", "AZURE_CLIENT_SECRET"),
-                      SEED_CLIENT_SECRET)),
-            ("NOTEBOOKUTILS_VAULT_URL", t.vault_url),
-            ("NOTEBOOKUTILS_INSECURE", "1"),
-        ]
-    else:
-        e += [
-            ("NOTEBOOKUTILS_FABRIC_URL", "https://api.fabric.microsoft.com"),
-            ("NOTEBOOKUTILS_ONELAKE_URL", t.onelake_url),
-            ("NOTEBOOKUTILS_ENTRA_URL", t.entra_url),
-            ("NOTEBOOKUTILS_TENANT", t.tenant),
-            ("NOTEBOOKUTILS_INSECURE", "0"),
-            # az-login-friendly auth hints for env-driven tools:
-            ("AZCOPY_AUTO_LOGIN_TYPE", "AZCLI"),
-        ]
-        if t.vault_url:
-            e.append(("NOTEBOOKUTILS_VAULT_URL", t.vault_url))
-    return e
+from . import Target, TargetError, _env, notebook_env
 
 
 def main(argv):
@@ -56,7 +25,7 @@ def main(argv):
         return 1
 
     if cmd == "env":
-        for k, v in _lines(t):
+        for k, v in notebook_env(t):
             print(f"export {k}={shlex.quote(v)}")
         # Unexported on purpose (comments are eval-safe):
         print(f"# fabric_target: profile '{t.name}' — api {t.api_root}")

--- a/python/fabric-target/tests/test_fabric_target.py
+++ b/python/fabric-target/tests/test_fabric_target.py
@@ -169,3 +169,58 @@ def test_env_emitter_real_never_leaks_seeds(monkeypatch, capsys):
 def test_show_runs(capsys):
     assert main(["prog", "show"]) == 0
     assert "api_root" in capsys.readouterr().out
+
+
+# --- the notebook runtime context -------------------------------------------
+# `python -m fabric_target env` and apply_notebook_env are ONE definition
+# (notebook_env), because two would let the shim and the resolver disagree about
+# which entra a token comes from while both look right.
+
+def test_apply_notebook_env_wires_the_shim_for_this_process(monkeypatch):
+    monkeypatch.setenv("FABRIC_EMULATOR_URL", "https://localhost:19443")
+    monkeypatch.setenv("ENTRA_EMULATOR_URL", "https://localhost:18443")
+    applied = fabric_target.apply_notebook_env(Target("emulator"))
+    assert os.environ["NOTEBOOKUTILS_FABRIC_URL"] == "https://localhost:19443"
+    assert os.environ["NOTEBOOKUTILS_ENTRA_URL"] == "https://localhost:18443"
+    # Self-signed family certs: without this, getSecret fails TLS verification
+    # against the emulator's vault and the failure names the certificate, not
+    # the missing wiring.
+    assert os.environ["NOTEBOOKUTILS_INSECURE"] == "1"
+    assert os.environ["NOTEBOOKUTILS_VAULT_URL"] == "https://localhost:8444"
+    assert applied["FABRIC_TARGET"] == "emulator"
+
+
+def test_apply_notebook_env_does_not_overwrite_a_deliberate_value(monkeypatch):
+    """`eval "$(python -m fabric_target env ...)"` and a compose file are both
+    deliberate. Silently overwriting them makes the toggle unpredictable for the
+    case it exists to serve."""
+    monkeypatch.setenv("NOTEBOOKUTILS_VAULT_URL", "https://mine.vault.azure.net")
+    fabric_target.apply_notebook_env(Target("emulator"))
+    assert os.environ["NOTEBOOKUTILS_VAULT_URL"] == "https://mine.vault.azure.net"
+    fabric_target.apply_notebook_env(Target("emulator"), override=True)
+    assert os.environ["NOTEBOOKUTILS_VAULT_URL"] == "https://localhost:8444"
+
+
+def test_notebook_env_real_carries_no_credential(monkeypatch):
+    """A notebook has no client secret to give. Real mode emits none, so
+    credentials.getToken falls through to DefaultAzureCredential."""
+    monkeypatch.setenv("FABRIC_WORKSPACE", "ws")
+    monkeypatch.setattr(fabric_target, "_az_logged_in", lambda: True)
+    env = dict(fabric_target.notebook_env(Target("real")))
+    assert "NOTEBOOKUTILS_CLIENT_SECRET" not in env
+    assert "NOTEBOOKUTILS_CLIENT_ID" not in env
+    assert env["NOTEBOOKUTILS_INSECURE"] == "0"
+    assert env["NOTEBOOKUTILS_ENTRA_URL"] == "https://login.microsoftonline.com"
+
+
+def test_notebook_env_and_the_emitter_cannot_drift(monkeypatch, capsys):
+    """The emitter prints exactly what apply_notebook_env applies. Asserted
+    rather than assumed: they were two copies of this list until they were one."""
+    monkeypatch.setenv("FABRIC_EMULATOR_URL", "https://localhost:19443")
+    assert main(["prog", "env", "emulator"]) == 0
+    printed = {}
+    for line in capsys.readouterr().out.splitlines():
+        if line.startswith("export "):
+            k, _, v = line[len("export "):].partition("=")
+            printed[k] = v.strip("'")
+    assert printed == dict(fabric_target.notebook_env(Target("emulator")))

--- a/python/tests/test_check_example_portability.py
+++ b/python/tests/test_check_example_portability.py
@@ -48,6 +48,15 @@ def test_a_step_hardcoding_a_localhost_endpoint_is_caught(tmp_path):
     assert any("localhost:9443" in p for p in problems), problems
 
 
+def test_a_step_naming_the_sql_endpoint_is_caught(tmp_path):
+    """The SQL address has no URL scheme, so the localhost rule above cannot see
+    it — and on real Fabric it is per-item and assigned by the service, which
+    makes a named host the same opt-out as a named control plane."""
+    for body in ('SERVER = "localhost,1433"\n', 'cs = "localhost:1433"\n'):
+        problems = _tree(tmp_path, {"demo/gold.py": body})
+        assert any("SQL endpoint" in p for p in problems), (body, problems)
+
+
 def test_a_resolver_that_restates_the_contract_is_caught(tmp_path):
     problems = _tree(tmp_path, {}, resolver='TENANT = "6f89cf12-978b-4d23-ac18-9ef0c127cf87"\n')
     assert any("does not import fabric_target" in p for p in problems), problems

--- a/python/tests/test_check_example_portability.py
+++ b/python/tests/test_check_example_portability.py
@@ -1,0 +1,103 @@
+"""The portability gate must fail on the states it exists to prevent.
+
+A checker nobody has watched fail is a longer sentence, not a gate. Each test
+below constructs the violation in a temp tree and asserts the checker reports
+it — and the last two assert what it must NOT report, because the first version
+of this checker flagged 31 things, none of them real: it read `.venv` and treated
+every `"path"` key as a definition part, including shortcut targets and URLs.
+"""
+import importlib.util
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+spec = importlib.util.spec_from_file_location(
+    "check_example_portability", REPO / "scripts" / "check_example_portability.py")
+assert spec and spec.loader
+cep = importlib.util.module_from_spec(spec)
+sys.modules["check_example_portability"] = cep
+spec.loader.exec_module(cep)
+
+
+def _tree(tmp_path, files, resolver="from fabric_target import target\n"):
+    """Build a fake repo: examples/<...> plus the resolver the checker expects."""
+    (tmp_path / "examples" / "contoso-fixtures").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "examples" / "contoso-fixtures" / "common.py").write_text(resolver)
+    for rel, body in files.items():
+        p = tmp_path / "examples" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    cep.ROOT = tmp_path
+    cep.EXAMPLES = tmp_path / "examples"
+    problems = []
+    cep.check_no_pinned_target(problems)
+    cep.check_resolver_uses_the_contract(problems)
+    cep.check_definition_parts(problems)
+    return problems
+
+
+def test_a_step_hardcoding_the_seeded_secret_is_caught(tmp_path):
+    problems = _tree(tmp_path, {"demo/step.py": 'SECRET = "daemon-app-secret"\n'})
+    assert any("seeded credential" in p for p in problems), problems
+
+
+def test_a_step_hardcoding_a_localhost_endpoint_is_caught(tmp_path):
+    problems = _tree(tmp_path, {"demo/step.py": 'API = "https://localhost:9443"\n'})
+    assert any("localhost:9443" in p for p in problems), problems
+
+
+def test_a_resolver_that_restates_the_contract_is_caught(tmp_path):
+    problems = _tree(tmp_path, {}, resolver='TENANT = "6f89cf12-978b-4d23-ac18-9ef0c127cf87"\n')
+    assert any("does not import fabric_target" in p for p in problems), problems
+
+
+def test_an_invented_definition_part_path_is_caught(tmp_path):
+    problems = _tree(tmp_path, {
+        "demo/step.py": 'create_item("n", "Notebook", {"notebook.py": BODY})\n'})
+    assert any("source-format path" in p for p in problems), problems
+
+
+def test_the_real_part_paths_are_accepted(tmp_path):
+    problems = _tree(tmp_path, {
+        "demo/nb.py": 'create_item("n", "Notebook", {"notebook-content.py": BODY})\n',
+        "demo/pl.py": 'create_item("p", "DataPipeline", {"pipeline-content.json": BODY})\n',
+        "demo/sm.py": '[{"path": "definition/tables/Sales.tmdl", "payloadType": "InlineBase64"}]\n',
+    })
+    assert problems == [], problems
+
+
+# --- the false positives the first version produced ------------------------
+
+def test_a_shortcut_target_is_not_a_definition_part(tmp_path):
+    """`"path": "Tables/bronze_orders"` is a OneLake shortcut target. It has no
+    payloadType, is not item source, and flagging it made the gate noise."""
+    problems = _tree(tmp_path, {
+        "demo/step.py": 'body = {"target": {"path": "Tables/bronze_orders"}}\n'})
+    assert problems == [], problems
+
+
+def test_installed_dependencies_are_not_scanned(tmp_path):
+    """site-packages is other people's code; reading it trains readers to ignore
+    the gate."""
+    problems = _tree(tmp_path, {
+        "demo/.venv/lib/python3.13/site-packages/dep/x.py":
+            'SECRET = "daemon-app-secret"\nAPI = "https://localhost:9443"\n'})
+    assert problems == [], problems
+
+
+def test_a_companion_service_endpoint_is_not_a_violation(tmp_path):
+    """OpenMetadata and mock source APIs have no real-Fabric counterpart, so the
+    toggle has nothing to resolve them to. Only the Fabric surfaces (9443 control
+    plane, 8443 authority, 8444 vault) are its business — the same line
+    contoso-data-platform's own check draws."""
+    problems = _tree(tmp_path, {
+        "demo/govern.py": 'OM = "http://localhost:8585/api/v1"\n',
+        "demo/sources.py": 'POS = "http://localhost:18090"\n'})
+    assert problems == [], problems
+
+
+def test_a_fabric_surface_endpoint_IS_a_violation(tmp_path):
+    for port in ("9443", "8443", "8444"):
+        problems = _tree(tmp_path, {"demo/step.py": f'API = "https://localhost:{port}"\n'})
+        assert any(port in p for p in problems), (port, problems)

--- a/python/tests/test_check_example_portability.py
+++ b/python/tests/test_check_example_portability.py
@@ -32,6 +32,7 @@ def _tree(tmp_path, files, resolver="from fabric_target import target\n"):
     cep.EXAMPLES = tmp_path / "examples"
     problems = []
     cep.check_no_pinned_target(problems)
+    cep.check_no_emulator_only_leaks(problems)
     cep.check_resolver_uses_the_contract(problems)
     cep.check_definition_parts(problems)
     return problems
@@ -101,3 +102,28 @@ def test_a_fabric_surface_endpoint_IS_a_violation(tmp_path):
     for port in ("9443", "8443", "8444"):
         problems = _tree(tmp_path, {"demo/step.py": f'API = "https://localhost:{port}"\n'})
         assert any(port in p for p in problems), (port, problems)
+
+
+def test_a_tls_bypass_outside_the_resolver_is_caught(tmp_path):
+    """Real Fabric serves real certificates. A bypass in a step ships to
+    production invisibly — the emulator would go on passing."""
+    for body in ('r = S.get(url, verify=False)\n',
+                 'opts["azure_allow_invalid_certificates"] = "true"\n'):
+        problems = _tree(tmp_path, {"demo/step.py": body})
+        assert any("TLS" in p for p in problems), (body, problems)
+
+
+def test_an_emulator_only_control_lever_is_caught(tmp_path):
+    """The clock, fault injection and the event stream have no real counterpart.
+    Using one unguarded is the clearest possible pin to the emulator."""
+    problems = _tree(tmp_path, {
+        "demo/step.py": 'S.post(f"{API}/_emulator/clock", json={"advance": 60})\n'})
+    assert any("emulator-only control endpoint" in p for p in problems), problems
+
+
+def test_the_resolver_may_still_hold_local_reality(tmp_path):
+    """The bypass belongs somewhere — in the resolver, behind the target."""
+    problems = _tree(
+        tmp_path, {},
+        resolver='from fabric_target import target\nS.verify = False\n')
+    assert problems == [], problems

--- a/python/tests/test_check_example_portability.py
+++ b/python/tests/test_check_example_portability.py
@@ -33,9 +33,104 @@ def _tree(tmp_path, files, resolver="from fabric_target import target\n"):
     problems = []
     cep.check_no_pinned_target(problems)
     cep.check_no_emulator_only_leaks(problems)
+    cep.check_definition_folders(problems)
     cep.check_resolver_uses_the_contract(problems)
     cep.check_definition_parts(problems)
     return problems
+
+
+def _definitions(tmp_path, folders):
+    """Build examples/demo/definitions/<folder>/<file> from {folder: {name: body}}."""
+    (tmp_path / "examples" / "contoso-fixtures").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "examples" / "contoso-fixtures" / "common.py").write_text(
+        "from fabric_target import target\n")
+    for folder, files in folders.items():
+        d = tmp_path / "examples" / "demo" / "definitions" / folder
+        d.mkdir(parents=True, exist_ok=True)
+        for name, body in files.items():
+            (d / name).write_text(body)
+    cep.ROOT = tmp_path
+    cep.EXAMPLES = tmp_path / "examples"
+    problems = []
+    cep.check_definition_folders(problems)
+    return problems
+
+
+# --- the definitions/ layout rule ------------------------------------------
+# These four had NO test, which is the state this file's docstring calls a longer
+# sentence rather than a gate: every one of them is a shape real Fabric's Git
+# integration would not produce and the emulator would accept anyway.
+
+def test_a_definition_folder_must_carry_platform(tmp_path):
+    """`.platform` holds the logicalId that survives renames. A folder without
+    one deploys fine against the emulator, which stores whatever parts it is
+    given, and is not what Git integration writes."""
+    problems = _definitions(tmp_path, {"bronze.Notebook": {"notebook-content.py": "x = 1\n"}})
+    assert any(".platform" in p for p in problems), problems
+
+
+def test_a_definition_folder_must_be_named_name_dot_type(tmp_path):
+    problems = _definitions(tmp_path, {"bronze_notebook": {".platform": "{}"}})
+    assert any("<display name>.<Type>" in p for p in problems), problems
+
+
+def test_a_platform_with_no_definition_file_is_caught(tmp_path):
+    """An item folder that is only metadata deploys an item with no content."""
+    problems = _definitions(tmp_path, {"bronze.Notebook": {".platform": "{}"}})
+    assert any("no definition file" in p for p in problems), problems
+
+
+def test_an_empty_definitions_directory_is_caught(tmp_path):
+    """An examples/*/definitions that holds nothing reads as "this example has
+    on-disk definitions" to anyone skimming, and deploys nothing."""
+    (tmp_path / "examples" / "demo" / "definitions").mkdir(parents=True)
+    (tmp_path / "examples" / "contoso-fixtures").mkdir(parents=True)
+    (tmp_path / "examples" / "contoso-fixtures" / "common.py").write_text(
+        "from fabric_target import target\n")
+    cep.ROOT, cep.EXAMPLES = tmp_path, tmp_path / "examples"
+    problems = []
+    cep.check_definition_folders(problems)
+    assert any("no item folders" in p for p in problems), problems
+
+
+def test_the_real_source_format_layout_is_accepted(tmp_path):
+    problems = _definitions(tmp_path, {
+        "bronze-orders.Notebook": {".platform": "{}", "notebook-content.py": "x = 1\n"},
+        "bronze-ingest.DataPipeline": {".platform": "{}", "pipeline-content.json": "{}"},
+    })
+    assert problems == [], problems
+
+
+# --- the exit status, which is what CI actually reads -----------------------
+
+def test_main_exits_zero_on_a_clean_tree(tmp_path, capsys):
+    _definitions(tmp_path, {
+        "bronze.Notebook": {".platform": "{}", "notebook-content.py": "x = 1\n"}})
+    (tmp_path / "examples" / "demo" / "README.md").write_text("# demo\n")
+    assert cep.main() == 0
+    assert "every example resolves its target" in capsys.readouterr().out
+
+
+def test_main_exits_nonzero_and_names_every_violation(tmp_path, capsys):
+    """A gate that finds problems and exits 0 is worse than no gate: CI goes
+    green and the output looks like a report."""
+    _tree(tmp_path, {"demo/step.py": 'SECRET = "daemon-app-secret"\n'})
+    assert cep.main() == 1
+    out = capsys.readouterr().out
+    assert "would not survive FABRIC_TARGET=real" in out
+    assert "seeded credential" in out
+
+
+def test_paths_are_compared_with_forward_slashes(tmp_path):
+    """The resolver's exemption is a STRING comparison against
+    "examples/contoso-fixtures/common.py". `str(Path)` yields backslashes on
+    Windows, so the exemption silently stopped matching there and the gate
+    reported the resolver's own legitimate localhost default, TLS bypass and
+    clock docstring as violations — green on Linux and macOS, red on Windows,
+    blaming the one file allowed to hold them. This fails on the platform where
+    that bug exists, which is the only place it can be observed."""
+    cep.ROOT = tmp_path
+    assert cep.rel(tmp_path / "examples" / "contoso-fixtures" / "common.py") == cep.RESOLVER
 
 
 def test_a_step_hardcoding_the_seeded_secret_is_caught(tmp_path):

--- a/python/tests/test_example_sql_endpoint.py
+++ b/python/tests/test_example_sql_endpoint.py
@@ -1,0 +1,243 @@
+"""The examples' SQL endpoint resolution, both targets, no emulator.
+
+WHY THIS IS TESTED HERE. `sql_endpoint()` is the one piece of the examples whose
+REAL branch cannot be exercised by the local e2e: it reads properties only a real
+tenant fills in, and returns a different database name and TLS mode. The emulator
+leg is covered end to end by e2e/medallion; this file covers the branch that leg
+cannot reach, against the response shapes Microsoft's REST reference documents:
+
+  Lakehouse: properties.sqlEndpointProperties.{connectionString, provisioningStatus}
+  Warehouse: properties.connectionString
+
+It does NOT claim the real path connects — only that what it would dial is built
+from the API's answer rather than from a pinned host.
+"""
+import importlib
+import os
+import pathlib
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "python" / "fabric-target"))
+sys.path.insert(0, str(REPO / "examples" / "contoso-fixtures"))
+
+import fabric_target  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    """Answers the two GETs sql_endpoint makes: the generic item record (type and
+    display name, which real Fabric does return there) and the typed route that
+    carries the properties."""
+
+    def __init__(self, routes):
+        self.routes = routes
+        self.asked = []
+
+    def get(self, url, **_):
+        self.asked.append(url)
+        for suffix, payload in self.routes.items():
+            if url.endswith(suffix):
+                return FakeResponse(payload)
+        raise AssertionError(f"unexpected GET {url}")
+
+
+def load_common(monkeypatch, tmp_path, target_name, **env):
+    """Import examples/contoso-fixtures/common.py against a chosen target.
+
+    Re-imported per test because the module resolves its target once at import,
+    which is the behaviour under test: a step cannot change target mid-run.
+    """
+    for k in ("FABRIC_TARGET", "FABRIC_WORKSPACE", "TDS_SERVER", "AZURE_CLIENT_SECRET",
+              "AZURE_CLIENT_ID", "AZURE_TENANT_ID", "FABRIC_VAULT_URL",
+              "AZURE_KEY_VAULT_URL", "PIPELINE_STATE"):
+        monkeypatch.delenv(k, raising=False)
+    # Also the notebook runtime context: apply_notebook_env deliberately does not
+    # overwrite an existing value, so a previous test's target would survive into
+    # this one. Each step is its own process in real life; make the test one too.
+    for k in [k for k in os.environ if k.startswith("NOTEBOOKUTILS_")]:
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("FABRIC_TARGET", target_name)
+    monkeypatch.setenv("PIPELINE_STATE", str(tmp_path / "state.json"))
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setattr(fabric_target, "_az_logged_in", lambda: True)
+    fabric_target._cached = None
+    sys.modules.pop("common", None)
+    common = importlib.import_module("common")
+    (tmp_path / "state.json").write_text('{"workspace": "ws-1"}')
+    return common
+
+
+LAKEHOUSE_REAL = {
+    "displayName": "contoso_lake", "type": "Lakehouse", "id": "lh-1",
+    "properties": {
+        "sqlEndpointProperties": {
+            "connectionString": "abc123-xyz.datawarehouse.fabric.microsoft.com",
+            "id": "37dc8a41-dea9-465d-b528-3e95043b2356",
+            "provisioningStatus": "Success",
+        },
+    },
+}
+WAREHOUSE_REAL = {
+    "displayName": "contoso_gold", "type": "Warehouse", "id": "wh-1",
+    "properties": {"connectionString": "abc123-xyz.datawarehouse.fabric.microsoft.com"},
+}
+
+
+def test_real_dials_the_address_the_api_reports(monkeypatch, tmp_path):
+    """The whole point: on real Fabric the SQL host is assigned by the service, so
+    an example that hardcodes one is emulator-only however carefully everything
+    else is resolved."""
+    common = load_common(monkeypatch, tmp_path, "real",
+                         FABRIC_WORKSPACE="ws", FABRIC_VAULT_URL="https://kv.vault.azure.net")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    monkeypatch.setattr(common, "S", FakeSession({
+        "/items/lh-1": LAKEHOUSE_REAL,
+        "/lakehouses/lh-1": LAKEHOUSE_REAL,
+    }))
+    t = common.sql_endpoint("lh-1")
+    assert t.server == "abc123-xyz.datawarehouse.fabric.microsoft.com"
+    # Fabric addresses a database by DISPLAY NAME, with the workspace in the
+    # server name. The item id is the emulator's addressing and means nothing there.
+    assert t.database == "contoso_lake"
+    assert t.encrypt is True  # real Fabric's endpoint requires TLS
+
+
+def test_real_warehouse_uses_its_own_property(monkeypatch, tmp_path):
+    common = load_common(monkeypatch, tmp_path, "real",
+                         FABRIC_WORKSPACE="ws", FABRIC_VAULT_URL="https://kv.vault.azure.net")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    monkeypatch.setattr(common, "S", FakeSession({
+        "/items/wh-1": WAREHOUSE_REAL,
+        "/warehouses/wh-1": WAREHOUSE_REAL,
+    }))
+    t = common.sql_endpoint("wh-1")
+    assert (t.server, t.database) == ("abc123-xyz.datawarehouse.fabric.microsoft.com", "contoso_gold")
+
+
+def test_a_pending_analytics_endpoint_is_refused_by_name(monkeypatch, tmp_path):
+    """Real Fabric provisions the analytics endpoint asynchronously. "InProgress"
+    is a wait, not a missing feature, and saying so beats a connection timeout
+    that names nothing."""
+    pending = {**LAKEHOUSE_REAL, "properties": {"sqlEndpointProperties": {
+        "connectionString": "abc.datawarehouse.fabric.microsoft.com",
+        "provisioningStatus": "InProgress"}}}
+    common = load_common(monkeypatch, tmp_path, "real",
+                         FABRIC_WORKSPACE="ws", FABRIC_VAULT_URL="https://kv.vault.azure.net")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    monkeypatch.setattr(common, "S", FakeSession({
+        "/items/lh-1": pending, "/lakehouses/lh-1": pending}))
+    with pytest.raises(AssertionError, match="InProgress"):
+        common.sql_endpoint("lh-1")
+
+
+def test_emulator_addresses_the_item_by_id_over_plain_tds(monkeypatch, tmp_path):
+    """The emulator serves one host for every workspace, so it addresses by item
+    id (internal/server/warehouse.go accepts both), and its TDS front terminates
+    FedAuth without TLS."""
+    lake = {"displayName": "contoso_lake", "type": "Lakehouse", "id": "lh-1",
+            "properties": {"sqlEndpointProperties": {
+                "connectionString": "localhost:1433", "provisioningStatus": "Success"}}}
+    common = load_common(monkeypatch, tmp_path, "emulator")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    monkeypatch.setattr(common, "S", FakeSession({
+        "/items/lh-1": lake, "/lakehouses/lh-1": lake}))
+    t = common.sql_endpoint("lh-1")
+    # host:port is what the emulator advertises; host,port is what the SQL Server
+    # ODBC driver accepts. A real connection string is a bare FQDN and unaffected.
+    assert t.server == "localhost,1433"
+    assert t.database == "lh-1"
+    assert t.encrypt is False
+
+
+def test_tds_server_overrides_discovery_without_asking_the_api(monkeypatch, tmp_path):
+    """The emulator advertises the port it LISTENS on, not the port Docker
+    published it to, so a remapped isolated stack is the one case discovery gets
+    wrong. Fabric has no such distinction, which is why this is an override."""
+    lake = {"displayName": "contoso_lake", "type": "Lakehouse", "id": "lh-1"}
+    common = load_common(monkeypatch, tmp_path, "emulator", TDS_SERVER="localhost,11533")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    session = FakeSession({"/items/lh-1": lake})  # the typed route is NOT stubbed
+    monkeypatch.setattr(common, "S", session)
+    assert common.sql_endpoint("lh-1").server == "localhost,11533"
+    assert not any("lakehouses" in u for u in session.asked)
+
+
+def test_an_item_with_no_sql_endpoint_says_so(monkeypatch, tmp_path):
+    nb = {"displayName": "bronze-orders", "type": "Notebook", "id": "nb-1"}
+    common = load_common(monkeypatch, tmp_path, "emulator")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    monkeypatch.setattr(common, "S", FakeSession({"/items/nb-1": nb}))
+    with pytest.raises(AssertionError, match="no SQL endpoint"):
+        common.sql_endpoint("nb-1")
+
+
+def test_a_stack_without_its_sql_sidecar_names_the_override(monkeypatch, tmp_path):
+    """The contract-only stack advertises no connection string. The failure should
+    name the way out rather than surface as a connect timeout."""
+    lake = {"displayName": "contoso_lake", "type": "Lakehouse", "id": "lh-1",
+            "properties": {}}
+    common = load_common(monkeypatch, tmp_path, "emulator")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    monkeypatch.setattr(common, "S", FakeSession({
+        "/items/lh-1": lake, "/lakehouses/lh-1": lake}))
+    with pytest.raises(AssertionError, match="TDS_SERVER"):
+        common.sql_endpoint("lh-1")
+
+
+def test_odbc_server_rewrites_only_a_trailing_port(monkeypatch, tmp_path):
+    common = load_common(monkeypatch, tmp_path, "emulator")
+    for given, want in {
+        "localhost:1433": "localhost,1433",
+        "[::1]:1433": "[::1],1433",
+        # A real Fabric connection string carries no port and must survive intact.
+        "abc-xyz.datawarehouse.fabric.microsoft.com": "abc-xyz.datawarehouse.fabric.microsoft.com",
+        "fabric-emulator:1433": "fabric-emulator,1433",
+    }.items():
+        assert common._odbc_server(given) == want, given
+
+
+def test_the_skip_and_refuse_guards_are_opposites(monkeypatch, tmp_path):
+    """skip_on_real exits 0 (the pipeline does not need this step's output on real
+    Fabric); only_the_emulator_can exits non-zero (it does, and cannot have it).
+    Getting these the wrong way round is how ensure_app blocked four steps from
+    being portable at all."""
+    common = load_common(monkeypatch, tmp_path, "real",
+                         FABRIC_WORKSPACE="ws", FABRIC_VAULT_URL="https://kv.vault.azure.net")
+    with pytest.raises(SystemExit) as skipped:
+        common.skip_on_real("the notebook engine", "Fabric runs it on its own pool")
+    assert skipped.value.code == 0
+
+    with pytest.raises(SystemExit) as refused:
+        common.only_the_emulator_can("driving Spark Connect", because="no endpoint",
+                                     instead="a Notebook definition")
+    assert refused.value.code != 0
+    assert "instead" in str(refused.value)
+
+
+def test_neither_guard_fires_under_the_emulator(monkeypatch, tmp_path):
+    common = load_common(monkeypatch, tmp_path, "emulator")
+    common.skip_on_real("x", "y")
+    common.only_the_emulator_can("x", because="y", instead="z")
+
+
+def test_the_notebook_runtime_is_wired_from_the_resolved_target(monkeypatch, tmp_path):
+    """A step that uses notebookutils.credentials.getSecret and the control plane
+    in one process must not get its tokens from two different entras."""
+    load_common(monkeypatch, tmp_path, "emulator", ENTRA_EMULATOR_URL="https://localhost:18443")
+    assert os.environ["NOTEBOOKUTILS_ENTRA_URL"] == "https://localhost:18443"
+    assert os.environ["NOTEBOOKUTILS_INSECURE"] == "1"

--- a/scripts/check_example_portability.py
+++ b/scripts/check_example_portability.py
@@ -49,6 +49,14 @@ SEEDS = (
 # contoso-data-platform's own equivalent check draws the line in the same place.
 LOCALHOST = re.compile(r"https?://localhost:(9443|8443|8444)\b")
 
+# The SQL endpoint is the same problem without a scheme, so the pattern above
+# cannot see it. On real Fabric the address is per-item and assigned by the
+# service (`properties.connectionString`, or `sqlEndpointProperties.connectionString`
+# for a lakehouse's analytics endpoint), so a step naming a host has opted out of
+# the toggle no matter how carefully it resolves everything else. Ask
+# common.sql_endpoint() — see docs/46-artifact-persistence.md.
+SQL_HOST = re.compile(r"localhost[,:]1433\b")
+
 # Fabric's own definition part paths. Extend deliberately, with a doc reference:
 # a path that is not here is either a typo or a contract this repo has not read.
 KNOWN_PARTS = {
@@ -116,6 +124,12 @@ def check_no_pinned_target(problems):
             problems.append(
                 f"{rel(f)} hardcodes {m.group(0)}. An example that names an endpoint "
                 f"cannot follow FABRIC_TARGET; resolve it through {RESOLVER}.")
+        for m in SQL_HOST.finditer(text):
+            problems.append(
+                f"{rel(f)} hardcodes the SQL endpoint {m.group(0)}. On real Fabric "
+                f"that address is per-item and only the API knows it — ask "
+                f"{RESOLVER}'s sql_endpoint(), which discovers it on both targets "
+                f"(docs/46-artifact-persistence.md).")
 
 
 # A TLS bypass and an emulator-only control endpoint are the other two ways an

--- a/scripts/check_example_portability.py
+++ b/scripts/check_example_portability.py
@@ -106,7 +106,15 @@ def python_files(root):
 
 
 def rel(p):
-    return str(p.relative_to(ROOT))
+    """Repo-relative path with FORWARD SLASHES on every OS.
+
+    `str(Path)` gives `examples\\contoso-fixtures\\common.py` on Windows, which
+    never equals RESOLVER — so the resolver lost its own exemption and the gate
+    reported the resolver's legitimate localhost default, TLS bypass and clock
+    docstring as four violations. Green on macOS and Linux, red on Windows only,
+    and the failure blamed the one file allowed to hold those things.
+    """
+    return p.relative_to(ROOT).as_posix()
 
 
 def check_no_pinned_target(problems):

--- a/scripts/check_example_portability.py
+++ b/scripts/check_example_portability.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Every example must be target-portable, and persist artifacts the way Fabric does.
+
+Two properties, both of which were false before this check existed and neither of
+which prose was holding:
+
+1. **The target is resolved in one place.** An example that hardcodes the
+   emulator's seeded principal or a `localhost` endpoint is not portable, however
+   loudly its README says otherwise — and the failure is invisible until someone
+   sets `FABRIC_TARGET=real` and watches it authenticate against nothing. The
+   four medallion examples were in exactly that state: `common.py` carried
+   `daemon-app-secret` and `https://localhost:9443` defaults, so the toggle
+   `docs/21` documents did not reach them at all.
+
+2. **Definitions use Fabric's own part paths.** An item's source lives in
+   definition parts whose paths are the CI/CD source format —
+   `notebook-content.py`, `pipeline-content.json`, `.platform`
+   (docs/46-artifact-persistence.md). An example that invents a path teaches a
+   layout real Fabric will not accept, and nothing else in CI notices, because
+   the emulator stores parts verbatim by design.
+
+Usage:
+    check_example_portability.py     exit non-zero on the first violation
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+EXAMPLES = ROOT / "examples"
+
+# The resolver, and only the resolver, may name these. Everything else must ask it.
+RESOLVER = "examples/contoso-fixtures/common.py"
+
+# entra-emulator's seeded dev values. Hardcoding one pins an example to the
+# emulator; `fabric-target` refuses them by value in real mode precisely because
+# a leftover shell variable would otherwise reach production.
+SEEDS = (
+    "daemon-app-secret",
+    "6f89cf12-978b-4d23-ac18-9ef0c127cf87",  # seeded tenant
+    "00d88624-f0d7-46f6-a641-6232c2608928",  # seeded daemon SP
+)
+
+# A hardcoded FABRIC-SURFACE endpoint is the other half of the same problem. Only
+# the surfaces the toggle actually resolves count: the control plane (9443), the
+# token authority (8443) and the vault (8444). A companion service — OpenMetadata,
+# a mock source API — is genuinely local policy with no real-Fabric counterpart to
+# switch to, and flagging it would make this gate fire on correct code.
+# contoso-data-platform's own equivalent check draws the line in the same place.
+LOCALHOST = re.compile(r"https?://localhost:(9443|8443|8444)\b")
+
+# Fabric's own definition part paths. Extend deliberately, with a doc reference:
+# a path that is not here is either a typo or a contract this repo has not read.
+KNOWN_PARTS = {
+    ".platform",
+    "notebook-content.py",
+    "notebook-content.ipynb",
+    "pipeline-content.json",
+    "definition.pbism",
+    "definition.pbir",
+    "report.json",
+    "definition/database.tmdl",
+    "definition/model.tmdl",
+    "definition/expressions.tmdl",
+    "model.bim",
+    "data.json",  # the emulator's own import-data part, documented in doc 46
+    "Spark.json",
+    "SparkJobDefinitionV1.json",
+}
+
+# A part path may also be a TMDL table file or a PBIP subpath, which are
+# per-model names rather than a fixed list.
+PART_SHAPES = (
+    re.compile(r"^definition/tables/[^/]+\.tmdl$"),
+    re.compile(r"^definition\.pbidataset$"),
+    re.compile(r"^StaticResources/.+$"),
+)
+
+# Only paths that are DEFINITION parts, which is not every `"path"` key: the
+# examples also carry shortcut targets ("Tables/bronze_orders"), source URLs, and
+# PBIP directory names, none of which are item source. The tell for a real part
+# is `payloadType` in the same object — that is what makes it a part rather than
+# a path-shaped string. Getting this wrong made the first version of this check
+# report 31 violations, none of them real.
+PART_KEY = re.compile(r'"path"\s*:\s*"([^"]+)"[^}]{0,120}?payloadType', re.S)
+# The examples' own helper: create_item(name, type, {"<part path>": body}).
+PART_DICT = re.compile(r'create_item\(\s*[^,]+,\s*[^,]+,\s*\{\s*"([^"]+)"\s*:', re.S)
+
+
+# Installed dependencies are not this repo's examples. A gate that reads
+# site-packages reports other people's code and trains its readers to ignore it.
+SKIP_DIRS = {"__pycache__", ".venv", "site-packages", "node_modules", "build"}
+
+
+def python_files(root):
+    return sorted(p for p in root.rglob("*.py")
+                  if not SKIP_DIRS & set(p.parts))
+
+
+def rel(p):
+    return str(p.relative_to(ROOT))
+
+
+def check_no_pinned_target(problems):
+    """Only the resolver may name a seed or a localhost endpoint."""
+    for f in python_files(EXAMPLES):
+        if rel(f) == RESOLVER:
+            continue
+        text = f.read_text()
+        for seed in SEEDS:
+            if seed in text:
+                problems.append(
+                    f"{rel(f)} hardcodes the emulator's seeded credential ({seed[:18]}…). "
+                    f"Ask the resolver instead — see {RESOLVER} and docs/21.")
+        for m in LOCALHOST.finditer(text):
+            problems.append(
+                f"{rel(f)} hardcodes {m.group(0)}. An example that names an endpoint "
+                f"cannot follow FABRIC_TARGET; resolve it through {RESOLVER}.")
+
+
+def check_resolver_uses_the_contract(problems):
+    """The resolver must consume `fabric-target`, not restate it."""
+    f = ROOT / RESOLVER
+    if not f.exists():
+        problems.append(f"{RESOLVER} is missing — the resolver is where the target is decided.")
+        return
+    text = f.read_text()
+    if "fabric_target" not in text:
+        problems.append(
+            f"{RESOLVER} does not import fabric_target. Restating the contract is how "
+            f"contoso-data-platform drifted into requiring a client secret, which broke "
+            f"az login, managed identity, and running inside a Fabric notebook.")
+    if "daemon-app-secret" in text:
+        problems.append(
+            f"{RESOLVER} still hardcodes the seeded secret; the resolver should take it "
+            f"from fabric_target so real mode can refuse it by value.")
+
+
+def known_part(path):
+    return path in KNOWN_PARTS or any(s.match(path) for s in PART_SHAPES)
+
+
+def check_definition_parts(problems):
+    """Every definition part path must be one Fabric actually accepts."""
+    for f in python_files(EXAMPLES):
+        text = f.read_text()
+        for pat in (PART_KEY, PART_DICT):
+            for m in pat.finditer(text):
+                path = m.group(1)
+                if not known_part(path):
+                    problems.append(
+                        f"{rel(f)} writes a definition part {path!r}, which is not a "
+                        f"Fabric source-format path. See docs/46-artifact-persistence.md; "
+                        f"add it to KNOWN_PARTS only with a reference to the contract.")
+
+
+def main():
+    problems = []
+    check_no_pinned_target(problems)
+    check_resolver_uses_the_contract(problems)
+    check_definition_parts(problems)
+
+    examples = sorted(d.name for d in EXAMPLES.iterdir()
+                      if d.is_dir() and (d / "README.md").exists())
+    print(f"example portability: {len(examples)} examples, "
+          f"target resolved in {RESOLVER}")
+    if problems:
+        print("\nExamples that would not survive FABRIC_TARGET=real:")
+        for p in problems:
+            print(f"  {p}")
+        print(f"\nFAIL: {len(problems)} violation(s). docs/46-artifact-persistence.md "
+              f"and docs/21-real-fabric-toggle.md are the contracts.")
+        return 1
+    print("every example resolves its target through the contract, and every "
+          "definition part uses a Fabric source-format path")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_example_portability.py
+++ b/scripts/check_example_portability.py
@@ -118,6 +118,36 @@ def check_no_pinned_target(problems):
                 f"cannot follow FABRIC_TARGET; resolve it through {RESOLVER}.")
 
 
+# A TLS bypass and an emulator-only control endpoint are the other two ways an
+# example silently pins itself. Both were absent when this gate was written —
+# absent by luck, since nothing checked. contoso-data-platform's equivalent
+# already covers the TLS half, so matching it keeps the two repos honest about
+# the same thing.
+TLS_BYPASS = re.compile(r"verify\s*=\s*False|allow_invalid_certificates|azure_allow_http")
+EMULATOR_CONTROL = re.compile(r"_emulator/(clock|faults|events)")
+
+
+def check_no_emulator_only_leaks(problems):
+    """A TLS bypass or a control-plane lever outside the resolver is a pin."""
+    for f in python_files(EXAMPLES):
+        if rel(f) == RESOLVER:
+            continue  # the resolver is where local reality is allowed to exist
+        for i, line in enumerate(f.read_text().splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue
+            if TLS_BYPASS.search(line):
+                problems.append(
+                    f"{rel(f)}:{i} bypasses TLS verification. Real Fabric serves real "
+                    f"certificates; a bypass here ships to production invisibly. Put it "
+                    f"in {RESOLVER}, behind the target.")
+            if EMULATOR_CONTROL.search(line):
+                problems.append(
+                    f"{rel(f)}:{i} calls an emulator-only control endpoint "
+                    f"({EMULATOR_CONTROL.search(line).group(0)}). Real Fabric has no such "
+                    f"lever — guard it with the target's emulator_only()/clock capability, "
+                    f"as contoso-data-platform's platform/schedule.py does.")
+
+
 def check_resolver_uses_the_contract(problems):
     """The resolver must consume `fabric-target`, not restate it."""
     f = ROOT / RESOLVER
@@ -157,6 +187,7 @@ def check_definition_parts(problems):
 def main():
     problems = []
     check_no_pinned_target(problems)
+    check_no_emulator_only_leaks(problems)
     check_resolver_uses_the_contract(problems)
     check_definition_parts(problems)
 

--- a/scripts/check_example_portability.py
+++ b/scripts/check_example_portability.py
@@ -148,6 +148,37 @@ def check_no_emulator_only_leaks(problems):
                     f"as contoso-data-platform's platform/schedule.py does.")
 
 
+def check_definition_folders(problems):
+    """Any `definitions/` directory must hold Fabric's source format.
+
+    The layout is the artefact: `<display name>.<Type>/` with the definition
+    files AND `.platform`. A folder missing `.platform` deploys fine here — the
+    emulator stores whatever parts it is given — and is not what Fabric's Git
+    integration produces, so the example would be teaching a shape no CI/CD tool
+    round-trips. That asymmetry is the whole reason this is checked rather than
+    described.
+    """
+    for defs in sorted(EXAMPLES.glob("*/definitions")):
+        if not defs.is_dir():
+            continue
+        folders = [d for d in sorted(defs.iterdir()) if d.is_dir()]
+        if not folders:
+            problems.append(f"{rel(defs)} exists but holds no item folders.")
+        for d in folders:
+            name, _, item_type = d.name.rpartition(".")
+            if not name or not item_type:
+                problems.append(
+                    f"{rel(d)} is not named '<display name>.<Type>' — that is the "
+                    f"layout Fabric's Git integration writes (docs/46).")
+                continue
+            if not (d / ".platform").is_file():
+                problems.append(
+                    f"{rel(d)} has no .platform. Every item carries one; it holds the "
+                    f"logicalId that survives renames (docs/46).")
+            if not any(f.is_file() and f.name != ".platform" for f in d.iterdir()):
+                problems.append(f"{rel(d)} has a .platform and no definition file.")
+
+
 def check_resolver_uses_the_contract(problems):
     """The resolver must consume `fabric-target`, not restate it."""
     f = ROOT / RESOLVER
@@ -188,6 +219,7 @@ def main():
     problems = []
     check_no_pinned_target(problems)
     check_no_emulator_only_leaks(problems)
+    check_definition_folders(problems)
     check_resolver_uses_the_contract(problems)
     check_definition_parts(problems)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1396,6 +1396,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyyaml" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -1494,6 +1495,7 @@ test = [
     { name = "pytest", specifier = ">=8.3,<10" },
     { name = "pytest-cov", specifier = ">=5,<8" },
     { name = "pyyaml", specifier = ">=6,<7" },
+    { name = "requests", specifier = ">=2.32,<3" },
 ]
 
 [[package]]

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
             { slug: '19-semantic-model-plan' },
             { slug: '20-lakesail-engine' },
             { slug: '21-real-fabric-toggle' },
+            { slug: '46-artifact-persistence' },
             { slug: '22-openmetadata' },
             { slug: '23-deployment-pipelines' },
             { slug: '24-parity-completion' },


### PR DESCRIPTION
The four medallion examples claimed real-Fabric portability and did not have it. `examples/README.md` already said so in its own words — contoso-data-platform "implements the `FABRIC_TARGET` toggle. The emulator's own examples show a data platform; a downstream consumer shows the emulator's fidelity. **That is the wrong way round.**" This inverts it.

## What was actually wrong

`examples/contoso-fixtures/common.py` — the module all four examples import — hardcoded the emulator's seeded tenant, client id and `daemon-app-secret`, and defaulted every endpoint to `https://localhost:*`. There was no flag. `grep -rl fabric_target examples/` returned **nothing**. So `docs/21`'s toggle never reached the examples at all, and the failure was invisible: the emulator would go on passing forever.

## One file, four examples

`common.py` now resolves through the published `fabric-target` contract and nothing else names a target:

- endpoints, tenant, credential and TLS come from `target()`
- `token()` uses the resolved credential — the seeded daemon locally, `DefaultAzureCredential` (env SP, managed identity, or `az login`) under real
- `ensure_app()` is declared `emulator_only`: it POSTs entra-emulator's admin API, which has no Entra ID counterpart, so a real run is refused **at the call** rather than failing somewhere stranger later
- `OM_URL` joins `SPARK_REMOTE`/`TDS_SERVER`/`KV_INTERNAL` as local policy in the resolver — companion services the toggle has nothing to resolve to

It **consumes** the contract rather than restating it, which is the specific mistake contoso-data-platform made and documented: its local restatement drifted into requiring `AZURE_CLIENT_SECRET`, breaking `az login`, managed identity, and running inside a Fabric notebook at all.

Verified live against a running stack: token minted (952 bytes), `GET /v1/workspaces` → 200, `ensure_app` allowed under `emulator`. And both real-mode guards fire — a missing `FABRIC_WORKSPACE` is refused, and a leftover `AZURE_CLIENT_SECRET=daemon-app-secret` is refused **by value**, so a shell left over from a local run cannot authenticate as a dev daemon against production.

## docs/46 — where artifacts persist

Verified against Microsoft's documentation, not inferred from this emulator. Definitions are base64 **parts** whose paths are Fabric's own (`notebook-content.py`, `pipeline-content.json`, `.platform`), held in the workspace metadata store and mirrored to Git as `{display name}.{public facing type}/`. `logicalId` is the identity that survives renames. **OneLake data is never in Git** and deployments never overwrite it — your notebook code is versioned, the tables it writes are not.

Cross-linked from doc 21, registered in the sidebar, sources cited. It also records that the Git source-code-format page omits data pipelines, so nobody reads it as an inventory.

## The gate

`scripts/check_example_portability.py`, in `make check`, fails when a step hardcodes the seeded principal or a Fabric-surface endpoint, when the resolver stops consuming `fabric-target`, or when a definition part uses a path Fabric would not accept.

Mutation-checked — each rule was watched failing on a real violation, then restored.

**Its first version was wrong and that is in the tests.** It reported 31 violations, none real: it read `.venv`, and treated every `"path"` key as a definition part, including OneLake shortcut targets and source URLs. Now a part must carry `payloadType` in the same object, and `site-packages` is skipped. Two tests assert those exact false positives stay dead.

The endpoint rule is deliberately narrow — only `9443`/`8443`/`8444`, the surfaces the toggle resolves. OpenMetadata and mock source APIs have no real counterpart to switch to, so flagging them would make the gate fire on correct code. **contoso-data-platform's own equivalent check draws the line in the same place**, and matching it means the two repos cannot disagree about what portability means.

`make check`, `make lint`, and 515 Python tests pass.

## contoso-data-platform: already compliant, audited not assumed

Its `platform/target.py` consumes the published contract ("THIS PLATFORM IS FABRIC CODE"), it publishes notebooks as `notebook-content.py` via `updateDefinition`, carries a real `.platform` in `artifacts/pbip/`, and **already enforces this itself** — `tests/test_the_emulator_appears_only_in_the_target_resolver` passes today. The one gap is documentation: it cites no persistence contract, so it should reference docs/46 once this lands.