### PR TITLE
The advanced example's silver runs as a Notebook job as well

### DIFF
--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -474,7 +474,19 @@ def report_lineage(step, moves):
     groups the code actually computes.
 
     Each read/write is an (item_id, path) pair, e.g. (lakehouse, "Tables/x").
+
+    SKIPPED under `real`, because there is nothing to tell. The flow graph is the
+    emulator's own record of what moved through it; real Fabric publishes no
+    endpoint that accepts a claim like this, and Purview — its answer to the same
+    question — is a different integration with a different model, not this call to
+    a different host. Skipping rather than refusing for the reason lineage.py
+    gives: the step's real work is the transform, and a graph the target does not
+    keep is not a result the pipeline needs.
     """
+    if _T.is_real:
+        log(f"skipping the {step} lineage report: the flow graph is the emulator's "
+            f"own record of what moved, and Purview is Fabric's counterpart")
+        return
     st = load()
     body = {"step": step, "moves": [
         {"reads": [{"itemId": i, "path": p} for i, p in reads],

--- a/examples/medallion-advanced-pyspark/definitions/silver.Notebook/.platform
+++ b/examples/medallion-advanced-pyspark/definitions/silver.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "silver",
+    "description": "Bronze to silver: dedupe on the vendor's event sequence, conform country codes and emails, quarantine malformed orders."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "3f7c9b14-52ad-4e6b-8c0f-91d5a2e7b643"
+  }
+}

--- a/examples/medallion-advanced-pyspark/definitions/silver.Notebook/notebook-content.py
+++ b/examples/medallion-advanced-pyspark/definitions/silver.Notebook/notebook-content.py
@@ -1,0 +1,102 @@
+# Fabric notebook source
+
+# CELL ********************
+
+# Silver: dedupe, conform, quarantine — the rules bronze deliberately does not
+# apply. Latest event wins per order, emails lower-cased, country codes
+# conformed, malformed rows quarantined rather than dropped.
+#
+# THIS IS A NOTEBOOK, AND THAT IS THE POINT. The transform used to live in
+# silver.py and dial Spark Connect, which no Fabric tenant exposes — so the step
+# ran locally and could not run in production. Here the code is a Notebook
+# DEFINITION, submitted as a job: the emulator's Spark agent executes it locally,
+# and real Fabric executes it on the workspace's starter pool. Same file, same
+# cells, both targets.
+#
+# `spark` is injected by the runtime, exactly as in a Fabric notebook. Nothing
+# here imports the example's fixture package: a notebook runs on the pool, where
+# only what the definition carries exists. The numbers this must produce are
+# asserted by silver.py against the tables that land, which is the stronger
+# check anyway — it verifies the artifact rather than an in-process DataFrame.
+
+from pyspark.sql import Window
+from pyspark.sql import functions as F
+
+# ABFS addresses OneLake by its full account host, as a Fabric notebook does.
+base = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables"
+
+
+def read(table):
+    return spark.read.format("delta").load(f"{base}/{table}")
+
+
+def write(df, table):
+    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+
+
+# Every spelling the vendor emits, keyed by its uppercased/stripped form. This is
+# silver's own business rule, written out rather than derived from the source
+# system's own variant table on purpose: sharing that mapping would make the
+# conformance check agree with itself, and a new variant appearing upstream would
+# silently conform instead of failing.
+COUNTRY = {
+    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
+    "GB": "GB", "U.K.": "GB", "UK": "GB", "GBR": "GB", "UNITED KINGDOM": "GB",
+    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
+}
+
+# --- customers ---------------------------------------------------------------
+# The Copy activity lands CSV as strings, so every column here is text; only the
+# ones silver actually reasons about get touched. Silver keeps the customer
+# record WIDE — narrowing to the columns gold needs would be the wrong place to
+# do it, because the star's dimensions are a projection of silver, not the
+# other way round.
+c = read("bronze_customers").dropDuplicates(["customer_id"])
+conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
+country_key = F.upper(F.trim(F.col("country")))
+silver_customers = (
+    c.withColumn("email", F.lower(F.trim(F.coalesce(F.col("email"), F.lit("")))))
+     .withColumn("country", F.coalesce(conform[country_key], country_key))
+)
+
+# --- orders ------------------------------------------------------------------
+# Latest event wins: rank each order's events by the vendor's own sequence and
+# keep the last. `dropDuplicates` would keep an ARBITRARY row per key — correct
+# only by luck, and silently wrong the day the redelivery carries a different
+# status.
+o = read("bronze_orders")
+latest = Window.partitionBy("order_id").orderBy(F.col("event_seq").desc())
+o = (o.withColumn("_rn", F.row_number().over(latest))
+      .filter(F.col("_rn") == 1)
+      .drop("_rn"))
+
+bad = (F.col("quantity") <= 0) | F.col("unit_price").isNull()
+quarantine = o.filter(bad)
+clean = (o.filter(~bad)
+          .withColumn("order_date", F.to_date("order_date"))
+          .withColumn("amount", F.col("quantity") * F.col("unit_price")))
+
+silver_orders = clean.select(
+    "order_id", "customer_id", "product_id", "order_date", "channel",
+    "store_id", "currency", "discount_pct", "tax_rate", "shipping_fee",
+    "payment_method", "is_gift", "promo_code", "quantity",
+    "unit_price", "amount", "status")
+
+write(silver_customers, "silver_customers")
+write(silver_orders, "silver_orders")
+write(quarantine, "silver_quarantine_orders")
+
+# Invariants of the TRANSFORM, asserted here because a failing cell fails the
+# job — and because these need no knowledge of the fixture's exact numbers, which
+# is what keeps this notebook runnable on any tenant. The row counts belong to
+# silver.py, which knows what the generator produced.
+n_orders = silver_orders.count()
+assert silver_orders.select("order_id").distinct().count() == n_orders, \
+    "silver_orders still has duplicate order ids after the dedupe"
+# The unresolvable people are still here, not quietly dropped: a resolution step
+# downstream claiming 100% would be lying, and this cohort is what proves it.
+assert silver_customers.filter(F.col("email") == "").count() > 0, \
+    "the missing-email cohort vanished"
+
+print(f"silver: {silver_customers.count()} customers, {n_orders} orders, "
+      f"{quarantine.count()} quarantined")

--- a/examples/medallion-advanced-pyspark/pipeline.py
+++ b/examples/medallion-advanced-pyspark/pipeline.py
@@ -26,7 +26,7 @@ BASIC = [
     ("extract_load", "extract from Contoso POS into Files/landing"),
     ("bronze", "a real DataPipeline: a Copy activity plus a Notebook activity"),
     ("engine", "Spark executes the queued notebook run and reports lineage"),
-    ("silver", "PySpark: dedupe, conform, quarantine"),
+    ("silver", "silver as a Notebook job, on whichever Spark the target has"),
     ("reflect", "reflect silver into the lakehouse SQL endpoint"),
     ("gold", "dbt-fabric builds the single-source star in the WAREHOUSE"),
     ("dq_gate", "verify the DQ gate rejects bad data"),

--- a/examples/medallion-advanced-pyspark/silver.py
+++ b/examples/medallion-advanced-pyspark/silver.py
@@ -1,147 +1,103 @@
-"""Silver: dedupe, conform, quarantine — the rules bronze deliberately does not
-apply. Latest event wins per order, emails lower-cased and case-folded, country
-codes conformed, malformed rows quarantined rather than dropped.
+"""Silver: deploy the transform as a NOTEBOOK, submit it, verify what landed.
 
-**This runs on Spark**, over Spark Connect against the engine `docker compose up`
-attaches (Sail). That is the point of the step as much as the transforms are:
-Lakehouse-to-Lakehouse ETL on Fabric is Spark work. This step used to read the
-Delta into pandas and transform on the client, which is a fine way to move ten
-thousand rows and the wrong shape entirely for a hundred million — the data
-never has to leave the lakehouse, and here it does not.
+The transform itself is `definitions/silver.Notebook/notebook-content.py`. This
+step deploys that definition and submits a `RunNotebook` job — which is the whole
+reason it is shaped this way.
+
+WHAT CHANGED AND WHY IT MATTERS. This step used to build the DataFrames here and
+dial Spark Connect directly. That works against the emulator, which attaches an
+engine (Sail) on a port, and it can never work against real Fabric, which exposes
+no Spark endpoint to dial: on Fabric, Spark runs INSIDE the service and the unit
+of work is a submitted job. So the step was portable in every respect except the
+one that mattered, and it refused under FABRIC_TARGET=real rather than pretend.
+Moving the code into a notebook definition removes the refusal: the emulator's
+Spark agent executes the cells locally, real Fabric executes the same cells on
+the workspace's starter pool (or a custom pool via an Environment), and neither
+this file nor the notebook changes between them.
+
+WHY THE ASSERTIONS LIVE HERE AND THE TRANSFORM DOES NOT. A notebook runs on the
+pool, where the example's fixture package does not exist — so the numbers the
+seeded generator implies cannot be checked in there. They are checked here, by
+reading the Delta tables the run produced. That is the stronger check: it
+verifies the ARTIFACT rather than an in-process DataFrame, so a transform that
+computed the right answer and wrote it to the wrong place still fails.
 
 The same transform written as **dbt-fabricspark models** is in
-`../medallion-dbt-fabricspark`, which builds the identical silver declaratively and then
-compares the two. Imperative Spark or declarative dbt is a real choice a Fabric
-team makes; neither example claims it is the only one.
-
-Silver keeps the customer record WIDE. Narrowing to the handful of columns gold
-needs would be the wrong place to do it: silver is the conformed customer-360,
-and the star's dimensions are a projection of it, not the other way round.
+`../medallion-advanced-dbt-fabricspark`, which builds the identical silver
+declaratively and then compares the two. Imperative Spark or declarative dbt is a
+real choice a Fabric team makes; neither example claims it is the only one.
 """
-import source_system as src
-from common import SPARK_REMOTE, load, log, only_the_emulator_can, report_lineage
+import json
+import pathlib
+import time
 
-# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
-# portability line falls. Real Fabric does not expose a Spark endpoint to dial
-# from outside: its compute runs the notebook. So this transform is portable only
-# once it LIVES in a notebook definition, which is a rewrite of where the code
-# sits rather than of what it does.
-only_the_emulator_can(
-    "driving Spark directly over Spark Connect",
-    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
-            "the service, on the workspace's starter pool or a custom pool chosen "
-            "through an Environment",
-    instead="move this transform into a Notebook definition under definitions/ and "
-            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
-            "accept; the Livy API "
-            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
-            "is the other route on real Fabric")
+import source_system as src
+from common import (
+    create_item_from_definition,
+    load,
+    log,
+    report_lineage,
+    run_job,
+    storage_options,
+    tables_uri,
+)
+from deltalake import DeltaTable
 
 st = load()
-assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"
 
-from pyspark.sql import SparkSession, Window  # noqa: E402
-from pyspark.sql import functions as F  # noqa: E402
+nb = create_item_from_definition(
+    "silver.Notebook", WORKSPACE_ID=st["workspace"], LAKEHOUSE_ID=st["lakehouse"])
 
-spark = SparkSession.builder.remote(SPARK_REMOTE).getOrCreate()
+# The build clock covers the submit and the run, which is what a reader comparing
+# engines cares about: the wall time from "go" to "silver exists".
+t0 = time.time()
+jid, status = run_job(nb, "RunNotebook")
+assert status == "Completed", f"silver notebook run {jid}: {status}"
+build_secs = time.time() - t0
 
-import time as _time  # noqa: E402
-
-_t0 = _time.time()  # build clock: the transform starts here
-
-base = (f"abfs://{st['workspace']}@onelake.dfs.fabric.microsoft.com"
-        f"/{st['lakehouse']}/Tables")
-
-
-def read(table):
-    return spark.read.format("delta").load(f"{base}/{table}")
-
-
-def write(df, table):
-    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+# --- verify what landed -------------------------------------------------------
+# delta-rs reads OneLake directly with a storage-audience token, independent of
+# whatever engine wrote the tables. Deliberately a different reader from the
+# writer: if both halves were Spark, a Spark-shaped misunderstanding of the Delta
+# log would agree with itself.
+opts = storage_options()
 
 
-# Every spelling the vendor emits, keyed by its uppercased/stripped form. This
-# is silver's own business rule, written out rather than derived from
-# source_system.COUNTRY_VARIANTS on purpose: importing the generator's mapping
-# would make the conformance assert agree with itself, and a new variant
-# appearing upstream would silently conform instead of failing here.
-COUNTRY = {
-    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
-    "GB": "GB", "U.K.": "GB", "UK": "GB", "GBR": "GB", "UNITED KINGDOM": "GB",
-    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
-}
+def table(name):
+    return DeltaTable(f"{tables_uri()}/{name}", storage_options=opts).to_pandas()
 
-# --- customers ---------------------------------------------------------------
-# The Copy activity lands CSV as strings, so every column here is text; only the
-# ones silver actually reasons about get touched.
-c = read("bronze_customers").dropDuplicates(["customer_id"])
-conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
-country_key = F.upper(F.trim(F.col("country")))
-silver_customers = (
-    c.withColumn("email", F.lower(F.trim(F.coalesce(F.col("email"), F.lit("")))))
-     .withColumn("country", F.coalesce(conform[country_key], country_key))
-)
 
-# --- orders ------------------------------------------------------------------
-# Latest event wins: rank each order's events by the vendor's own sequence and
-# keep the last. `dropDuplicates` would keep an ARBITRARY row per key — correct
-# only by luck, and silently wrong the day the redelivery carries a different
-# status.
-o = read("bronze_orders")
-latest = Window.partitionBy("order_id").orderBy(F.col("event_seq").desc())
-o = (o.withColumn("_rn", F.row_number().over(latest))
-      .filter(F.col("_rn") == 1)
-      .drop("_rn"))
+customers = table("silver_customers")
+orders = table("silver_orders")
+quarantine = table("silver_quarantine_orders")
 
-bad = (F.col("quantity") <= 0) | F.col("unit_price").isNull()
-quarantine = o.filter(bad)
-clean = (o.filter(~bad)
-          .withColumn("order_date", F.to_date("order_date"))
-          .withColumn("amount", F.col("quantity") * F.col("unit_price")))
-
-silver_orders = clean.select(
-    "order_id", "customer_id", "product_id", "order_date", "channel",
-    "store_id", "currency", "discount_pct", "tax_rate", "shipping_fee",
-    "payment_method", "is_gift", "promo_code", "quantity",
-    "unit_price", "amount", "status")
-
-write(silver_customers, "silver_customers")
-write(silver_orders, "silver_orders")
-write(quarantine, "silver_quarantine_orders")
-
-n_customers = silver_customers.count()
-n_orders = silver_orders.count()
-n_quarantine = quarantine.count()
-countries = {r["country"] for r in silver_customers.select("country").distinct().collect()}
+n_customers, n_orders, n_quarantine = len(customers), len(orders), len(quarantine)
+countries = set(customers["country"].unique())
 
 assert n_customers == src.EXPECTED_SILVER_CUSTOMERS, n_customers
 assert n_orders == src.EXPECTED_SILVER_ORDERS, n_orders
 assert n_quarantine == src.EXPECTED_QUARANTINED, n_quarantine
 assert countries == src.EXPECTED_COUNTRIES, countries
-assert len(silver_customers.columns) == src.EXPECTED_CUSTOMER_COLUMNS, silver_customers.columns
-assert silver_orders.select("order_id").distinct().count() == n_orders, \
-    "silver_orders still has duplicate order ids"
-# The unresolvable people are still here, not quietly dropped — web_bronze.py
-# depends on them existing to prove a resolution step that claims 100% is lying.
-assert silver_customers.filter(F.col("email") == "").count() > 0, \
-    "the missing-email cohort vanished"
+assert len(customers.columns) == src.EXPECTED_CUSTOMER_COLUMNS, list(customers.columns)
+assert orders["order_id"].nunique() == n_orders, "silver_orders still has duplicate order ids"
+# The unresolvable people are still here, not quietly dropped — the resolution
+# step in the advanced example depends on them existing to prove that a claim of
+# 100% is a lie. The notebook asserts this too; both are cheap and the failure
+# reads differently from each side.
+assert (customers["email"] == "").sum() > 0, "the missing-email cohort vanished"
 
-log(f"silver (PySpark): {n_customers:,} customers x {len(silver_customers.columns)} cols, "
-    f"{n_orders:,} orders, {n_quarantine:,} quarantined")
+log(f"silver (notebook on the target's own Spark): {n_customers:,} customers x "
+    f"{len(customers.columns)} cols, {n_orders:,} orders, {n_quarantine:,} quarantined")
 
 # A machine-readable summary of what this tool produced, so
 # ../medallion-dbt-fabricspark can compare its declarative build against this
 # imperative one without either example importing the other's code.
-import json  # noqa: E402
-import pathlib  # noqa: E402
-
 pathlib.Path(__file__).resolve().parent.joinpath("silver_summary.json").write_text(
     json.dumps({
-        "engine": "PySpark (Spark Connect)",
+        "engine": "PySpark (Notebook job)",
         "target": "Lakehouse (Delta in OneLake)",
-        "compute": "Sail (Rust Spark Connect, no JVM)",
-        "build_seconds": round(_time.time() - _t0, 2),
+        "compute": "the target's own Spark: agent-driven Sail locally, a Fabric pool on real",
+        "build_seconds": round(build_secs, 2),
         "rows": {"silver_customers": n_customers, "silver_orders": n_orders,
                  "silver_quarantine_orders": n_quarantine},
         # Empty, and that is the finding rather than an omission: Spark SQL
@@ -150,15 +106,15 @@ pathlib.Path(__file__).resolve().parent.joinpath("silver_summary.json").write_te
         "dialect_adaptations": [],
     }, indent=2))
 
-# The flow graph's bronze → silver hop. PySpark writes Delta straight to
+# The flow graph's bronze -> silver hop. The notebook writes Delta straight to
 # OneLake, so the emulator sees every byte and every table version — but not
 # which input produced which output. This step is the only thing that knows.
 #
 # Two movements, not one cross product: the conformed customers come from the
-# customer export alone, and both order tables — clean and quarantined — are
-# the two halves of the same order export. Reporting one reads/writes pair
-# would claim bronze_customers produced the quarantine, which it did not.
-_lake = load()["lakehouse"]
+# customer export alone, and both order tables — clean and quarantined — are the
+# two halves of the same order export. Reporting one reads/writes pair would
+# claim bronze_customers produced the quarantine, which it did not.
+_lake = st["lakehouse"]
 report_lineage("silver", [
     ([(_lake, "Tables/bronze_customers")], [(_lake, "Tables/silver_customers")]),
     ([(_lake, "Tables/bronze_orders")],

--- a/scripts/check_example_parity.py
+++ b/scripts/check_example_parity.py
@@ -93,6 +93,9 @@ PAIRS = [
         "only_in": {
             "check_wh.py": "PySpark only: warehouse probe",
             "compare.py": "dbt-fabricspark only: reads both halves' summaries",
+            # Same axis as the simple pair: this half's silver is a Notebook
+            # definition submitted as a job, the other half's is a dbt project.
+            "definitions/silver.Notebook": "PySpark only: silver as a Notebook definition",
         },
         "extra_steps_in_b": ["compare"],
     },


### PR DESCRIPTION
Follows #166, same conversion applied to `medallion-advanced-pyspark`.

- `definitions/silver.Notebook/` holds the transform; `silver.py` deploys it, submits `run_job(nb, "RunNotebook")`, and verifies the Delta tables with delta-rs.
- The step keeps the flow-graph hop it owns: the emulator sees every byte a notebook writes but not which input produced which output, so the code that knows still says so.
- **`report_lineage()` now skips under `real` in the resolver**, not at each caller. It POSTs to the emulator's own lineage endpoint; real Fabric publishes nothing that accepts a claim like that, and Purview is a different integration rather than the same call to a different host. One change covers `silver.py`, `star_silver.py` and `semantic_model.py` in both advanced examples.

`star_silver.py` still refuses under `real`, deliberately and not for lack of trying: its assertions depend on quantities that exist only inside the transform (how many phone keys were too ambiguous to match on, the ERP and web input totals), and `compare.py` asserts on them across the pair. Returning those from a notebook needs a channel — the portable one is a one-row metrics table in the lakehouse, since a job's exit value is not something real Fabric exposes for a REST-submitted run. That is the next PR rather than a guess inside this one.

**Verified:** `e2e/medallion-advanced` 23/23 exit 0, silver producing identical numbers (100,000 customers x 101 cols, 247,500 orders, 2,500 quarantined) and still recording its 3 lineage edges. Lint, parity and portability gates clean, 538 python tests.