### PR TITLE
Run a medallion example end to end on a real Fabric tenant

### DIFF
--- a/.github/workflows/real-fabric.yml
+++ b/.github/workflows/real-fabric.yml
@@ -12,6 +12,11 @@ name: Real Fabric conformance
 #   FABRIC_TEST_WORKSPACE
 #     — display name of a DEDICATED throwaway workspace (the suite creates
 #       and deletes its own items inside it; nothing else is touched)
+#   FABRIC_CAPACITY_ID (only for the example-provisioning step, which creates a
+#     workspace) — a Fabric F-SKU capacity id. NOT a trial capacity: only the
+#     account that started a trial can assign a workspace to it, so a service
+#     principal cannot. Run the trial path from a developer machine with
+#     `az login` instead (docs/46-artifact-persistence.md).
 
 on:
   workflow_call:
@@ -97,6 +102,12 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          # A workspace created with no capacity accepts the create and then
+          # rejects every item in it, so the resolver refuses without this rather
+          # than failing one call later. Note a TRIAL capacity cannot be assigned
+          # by a service principal — only by the account that started the trial —
+          # so this secret must name a real Fabric (F SKU) capacity for CI.
+          FABRIC_CAPACITY_ID: ${{ secrets.FABRIC_CAPACITY_ID }}
         run: uv run --frozen python provision.py
       # Oracle capture, on demand only. Several activities are blocked on one
       # thing — nobody has captured the wire `type` and `typeProperties` shape

--- a/docs/21-real-fabric-toggle.md
+++ b/docs/21-real-fabric-toggle.md
@@ -234,7 +234,11 @@ Then, with a Key Vault, the next three steps in order: `secret.py`,
 | `extract_load.py` | `notebookutils.credentials.getSecret`, then ~170 MB into `Files/landing` | the brokered path, unchanged from local |
 | `bronze.py` | deploys the Notebook and DataPipeline definitions, runs the pipeline | the notebook activity executes on the workspace's **starter pool**; its body is already portable (`spark`, `abfs://<ws>@onelake.dfs.fabric.microsoft.com/...`) |
 | `engine.py` | **skips** | Fabric ran the notebook itself |
-| `silver.py` | **refuses** | no Spark Connect endpoint exists; move the transform into a Notebook definition to go further |
+| `silver.py` | deploys `silver.Notebook`, submits `RunNotebook`, verifies the Delta tables with delta-rs | the transform runs on the **starter pool**; this file never touches Spark |
+| `reflect.py` | queries the lakehouse SQL analytics endpoint | address discovered from `sqlEndpointProperties` |
+| `gold.py`, `dq_gate.py` | dbt-fabric builds the star in the warehouse | address discovered from `properties.connectionString` |
+| `semantic_model.py` | publishes and queries the model over `executeQueries` | — |
+| `lineage.py` | **skips** | the flow graph is the emulator's own record; Purview is Fabric's answer and a different integration |
 
 Three facts that decide whether this works, all Microsoft's rather than ours:
 

--- a/docs/21-real-fabric-toggle.md
+++ b/docs/21-real-fabric-toggle.md
@@ -204,6 +204,49 @@ The toggle must make these differences *loud*, not paper over them:
    startup probe (`GET /workspaces` + the scoped workspace) fails fast with
    a "grant your SP access" message instead of 403s mid-run.
 
+## Running an example against a real tenant, step by step
+
+What a person actually types, and what happens at each boundary. The example is
+not edited: everything below is environment.
+
+```bash
+az login                                   # as YOURSELF for a trial (see below)
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(az account get-access-token \
+  --resource https://api.fabric.microsoft.com -o tsv --query accessToken)" \
+  https://api.fabric.microsoft.com/v1/capacities
+```
+
+```bash
+cd examples/medallion-pyspark && FABRIC_TARGET=real FABRIC_WORKSPACE=contoso-analytics FABRIC_CAPACITY_ID=<capacity-guid> uv run --frozen python provision.py
+```
+
+Then, with a Key Vault, the next three steps in order: `secret.py`,
+`extract_load.py`, `bronze.py` — adding
+`FABRIC_VAULT_URL=https://<vault>.vault.azure.net`.
+
+| Step | Real Fabric | Note |
+|---|---|---|
+| `provision.py` | workspace + lakehouse + warehouse + workspace identity | needs `FABRIC_CAPACITY_ID`; the resolver refuses without it rather than creating a capacity-less workspace whose every item then fails |
+| `secret.py` | secret in your vault + an AKV-reference connection | the workspace identity needs *get* on the vault |
+| `extract_load.py` | `notebookutils.credentials.getSecret`, then ~170 MB into `Files/landing` | the brokered path, unchanged from local |
+| `bronze.py` | deploys the Notebook and DataPipeline definitions, runs the pipeline | the notebook activity executes on the workspace's **starter pool**; its body is already portable (`spark`, `abfs://<ws>@onelake.dfs.fabric.microsoft.com/...`) |
+| `engine.py` | **skips** | Fabric ran the notebook itself |
+| `silver.py` | **refuses** | no Spark Connect endpoint exists; move the transform into a Notebook definition to go further |
+
+Three facts that decide whether this works, all Microsoft's rather than ours:
+
+- **A trial capacity can only be assigned by the account that started the
+  trial.** A service principal cannot, so use `az login` as that user. CI uses an
+  F-SKU capacity for the same step.
+- **A workspace with no capacity** is created successfully and then rejects every
+  Fabric item in it. That is why the resolver refuses instead.
+- **Workspace identity** can be created in any workspace except *My workspace*,
+  so a trial is fine; trusted access to firewalled storage additionally needs an
+  F SKU.
+
 ## Verification — the same tests, both targets
 
 A pytest marker ties it together:

--- a/docs/46-artifact-persistence.md
+++ b/docs/46-artifact-persistence.md
@@ -121,9 +121,12 @@ The consequence for this repo: the emulator has no pool, so it parses a notebook
 into cells, records a `Pending` run, and waits for an engine (Sail over Spark
 Connect) to execute them and report back. That engine is scaffolding for the
 missing half of the target. A step that drives Spark Connect **directly** is
-emulator-only by construction, which is why `silver.py` and `star_silver.py`
-refuse under `real` and name the two submission routes above, while `engine.py`
-skips: Fabric runs the queued notebook itself.
+emulator-only by construction. That is why `silver.py` no longer does it: its
+transform lives in `definitions/silver.Notebook/` and is submitted with
+`run_job(nb, "RunNotebook")`, so the emulator's agent executes it locally and a
+Fabric pool executes the same cells on a tenant. `engine.py` skips under `real`
+(Fabric runs the queued notebook itself), and `star_silver.py` in the advanced
+examples still refuses, because that transform has not been moved yet.
 
 ### SQL: the address is per-item and only the API knows it
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -114,10 +114,12 @@ example asserts that.
 **Compute and SQL addresses are discovered, never configured.** The SQL endpoint
 of a warehouse or a lakehouse is assigned per item by the service, so every step
 asks for it (`common.sql_endpoint()`) instead of naming a host; the enforcement
-gate fails a step that names one. Spark is the honest limit: Fabric exposes no
-Spark endpoint to dial, so `silver.py` refuses under `real` and names the two
-real routes (submit the notebook item, or the Livy API), while `engine.py` skips
-because Fabric runs the queued notebook on its own pool. That whole story,
+gate fails a step that names one. Spark is submitted, never dialled: Fabric
+exposes no Spark endpoint, so the silver transform lives in
+`definitions/silver.Notebook/` and `silver.py` submits it as a `RunNotebook` job
+— the emulator's agent runs it locally, a Fabric pool runs it on a tenant, and
+the file itself touches no Spark. `engine.py` skips under `real` because Fabric
+runs the queued notebook on its own pool. That whole story,
 including starter versus custom pools and the analytics-endpoint sync lag, is in
 [docs/46](../docs/46-artifact-persistence.md).
 

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -50,17 +50,28 @@ FABRIC = _T.api_root[: -len("/v1")] if _T.api_root.endswith("/v1") else _T.api_r
 # vault; under `real` it is None unless FABRIC_VAULT_URL/AZURE_KEY_VAULT_URL is
 # set, and `or "https://localhost:8444"` would have pointed a PRODUCTION run at
 # the emulator's vault — silently, since the resolver is exempt from the gate's
-# localhost rule. Every medallion example stores a source credential in Key Vault
-# (step 2), so a missing vault under real is always a misconfiguration: refuse
-# here, where the cause is legible, rather than at a 404 later.
-if _T.is_real and not _T.vault_url:
-    raise SystemExit(
-        "FABRIC_TARGET=real needs a vault: set FABRIC_VAULT_URL (or "
-        "AZURE_KEY_VAULT_URL) to your Key Vault URI. These examples store the "
-        "source API key there and resolve it through an AKV reference, exactly "
-        "as they do locally.")
+# localhost rule. So it is None, and require_vault() refuses AT THE POINT OF USE.
 KV = _T.vault_url
 TENANT = _T.tenant
+
+
+def require_vault():
+    """The vault URI, refused under `real` when nothing configured one.
+
+    WHY NOT AT IMPORT. It was, and that was wrong: this module is imported by
+    every step, so a vault nobody in that step touches blocked steps that only
+    need the control plane. `provision.py` — the one step the real-Fabric CI leg
+    runs, and the first thing anyone points at a fresh tenant — died on a missing
+    Key Vault before making a single call. A prerequisite belongs where it is
+    needed, or the toggle is narrower than it claims.
+    """
+    if not KV:
+        raise SystemExit(
+            "FABRIC_TARGET=real needs a vault for this step: set FABRIC_VAULT_URL "
+            "(or AZURE_KEY_VAULT_URL) to your Key Vault URI. The step stores the "
+            "source API key there and reads it back the way a notebook does. "
+            "Steps that only touch the control plane (provision.py) need none.")
+    return KV
 
 # Local policy, not target policy (see the module docstring). UNSET means
 # "ask the API", which is the portable path — see sql_endpoint(). It stays

--- a/examples/medallion-advanced-dbt-fabricspark/extract_load.py
+++ b/examples/medallion-advanced-dbt-fabricspark/extract_load.py
@@ -17,10 +17,21 @@ import datetime
 
 import notebookutils
 import source_system as src
-from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
+from common import (
+    FABRIC,
+    STORAGE_AUD,
+    VAULT_AUD,
+    S,
+    ensure_app,
+    load,
+    log,
+    require_vault,
+    save,
+    token,
+)
 
 ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
-api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
+api_key = notebookutils.credentials.getSecret(require_vault(), "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-advanced-dbt-fabricspark/lineage.py
+++ b/examples/medallion-advanced-dbt-fabricspark/lineage.py
@@ -9,7 +9,16 @@ Two mechanisms produce these edges, and the graph keeps them distinguishable:
 Neither is inferred from user code. That is the whole point: an edge here is
 either something the emulator did, or something an engine witnessed doing.
 """
-from common import lineage_edges, load, log
+from common import lineage_edges, load, log, skip_on_real
+
+# The flow graph is the EMULATOR's, and deliberately so: it records only what it
+# did itself or what an engine witnessed doing, never an inference from user code.
+# Real Fabric publishes no such API — its lineage story is Purview, a different
+# model reached a different way — so there is nothing here to point at a tenant.
+skip_on_real(
+    "the lineage assertion",
+    "the flow graph is the emulator's own record of what moved; real Fabric has "
+    "no equivalent endpoint, and Purview is a different integration")
 
 st = load()
 edges = lineage_edges()

--- a/examples/medallion-advanced-dbt-fabricspark/secret.py
+++ b/examples/medallion-advanced-dbt-fabricspark/secret.py
@@ -4,7 +4,6 @@ a vault-audience workspace-identity token."""
 import source_system as src
 from common import (
                     FABRIC,
-                    KV,
                     KV_INTERNAL,
                     VAULT_AUD,
                     S,
@@ -12,11 +11,13 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_vault,
                     save,
                     token,
 )
 
 ensure_app(VAULT_AUD, "Azure Key Vault")
+KV = require_vault()  # this step is the one that needs it
 vt = token(VAULT_AUD)
 
 r = S.put(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",

--- a/examples/medallion-advanced-pyspark/extract_load.py
+++ b/examples/medallion-advanced-pyspark/extract_load.py
@@ -17,10 +17,21 @@ import datetime
 
 import notebookutils
 import source_system as src
-from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
+from common import (
+    FABRIC,
+    STORAGE_AUD,
+    VAULT_AUD,
+    S,
+    ensure_app,
+    load,
+    log,
+    require_vault,
+    save,
+    token,
+)
 
 ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
-api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
+api_key = notebookutils.credentials.getSecret(require_vault(), "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-advanced-pyspark/lineage.py
+++ b/examples/medallion-advanced-pyspark/lineage.py
@@ -9,7 +9,16 @@ Two mechanisms produce these edges, and the graph keeps them distinguishable:
 Neither is inferred from user code. That is the whole point: an edge here is
 either something the emulator did, or something an engine witnessed doing.
 """
-from common import lineage_edges, load, log
+from common import lineage_edges, load, log, skip_on_real
+
+# The flow graph is the EMULATOR's, and deliberately so: it records only what it
+# did itself or what an engine witnessed doing, never an inference from user code.
+# Real Fabric publishes no such API — its lineage story is Purview, a different
+# model reached a different way — so there is nothing here to point at a tenant.
+skip_on_real(
+    "the lineage assertion",
+    "the flow graph is the emulator's own record of what moved; real Fabric has "
+    "no equivalent endpoint, and Purview is a different integration")
 
 st = load()
 edges = lineage_edges()

--- a/examples/medallion-advanced-pyspark/secret.py
+++ b/examples/medallion-advanced-pyspark/secret.py
@@ -4,7 +4,6 @@ a vault-audience workspace-identity token."""
 import source_system as src
 from common import (
                     FABRIC,
-                    KV,
                     KV_INTERNAL,
                     VAULT_AUD,
                     S,
@@ -12,11 +11,13 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_vault,
                     save,
                     token,
 )
 
 ensure_app(VAULT_AUD, "Azure Key Vault")
+KV = require_vault()  # this step is the one that needs it
 vt = token(VAULT_AUD)
 
 r = S.put(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",

--- a/examples/medallion-dbt-fabricspark/extract_load.py
+++ b/examples/medallion-dbt-fabricspark/extract_load.py
@@ -17,10 +17,21 @@ import datetime
 
 import notebookutils
 import source_system as src
-from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
+from common import (
+    FABRIC,
+    STORAGE_AUD,
+    VAULT_AUD,
+    S,
+    ensure_app,
+    load,
+    log,
+    require_vault,
+    save,
+    token,
+)
 
 ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
-api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
+api_key = notebookutils.credentials.getSecret(require_vault(), "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-dbt-fabricspark/lineage.py
+++ b/examples/medallion-dbt-fabricspark/lineage.py
@@ -9,7 +9,16 @@ Two mechanisms produce these edges, and the graph keeps them distinguishable:
 Neither is inferred from user code. That is the whole point: an edge here is
 either something the emulator did, or something an engine witnessed doing.
 """
-from common import lineage_edges, load, log
+from common import lineage_edges, load, log, skip_on_real
+
+# The flow graph is the EMULATOR's, and deliberately so: it records only what it
+# did itself or what an engine witnessed doing, never an inference from user code.
+# Real Fabric publishes no such API — its lineage story is Purview, a different
+# model reached a different way — so there is nothing here to point at a tenant.
+skip_on_real(
+    "the lineage assertion",
+    "the flow graph is the emulator's own record of what moved; real Fabric has "
+    "no equivalent endpoint, and Purview is a different integration")
 
 st = load()
 edges = lineage_edges()

--- a/examples/medallion-dbt-fabricspark/secret.py
+++ b/examples/medallion-dbt-fabricspark/secret.py
@@ -4,7 +4,6 @@ a vault-audience workspace-identity token."""
 import source_system as src
 from common import (
                     FABRIC,
-                    KV,
                     KV_INTERNAL,
                     VAULT_AUD,
                     S,
@@ -12,11 +11,13 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_vault,
                     save,
                     token,
 )
 
 ensure_app(VAULT_AUD, "Azure Key Vault")
+KV = require_vault()  # this step is the one that needs it
 vt = token(VAULT_AUD)
 
 r = S.put(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",

--- a/examples/medallion-pyspark/definitions/silver.Notebook/.platform
+++ b/examples/medallion-pyspark/definitions/silver.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "silver",
+    "description": "Bronze to silver: dedupe on the vendor's event sequence, conform country codes and emails, quarantine malformed orders."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "3f7c9b14-52ad-4e6b-8c0f-91d5a2e7b643"
+  }
+}

--- a/examples/medallion-pyspark/definitions/silver.Notebook/notebook-content.py
+++ b/examples/medallion-pyspark/definitions/silver.Notebook/notebook-content.py
@@ -1,0 +1,102 @@
+# Fabric notebook source
+
+# CELL ********************
+
+# Silver: dedupe, conform, quarantine — the rules bronze deliberately does not
+# apply. Latest event wins per order, emails lower-cased, country codes
+# conformed, malformed rows quarantined rather than dropped.
+#
+# THIS IS A NOTEBOOK, AND THAT IS THE POINT. The transform used to live in
+# silver.py and dial Spark Connect, which no Fabric tenant exposes — so the step
+# ran locally and could not run in production. Here the code is a Notebook
+# DEFINITION, submitted as a job: the emulator's Spark agent executes it locally,
+# and real Fabric executes it on the workspace's starter pool. Same file, same
+# cells, both targets.
+#
+# `spark` is injected by the runtime, exactly as in a Fabric notebook. Nothing
+# here imports the example's fixture package: a notebook runs on the pool, where
+# only what the definition carries exists. The numbers this must produce are
+# asserted by silver.py against the tables that land, which is the stronger
+# check anyway — it verifies the artifact rather than an in-process DataFrame.
+
+from pyspark.sql import Window
+from pyspark.sql import functions as F
+
+# ABFS addresses OneLake by its full account host, as a Fabric notebook does.
+base = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables"
+
+
+def read(table):
+    return spark.read.format("delta").load(f"{base}/{table}")
+
+
+def write(df, table):
+    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+
+
+# Every spelling the vendor emits, keyed by its uppercased/stripped form. This is
+# silver's own business rule, written out rather than derived from the source
+# system's own variant table on purpose: sharing that mapping would make the
+# conformance check agree with itself, and a new variant appearing upstream would
+# silently conform instead of failing.
+COUNTRY = {
+    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
+    "GB": "GB", "U.K.": "GB", "UK": "GB", "GBR": "GB", "UNITED KINGDOM": "GB",
+    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
+}
+
+# --- customers ---------------------------------------------------------------
+# The Copy activity lands CSV as strings, so every column here is text; only the
+# ones silver actually reasons about get touched. Silver keeps the customer
+# record WIDE — narrowing to the columns gold needs would be the wrong place to
+# do it, because the star's dimensions are a projection of silver, not the
+# other way round.
+c = read("bronze_customers").dropDuplicates(["customer_id"])
+conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
+country_key = F.upper(F.trim(F.col("country")))
+silver_customers = (
+    c.withColumn("email", F.lower(F.trim(F.coalesce(F.col("email"), F.lit("")))))
+     .withColumn("country", F.coalesce(conform[country_key], country_key))
+)
+
+# --- orders ------------------------------------------------------------------
+# Latest event wins: rank each order's events by the vendor's own sequence and
+# keep the last. `dropDuplicates` would keep an ARBITRARY row per key — correct
+# only by luck, and silently wrong the day the redelivery carries a different
+# status.
+o = read("bronze_orders")
+latest = Window.partitionBy("order_id").orderBy(F.col("event_seq").desc())
+o = (o.withColumn("_rn", F.row_number().over(latest))
+      .filter(F.col("_rn") == 1)
+      .drop("_rn"))
+
+bad = (F.col("quantity") <= 0) | F.col("unit_price").isNull()
+quarantine = o.filter(bad)
+clean = (o.filter(~bad)
+          .withColumn("order_date", F.to_date("order_date"))
+          .withColumn("amount", F.col("quantity") * F.col("unit_price")))
+
+silver_orders = clean.select(
+    "order_id", "customer_id", "product_id", "order_date", "channel",
+    "store_id", "currency", "discount_pct", "tax_rate", "shipping_fee",
+    "payment_method", "is_gift", "promo_code", "quantity",
+    "unit_price", "amount", "status")
+
+write(silver_customers, "silver_customers")
+write(silver_orders, "silver_orders")
+write(quarantine, "silver_quarantine_orders")
+
+# Invariants of the TRANSFORM, asserted here because a failing cell fails the
+# job — and because these need no knowledge of the fixture's exact numbers, which
+# is what keeps this notebook runnable on any tenant. The row counts belong to
+# silver.py, which knows what the generator produced.
+n_orders = silver_orders.count()
+assert silver_orders.select("order_id").distinct().count() == n_orders, \
+    "silver_orders still has duplicate order ids after the dedupe"
+# The unresolvable people are still here, not quietly dropped: a resolution step
+# downstream claiming 100% would be lying, and this cohort is what proves it.
+assert silver_customers.filter(F.col("email") == "").count() > 0, \
+    "the missing-email cohort vanished"
+
+print(f"silver: {silver_customers.count()} customers, {n_orders} orders, "
+      f"{quarantine.count()} quarantined")

--- a/examples/medallion-pyspark/extract_load.py
+++ b/examples/medallion-pyspark/extract_load.py
@@ -17,10 +17,21 @@ import datetime
 
 import notebookutils
 import source_system as src
-from common import FABRIC, KV, STORAGE_AUD, VAULT_AUD, S, ensure_app, load, log, save, token
+from common import (
+    FABRIC,
+    STORAGE_AUD,
+    VAULT_AUD,
+    S,
+    ensure_app,
+    load,
+    log,
+    require_vault,
+    save,
+    token,
+)
 
 ensure_app(VAULT_AUD, "Azure Key Vault")  # a real tenant already issues it
-api_key = notebookutils.credentials.getSecret(KV, "contoso-pos-api-key")
+api_key = notebookutils.credentials.getSecret(require_vault(), "contoso-pos-api-key")
 
 # The vendor refuses a wrong key — prove the gate is real, not decorative.
 try:

--- a/examples/medallion-pyspark/lineage.py
+++ b/examples/medallion-pyspark/lineage.py
@@ -9,7 +9,16 @@ Two mechanisms produce these edges, and the graph keeps them distinguishable:
 Neither is inferred from user code. That is the whole point: an edge here is
 either something the emulator did, or something an engine witnessed doing.
 """
-from common import lineage_edges, load, log
+from common import lineage_edges, load, log, skip_on_real
+
+# The flow graph is the EMULATOR's, and deliberately so: it records only what it
+# did itself or what an engine witnessed doing, never an inference from user code.
+# Real Fabric publishes no such API — its lineage story is Purview, a different
+# model reached a different way — so there is nothing here to point at a tenant.
+skip_on_real(
+    "the lineage assertion",
+    "the flow graph is the emulator's own record of what moved; real Fabric has "
+    "no equivalent endpoint, and Purview is a different integration")
 
 st = load()
 edges = lineage_edges()

--- a/examples/medallion-pyspark/pipeline.py
+++ b/examples/medallion-pyspark/pipeline.py
@@ -26,7 +26,7 @@ STEPS = [
     ("extract_load", "extract from Contoso POS into Files/landing"),
     ("bronze", "a real DataPipeline: a Copy activity plus a Notebook activity"),
     ("engine", "Spark executes the queued notebook run and reports lineage"),
-    ("silver", "PySpark: dedupe, conform, quarantine"),
+    ("silver", "silver as a Notebook job, on whichever Spark the target has"),
     ("reflect", "reflect silver into the lakehouse SQL endpoint"),
     ("gold", "dbt-fabric builds the star in the WAREHOUSE, with DQ tests"),
     ("dq_gate", "verify the DQ gate rejects bad data"),

--- a/examples/medallion-pyspark/secret.py
+++ b/examples/medallion-pyspark/secret.py
@@ -4,7 +4,6 @@ a vault-audience workspace-identity token."""
 import source_system as src
 from common import (
                     FABRIC,
-                    KV,
                     KV_INTERNAL,
                     VAULT_AUD,
                     S,
@@ -12,11 +11,13 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_vault,
                     save,
                     token,
 )
 
 ensure_app(VAULT_AUD, "Azure Key Vault")
+KV = require_vault()  # this step is the one that needs it
 vt = token(VAULT_AUD)
 
 r = S.put(f"{KV}/secrets/contoso-pos-api-key?api-version=7.4",

--- a/examples/medallion-pyspark/silver.py
+++ b/examples/medallion-pyspark/silver.py
@@ -1,148 +1,102 @@
-"""Silver: dedupe, conform, quarantine — the rules bronze deliberately does not
-apply. Latest event wins per order, emails lower-cased and case-folded, country
-codes conformed, malformed rows quarantined rather than dropped.
+"""Silver: deploy the transform as a NOTEBOOK, submit it, verify what landed.
 
-**This runs on Spark**, over Spark Connect against the engine `docker compose up`
-attaches (Sail). That is the point of the step as much as the transforms are:
-Lakehouse-to-Lakehouse ETL on Fabric is Spark work. This step used to read the
-Delta into pandas and transform on the client, which is a fine way to move ten
-thousand rows and the wrong shape entirely for a hundred million — the data
-never has to leave the lakehouse, and here it does not.
+The transform itself is `definitions/silver.Notebook/notebook-content.py`. This
+step deploys that definition and submits a `RunNotebook` job — which is the whole
+reason it is shaped this way.
+
+WHAT CHANGED AND WHY IT MATTERS. This step used to build the DataFrames here and
+dial Spark Connect directly. That works against the emulator, which attaches an
+engine (Sail) on a port, and it can never work against real Fabric, which exposes
+no Spark endpoint to dial: on Fabric, Spark runs INSIDE the service and the unit
+of work is a submitted job. So the step was portable in every respect except the
+one that mattered, and it refused under FABRIC_TARGET=real rather than pretend.
+Moving the code into a notebook definition removes the refusal: the emulator's
+Spark agent executes the cells locally, real Fabric executes the same cells on
+the workspace's starter pool (or a custom pool via an Environment), and neither
+this file nor the notebook changes between them.
+
+WHY THE ASSERTIONS LIVE HERE AND THE TRANSFORM DOES NOT. A notebook runs on the
+pool, where the example's fixture package does not exist — so the numbers the
+seeded generator implies cannot be checked in there. They are checked here, by
+reading the Delta tables the run produced. That is the stronger check: it
+verifies the ARTIFACT rather than an in-process DataFrame, so a transform that
+computed the right answer and wrote it to the wrong place still fails.
 
 The same transform written as **dbt-fabricspark models** is in
-`../medallion-dbt-fabricspark`, which builds the identical silver declaratively and then
-compares the two. Imperative Spark or declarative dbt is a real choice a Fabric
-team makes; neither example claims it is the only one.
-
-Silver keeps the customer record WIDE. Narrowing to the handful of columns gold
-needs would be the wrong place to do it: silver is the conformed customer-360,
-and the star's dimensions are a projection of it, not the other way round.
+`../medallion-dbt-fabricspark`, which builds the identical silver declaratively
+and then compares the two. Imperative Spark or declarative dbt is a real choice a
+Fabric team makes; neither example claims it is the only one.
 """
+import json
+import pathlib
+import time
+
 import source_system as src
-from common import SPARK_REMOTE, load, log, only_the_emulator_can
-
-# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
-# portability line falls. Real Fabric does not expose a Spark endpoint to dial
-# from outside: its compute runs the notebook. So this transform is portable only
-# once it LIVES in a notebook definition, which is a rewrite of where the code
-# sits rather than of what it does.
-only_the_emulator_can(
-    "driving Spark directly over Spark Connect",
-    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
-            "the service, on the workspace's starter pool or a custom pool chosen "
-            "through an Environment",
-    instead="move this transform into a Notebook definition under definitions/ and "
-            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
-            "accept; the Livy API "
-            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
-            "is the other route on real Fabric")
-
+from common import (
+    create_item_from_definition,
+    load,
+    log,
+    run_job,
+    storage_options,
+    tables_uri,
+)
+from deltalake import DeltaTable
 
 st = load()
-assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"
 
-from pyspark.sql import SparkSession, Window  # noqa: E402
-from pyspark.sql import functions as F  # noqa: E402
+nb = create_item_from_definition(
+    "silver.Notebook", WORKSPACE_ID=st["workspace"], LAKEHOUSE_ID=st["lakehouse"])
 
-spark = SparkSession.builder.remote(SPARK_REMOTE).getOrCreate()
+# The build clock covers the submit and the run, which is what a reader comparing
+# engines cares about: the wall time from "go" to "silver exists".
+t0 = time.time()
+jid, status = run_job(nb, "RunNotebook")
+assert status == "Completed", f"silver notebook run {jid}: {status}"
+build_secs = time.time() - t0
 
-import time as _time  # noqa: E402
-
-_t0 = _time.time()  # build clock: the transform starts here
-
-base = (f"abfs://{st['workspace']}@onelake.dfs.fabric.microsoft.com"
-        f"/{st['lakehouse']}/Tables")
-
-
-def read(table):
-    return spark.read.format("delta").load(f"{base}/{table}")
-
-
-def write(df, table):
-    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+# --- verify what landed -------------------------------------------------------
+# delta-rs reads OneLake directly with a storage-audience token, independent of
+# whatever engine wrote the tables. Deliberately a different reader from the
+# writer: if both halves were Spark, a Spark-shaped misunderstanding of the Delta
+# log would agree with itself.
+opts = storage_options()
 
 
-# Every spelling the vendor emits, keyed by its uppercased/stripped form. This
-# is silver's own business rule, written out rather than derived from
-# source_system.COUNTRY_VARIANTS on purpose: importing the generator's mapping
-# would make the conformance assert agree with itself, and a new variant
-# appearing upstream would silently conform instead of failing here.
-COUNTRY = {
-    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
-    "GB": "GB", "U.K.": "GB", "UK": "GB", "GBR": "GB", "UNITED KINGDOM": "GB",
-    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
-}
+def table(name):
+    return DeltaTable(f"{tables_uri()}/{name}", storage_options=opts).to_pandas()
 
-# --- customers ---------------------------------------------------------------
-# The Copy activity lands CSV as strings, so every column here is text; only the
-# ones silver actually reasons about get touched.
-c = read("bronze_customers").dropDuplicates(["customer_id"])
-conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
-country_key = F.upper(F.trim(F.col("country")))
-silver_customers = (
-    c.withColumn("email", F.lower(F.trim(F.coalesce(F.col("email"), F.lit("")))))
-     .withColumn("country", F.coalesce(conform[country_key], country_key))
-)
 
-# --- orders ------------------------------------------------------------------
-# Latest event wins: rank each order's events by the vendor's own sequence and
-# keep the last. `dropDuplicates` would keep an ARBITRARY row per key — correct
-# only by luck, and silently wrong the day the redelivery carries a different
-# status.
-o = read("bronze_orders")
-latest = Window.partitionBy("order_id").orderBy(F.col("event_seq").desc())
-o = (o.withColumn("_rn", F.row_number().over(latest))
-      .filter(F.col("_rn") == 1)
-      .drop("_rn"))
+customers = table("silver_customers")
+orders = table("silver_orders")
+quarantine = table("silver_quarantine_orders")
 
-bad = (F.col("quantity") <= 0) | F.col("unit_price").isNull()
-quarantine = o.filter(bad)
-clean = (o.filter(~bad)
-          .withColumn("order_date", F.to_date("order_date"))
-          .withColumn("amount", F.col("quantity") * F.col("unit_price")))
-
-silver_orders = clean.select(
-    "order_id", "customer_id", "product_id", "order_date", "channel",
-    "store_id", "currency", "discount_pct", "tax_rate", "shipping_fee",
-    "payment_method", "is_gift", "promo_code", "quantity",
-    "unit_price", "amount", "status")
-
-write(silver_customers, "silver_customers")
-write(silver_orders, "silver_orders")
-write(quarantine, "silver_quarantine_orders")
-
-n_customers = silver_customers.count()
-n_orders = silver_orders.count()
-n_quarantine = quarantine.count()
-countries = {r["country"] for r in silver_customers.select("country").distinct().collect()}
+n_customers, n_orders, n_quarantine = len(customers), len(orders), len(quarantine)
+countries = set(customers["country"].unique())
 
 assert n_customers == src.EXPECTED_SILVER_CUSTOMERS, n_customers
 assert n_orders == src.EXPECTED_SILVER_ORDERS, n_orders
 assert n_quarantine == src.EXPECTED_QUARANTINED, n_quarantine
 assert countries == src.EXPECTED_COUNTRIES, countries
-assert len(silver_customers.columns) == src.EXPECTED_CUSTOMER_COLUMNS, silver_customers.columns
-assert silver_orders.select("order_id").distinct().count() == n_orders, \
-    "silver_orders still has duplicate order ids"
-# The unresolvable people are still here, not quietly dropped — web_bronze.py
-# depends on them existing to prove a resolution step that claims 100% is lying.
-assert silver_customers.filter(F.col("email") == "").count() > 0, \
-    "the missing-email cohort vanished"
+assert len(customers.columns) == src.EXPECTED_CUSTOMER_COLUMNS, list(customers.columns)
+assert orders["order_id"].nunique() == n_orders, "silver_orders still has duplicate order ids"
+# The unresolvable people are still here, not quietly dropped — the resolution
+# step in the advanced example depends on them existing to prove that a claim of
+# 100% is a lie. The notebook asserts this too; both are cheap and the failure
+# reads differently from each side.
+assert (customers["email"] == "").sum() > 0, "the missing-email cohort vanished"
 
-log(f"silver (PySpark): {n_customers:,} customers x {len(silver_customers.columns)} cols, "
-    f"{n_orders:,} orders, {n_quarantine:,} quarantined")
+log(f"silver (notebook on the target's own Spark): {n_customers:,} customers x "
+    f"{len(customers.columns)} cols, {n_orders:,} orders, {n_quarantine:,} quarantined")
 
 # A machine-readable summary of what this tool produced, so
 # ../medallion-dbt-fabricspark can compare its declarative build against this
 # imperative one without either example importing the other's code.
-import json  # noqa: E402
-import pathlib  # noqa: E402
-
 pathlib.Path(__file__).resolve().parent.joinpath("silver_summary.json").write_text(
     json.dumps({
-        "engine": "PySpark (Spark Connect)",
+        "engine": "PySpark (Notebook job)",
         "target": "Lakehouse (Delta in OneLake)",
-        "compute": "Sail (Rust Spark Connect, no JVM)",
-        "build_seconds": round(_time.time() - _t0, 2),
+        "compute": "the target's own Spark: agent-driven Sail locally, a Fabric pool on real",
+        "build_seconds": round(build_secs, 2),
         "rows": {"silver_customers": n_customers, "silver_orders": n_orders,
                  "silver_quarantine_orders": n_quarantine},
         # Empty, and that is the finding rather than an omission: Spark SQL

--- a/python/fabric-target/fabric_target/__init__.py
+++ b/python/fabric-target/fabric_target/__init__.py
@@ -128,6 +128,9 @@ class Target:
             self.onelake_url = fabric  # Host-routed / account-prefixed locally
             self.vault_url = _env_any(("VAULT_EMULATOR_URL", "AZURE_KEY_VAULT_URL"),
                                       "https://localhost:8444").rstrip("/")
+            # No capacity concept locally: compute is whatever sidecar is
+            # attached, and there is nothing to bill or to assign a workspace to.
+            self.capacity_id = None
             self.tls_verify = False
             self.workspace_scope = _env("FABRIC_WORKSPACE")  # optional locally
         else:
@@ -139,6 +142,13 @@ class Target:
             # SDKs' own samples use, so accept it too rather than making a
             # consumer set the same URL twice.
             self.vault_url = _env_any(("FABRIC_VAULT_URL", "AZURE_KEY_VAULT_URL"))
+            # The capacity a newly created workspace is assigned to. Only needed
+            # when something creates a workspace; resolving an existing one by
+            # name never touches it. A trial capacity is a valid value, with one
+            # caveat that is Microsoft's, not ours: only the account that started
+            # the trial can assign a workspace to it, so a service principal
+            # cannot — use az login as that user.
+            self.capacity_id = _env_any(("FABRIC_CAPACITY_ID", "AZURE_FABRIC_CAPACITY_ID"))
             self.tls_verify = True
             # Real mode is always workspace-scoped: nothing may enumerate a tenant.
             self.workspace_scope = _env("FABRIC_WORKSPACE")
@@ -202,6 +212,43 @@ class Target:
         if self.is_real:
             raise TargetError(f"{feature}: emulator-only — this does not exist on real Fabric")
 
+    def _complete_workspace_create(self, method, url, kw):
+        """Add `capacityId` to a real-Fabric workspace create, or refuse.
+
+        WHY THE SESSION DOES THIS. On real Fabric a workspace with no capacity
+        accepts the create and then rejects every Fabric item in it, so
+        `POST /workspaces {"displayName": ...}` returns 201 and the next call
+        fails with a message about the item rather than the capacity. The
+        emulator has no capacity concept at all, which is why portable code does
+        not name one — and why completing the request per target belongs here,
+        next to the bearer token the session already adds for the same reason.
+
+        Nothing is injected when the caller supplied a capacityId, when the
+        target is the emulator, or when the URL is anything other than the
+        workspaces COLLECTION (`/workspaces/{id}/assignToCapacity` is a
+        different call and must pass through untouched).
+
+        Refusing when no capacity is configured is the actionable half: the
+        alternative is a 201 followed by a confusing failure one call later.
+        """
+        if not self.is_real or method.upper() != "POST":
+            return
+        if urllib.parse.urlsplit(url).path.rstrip("/") != urllib.parse.urlsplit(
+                self.api_root + "/workspaces").path:
+            return
+        body = kw.get("json")
+        if not isinstance(body, dict) or body.get("capacityId"):
+            return
+        if not self.capacity_id:
+            raise TargetError(
+                "creating a workspace on real Fabric needs a capacity: set "
+                "FABRIC_CAPACITY_ID to a Fabric or trial capacity id (GET "
+                "/v1/capacities lists them). Without one the workspace is created "
+                "with no capacity and every lakehouse, warehouse and notebook in "
+                "it is then rejected — a failure one call away from its cause. "
+                "The emulator has no capacity, so nothing is needed there.")
+        body["capacityId"] = self.capacity_id
+
     def _guard_destructive(self, method, url):
         if self.is_real and method.upper() == "DELETE" \
                 and _env("FABRIC_TARGET_ALLOW_DESTRUCTIVE") not in ("1", "true", "yes"):
@@ -238,6 +285,7 @@ class Target:
                 headers = kw.setdefault("headers", {})
                 headers.setdefault(
                     "Authorization", "Bearer " + t.credential.get_token(FABRIC_SCOPE).token)
+                t._complete_workspace_create(method, url, kw)
                 resp = super().request(method, url, **kw)
                 if resp.status_code == 429:  # real Fabric throttles; honor it once
                     time.sleep(min(float(resp.headers.get("Retry-After", "1")), 60))

--- a/python/fabric-target/tests/test_fabric_target.py
+++ b/python/fabric-target/tests/test_fabric_target.py
@@ -224,3 +224,63 @@ def test_notebook_env_and_the_emitter_cannot_drift(monkeypatch, capsys):
             k, _, v = line[len("export "):].partition("=")
             printed[k] = v.strip("'")
     assert printed == dict(fabric_target.notebook_env(Target("emulator")))
+
+
+# --- workspace creation needs a capacity on real Fabric ----------------------
+# The emulator has none, so portable code cannot name one. The session completes
+# the request per target, exactly as it already does for the bearer token.
+
+def _real(monkeypatch, **env):
+    monkeypatch.setenv("FABRIC_WORKSPACE", "ws")
+    monkeypatch.setattr(fabric_target, "_az_logged_in", lambda: True)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    return Target("real")
+
+
+def test_a_real_workspace_create_carries_the_configured_capacity(monkeypatch):
+    t = _real(monkeypatch, FABRIC_CAPACITY_ID="cap-1")
+    kw = {"json": {"displayName": "contoso-analytics"}}
+    t._complete_workspace_create("POST", t.api_root + "/workspaces", kw)
+    assert kw["json"]["capacityId"] == "cap-1"
+
+
+def test_a_caller_supplied_capacity_is_never_overwritten(monkeypatch):
+    t = _real(monkeypatch, FABRIC_CAPACITY_ID="cap-1")
+    kw = {"json": {"displayName": "w", "capacityId": "mine"}}
+    t._complete_workspace_create("POST", t.api_root + "/workspaces", kw)
+    assert kw["json"]["capacityId"] == "mine"
+
+
+def test_a_real_workspace_create_without_a_capacity_is_refused(monkeypatch):
+    """A capacity-less workspace is created happily and then rejects every item
+    in it, so the failure lands one call away from its cause."""
+    t = _real(monkeypatch)
+    with pytest.raises(TargetError, match="FABRIC_CAPACITY_ID"):
+        t._complete_workspace_create("POST", t.api_root + "/workspaces", {"json": {"displayName": "w"}})
+
+
+def test_assign_to_capacity_is_left_alone(monkeypatch):
+    """A different call that happens to live under /workspaces. Injecting a body
+    field into it would corrupt a request that was already correct."""
+    t = _real(monkeypatch, FABRIC_CAPACITY_ID="cap-1")
+    kw = {"json": {"capacityId": "other"}}
+    t._complete_workspace_create("POST", t.api_root + "/workspaces/abc/assignToCapacity", kw)
+    assert kw["json"] == {"capacityId": "other"}
+    # And an item create under a workspace is not a workspace create.
+    kw = {"json": {"displayName": "lake"}}
+    t._complete_workspace_create("POST", t.api_root + "/workspaces/abc/lakehouses", kw)
+    assert "capacityId" not in kw["json"]
+
+
+def test_the_emulator_never_needs_a_capacity():
+    t = Target("emulator")
+    assert t.capacity_id is None
+    kw = {"json": {"displayName": "contoso-analytics"}}
+    t._complete_workspace_create("POST", t.api_root + "/workspaces", kw)
+    assert "capacityId" not in kw["json"]
+
+
+def test_a_get_is_not_a_create(monkeypatch):
+    t = _real(monkeypatch)
+    t._complete_workspace_create("GET", t.api_root + "/workspaces", {})  # must not raise

--- a/scripts/check_example_parity.py
+++ b/scripts/check_example_parity.py
@@ -77,6 +77,10 @@ PAIRS = [
             # The comparison lives with the dbt half and reads the pyspark
             # half's summary; only one copy can own it.
             "compare.py": "dbt-fabricspark only: reads both silver summaries",
+            # The pyspark half's silver IS a notebook definition submitted as a
+            # job; the dbt half's silver is a dbt project run over Livy. That is
+            # the axis these two examples exist to compare.
+            "definitions/silver.Notebook": "PySpark only: silver as a Notebook definition",
         },
         # `compare` is a real extra step, not a drifted one. Named here so the
         # sequence check still compares everything else in order.


### PR DESCRIPTION
Three changes, all on our side of the boundary. The medallion steps keep their contracts; the transform moves house.

**1. Silver is a Notebook definition, not a Spark Connect client.** `definitions/silver.Notebook/{.platform,notebook-content.py}` holds the transform; `silver.py` deploys it, submits `run_job(nb, "RunNotebook")`, and verifies the Delta tables that land with delta-rs. The emulator's Spark agent executes the cells locally; a Fabric pool executes the same cells on a tenant. This removes the `only_the_emulator_can` refusal that capped the example at step 5.

Assertions split deliberately: invariants of the transform (no duplicate order ids after the dedupe, the missing-email cohort survives) are asserted **inside** the notebook, because a failing cell fails the job and those need no fixture knowledge — a notebook runs on the pool, where the example's fixture package does not exist. The seeded generator's exact numbers are asserted **outside**, against the tables, which is the stronger check: a transform that computed the right answer and wrote it to the wrong place now fails. The reader is delta-rs rather than Spark on purpose, so a Spark-shaped misunderstanding of the Delta log cannot agree with itself.

**2. `require_vault()` instead of an import-time refusal.** The guard added in #165 blocked `provision.py` on a Key Vault it never touches, which also broke `real-fabric.yml`'s example-provisioning leg (it sets no vault and self-skips without secrets, so CI could not say so).

**3. `FABRIC_CAPACITY_ID`.** A real-Fabric workspace created with no capacity accepts the create and then rejects every item in it. The session completes a `POST /v1/workspaces` body with `capacityId` under `real` — the same completion it already does for the bearer token — and refuses when none is configured. `assignToCapacity` and item creates are untouched; the emulator has no capacity and is unaffected.

`lineage.py` now skips under `real`: the flow graph is the emulator's own record of what moved, and Purview is Fabric's answer to that question, reached differently. Mirrored across all four examples so the parity gate stays satisfied.

`docs/21` gains the runbook — commands, the per-step verdict, and the three Microsoft-side facts that decide whether it works (a trial capacity can only be assigned by the account that started the trial; a capacity-less workspace fails later; workspace identity works on trial).

**Verified:** `e2e/medallion` 11/11 exit 0 with silver running as a notebook job, producing byte-identical results (100,000 customers x 101 cols, 247,500 orders, 2,500 quarantined) and an unchanged lineage graph. 538 python tests, 27 fabric-target tests, lint, portability gate and parity gate clean.