### PR TITLE
Close the remaining portability gaps: star_silver, the SQL sync, and an honest gate

### DIFF
--- a/docs/21-real-fabric-toggle.md
+++ b/docs/21-real-fabric-toggle.md
@@ -240,7 +240,37 @@ Then, with a Key Vault, the next three steps in order: `secret.py`,
 | `semantic_model.py` | publishes and queries the model over `executeQueries` | — |
 | `lineage.py` | **skips** | the flow graph is the emulator's own record; Purview is Fabric's answer and a different integration |
 
-Three facts that decide whether this works, all Microsoft's rather than ours:
+**Verified against a real trial on 2026-08-11**, and every one of these was a
+code-reading until then:
+
+```
+==> provisioned workspace=f2c82a4e-… lakehouse=450d5027-… warehouse=c6c4ba99-…
+lakehouse  server=<opaque>-<opaque>.datawarehouse.fabric.microsoft.com
+           database='lake' encrypt=True endpoint_id=803c8e33-…
+warehouse  same server, database='dw' encrypt=True endpoint_id=None
+```
+
+Four things that only a real run could establish:
+
+1. **`FABRIC_CAPACITY_ID` works**: the workspace came up with the trial capacity
+   assigned, from an unmodified example.
+2. **A Warehouse create is ASYNCHRONOUS on real Fabric** — 202 with an operation
+   and no body, where the emulator answers 201 with the item. `provision.py` read
+   `None["id"]` and failed three calls after the assumption that caused it. Every
+   create now resolves an operation when one is offered (`post_and_wait`).
+3. **`AZURE_TENANT_ID` did not reach the `az` CLI credential.**
+   `DefaultAzureCredential` takes tenant hints for the browser, VS Code,
+   shared-cache and workload-identity links and has none for the CLI, so a
+   developer whose `az` default tenant differs from the configured one got tokens
+   for the wrong tenant — and Fabric answered `UserNotLicensed`, which reads as a
+   licensing problem rather than a tenant one. Fixed in `fabric_target`.
+4. **The lakehouse's `sqlEndpointProperties.id` is a DIFFERENT GUID from the
+   lakehouse** (`803c8e33…` vs `450d5027…`), and a Warehouse has none. That
+   confirms the emulator is right to omit the field rather than report the
+   lakehouse id: code using it as an endpoint id would work locally and address
+   the wrong thing on a tenant.
+
+Three more facts that decide whether this works, all Microsoft's rather than ours:
 
 - **A trial capacity can only be assigned by the account that started the
   trial.** A service principal cannot, so use `az login` as that user. CI uses an

--- a/docs/46-artifact-persistence.md
+++ b/docs/46-artifact-persistence.md
@@ -124,9 +124,24 @@ missing half of the target. A step that drives Spark Connect **directly** is
 emulator-only by construction. That is why `silver.py` no longer does it: its
 transform lives in `definitions/silver.Notebook/` and is submitted with
 `run_job(nb, "RunNotebook")`, so the emulator's agent executes it locally and a
-Fabric pool executes the same cells on a tenant. `engine.py` skips under `real`
-(Fabric runs the queued notebook itself), and `star_silver.py` in the advanced
-examples still refuses, because that transform has not been moved yet.
+Fabric pool executes the same cells on a tenant. `star_silver.py` in the advanced examples
+moved the same way, and needed one thing more: its assertions depend on
+quantities that exist only inside the transform (how many keys were too ambiguous
+to match on, the ERP and web input totals), and a notebook has no way to return
+those — real Fabric exposes no exit value for a REST-submitted run. So the
+notebook writes them as a one-row Delta table, `silver_resolution_metrics`, which
+is portable by construction and inspectable afterwards. `engine.py` skips under
+`real`, because Fabric runs the queued notebook itself.
+
+**What is still emulator-only, stated rather than left to be discovered:** a
+semantic model's rows. `semantic_model.py` and `tmdl_pbip.py` publish a `data.json`
+part — the emulator's inline row snapshot. Real Fabric has no such part; a model's
+data comes from a partition, either Direct Lake over OneLake Delta or an import
+partition whose M expression reads `Sql.Database(<connectionString>, …)`. The
+emulator evaluates Direct Lake and inline data, not `Sql.Database` import, and the
+warehouse's gold tables are not Delta in OneLake locally — so converting needs
+emulator work first, and `scripts/check_example_portability.py` prints the debt on
+every run instead of hiding it in a whitelist.
 
 ### SQL: the address is per-item and only the API knows it
 

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -222,7 +222,7 @@ def tables_uri():
 # (docs/46-artifact-persistence.md).
 _SQL_COLLECTION = {"Warehouse": "warehouses", "SQLDatabase": "sqlDatabases",
                    "Lakehouse": "lakehouses"}
-SqlTarget = collections.namedtuple("SqlTarget", "server database encrypt")
+SqlTarget = collections.namedtuple("SqlTarget", "server database encrypt endpoint_id")
 _SQL_CACHE = {}
 
 
@@ -270,38 +270,79 @@ def sql_endpoint(item_id):
     collection = _SQL_COLLECTION.get(item["type"])
     assert collection, f"item {item['displayName']!r} is a {item['type']}, which has no SQL endpoint"
 
-    server = TDS_SERVER
-    if not server:
-        r = S.get(f"{base}/{collection}/{item_id}", headers=H)
-        r.raise_for_status()
-        props = r.json().get("properties") or {}
-        if item["type"] == "Lakehouse":
-            ep = props.get("sqlEndpointProperties") or {}
-            # Real Fabric provisions the analytics endpoint asynchronously, so a
-            # status that is not Success is a wait-or-fail, not a missing feature.
-            # Saying which beats a connection timeout that names nothing. Only
-            # when the property is THERE, though: absent means this build serves
-            # no SQL at all, which the no-endpoint branch below explains better.
-            if ep:
-                assert ep.get("provisioningStatus") == "Success", (
-                    f"the SQL analytics endpoint of {item['displayName']!r} is "
-                    f"{ep['provisioningStatus']}; it cannot be queried yet")
-            server = ep.get("connectionString")
-        else:
-            server = props.get("connectionString")
-        assert server, (
-            f"{item['type']} {item['displayName']!r} advertises no SQL endpoint. "
-            f"Locally that means the stack runs without its SQL sidecar; set "
-            f"TDS_SERVER to override.")
-        server = _odbc_server(server)
+    # The typed route is asked even when TDS_SERVER overrides the address: the
+    # endpoint id is a different fact from the host, and sync_sql_endpoint needs it.
+    server, endpoint_id = TDS_SERVER, None
+    r = S.get(f"{base}/{collection}/{item_id}", headers=H)
+    r.raise_for_status()
+    props = r.json().get("properties") or {}
+    if item["type"] == "Lakehouse":
+        ep = props.get("sqlEndpointProperties") or {}
+        # Real Fabric's analytics endpoint is a SQLEndpoint item with its own
+        # id, which is what refreshMetadata is addressed by. The emulator has
+        # no such item and reflects on connect, so it reports no id and
+        # sync_sql_endpoint takes the other branch.
+        endpoint_id = ep.get("id")
+        # Real Fabric provisions the analytics endpoint asynchronously, so a
+        # status that is not Success is a wait-or-fail, not a missing feature.
+        # Saying which beats a connection timeout that names nothing. Only
+        # when the property is THERE, though: absent means this build serves
+        # no SQL at all, which the no-endpoint branch below explains better.
+        if ep:
+            assert ep.get("provisioningStatus") == "Success", (
+                f"the SQL analytics endpoint of {item['displayName']!r} is "
+                f"{ep['provisioningStatus']}; it cannot be queried yet")
+        server = server or ep.get("connectionString")
+    else:
+        server = server or props.get("connectionString")
+    assert server, (
+        f"{item['type']} {item['displayName']!r} advertises no SQL endpoint. "
+        f"Locally that means the stack runs without its SQL sidecar; set "
+        f"TDS_SERVER to override.")
+    server = _odbc_server(server)
 
     _SQL_CACHE[item_id] = SqlTarget(
         server=server,
+        endpoint_id=endpoint_id,
         database=item["displayName"] if _T.is_real else item_id,
         # Real Fabric's endpoint requires TLS. The emulator's TDS front
         # terminates FedAuth without it (it advertises ENCRYPT_NOT_SUP).
         encrypt=_T.is_real)
     return _SQL_CACHE[item_id]
+
+
+def sync_sql_endpoint(item_id):
+    """Make a lakehouse's SQL analytics endpoint see the CURRENT Delta state.
+
+    THE MECHANISM DIFFERS BY TARGET, AND THAT IS THE WHOLE REASON THIS EXISTS.
+
+    The emulator reflects on connect: opening a session makes it read each
+    `Tables/<t>` Delta and rebuild the SQL view, so "connect" and "sync" are the
+    same act. Steps relied on that — `dq_gate.py` opened a throwaway connection
+    with the comment "re-reflect whatever silver now holds" — and on real Fabric
+    that is a NO-OP with a plausible shape: the analytics endpoint syncs on its
+    own schedule, normally under a minute, so a table Spark just wrote can be
+    briefly absent and the step reads stale data instead of failing. A silent
+    wrong answer, which is the worst kind.
+
+    Real Fabric's explicit lever is
+    `POST /v1/workspaces/{ws}/sqlEndpoints/{sqlEndpointId}/refreshMetadata`, and
+    it is addressed by the ENDPOINT's id — a separate SQLEndpoint item, which the
+    emulator does not have and does not report. So the absence of that id is
+    exactly the signal that the connect-to-reflect path is the right one here.
+    """
+    t = sql_endpoint(item_id)
+    if not t.endpoint_id:
+        with tds_connect(item_id):  # connecting IS the sync locally
+            pass
+        return
+    st = load()
+    r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/sqlEndpoints/"
+               f"{t.endpoint_id}/refreshMetadata", headers=fabric_headers(), json={})
+    # 200 with a per-table report, or a 202 whose operation must be followed.
+    assert r.status_code in (200, 202), f"refreshMetadata: {r.status_code} {r.text}"
+    _T.poll_lro(r)
+    log(f"SQL analytics endpoint {t.endpoint_id} metadata refreshed")
 
 
 def tds_connect(item_id, token_value=None, timeout=60):

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -425,6 +425,43 @@ def create_item_from_definition(folder, display_name=None, **substitutions):
     return create_item(display_name or name, item_type, parts)
 
 
+def post_and_wait(url, body):
+    """POST a create and return the created object, resolving a 202 if there is one.
+
+    FOUND BY RUNNING IT ON A REAL TENANT, which is the only way this class of bug
+    surfaces. Real Fabric creates a **Warehouse asynchronously**: it answers 202
+    with an operation id and NO body, where the emulator answers 201 with the item.
+    `provision.py` assumed the 201 and did `None["id"]` against a trial — after
+    the workspace and lakehouse had already been created, so the failure was three
+    calls away from the assumption that caused it.
+
+    Every Fabric create can be async; which ones ARE is a service decision that
+    can change. So this resolves the operation whenever one is offered rather than
+    per item type, which is also what fabric-cicd does.
+    """
+    import time
+
+    H = fabric_headers()
+    r = S.post(url, headers=H, json=body)
+    assert r.status_code in (200, 201, 202), f"{url} -> {r.status_code} {r.text}"
+    if r.status_code != 202:
+        return r.json()
+    op = r.headers.get("x-ms-operation-id") \
+        or r.headers["Location"].rstrip("/").rsplit("/", 1)[-1]
+    for _ in range(150):
+        got = S.get(f"{FABRIC}/v1/operations/{op}", headers=H)
+        status = (got.json() or {}).get("status")
+        if status in ("Succeeded", "Failed"):
+            break
+        # Honour the service's own pacing when it states one: real creates take
+        # real seconds, and polling faster than asked earns a 429.
+        time.sleep(min(float(got.headers.get("Retry-After", "2")), 20))
+    else:
+        raise SystemExit(f"{url}: operation {op} never reached a terminal state")
+    assert status == "Succeeded", f"{url}: operation {op} {status}"
+    return S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()
+
+
 def create_item(display_name, item_type, parts):
     """Create an item with a definition, resolving the LRO if the create is async."""
     import base64

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/star-silver.Notebook/.platform
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/star-silver.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "star-silver",
+    "description": "Materialise the identity resolution: the crosswalk, the conformed dimension, the web fact grain, and the input metrics."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "8d4a1c67-2b95-4f03-ae18-56c7092fb3d1"
+  }
+}

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/star-silver.Notebook/notebook-content.py
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/star-silver.Notebook/notebook-content.py
@@ -1,0 +1,243 @@
+# Fabric notebook source
+
+# CELL ********************
+
+# Materialise the identity resolution, so gold has a key to join on.
+#
+# `resolve.py` computes the identity graph, asserts it and writes nothing — the
+# resolution exists there as a PROOF. A proof is not a table, and gold cannot join
+# three sources on an argument. This notebook turns it into two tables plus the
+# web fact grain, and a fourth table nobody joins:
+#
+#   * `silver_customer_xref`         — (source_system, source_id) -> customer_key
+#   * `silver_customer_conformed`    — one row per customer_key, attributes survived
+#   * `silver_web_order_lines`       — clean web lines carrying customer_key
+#   * `silver_resolution_metrics`    — one row: what the INPUTS looked like
+#
+# THAT FOURTH TABLE IS WHY THIS IS A NOTEBOOK AND NOT A SCRIPT, so it is worth
+# being explicit. The transform used to run in star_silver.py over Spark Connect,
+# which no Fabric tenant exposes. Moving it into a notebook definition is what
+# makes it run on a real pool — but the step's assertions need quantities that
+# only exist INSIDE the transform: how many phone keys were too ambiguous to match
+# on, how many ERP and web accounts came in. A notebook cannot return those
+# through a job (real Fabric exposes no exit value for a REST-submitted run), and
+# inventing an emulator-only channel would give us a green local test and nothing
+# on a tenant. So they are written where every other output goes: a Delta table in
+# the lakehouse. Portable by construction, and inspectable long after the run.
+#
+# `spark` is injected by the runtime. Nothing here imports the example's fixture
+# package: a notebook runs on the pool, where only what the definition carries
+# exists. Every assertion below is therefore an invariant of the TRANSFORM; the
+# numbers the seeded generator implies are asserted by star_silver.py against
+# these tables.
+
+from pyspark.sql import functions as F
+
+base = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables"
+
+
+def read(table):
+    return spark.read.format("delta").load(f"{base}/{table}")
+
+
+def write(df, table):
+    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+
+
+def key(namespace, col):
+    """A stable surrogate over a namespaced identity."""
+    return F.sha2(F.concat(F.lit(namespace + ":"), col), 256)
+
+
+# Country, conformed across FOUR spelling conventions.
+#
+# silver.py conforms POS's five variants and stops there, because POS is all it
+# sees. Survivorship then used to coalesce that conformed value with the web
+# store's RAW one, so `country` in the resolved dimension held ISO-2 for anyone
+# POS knew, "United States" for the web-only, and NULL for the ERP-only —
+# because ERP's country was never even selected. Three answers to one question,
+# in the column whose entire job is to have one answer.
+#
+# Written out here rather than imported from the fixtures, for the reason
+# silver.py gives: a rule derived from the generator's own COUNTRY_VARIANTS
+# agrees with itself by construction, and a new upstream variant would conform
+# silently instead of failing. Duplicated from silver.py for the same reason it
+# is duplicated into the dbt model — it is silver's business rule, and silver
+# has more than one implementation.
+COUNTRY = {
+    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
+    "GB": "GB", "GBR": "GB", "U.K.": "GB", "UK": "GB", "UNITED KINGDOM": "GB",
+    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
+}
+_conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
+
+
+def conform_country(col):
+    """ISO-3166 alpha-2, or the upper-cased input if the rule does not know it.
+
+    Falling through unchanged rather than to NULL is deliberate: an unknown
+    spelling must stay visible so the assertion below fails on it, instead of
+    being quietly erased into "we have no country for this person".
+    """
+    k = F.upper(F.trim(col))
+    return F.coalesce(_conform[k], k)
+
+
+# --- the spine ---------------------------------------------------------------
+pos = (read("silver_customers")
+       .select("customer_id", "name", "email", "country", "phone")
+       # silver already lower-cased and trimmed email; "" is the missing marker
+       # rather than NULL, and it must NOT be treated as a joinable value.
+       .withColumn("email_key", F.when(F.col("email") != "", F.col("email")))
+       .withColumn("phone_key", F.trim(F.col("phone").cast("string")))
+       .withColumn("customer_key", key("pos", F.col("customer_id"))))
+
+web_c = (read("bronze_web_customers")
+         .select(F.lower(F.trim("email")).alias("email_key"),
+                 F.col("full_name"),
+                 conform_country(F.col("country")).alias("web_country")))
+
+# ERP's country comes through CONFORMED like the others, where it used to be
+# dropped on the floor. ERP spells countries ISO-3 (USA/GBR/SGP) — a fourth
+# convention — and an ERP-only customer is someone no other system has ever
+# seen, so this column is the only place their country can come from.
+erp_now = (read("dim_customer_scd2").filter(F.col("is_current"))
+           .select("erp_customer_id", "legal_name", "account_tier", "segment",
+                   "credit_band", conform_country(F.col("country")).alias("erp_country"),
+                   F.trim(F.col("phone").cast("string")).alias("phone_key")))
+
+# An AMBIGUOUS key is not a match.
+#
+# POS phone numbers are not unique — the generator collides on a handful out of
+# 100,000, which is realistic and would be far more common in a real CRM. If an
+# ERP account's phone matches several POS customers, we cannot say WHICH person
+# it is, and joining anyway does two bad things at once: it fans the row out, so
+# one source record acquires several customer_keys and every downstream
+# aggregate double-counts; and it asserts an identity nobody established.
+#
+# So a key that is not unique on the POS side is excluded from matching. The
+# affected records then key on their own identity and join the unresolved
+# cohorts, which is what resolve.py already says about people it cannot place.
+# Guessing would be worse than not matching: a wrong merge is invisible, while
+# an unmatched record is counted and reported.
+def unambiguous(df, col):
+    """The values of `col` that identify exactly one POS customer."""
+    return (df.filter(F.col(col).isNotNull())
+              .groupBy(col).agg(F.count("*").alias("_n"), F.first("customer_key").alias("customer_key"))
+              .filter(F.col("_n") == 1)
+              .select(col, "customer_key"))
+
+
+pos_by_email = unambiguous(pos, "email_key")
+pos_by_phone = unambiguous(pos, "phone_key")
+
+# Left joins from web/erp onto those, never the reverse: a POS customer with no
+# web or ERP counterpart must keep their key.
+web_keyed = (web_c.join(pos_by_email, "email_key", "left")
+             .withColumn("customer_key",
+                         F.coalesce(F.col("customer_key"), key("web", F.col("email_key")))))
+
+erp_keyed = (erp_now.join(pos_by_phone, "phone_key", "left")
+             .withColumn("customer_key",
+                         F.coalesce(F.col("customer_key"), key("erp", F.col("erp_customer_id")))))
+
+# --- the crosswalk -----------------------------------------------------------
+xref = (
+    pos.select(F.lit("contoso_pos").alias("source_system"),
+               F.col("customer_id").alias("source_id"), "customer_key")
+    .unionByName(web_keyed.select(F.lit("contoso_web").alias("source_system"),
+                                  F.col("email_key").alias("source_id"), "customer_key"))
+    .unionByName(erp_keyed.select(F.lit("contoso_erp").alias("source_system"),
+                                  F.col("erp_customer_id").alias("source_id"), "customer_key"))
+)
+
+# --- survivorship ------------------------------------------------------------
+# Which system wins is a business decision, so it is written down rather than
+# implied by a join order. Web is where a customer maintains their own profile;
+# POS is a till system capturing whatever the cashier typed; ERP holds the legal
+# and commercial truth and nothing else does.
+#
+# Falling THROUGH a null is the rule that matters: a higher-priority source that
+# simply does not hold an attribute must not blank out one that does.
+conformed = (
+    pos.select("customer_key", "customer_id", "name", "email", "country", "phone")
+    .join(web_keyed.select("customer_key", "full_name", "web_country"), "customer_key", "full_outer")
+    .join(erp_keyed.select("customer_key", "legal_name", "account_tier", "segment",
+                           "credit_band", "erp_country"),
+          "customer_key", "full_outer")
+    .select(
+        "customer_key",
+        F.coalesce("full_name", "name", "legal_name").alias("name"),
+        F.when(F.col("email") != "", F.col("email")).alias("email"),
+        # POS first, then web, then ERP — all three now conformed, so the
+        # precedence decides WHOSE ANSWER wins rather than which spelling
+        # survives. ERP is appended rather than inserted: it can only fill rows
+        # where neither of the other two holds a country, so no existing value
+        # changes hands and the only rows affected are the ERP-only, which were
+        # NULL before.
+        F.coalesce("country", "web_country", "erp_country").alias("country"),
+        "phone", "account_tier", "segment", "credit_band",
+        F.col("customer_id").isNotNull().alias("in_pos"),
+        F.col("full_name").isNotNull().alias("in_web"),
+        F.col("legal_name").isNotNull().alias("in_erp"))
+    .withColumn("source_count",
+                F.col("in_pos").cast("int") + F.col("in_web").cast("int")
+                + F.col("in_erp").cast("int"))
+)
+
+# --- the web fact grain ------------------------------------------------------
+# Cancelled orders and lines pointing at a product the catalogue does not carry
+# are excluded from the FACT, not deleted: bronze still holds every one of them.
+products = read("bronze_web_products").select("product_id")
+lines = read("bronze_web_order_lines")
+web_lines = (
+    lines.join(F.broadcast(products), "product_id", "left_semi")
+         .filter(F.col("order_status") != "cancelled")
+         .withColumn("email_key", F.lower(F.trim("email")))
+         .join(xref.filter(F.col("source_system") == "contoso_web")
+                   .select(F.col("source_id").alias("email_key"), "customer_key"),
+               "email_key", "left")
+         # placed_at carries a source offset; normalise to UTC so a day means
+         # one thing across channels. Some orders change calendar day here, and
+         # that is the correct answer rather than a rounding artefact.
+         .withColumn("order_date", F.to_date(F.to_utc_timestamp(F.col("placed_at"), "UTC")))
+         .withColumn("amount", F.col("quantity") * F.col("unit_price"))
+         .select("web_order_id", "line_no", "customer_key", "product_id", "order_date",
+                 "quantity", "unit_price", "amount",
+                 F.lit("web").alias("channel"))
+)
+
+write(xref, "silver_customer_xref")
+write(conformed, "silver_customer_conformed")
+write(web_lines, "silver_web_order_lines")
+
+# --- invariants of the transform ---------------------------------------------
+# Asserted here because a failing cell fails the job, and because none of these
+# needs to know what the generator produced.
+
+# Every source record maps to exactly one key, or the crosswalk is not a function
+# and every downstream join fans out.
+assert xref.count() == xref.select("source_system", "source_id").distinct().count(), \
+    "a source record resolves to more than one customer_key"
+assert conformed.select("customer_key").distinct().count() == conformed.count(), \
+    "silver_customer_conformed is not one row per customer_key"
+assert web_lines.filter(F.col("customer_key").isNull()).count() == 0, \
+    "a web order line does not resolve to a customer"
+
+# --- what the inputs looked like ---------------------------------------------
+# One row, written as Delta like everything else. `amb_*` are the keys shared by
+# more than one POS customer: a match nobody could safely make, which must be
+# COUNTED rather than absorbed into a match rate. star_silver.py turns these into
+# the assertions that need the fixture, and into what compare.py reads.
+# An explicit schema rather than dict inference: one row is the case where
+# inference buys nothing and engines disagree most.
+metrics = spark.createDataFrame(
+    [(erp_now.count(), web_c.count(),
+      pos.filter(F.col("email_key").isNotNull()).count(), pos_by_email.count(),
+      pos.filter(F.col("phone_key").isNotNull()).count(), pos_by_phone.count())],
+    "erp_current long, web_customers long, pos_email_present long, "
+    "pos_email_unambiguous long, pos_phone_present long, pos_phone_unambiguous long")
+write(metrics, "silver_resolution_metrics")
+
+print(f"materialised {xref.count()} xref rows, {conformed.count()} identities, "
+      f"{web_lines.count()} web order lines")

--- a/examples/medallion-advanced-dbt-fabricspark/dq_gate.py
+++ b/examples/medallion-advanced-dbt-fabricspark/dq_gate.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 
 import pandas as pd
-from common import GOLD_PROJECT, load, log, storage_options, tables_uri, tds_connect
+from common import GOLD_PROJECT, load, log, storage_options, sync_sql_endpoint, tables_uri
 from deltalake import DeltaTable, write_deltalake
 
 st = load()
@@ -18,8 +18,12 @@ env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakeh
 
 
 def rebuild():
-    with tds_connect(st["lakehouse"]):  # re-reflect whatever silver now holds
-        pass
+    # Make the SQL endpoint see what silver now holds. NOT a throwaway connection:
+    # connect-to-reflect is the emulator's behaviour, and on real Fabric the
+    # analytics endpoint syncs on its own schedule — so a connection would return
+    # STALE rows and this gate would pass on data it never rebuilt. The resolver
+    # picks the mechanism the target actually has (docs/46).
+    sync_sql_endpoint(st["lakehouse"])
     return subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 
 

--- a/examples/medallion-advanced-dbt-fabricspark/provision.py
+++ b/examples/medallion-advanced-dbt-fabricspark/provision.py
@@ -1,16 +1,19 @@
 """Provision the workspace, lakehouse, warehouse, and workspace identity."""
-from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, save
+from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, post_and_wait, save
 
 H = fabric_headers()
 
 
 def create(url, body):
-    """Fail loudly with the emulator's error, not a KeyError three lines later.
+    """Fail loudly with the target's error, not a KeyError three lines later.
     Display names are unique per workspace, so a second run on a dirty stack
-    lands here — see Cleanup in the tutorial."""
-    r = S.post(url, headers=H, json=body)
-    assert r.status_code in (200, 201, 202), f"{url} -> {r.status_code} {r.text}"
-    return r.json()
+    lands here — see Cleanup in the tutorial.
+
+    `post_and_wait` because real Fabric creates a Warehouse ASYNCHRONOUSLY: 202
+    with an operation and no body, where a development stack answers 201 with the
+    item. Reading `.json()["id"]` off that 202 is a TypeError on a tenant and
+    nothing locally — found by running this against a real trial."""
+    return post_and_wait(url, body)
 
 
 ws = create(f"{FABRIC}/v1/workspaces", {"displayName": WORKSPACE_NAME})

--- a/examples/medallion-advanced-dbt-fabricspark/reflect.py
+++ b/examples/medallion-advanced-dbt-fabricspark/reflect.py
@@ -7,11 +7,17 @@ read-only, refreshed on every connect.
 import time
 
 import source_system as src
-from common import SQL_AUD, ensure_app, load, log, tds_connect, token
+from common import SQL_AUD, ensure_app, load, log, sync_sql_endpoint, tds_connect, token
 
 st = load()
 ensure_app(SQL_AUD, "Azure SQL")
 sql_tok = token(SQL_AUD)
+
+# Ask the endpoint to catch up with the Delta silver just wrote. Locally that is
+# the connect itself; on real Fabric it is refreshMetadata, because the endpoint
+# syncs asynchronously and a query can otherwise read a table that is not there
+# yet — or worse, an older version of one that is (docs/46).
+sync_sql_endpoint(st["lakehouse"])
 
 # The first connect makes the emulator create and start the per-item database on
 # the sidecar, which can be slow — retry until it is online.

--- a/examples/medallion-advanced-dbt-fabricspark/star_silver.py
+++ b/examples/medallion-advanced-dbt-fabricspark/star_silver.py
@@ -8,6 +8,20 @@ fact grain:
   * `silver_customer_xref`      — (source_system, source_id) -> customer_key
   * `silver_customer_conformed` — one row per customer_key, attributes survived
   * `silver_web_order_lines`    — clean web lines carrying customer_key
+  * `silver_resolution_metrics` — one row describing what the INPUTS held
+
+THE TRANSFORM IS A NOTEBOOK: `definitions/star-silver.Notebook/`. It used to run
+here over Spark Connect, which no Fabric tenant exposes, so this step could never
+have run in production. Now it deploys the definition, submits a `RunNotebook`
+job, and asserts against the tables that land — verifying the artifact rather than
+a DataFrame it built itself.
+
+The metrics table is how the numbers this step needs get out of the notebook. Its
+assertions depend on quantities that exist only INSIDE the transform (how many
+phone keys were shared by more than one POS customer, how many ERP and web
+accounts arrived), and a notebook cannot return those through a job: real Fabric
+exposes no exit value for a REST-submitted run. A Delta table is portable by
+construction, and materialising run metrics is something real teams do anyway.
 
 POS is the spine, and not by preference: every edge runs through it. Web joins
 POS on email, ERP joins POS on phone, and Web and ERP share no key at all, so a
@@ -24,255 +38,87 @@ email is re-keyed and looks like a new person. Real MDM keeps a persisted
 registry and records merge/split events; pretending this is that would be worse
 than saying so.
 """
+import json
+import pathlib
+
 import erp_system as erp
 import source_system as src
 import web_store as web
-from common import SPARK_REMOTE, load, log, only_the_emulator_can, report_lineage
-
-# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
-# portability line falls. Real Fabric does not expose a Spark endpoint to dial
-# from outside: its compute runs the notebook. So this transform is portable only
-# once it LIVES in a notebook definition, which is a rewrite of where the code
-# sits rather than of what it does.
-only_the_emulator_can(
-    "driving Spark directly over Spark Connect",
-    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
-            "the service, on the workspace's starter pool or a custom pool chosen "
-            "through an Environment",
-    instead="move this transform into a Notebook definition under definitions/ and "
-            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
-            "accept; the Livy API "
-            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
-            "is the other route on real Fabric")
-
+from common import (
+    create_item_from_definition,
+    load,
+    log,
+    report_lineage,
+    run_job,
+    storage_options,
+    tables_uri,
+)
+from deltalake import DeltaTable
 
 st = load()
-assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"
 
-from pyspark.sql import SparkSession  # noqa: E402
-from pyspark.sql import functions as F  # noqa: E402
+nb = create_item_from_definition(
+    "star-silver.Notebook",
+    WORKSPACE_ID=st["workspace"], LAKEHOUSE_ID=st["lakehouse"])
+jid, status = run_job(nb, "RunNotebook")
+assert status == "Completed", f"star-silver notebook run {jid}: {status}"
 
-spark = SparkSession.builder.remote(SPARK_REMOTE).getOrCreate()
-
-base = (f"abfs://{st['workspace']}@onelake.dfs.fabric.microsoft.com"
-        f"/{st['lakehouse']}/Tables")
-
-
-def read(table):
-    return spark.read.format("delta").load(f"{base}/{table}")
+# --- read back what landed ----------------------------------------------------
+# delta-rs, not Spark: a different reader from the writer, so a Spark-shaped
+# misunderstanding of the Delta log cannot agree with itself.
+opts = storage_options()
 
 
-def write(df, table):
-    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+def table(name):
+    return DeltaTable(f"{tables_uri()}/{name}", storage_options=opts).to_pandas()
 
 
-def key(namespace, col):
-    """A stable surrogate over a namespaced identity."""
-    return F.sha2(F.concat(F.lit(namespace + ":"), col), 256)
+xref = table("silver_customer_xref")
+conformed = table("silver_customer_conformed")
+web_lines = table("silver_web_order_lines")
+m = table("silver_resolution_metrics").iloc[0]
 
-
-# Country, conformed across FOUR spelling conventions.
-#
-# silver.py conforms POS's five variants and stops there, because POS is all it
-# sees. Survivorship then used to coalesce that conformed value with the web
-# store's RAW one, so `country` in the resolved dimension held ISO-2 for anyone
-# POS knew, "United States" for the web-only, and NULL for the ERP-only —
-# because ERP's country was never even selected. Three answers to one question,
-# in the column whose entire job is to have one answer.
-#
-# Written out here rather than imported from the fixtures, for the reason
-# silver.py gives: a rule derived from the generator's own COUNTRY_VARIANTS
-# agrees with itself by construction, and a new upstream variant would conform
-# silently instead of failing. Duplicated from silver.py for the same reason it
-# is duplicated into the dbt model — it is silver's business rule, and silver
-# has more than one implementation.
-COUNTRY = {
-    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
-    "GB": "GB", "GBR": "GB", "U.K.": "GB", "UK": "GB", "UNITED KINGDOM": "GB",
-    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
-}
-_conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
-
-
-def conform_country(col):
-    """ISO-3166 alpha-2, or the upper-cased input if the rule does not know it.
-
-    Falling through unchanged rather than to NULL is deliberate: an unknown
-    spelling must stay visible so the assertion below fails on it, instead of
-    being quietly erased into "we have no country for this person".
-    """
-    k = F.upper(F.trim(col))
-    return F.coalesce(_conform[k], k)
-
-
-# --- the spine ---------------------------------------------------------------
-pos = (read("silver_customers")
-       .select("customer_id", "name", "email", "country", "phone")
-       # silver already lower-cased and trimmed email; "" is the missing marker
-       # rather than NULL, and it must NOT be treated as a joinable value.
-       .withColumn("email_key", F.when(F.col("email") != "", F.col("email")))
-       .withColumn("phone_key", F.trim(F.col("phone").cast("string")))
-       .withColumn("customer_key", key("pos", F.col("customer_id"))))
-
-web_c = (read("bronze_web_customers")
-         .select(F.lower(F.trim("email")).alias("email_key"),
-                 F.col("full_name"),
-                 conform_country(F.col("country")).alias("web_country")))
-
-# ERP's country comes through CONFORMED like the others, where it used to be
-# dropped on the floor. ERP spells countries ISO-3 (USA/GBR/SGP) — a fourth
-# convention — and an ERP-only customer is someone no other system has ever
-# seen, so this column is the only place their country can come from.
-erp_now = (read("dim_customer_scd2").filter(F.col("is_current"))
-           .select("erp_customer_id", "legal_name", "account_tier", "segment",
-                   "credit_band", conform_country(F.col("country")).alias("erp_country"),
-                   F.trim(F.col("phone").cast("string")).alias("phone_key")))
-
-# An AMBIGUOUS key is not a match.
-#
-# POS phone numbers are not unique — the generator collides on a handful out of
-# 100,000, which is realistic and would be far more common in a real CRM. If an
-# ERP account's phone matches several POS customers, we cannot say WHICH person
-# it is, and joining anyway does two bad things at once: it fans the row out, so
-# one source record acquires several customer_keys and every downstream
-# aggregate double-counts; and it asserts an identity nobody established.
-#
-# So a key that is not unique on the POS side is excluded from matching. The
-# affected records then key on their own identity and join the unresolved
-# cohorts, which is what resolve.py already says about people it cannot place.
-# Guessing would be worse than not matching: a wrong merge is invisible, while
-# an unmatched record is counted and reported.
-def unambiguous(df, col):
-    """The values of `col` that identify exactly one POS customer."""
-    return (df.filter(F.col(col).isNotNull())
-              .groupBy(col).agg(F.count("*").alias("_n"), F.first("customer_key").alias("customer_key"))
-              .filter(F.col("_n") == 1)
-              .select(col, "customer_key"))
-
-
-pos_by_email = unambiguous(pos, "email_key")
-pos_by_phone = unambiguous(pos, "phone_key")
-
-# Left joins from web/erp onto those, never the reverse: a POS customer with no
-# web or ERP counterpart must keep their key.
-web_keyed = (web_c.join(pos_by_email, "email_key", "left")
-             .withColumn("customer_key",
-                         F.coalesce(F.col("customer_key"), key("web", F.col("email_key")))))
-
-erp_keyed = (erp_now.join(pos_by_phone, "phone_key", "left")
-             .withColumn("customer_key",
-                         F.coalesce(F.col("customer_key"), key("erp", F.col("erp_customer_id")))))
-
-# --- the crosswalk -----------------------------------------------------------
-xref = (
-    pos.select(F.lit("contoso_pos").alias("source_system"),
-               F.col("customer_id").alias("source_id"), "customer_key")
-    .unionByName(web_keyed.select(F.lit("contoso_web").alias("source_system"),
-                                  F.col("email_key").alias("source_id"), "customer_key"))
-    .unionByName(erp_keyed.select(F.lit("contoso_erp").alias("source_system"),
-                                  F.col("erp_customer_id").alias("source_id"), "customer_key"))
-)
-
-# --- survivorship ------------------------------------------------------------
-# Which system wins is a business decision, so it is written down rather than
-# implied by a join order. Web is where a customer maintains their own profile;
-# POS is a till system capturing whatever the cashier typed; ERP holds the legal
-# and commercial truth and nothing else does.
-#
-# Falling THROUGH a null is the rule that matters: a higher-priority source that
-# simply does not hold an attribute must not blank out one that does.
-conformed = (
-    pos.select("customer_key", "customer_id", "name", "email", "country", "phone")
-    .join(web_keyed.select("customer_key", "full_name", "web_country"), "customer_key", "full_outer")
-    .join(erp_keyed.select("customer_key", "legal_name", "account_tier", "segment",
-                           "credit_band", "erp_country"),
-          "customer_key", "full_outer")
-    .select(
-        "customer_key",
-        F.coalesce("full_name", "name", "legal_name").alias("name"),
-        F.when(F.col("email") != "", F.col("email")).alias("email"),
-        # POS first, then web, then ERP — all three now conformed, so the
-        # precedence decides WHOSE ANSWER wins rather than which spelling
-        # survives. ERP is appended rather than inserted: it can only fill rows
-        # where neither of the other two holds a country, so no existing value
-        # changes hands and the only rows affected are the ERP-only, which were
-        # NULL before.
-        F.coalesce("country", "web_country", "erp_country").alias("country"),
-        "phone", "account_tier", "segment", "credit_band",
-        F.col("customer_id").isNotNull().alias("in_pos"),
-        F.col("full_name").isNotNull().alias("in_web"),
-        F.col("legal_name").isNotNull().alias("in_erp"))
-    .withColumn("source_count",
-                F.col("in_pos").cast("int") + F.col("in_web").cast("int")
-                + F.col("in_erp").cast("int"))
-)
-
-# --- the web fact grain ------------------------------------------------------
-# Cancelled orders and lines pointing at a product the catalogue does not carry
-# are excluded from the FACT, not deleted: bronze still holds every one of them.
-products = read("bronze_web_products").select("product_id")
-lines = read("bronze_web_order_lines")
-web_lines = (
-    lines.join(F.broadcast(products), "product_id", "left_semi")
-         .filter(F.col("order_status") != "cancelled")
-         .withColumn("email_key", F.lower(F.trim("email")))
-         .join(xref.filter(F.col("source_system") == "contoso_web")
-                   .select(F.col("source_id").alias("email_key"), "customer_key"),
-               "email_key", "left")
-         # placed_at carries a source offset; normalise to UTC so a day means
-         # one thing across channels. Some orders change calendar day here, and
-         # that is the correct answer rather than a rounding artefact.
-         .withColumn("order_date", F.to_date(F.to_utc_timestamp(F.col("placed_at"), "UTC")))
-         .withColumn("amount", F.col("quantity") * F.col("unit_price"))
-         .select("web_order_id", "line_no", "customer_key", "product_id", "order_date",
-                 "quantity", "unit_price", "amount",
-                 F.lit("web").alias("channel"))
-)
-
-write(xref, "silver_customer_xref")
-write(conformed, "silver_customer_conformed")
-write(web_lines, "silver_web_order_lines")
+n_xref, n_conformed, n_lines = len(xref), len(conformed), len(web_lines)
 
 # --- what the materialisation has to preserve --------------------------------
-n_xref, n_conformed = xref.count(), conformed.count()
-n_lines = web_lines.count()
-
-# Every source record maps to exactly one key, or the crosswalk is not a
-# function and every downstream join fans out.
-assert xref.count() == xref.select("source_system", "source_id").distinct().count(), \
+# Every source record maps to exactly one key, or the crosswalk is not a function
+# and every downstream join fans out. (The notebook asserts this too; both are
+# cheap, and the failure reads differently from each side.)
+assert n_xref == len(xref.drop_duplicates(["source_system", "source_id"])), \
     "a source record resolves to more than one customer_key"
-assert conformed.select("customer_key").distinct().count() == n_conformed, \
+assert conformed["customer_key"].nunique() == n_conformed, \
     "silver_customer_conformed is not one row per customer_key"
 
-# The unplaceable cohorts survive as their own identities. resolve.py proves
-# they exist; this proves materialising did not quietly merge them away.
+# The unplaceable cohorts survive as their own identities. resolve.py proves they
+# exist; this proves materialising did not quietly merge them away.
 #
-# The invariant, NOT a fixture total. Contoso ERP is a change log: a delete
-# closes a customer's last version, so a deleted ERP-only customer has history
-# rows and no current one, and correctly never reaches the star. Comparing a
-# live count against EXPECTED_ERP_ONLY_COUNT — which counts everyone the source
-# ever had — asserts that the dead are still here. What must hold is that no
-# CURRENT account is lost: each one either bridged to POS or stands alone.
-web_only = conformed.filter(~F.col("in_pos") & F.col("in_web")).count()
-erp_only = conformed.filter(~F.col("in_pos") & F.col("in_erp")).count()
-erp_bridged = conformed.filter(F.col("in_pos") & F.col("in_erp")).count()
-web_bridged = conformed.filter(F.col("in_pos") & F.col("in_web")).count()
+# The invariant, NOT a fixture total. Contoso ERP is a change log: a delete closes
+# a customer's last version, so a deleted ERP-only customer has history rows and no
+# current one, and correctly never reaches the star. Comparing a live count against
+# EXPECTED_ERP_ONLY_COUNT — which counts everyone the source ever had — asserts
+# that the dead are still here. What must hold is that no CURRENT account is lost:
+# each one either bridged to POS or stands alone.
+in_pos, in_web, in_erp = conformed["in_pos"], conformed["in_web"], conformed["in_erp"]
+web_only = int((~in_pos & in_web).sum())
+erp_only = int((~in_pos & in_erp).sum())
+erp_bridged = int((in_pos & in_erp).sum())
+web_bridged = int((in_pos & in_web).sum())
 
-assert erp_bridged + erp_only == erp_now.count(), \
-    f"ERP accounts lost in the join: {erp_bridged} + {erp_only} != {erp_now.count()}"
-assert web_bridged + web_only == web_c.count(), \
-    f"web accounts lost in the join: {web_bridged} + {web_only} != {web_c.count()}"
+assert erp_bridged + erp_only == int(m["erp_current"]), \
+    f"ERP accounts lost in the join: {erp_bridged} + {erp_only} != {int(m['erp_current'])}"
+assert web_bridged + web_only == int(m["web_customers"]), \
+    f"web accounts lost in the join: {web_bridged} + {web_only} != {int(m['web_customers'])}"
 
-# Deletes and ambiguous keys can only SHRINK these cohorts, never grow them —
-# an excess means the join invented an identity.
+# Deletes and ambiguous keys can only SHRINK these cohorts, never grow them — an
+# excess means the join invented an identity.
 assert erp_only <= erp.EXPECTED_ERP_ONLY_COUNT, (erp_only, erp.EXPECTED_ERP_ONLY_COUNT)
 
 # The exact cohort, as the star sees it: EXPECTED_ERP_ONLY_COUNT less the
 # soft-deleted, plus the accounts whose phone is ambiguous in POS and so cannot
-# match. The invariants above cannot see a wrong SPLIT between bridged and only
-# — 100 accounts moving from one cohort to the other satisfies them both. This
+# match. The invariants above cannot see a wrong SPLIT between bridged and only —
+# 100 accounts moving from one cohort to the other satisfies them both. This
 # number catches that, and is computed in the fixture with the SAME `!= 1`
-# ambiguity rule this step applies, so a change to the resolution rule that is
+# ambiguity rule the transform applies, so a change to the resolution rule that is
 # not carried into the fixture SHOULD fail here: the cohort really did change.
 assert erp_only == erp.EXPECTED_ERP_ONLY_CURRENT, \
     (erp_only, erp.EXPECTED_ERP_ONLY_CURRENT)
@@ -280,30 +126,29 @@ assert web_only <= web.EXPECTED_WEB_ONLY_EMAIL_COUNT, \
     (web_only, web.EXPECTED_WEB_ONLY_EMAIL_COUNT)
 
 assert n_lines == web.EXPECTED_WEB_CLEAN_LINES, (n_lines, web.EXPECTED_WEB_CLEAN_LINES)
-assert web_lines.filter(F.col("customer_key").isNull()).count() == 0, \
+assert web_lines["customer_key"].isnull().sum() == 0, \
     "a web order line does not resolve to a customer"
 
 # CONFORMANCE, asserted rather than assumed. Four source conventions reach this
-# column — POS's five variants, the web store's full names, ERP's ISO-3 — and
-# conform_country falls unknown spellings THROUGH unchanged, so a convention
-# nobody taught it appears here as itself and fails. That is the whole point of
-# not mapping to NULL: silent erasure would leave this set looking correct.
+# column — POS's five variants, the web store's full names, ERP's ISO-3 — and the
+# transform falls unknown spellings THROUGH unchanged, so a convention nobody
+# taught it appears here as itself and fails. That is the whole point of not
+# mapping to NULL: silent erasure would leave this set looking correct.
 #
-# NULL is absent from the expected set deliberately: every identity now reaches
-# at least one system that states a country, so a NULL means a cohort lost its
+# NULL is absent from the expected set deliberately: every identity now reaches at
+# least one system that states a country, so a NULL means a cohort lost its
 # country on the way through survivorship.
-countries = {r["country"] for r in conformed.select("country").distinct().collect()}
+countries = set(conformed["country"].dropna().unique()) | (
+    {None} if conformed["country"].isnull().any() else set())
 assert countries == src.EXPECTED_COUNTRIES, (sorted(map(str, countries)),
                                              sorted(src.EXPECTED_COUNTRIES))
 
-multi = conformed.filter(F.col("source_count") > 1).count()
-# Say how many keys were too ambiguous to match on, rather than letting the
-# match rate quietly absorb them. A phone shared by two customers is not a
-# match nobody made — it is a match nobody could safely make.
-amb_phone = pos.filter(F.col("phone_key").isNotNull()).select("phone_key").count() \
-    - pos_by_phone.count()
-amb_email = pos.filter(F.col("email_key").isNotNull()).select("email_key").count() \
-    - pos_by_email.count()
+multi = int((conformed["source_count"] > 1).sum())
+# Say how many keys were too ambiguous to match on, rather than letting the match
+# rate quietly absorb them. A phone shared by two customers is not a match nobody
+# made — it is a match nobody could safely make.
+amb_phone = int(m["pos_phone_present"]) - int(m["pos_phone_unambiguous"])
+amb_email = int(m["pos_email_present"]) - int(m["pos_email_unambiguous"])
 log(f"materialised: {n_xref:,} source records -> {n_conformed:,} identities "
     f"({multi:,} multi-source, {web_only:,} web-only, {erp_only:,} erp-only)")
 if amb_phone or amb_email:
@@ -315,12 +160,12 @@ log(f"web fact grain: {n_lines:,} clean order lines, all resolved to a customer_
 # The resolution is the advanced example's whole claim, so it belongs in the
 # graph — reported as the derivations the code actually computes.
 #
-# Identity resolution really does read all three customer sets to write both
-# the xref and the conformed dimension: survivorship is a full outer join, so
-# that cross product is the truth. The web order-line grain is a SEPARATE
-# movement over the web catalogue and lines, joined to the xref for its
-# customer_key — and it never touched the ERP dimension.
-_lake = load()["lakehouse"]
+# Identity resolution really does read all three customer sets to write both the
+# xref and the conformed dimension: survivorship is a full outer join, so that
+# cross product is the truth. The web order-line grain is a SEPARATE movement over
+# the web catalogue and lines, joined to the xref for its customer_key — and it
+# never touched the ERP dimension.
+_lake = st["lakehouse"]
 report_lineage("star_silver", [
     ([(_lake, "Tables/silver_customers"), (_lake, "Tables/bronze_web_customers"),
       (_lake, "Tables/dim_customer_scd2")],
@@ -344,9 +189,6 @@ report_lineage("star_silver", [
 # The example NAMES ITSELF from its directory rather than carrying an engine
 # label: a hardcoded label would be the one line that differs between two files
 # required to be identical.
-import json  # noqa: E402
-import pathlib  # noqa: E402
-
 _here = pathlib.Path(__file__).resolve().parent
 _here.joinpath("star_silver_summary.json").write_text(json.dumps({
     "example": _here.name,

--- a/examples/medallion-advanced-pyspark/definitions/star-silver.Notebook/.platform
+++ b/examples/medallion-advanced-pyspark/definitions/star-silver.Notebook/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/platform/platformProperties.json",
+  "metadata": {
+    "type": "Notebook",
+    "displayName": "star-silver",
+    "description": "Materialise the identity resolution: the crosswalk, the conformed dimension, the web fact grain, and the input metrics."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "8d4a1c67-2b95-4f03-ae18-56c7092fb3d1"
+  }
+}

--- a/examples/medallion-advanced-pyspark/definitions/star-silver.Notebook/notebook-content.py
+++ b/examples/medallion-advanced-pyspark/definitions/star-silver.Notebook/notebook-content.py
@@ -1,0 +1,243 @@
+# Fabric notebook source
+
+# CELL ********************
+
+# Materialise the identity resolution, so gold has a key to join on.
+#
+# `resolve.py` computes the identity graph, asserts it and writes nothing — the
+# resolution exists there as a PROOF. A proof is not a table, and gold cannot join
+# three sources on an argument. This notebook turns it into two tables plus the
+# web fact grain, and a fourth table nobody joins:
+#
+#   * `silver_customer_xref`         — (source_system, source_id) -> customer_key
+#   * `silver_customer_conformed`    — one row per customer_key, attributes survived
+#   * `silver_web_order_lines`       — clean web lines carrying customer_key
+#   * `silver_resolution_metrics`    — one row: what the INPUTS looked like
+#
+# THAT FOURTH TABLE IS WHY THIS IS A NOTEBOOK AND NOT A SCRIPT, so it is worth
+# being explicit. The transform used to run in star_silver.py over Spark Connect,
+# which no Fabric tenant exposes. Moving it into a notebook definition is what
+# makes it run on a real pool — but the step's assertions need quantities that
+# only exist INSIDE the transform: how many phone keys were too ambiguous to match
+# on, how many ERP and web accounts came in. A notebook cannot return those
+# through a job (real Fabric exposes no exit value for a REST-submitted run), and
+# inventing an emulator-only channel would give us a green local test and nothing
+# on a tenant. So they are written where every other output goes: a Delta table in
+# the lakehouse. Portable by construction, and inspectable long after the run.
+#
+# `spark` is injected by the runtime. Nothing here imports the example's fixture
+# package: a notebook runs on the pool, where only what the definition carries
+# exists. Every assertion below is therefore an invariant of the TRANSFORM; the
+# numbers the seeded generator implies are asserted by star_silver.py against
+# these tables.
+
+from pyspark.sql import functions as F
+
+base = "abfs://{{WORKSPACE_ID}}@onelake.dfs.fabric.microsoft.com/{{LAKEHOUSE_ID}}/Tables"
+
+
+def read(table):
+    return spark.read.format("delta").load(f"{base}/{table}")
+
+
+def write(df, table):
+    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+
+
+def key(namespace, col):
+    """A stable surrogate over a namespaced identity."""
+    return F.sha2(F.concat(F.lit(namespace + ":"), col), 256)
+
+
+# Country, conformed across FOUR spelling conventions.
+#
+# silver.py conforms POS's five variants and stops there, because POS is all it
+# sees. Survivorship then used to coalesce that conformed value with the web
+# store's RAW one, so `country` in the resolved dimension held ISO-2 for anyone
+# POS knew, "United States" for the web-only, and NULL for the ERP-only —
+# because ERP's country was never even selected. Three answers to one question,
+# in the column whose entire job is to have one answer.
+#
+# Written out here rather than imported from the fixtures, for the reason
+# silver.py gives: a rule derived from the generator's own COUNTRY_VARIANTS
+# agrees with itself by construction, and a new upstream variant would conform
+# silently instead of failing. Duplicated from silver.py for the same reason it
+# is duplicated into the dbt model — it is silver's business rule, and silver
+# has more than one implementation.
+COUNTRY = {
+    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
+    "GB": "GB", "GBR": "GB", "U.K.": "GB", "UK": "GB", "UNITED KINGDOM": "GB",
+    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
+}
+_conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
+
+
+def conform_country(col):
+    """ISO-3166 alpha-2, or the upper-cased input if the rule does not know it.
+
+    Falling through unchanged rather than to NULL is deliberate: an unknown
+    spelling must stay visible so the assertion below fails on it, instead of
+    being quietly erased into "we have no country for this person".
+    """
+    k = F.upper(F.trim(col))
+    return F.coalesce(_conform[k], k)
+
+
+# --- the spine ---------------------------------------------------------------
+pos = (read("silver_customers")
+       .select("customer_id", "name", "email", "country", "phone")
+       # silver already lower-cased and trimmed email; "" is the missing marker
+       # rather than NULL, and it must NOT be treated as a joinable value.
+       .withColumn("email_key", F.when(F.col("email") != "", F.col("email")))
+       .withColumn("phone_key", F.trim(F.col("phone").cast("string")))
+       .withColumn("customer_key", key("pos", F.col("customer_id"))))
+
+web_c = (read("bronze_web_customers")
+         .select(F.lower(F.trim("email")).alias("email_key"),
+                 F.col("full_name"),
+                 conform_country(F.col("country")).alias("web_country")))
+
+# ERP's country comes through CONFORMED like the others, where it used to be
+# dropped on the floor. ERP spells countries ISO-3 (USA/GBR/SGP) — a fourth
+# convention — and an ERP-only customer is someone no other system has ever
+# seen, so this column is the only place their country can come from.
+erp_now = (read("dim_customer_scd2").filter(F.col("is_current"))
+           .select("erp_customer_id", "legal_name", "account_tier", "segment",
+                   "credit_band", conform_country(F.col("country")).alias("erp_country"),
+                   F.trim(F.col("phone").cast("string")).alias("phone_key")))
+
+# An AMBIGUOUS key is not a match.
+#
+# POS phone numbers are not unique — the generator collides on a handful out of
+# 100,000, which is realistic and would be far more common in a real CRM. If an
+# ERP account's phone matches several POS customers, we cannot say WHICH person
+# it is, and joining anyway does two bad things at once: it fans the row out, so
+# one source record acquires several customer_keys and every downstream
+# aggregate double-counts; and it asserts an identity nobody established.
+#
+# So a key that is not unique on the POS side is excluded from matching. The
+# affected records then key on their own identity and join the unresolved
+# cohorts, which is what resolve.py already says about people it cannot place.
+# Guessing would be worse than not matching: a wrong merge is invisible, while
+# an unmatched record is counted and reported.
+def unambiguous(df, col):
+    """The values of `col` that identify exactly one POS customer."""
+    return (df.filter(F.col(col).isNotNull())
+              .groupBy(col).agg(F.count("*").alias("_n"), F.first("customer_key").alias("customer_key"))
+              .filter(F.col("_n") == 1)
+              .select(col, "customer_key"))
+
+
+pos_by_email = unambiguous(pos, "email_key")
+pos_by_phone = unambiguous(pos, "phone_key")
+
+# Left joins from web/erp onto those, never the reverse: a POS customer with no
+# web or ERP counterpart must keep their key.
+web_keyed = (web_c.join(pos_by_email, "email_key", "left")
+             .withColumn("customer_key",
+                         F.coalesce(F.col("customer_key"), key("web", F.col("email_key")))))
+
+erp_keyed = (erp_now.join(pos_by_phone, "phone_key", "left")
+             .withColumn("customer_key",
+                         F.coalesce(F.col("customer_key"), key("erp", F.col("erp_customer_id")))))
+
+# --- the crosswalk -----------------------------------------------------------
+xref = (
+    pos.select(F.lit("contoso_pos").alias("source_system"),
+               F.col("customer_id").alias("source_id"), "customer_key")
+    .unionByName(web_keyed.select(F.lit("contoso_web").alias("source_system"),
+                                  F.col("email_key").alias("source_id"), "customer_key"))
+    .unionByName(erp_keyed.select(F.lit("contoso_erp").alias("source_system"),
+                                  F.col("erp_customer_id").alias("source_id"), "customer_key"))
+)
+
+# --- survivorship ------------------------------------------------------------
+# Which system wins is a business decision, so it is written down rather than
+# implied by a join order. Web is where a customer maintains their own profile;
+# POS is a till system capturing whatever the cashier typed; ERP holds the legal
+# and commercial truth and nothing else does.
+#
+# Falling THROUGH a null is the rule that matters: a higher-priority source that
+# simply does not hold an attribute must not blank out one that does.
+conformed = (
+    pos.select("customer_key", "customer_id", "name", "email", "country", "phone")
+    .join(web_keyed.select("customer_key", "full_name", "web_country"), "customer_key", "full_outer")
+    .join(erp_keyed.select("customer_key", "legal_name", "account_tier", "segment",
+                           "credit_band", "erp_country"),
+          "customer_key", "full_outer")
+    .select(
+        "customer_key",
+        F.coalesce("full_name", "name", "legal_name").alias("name"),
+        F.when(F.col("email") != "", F.col("email")).alias("email"),
+        # POS first, then web, then ERP — all three now conformed, so the
+        # precedence decides WHOSE ANSWER wins rather than which spelling
+        # survives. ERP is appended rather than inserted: it can only fill rows
+        # where neither of the other two holds a country, so no existing value
+        # changes hands and the only rows affected are the ERP-only, which were
+        # NULL before.
+        F.coalesce("country", "web_country", "erp_country").alias("country"),
+        "phone", "account_tier", "segment", "credit_band",
+        F.col("customer_id").isNotNull().alias("in_pos"),
+        F.col("full_name").isNotNull().alias("in_web"),
+        F.col("legal_name").isNotNull().alias("in_erp"))
+    .withColumn("source_count",
+                F.col("in_pos").cast("int") + F.col("in_web").cast("int")
+                + F.col("in_erp").cast("int"))
+)
+
+# --- the web fact grain ------------------------------------------------------
+# Cancelled orders and lines pointing at a product the catalogue does not carry
+# are excluded from the FACT, not deleted: bronze still holds every one of them.
+products = read("bronze_web_products").select("product_id")
+lines = read("bronze_web_order_lines")
+web_lines = (
+    lines.join(F.broadcast(products), "product_id", "left_semi")
+         .filter(F.col("order_status") != "cancelled")
+         .withColumn("email_key", F.lower(F.trim("email")))
+         .join(xref.filter(F.col("source_system") == "contoso_web")
+                   .select(F.col("source_id").alias("email_key"), "customer_key"),
+               "email_key", "left")
+         # placed_at carries a source offset; normalise to UTC so a day means
+         # one thing across channels. Some orders change calendar day here, and
+         # that is the correct answer rather than a rounding artefact.
+         .withColumn("order_date", F.to_date(F.to_utc_timestamp(F.col("placed_at"), "UTC")))
+         .withColumn("amount", F.col("quantity") * F.col("unit_price"))
+         .select("web_order_id", "line_no", "customer_key", "product_id", "order_date",
+                 "quantity", "unit_price", "amount",
+                 F.lit("web").alias("channel"))
+)
+
+write(xref, "silver_customer_xref")
+write(conformed, "silver_customer_conformed")
+write(web_lines, "silver_web_order_lines")
+
+# --- invariants of the transform ---------------------------------------------
+# Asserted here because a failing cell fails the job, and because none of these
+# needs to know what the generator produced.
+
+# Every source record maps to exactly one key, or the crosswalk is not a function
+# and every downstream join fans out.
+assert xref.count() == xref.select("source_system", "source_id").distinct().count(), \
+    "a source record resolves to more than one customer_key"
+assert conformed.select("customer_key").distinct().count() == conformed.count(), \
+    "silver_customer_conformed is not one row per customer_key"
+assert web_lines.filter(F.col("customer_key").isNull()).count() == 0, \
+    "a web order line does not resolve to a customer"
+
+# --- what the inputs looked like ---------------------------------------------
+# One row, written as Delta like everything else. `amb_*` are the keys shared by
+# more than one POS customer: a match nobody could safely make, which must be
+# COUNTED rather than absorbed into a match rate. star_silver.py turns these into
+# the assertions that need the fixture, and into what compare.py reads.
+# An explicit schema rather than dict inference: one row is the case where
+# inference buys nothing and engines disagree most.
+metrics = spark.createDataFrame(
+    [(erp_now.count(), web_c.count(),
+      pos.filter(F.col("email_key").isNotNull()).count(), pos_by_email.count(),
+      pos.filter(F.col("phone_key").isNotNull()).count(), pos_by_phone.count())],
+    "erp_current long, web_customers long, pos_email_present long, "
+    "pos_email_unambiguous long, pos_phone_present long, pos_phone_unambiguous long")
+write(metrics, "silver_resolution_metrics")
+
+print(f"materialised {xref.count()} xref rows, {conformed.count()} identities, "
+      f"{web_lines.count()} web order lines")

--- a/examples/medallion-advanced-pyspark/dq_gate.py
+++ b/examples/medallion-advanced-pyspark/dq_gate.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 
 import pandas as pd
-from common import GOLD_PROJECT, load, log, storage_options, tables_uri, tds_connect
+from common import GOLD_PROJECT, load, log, storage_options, sync_sql_endpoint, tables_uri
 from deltalake import DeltaTable, write_deltalake
 
 st = load()
@@ -18,8 +18,12 @@ env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakeh
 
 
 def rebuild():
-    with tds_connect(st["lakehouse"]):  # re-reflect whatever silver now holds
-        pass
+    # Make the SQL endpoint see what silver now holds. NOT a throwaway connection:
+    # connect-to-reflect is the emulator's behaviour, and on real Fabric the
+    # analytics endpoint syncs on its own schedule — so a connection would return
+    # STALE rows and this gate would pass on data it never rebuilt. The resolver
+    # picks the mechanism the target actually has (docs/46).
+    sync_sql_endpoint(st["lakehouse"])
     return subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 
 

--- a/examples/medallion-advanced-pyspark/provision.py
+++ b/examples/medallion-advanced-pyspark/provision.py
@@ -1,16 +1,19 @@
 """Provision the workspace, lakehouse, warehouse, and workspace identity."""
-from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, save
+from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, post_and_wait, save
 
 H = fabric_headers()
 
 
 def create(url, body):
-    """Fail loudly with the emulator's error, not a KeyError three lines later.
+    """Fail loudly with the target's error, not a KeyError three lines later.
     Display names are unique per workspace, so a second run on a dirty stack
-    lands here — see Cleanup in the tutorial."""
-    r = S.post(url, headers=H, json=body)
-    assert r.status_code in (200, 201, 202), f"{url} -> {r.status_code} {r.text}"
-    return r.json()
+    lands here — see Cleanup in the tutorial.
+
+    `post_and_wait` because real Fabric creates a Warehouse ASYNCHRONOUSLY: 202
+    with an operation and no body, where a development stack answers 201 with the
+    item. Reading `.json()["id"]` off that 202 is a TypeError on a tenant and
+    nothing locally — found by running this against a real trial."""
+    return post_and_wait(url, body)
 
 
 ws = create(f"{FABRIC}/v1/workspaces", {"displayName": WORKSPACE_NAME})

--- a/examples/medallion-advanced-pyspark/reflect.py
+++ b/examples/medallion-advanced-pyspark/reflect.py
@@ -7,11 +7,17 @@ read-only, refreshed on every connect.
 import time
 
 import source_system as src
-from common import SQL_AUD, ensure_app, load, log, tds_connect, token
+from common import SQL_AUD, ensure_app, load, log, sync_sql_endpoint, tds_connect, token
 
 st = load()
 ensure_app(SQL_AUD, "Azure SQL")
 sql_tok = token(SQL_AUD)
+
+# Ask the endpoint to catch up with the Delta silver just wrote. Locally that is
+# the connect itself; on real Fabric it is refreshMetadata, because the endpoint
+# syncs asynchronously and a query can otherwise read a table that is not there
+# yet — or worse, an older version of one that is (docs/46).
+sync_sql_endpoint(st["lakehouse"])
 
 # The first connect makes the emulator create and start the per-item database on
 # the sidecar, which can be slow — retry until it is online.

--- a/examples/medallion-advanced-pyspark/star_silver.py
+++ b/examples/medallion-advanced-pyspark/star_silver.py
@@ -8,6 +8,20 @@ fact grain:
   * `silver_customer_xref`      — (source_system, source_id) -> customer_key
   * `silver_customer_conformed` — one row per customer_key, attributes survived
   * `silver_web_order_lines`    — clean web lines carrying customer_key
+  * `silver_resolution_metrics` — one row describing what the INPUTS held
+
+THE TRANSFORM IS A NOTEBOOK: `definitions/star-silver.Notebook/`. It used to run
+here over Spark Connect, which no Fabric tenant exposes, so this step could never
+have run in production. Now it deploys the definition, submits a `RunNotebook`
+job, and asserts against the tables that land — verifying the artifact rather than
+a DataFrame it built itself.
+
+The metrics table is how the numbers this step needs get out of the notebook. Its
+assertions depend on quantities that exist only INSIDE the transform (how many
+phone keys were shared by more than one POS customer, how many ERP and web
+accounts arrived), and a notebook cannot return those through a job: real Fabric
+exposes no exit value for a REST-submitted run. A Delta table is portable by
+construction, and materialising run metrics is something real teams do anyway.
 
 POS is the spine, and not by preference: every edge runs through it. Web joins
 POS on email, ERP joins POS on phone, and Web and ERP share no key at all, so a
@@ -24,255 +38,87 @@ email is re-keyed and looks like a new person. Real MDM keeps a persisted
 registry and records merge/split events; pretending this is that would be worse
 than saying so.
 """
+import json
+import pathlib
+
 import erp_system as erp
 import source_system as src
 import web_store as web
-from common import SPARK_REMOTE, load, log, only_the_emulator_can, report_lineage
-
-# Spark Connect is the emulator's stand-in for a Fabric pool, and it is where the
-# portability line falls. Real Fabric does not expose a Spark endpoint to dial
-# from outside: its compute runs the notebook. So this transform is portable only
-# once it LIVES in a notebook definition, which is a rewrite of where the code
-# sits rather than of what it does.
-only_the_emulator_can(
-    "driving Spark directly over Spark Connect",
-    because="real Fabric exposes no Spark Connect endpoint. Its Spark runs inside "
-            "the service, on the workspace's starter pool or a custom pool chosen "
-            "through an Environment",
-    instead="move this transform into a Notebook definition under definitions/ and "
-            "submit it with run_job(notebook_id, 'RunNotebook'), which both targets "
-            "accept; the Livy API "
-            "(/v1/workspaces/{ws}/lakehouses/{lh}/livyapi/versions/2023-12-01/sessions) "
-            "is the other route on real Fabric")
-
+from common import (
+    create_item_from_definition,
+    load,
+    log,
+    report_lineage,
+    run_job,
+    storage_options,
+    tables_uri,
+)
+from deltalake import DeltaTable
 
 st = load()
-assert SPARK_REMOTE, "SPARK_REMOTE is empty — no Spark engine is attached"
 
-from pyspark.sql import SparkSession  # noqa: E402
-from pyspark.sql import functions as F  # noqa: E402
+nb = create_item_from_definition(
+    "star-silver.Notebook",
+    WORKSPACE_ID=st["workspace"], LAKEHOUSE_ID=st["lakehouse"])
+jid, status = run_job(nb, "RunNotebook")
+assert status == "Completed", f"star-silver notebook run {jid}: {status}"
 
-spark = SparkSession.builder.remote(SPARK_REMOTE).getOrCreate()
-
-base = (f"abfs://{st['workspace']}@onelake.dfs.fabric.microsoft.com"
-        f"/{st['lakehouse']}/Tables")
-
-
-def read(table):
-    return spark.read.format("delta").load(f"{base}/{table}")
+# --- read back what landed ----------------------------------------------------
+# delta-rs, not Spark: a different reader from the writer, so a Spark-shaped
+# misunderstanding of the Delta log cannot agree with itself.
+opts = storage_options()
 
 
-def write(df, table):
-    df.write.format("delta").mode("overwrite").save(f"{base}/{table}")
+def table(name):
+    return DeltaTable(f"{tables_uri()}/{name}", storage_options=opts).to_pandas()
 
 
-def key(namespace, col):
-    """A stable surrogate over a namespaced identity."""
-    return F.sha2(F.concat(F.lit(namespace + ":"), col), 256)
+xref = table("silver_customer_xref")
+conformed = table("silver_customer_conformed")
+web_lines = table("silver_web_order_lines")
+m = table("silver_resolution_metrics").iloc[0]
 
-
-# Country, conformed across FOUR spelling conventions.
-#
-# silver.py conforms POS's five variants and stops there, because POS is all it
-# sees. Survivorship then used to coalesce that conformed value with the web
-# store's RAW one, so `country` in the resolved dimension held ISO-2 for anyone
-# POS knew, "United States" for the web-only, and NULL for the ERP-only —
-# because ERP's country was never even selected. Three answers to one question,
-# in the column whose entire job is to have one answer.
-#
-# Written out here rather than imported from the fixtures, for the reason
-# silver.py gives: a rule derived from the generator's own COUNTRY_VARIANTS
-# agrees with itself by construction, and a new upstream variant would conform
-# silently instead of failing. Duplicated from silver.py for the same reason it
-# is duplicated into the dbt model — it is silver's business rule, and silver
-# has more than one implementation.
-COUNTRY = {
-    "US": "US", "USA": "US", "U.S.": "US", "UNITED STATES": "US",
-    "GB": "GB", "GBR": "GB", "U.K.": "GB", "UK": "GB", "UNITED KINGDOM": "GB",
-    "SG": "SG", "SGP": "SG", "SINGAPORE": "SG",
-}
-_conform = F.create_map([F.lit(x) for kv in COUNTRY.items() for x in kv])
-
-
-def conform_country(col):
-    """ISO-3166 alpha-2, or the upper-cased input if the rule does not know it.
-
-    Falling through unchanged rather than to NULL is deliberate: an unknown
-    spelling must stay visible so the assertion below fails on it, instead of
-    being quietly erased into "we have no country for this person".
-    """
-    k = F.upper(F.trim(col))
-    return F.coalesce(_conform[k], k)
-
-
-# --- the spine ---------------------------------------------------------------
-pos = (read("silver_customers")
-       .select("customer_id", "name", "email", "country", "phone")
-       # silver already lower-cased and trimmed email; "" is the missing marker
-       # rather than NULL, and it must NOT be treated as a joinable value.
-       .withColumn("email_key", F.when(F.col("email") != "", F.col("email")))
-       .withColumn("phone_key", F.trim(F.col("phone").cast("string")))
-       .withColumn("customer_key", key("pos", F.col("customer_id"))))
-
-web_c = (read("bronze_web_customers")
-         .select(F.lower(F.trim("email")).alias("email_key"),
-                 F.col("full_name"),
-                 conform_country(F.col("country")).alias("web_country")))
-
-# ERP's country comes through CONFORMED like the others, where it used to be
-# dropped on the floor. ERP spells countries ISO-3 (USA/GBR/SGP) — a fourth
-# convention — and an ERP-only customer is someone no other system has ever
-# seen, so this column is the only place their country can come from.
-erp_now = (read("dim_customer_scd2").filter(F.col("is_current"))
-           .select("erp_customer_id", "legal_name", "account_tier", "segment",
-                   "credit_band", conform_country(F.col("country")).alias("erp_country"),
-                   F.trim(F.col("phone").cast("string")).alias("phone_key")))
-
-# An AMBIGUOUS key is not a match.
-#
-# POS phone numbers are not unique — the generator collides on a handful out of
-# 100,000, which is realistic and would be far more common in a real CRM. If an
-# ERP account's phone matches several POS customers, we cannot say WHICH person
-# it is, and joining anyway does two bad things at once: it fans the row out, so
-# one source record acquires several customer_keys and every downstream
-# aggregate double-counts; and it asserts an identity nobody established.
-#
-# So a key that is not unique on the POS side is excluded from matching. The
-# affected records then key on their own identity and join the unresolved
-# cohorts, which is what resolve.py already says about people it cannot place.
-# Guessing would be worse than not matching: a wrong merge is invisible, while
-# an unmatched record is counted and reported.
-def unambiguous(df, col):
-    """The values of `col` that identify exactly one POS customer."""
-    return (df.filter(F.col(col).isNotNull())
-              .groupBy(col).agg(F.count("*").alias("_n"), F.first("customer_key").alias("customer_key"))
-              .filter(F.col("_n") == 1)
-              .select(col, "customer_key"))
-
-
-pos_by_email = unambiguous(pos, "email_key")
-pos_by_phone = unambiguous(pos, "phone_key")
-
-# Left joins from web/erp onto those, never the reverse: a POS customer with no
-# web or ERP counterpart must keep their key.
-web_keyed = (web_c.join(pos_by_email, "email_key", "left")
-             .withColumn("customer_key",
-                         F.coalesce(F.col("customer_key"), key("web", F.col("email_key")))))
-
-erp_keyed = (erp_now.join(pos_by_phone, "phone_key", "left")
-             .withColumn("customer_key",
-                         F.coalesce(F.col("customer_key"), key("erp", F.col("erp_customer_id")))))
-
-# --- the crosswalk -----------------------------------------------------------
-xref = (
-    pos.select(F.lit("contoso_pos").alias("source_system"),
-               F.col("customer_id").alias("source_id"), "customer_key")
-    .unionByName(web_keyed.select(F.lit("contoso_web").alias("source_system"),
-                                  F.col("email_key").alias("source_id"), "customer_key"))
-    .unionByName(erp_keyed.select(F.lit("contoso_erp").alias("source_system"),
-                                  F.col("erp_customer_id").alias("source_id"), "customer_key"))
-)
-
-# --- survivorship ------------------------------------------------------------
-# Which system wins is a business decision, so it is written down rather than
-# implied by a join order. Web is where a customer maintains their own profile;
-# POS is a till system capturing whatever the cashier typed; ERP holds the legal
-# and commercial truth and nothing else does.
-#
-# Falling THROUGH a null is the rule that matters: a higher-priority source that
-# simply does not hold an attribute must not blank out one that does.
-conformed = (
-    pos.select("customer_key", "customer_id", "name", "email", "country", "phone")
-    .join(web_keyed.select("customer_key", "full_name", "web_country"), "customer_key", "full_outer")
-    .join(erp_keyed.select("customer_key", "legal_name", "account_tier", "segment",
-                           "credit_band", "erp_country"),
-          "customer_key", "full_outer")
-    .select(
-        "customer_key",
-        F.coalesce("full_name", "name", "legal_name").alias("name"),
-        F.when(F.col("email") != "", F.col("email")).alias("email"),
-        # POS first, then web, then ERP — all three now conformed, so the
-        # precedence decides WHOSE ANSWER wins rather than which spelling
-        # survives. ERP is appended rather than inserted: it can only fill rows
-        # where neither of the other two holds a country, so no existing value
-        # changes hands and the only rows affected are the ERP-only, which were
-        # NULL before.
-        F.coalesce("country", "web_country", "erp_country").alias("country"),
-        "phone", "account_tier", "segment", "credit_band",
-        F.col("customer_id").isNotNull().alias("in_pos"),
-        F.col("full_name").isNotNull().alias("in_web"),
-        F.col("legal_name").isNotNull().alias("in_erp"))
-    .withColumn("source_count",
-                F.col("in_pos").cast("int") + F.col("in_web").cast("int")
-                + F.col("in_erp").cast("int"))
-)
-
-# --- the web fact grain ------------------------------------------------------
-# Cancelled orders and lines pointing at a product the catalogue does not carry
-# are excluded from the FACT, not deleted: bronze still holds every one of them.
-products = read("bronze_web_products").select("product_id")
-lines = read("bronze_web_order_lines")
-web_lines = (
-    lines.join(F.broadcast(products), "product_id", "left_semi")
-         .filter(F.col("order_status") != "cancelled")
-         .withColumn("email_key", F.lower(F.trim("email")))
-         .join(xref.filter(F.col("source_system") == "contoso_web")
-                   .select(F.col("source_id").alias("email_key"), "customer_key"),
-               "email_key", "left")
-         # placed_at carries a source offset; normalise to UTC so a day means
-         # one thing across channels. Some orders change calendar day here, and
-         # that is the correct answer rather than a rounding artefact.
-         .withColumn("order_date", F.to_date(F.to_utc_timestamp(F.col("placed_at"), "UTC")))
-         .withColumn("amount", F.col("quantity") * F.col("unit_price"))
-         .select("web_order_id", "line_no", "customer_key", "product_id", "order_date",
-                 "quantity", "unit_price", "amount",
-                 F.lit("web").alias("channel"))
-)
-
-write(xref, "silver_customer_xref")
-write(conformed, "silver_customer_conformed")
-write(web_lines, "silver_web_order_lines")
+n_xref, n_conformed, n_lines = len(xref), len(conformed), len(web_lines)
 
 # --- what the materialisation has to preserve --------------------------------
-n_xref, n_conformed = xref.count(), conformed.count()
-n_lines = web_lines.count()
-
-# Every source record maps to exactly one key, or the crosswalk is not a
-# function and every downstream join fans out.
-assert xref.count() == xref.select("source_system", "source_id").distinct().count(), \
+# Every source record maps to exactly one key, or the crosswalk is not a function
+# and every downstream join fans out. (The notebook asserts this too; both are
+# cheap, and the failure reads differently from each side.)
+assert n_xref == len(xref.drop_duplicates(["source_system", "source_id"])), \
     "a source record resolves to more than one customer_key"
-assert conformed.select("customer_key").distinct().count() == n_conformed, \
+assert conformed["customer_key"].nunique() == n_conformed, \
     "silver_customer_conformed is not one row per customer_key"
 
-# The unplaceable cohorts survive as their own identities. resolve.py proves
-# they exist; this proves materialising did not quietly merge them away.
+# The unplaceable cohorts survive as their own identities. resolve.py proves they
+# exist; this proves materialising did not quietly merge them away.
 #
-# The invariant, NOT a fixture total. Contoso ERP is a change log: a delete
-# closes a customer's last version, so a deleted ERP-only customer has history
-# rows and no current one, and correctly never reaches the star. Comparing a
-# live count against EXPECTED_ERP_ONLY_COUNT — which counts everyone the source
-# ever had — asserts that the dead are still here. What must hold is that no
-# CURRENT account is lost: each one either bridged to POS or stands alone.
-web_only = conformed.filter(~F.col("in_pos") & F.col("in_web")).count()
-erp_only = conformed.filter(~F.col("in_pos") & F.col("in_erp")).count()
-erp_bridged = conformed.filter(F.col("in_pos") & F.col("in_erp")).count()
-web_bridged = conformed.filter(F.col("in_pos") & F.col("in_web")).count()
+# The invariant, NOT a fixture total. Contoso ERP is a change log: a delete closes
+# a customer's last version, so a deleted ERP-only customer has history rows and no
+# current one, and correctly never reaches the star. Comparing a live count against
+# EXPECTED_ERP_ONLY_COUNT — which counts everyone the source ever had — asserts
+# that the dead are still here. What must hold is that no CURRENT account is lost:
+# each one either bridged to POS or stands alone.
+in_pos, in_web, in_erp = conformed["in_pos"], conformed["in_web"], conformed["in_erp"]
+web_only = int((~in_pos & in_web).sum())
+erp_only = int((~in_pos & in_erp).sum())
+erp_bridged = int((in_pos & in_erp).sum())
+web_bridged = int((in_pos & in_web).sum())
 
-assert erp_bridged + erp_only == erp_now.count(), \
-    f"ERP accounts lost in the join: {erp_bridged} + {erp_only} != {erp_now.count()}"
-assert web_bridged + web_only == web_c.count(), \
-    f"web accounts lost in the join: {web_bridged} + {web_only} != {web_c.count()}"
+assert erp_bridged + erp_only == int(m["erp_current"]), \
+    f"ERP accounts lost in the join: {erp_bridged} + {erp_only} != {int(m['erp_current'])}"
+assert web_bridged + web_only == int(m["web_customers"]), \
+    f"web accounts lost in the join: {web_bridged} + {web_only} != {int(m['web_customers'])}"
 
-# Deletes and ambiguous keys can only SHRINK these cohorts, never grow them —
-# an excess means the join invented an identity.
+# Deletes and ambiguous keys can only SHRINK these cohorts, never grow them — an
+# excess means the join invented an identity.
 assert erp_only <= erp.EXPECTED_ERP_ONLY_COUNT, (erp_only, erp.EXPECTED_ERP_ONLY_COUNT)
 
 # The exact cohort, as the star sees it: EXPECTED_ERP_ONLY_COUNT less the
 # soft-deleted, plus the accounts whose phone is ambiguous in POS and so cannot
-# match. The invariants above cannot see a wrong SPLIT between bridged and only
-# — 100 accounts moving from one cohort to the other satisfies them both. This
+# match. The invariants above cannot see a wrong SPLIT between bridged and only —
+# 100 accounts moving from one cohort to the other satisfies them both. This
 # number catches that, and is computed in the fixture with the SAME `!= 1`
-# ambiguity rule this step applies, so a change to the resolution rule that is
+# ambiguity rule the transform applies, so a change to the resolution rule that is
 # not carried into the fixture SHOULD fail here: the cohort really did change.
 assert erp_only == erp.EXPECTED_ERP_ONLY_CURRENT, \
     (erp_only, erp.EXPECTED_ERP_ONLY_CURRENT)
@@ -280,30 +126,29 @@ assert web_only <= web.EXPECTED_WEB_ONLY_EMAIL_COUNT, \
     (web_only, web.EXPECTED_WEB_ONLY_EMAIL_COUNT)
 
 assert n_lines == web.EXPECTED_WEB_CLEAN_LINES, (n_lines, web.EXPECTED_WEB_CLEAN_LINES)
-assert web_lines.filter(F.col("customer_key").isNull()).count() == 0, \
+assert web_lines["customer_key"].isnull().sum() == 0, \
     "a web order line does not resolve to a customer"
 
 # CONFORMANCE, asserted rather than assumed. Four source conventions reach this
-# column — POS's five variants, the web store's full names, ERP's ISO-3 — and
-# conform_country falls unknown spellings THROUGH unchanged, so a convention
-# nobody taught it appears here as itself and fails. That is the whole point of
-# not mapping to NULL: silent erasure would leave this set looking correct.
+# column — POS's five variants, the web store's full names, ERP's ISO-3 — and the
+# transform falls unknown spellings THROUGH unchanged, so a convention nobody
+# taught it appears here as itself and fails. That is the whole point of not
+# mapping to NULL: silent erasure would leave this set looking correct.
 #
-# NULL is absent from the expected set deliberately: every identity now reaches
-# at least one system that states a country, so a NULL means a cohort lost its
+# NULL is absent from the expected set deliberately: every identity now reaches at
+# least one system that states a country, so a NULL means a cohort lost its
 # country on the way through survivorship.
-countries = {r["country"] for r in conformed.select("country").distinct().collect()}
+countries = set(conformed["country"].dropna().unique()) | (
+    {None} if conformed["country"].isnull().any() else set())
 assert countries == src.EXPECTED_COUNTRIES, (sorted(map(str, countries)),
                                              sorted(src.EXPECTED_COUNTRIES))
 
-multi = conformed.filter(F.col("source_count") > 1).count()
-# Say how many keys were too ambiguous to match on, rather than letting the
-# match rate quietly absorb them. A phone shared by two customers is not a
-# match nobody made — it is a match nobody could safely make.
-amb_phone = pos.filter(F.col("phone_key").isNotNull()).select("phone_key").count() \
-    - pos_by_phone.count()
-amb_email = pos.filter(F.col("email_key").isNotNull()).select("email_key").count() \
-    - pos_by_email.count()
+multi = int((conformed["source_count"] > 1).sum())
+# Say how many keys were too ambiguous to match on, rather than letting the match
+# rate quietly absorb them. A phone shared by two customers is not a match nobody
+# made — it is a match nobody could safely make.
+amb_phone = int(m["pos_phone_present"]) - int(m["pos_phone_unambiguous"])
+amb_email = int(m["pos_email_present"]) - int(m["pos_email_unambiguous"])
 log(f"materialised: {n_xref:,} source records -> {n_conformed:,} identities "
     f"({multi:,} multi-source, {web_only:,} web-only, {erp_only:,} erp-only)")
 if amb_phone or amb_email:
@@ -315,12 +160,12 @@ log(f"web fact grain: {n_lines:,} clean order lines, all resolved to a customer_
 # The resolution is the advanced example's whole claim, so it belongs in the
 # graph — reported as the derivations the code actually computes.
 #
-# Identity resolution really does read all three customer sets to write both
-# the xref and the conformed dimension: survivorship is a full outer join, so
-# that cross product is the truth. The web order-line grain is a SEPARATE
-# movement over the web catalogue and lines, joined to the xref for its
-# customer_key — and it never touched the ERP dimension.
-_lake = load()["lakehouse"]
+# Identity resolution really does read all three customer sets to write both the
+# xref and the conformed dimension: survivorship is a full outer join, so that
+# cross product is the truth. The web order-line grain is a SEPARATE movement over
+# the web catalogue and lines, joined to the xref for its customer_key — and it
+# never touched the ERP dimension.
+_lake = st["lakehouse"]
 report_lineage("star_silver", [
     ([(_lake, "Tables/silver_customers"), (_lake, "Tables/bronze_web_customers"),
       (_lake, "Tables/dim_customer_scd2")],
@@ -344,9 +189,6 @@ report_lineage("star_silver", [
 # The example NAMES ITSELF from its directory rather than carrying an engine
 # label: a hardcoded label would be the one line that differs between two files
 # required to be identical.
-import json  # noqa: E402
-import pathlib  # noqa: E402
-
 _here = pathlib.Path(__file__).resolve().parent
 _here.joinpath("star_silver_summary.json").write_text(json.dumps({
     "example": _here.name,

--- a/examples/medallion-dbt-fabricspark/dq_gate.py
+++ b/examples/medallion-dbt-fabricspark/dq_gate.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 
 import pandas as pd
-from common import GOLD_PROJECT, load, log, storage_options, tables_uri, tds_connect
+from common import GOLD_PROJECT, load, log, storage_options, sync_sql_endpoint, tables_uri
 from deltalake import DeltaTable, write_deltalake
 
 st = load()
@@ -18,8 +18,12 @@ env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakeh
 
 
 def rebuild():
-    with tds_connect(st["lakehouse"]):  # re-reflect whatever silver now holds
-        pass
+    # Make the SQL endpoint see what silver now holds. NOT a throwaway connection:
+    # connect-to-reflect is the emulator's behaviour, and on real Fabric the
+    # analytics endpoint syncs on its own schedule — so a connection would return
+    # STALE rows and this gate would pass on data it never rebuilt. The resolver
+    # picks the mechanism the target actually has (docs/46).
+    sync_sql_endpoint(st["lakehouse"])
     return subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 
 

--- a/examples/medallion-dbt-fabricspark/provision.py
+++ b/examples/medallion-dbt-fabricspark/provision.py
@@ -1,16 +1,19 @@
 """Provision the workspace, lakehouse, warehouse, and workspace identity."""
-from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, save
+from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, post_and_wait, save
 
 H = fabric_headers()
 
 
 def create(url, body):
-    """Fail loudly with the emulator's error, not a KeyError three lines later.
+    """Fail loudly with the target's error, not a KeyError three lines later.
     Display names are unique per workspace, so a second run on a dirty stack
-    lands here — see Cleanup in the tutorial."""
-    r = S.post(url, headers=H, json=body)
-    assert r.status_code in (200, 201, 202), f"{url} -> {r.status_code} {r.text}"
-    return r.json()
+    lands here — see Cleanup in the tutorial.
+
+    `post_and_wait` because real Fabric creates a Warehouse ASYNCHRONOUSLY: 202
+    with an operation and no body, where a development stack answers 201 with the
+    item. Reading `.json()["id"]` off that 202 is a TypeError on a tenant and
+    nothing locally — found by running this against a real trial."""
+    return post_and_wait(url, body)
 
 
 ws = create(f"{FABRIC}/v1/workspaces", {"displayName": WORKSPACE_NAME})

--- a/examples/medallion-dbt-fabricspark/reflect.py
+++ b/examples/medallion-dbt-fabricspark/reflect.py
@@ -7,11 +7,17 @@ read-only, refreshed on every connect.
 import time
 
 import source_system as src
-from common import SQL_AUD, ensure_app, load, log, tds_connect, token
+from common import SQL_AUD, ensure_app, load, log, sync_sql_endpoint, tds_connect, token
 
 st = load()
 ensure_app(SQL_AUD, "Azure SQL")
 sql_tok = token(SQL_AUD)
+
+# Ask the endpoint to catch up with the Delta silver just wrote. Locally that is
+# the connect itself; on real Fabric it is refreshMetadata, because the endpoint
+# syncs asynchronously and a query can otherwise read a table that is not there
+# yet — or worse, an older version of one that is (docs/46).
+sync_sql_endpoint(st["lakehouse"])
 
 # The first connect makes the emulator create and start the per-item database on
 # the sidecar, which can be slow — retry until it is online.

--- a/examples/medallion-pyspark/dq_gate.py
+++ b/examples/medallion-pyspark/dq_gate.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 
 import pandas as pd
-from common import GOLD_PROJECT, load, log, storage_options, tables_uri, tds_connect
+from common import GOLD_PROJECT, load, log, storage_options, sync_sql_endpoint, tables_uri
 from deltalake import DeltaTable, write_deltalake
 
 st = load()
@@ -18,8 +18,12 @@ env = {**os.environ, "DBT_PROFILES_DIR": GOLD_PROJECT, "LAKEHOUSE_ID": st["lakeh
 
 
 def rebuild():
-    with tds_connect(st["lakehouse"]):  # re-reflect whatever silver now holds
-        pass
+    # Make the SQL endpoint see what silver now holds. NOT a throwaway connection:
+    # connect-to-reflect is the emulator's behaviour, and on real Fabric the
+    # analytics endpoint syncs on its own schedule — so a connection would return
+    # STALE rows and this gate would pass on data it never rebuilt. The resolver
+    # picks the mechanism the target actually has (docs/46).
+    sync_sql_endpoint(st["lakehouse"])
     return subprocess.run(["dbt", "--no-partial-parse", "build"], cwd=GOLD_PROJECT, env=env).returncode
 
 

--- a/examples/medallion-pyspark/provision.py
+++ b/examples/medallion-pyspark/provision.py
@@ -1,16 +1,19 @@
 """Provision the workspace, lakehouse, warehouse, and workspace identity."""
-from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, save
+from common import FABRIC, WORKSPACE_NAME, S, fabric_headers, log, post_and_wait, save
 
 H = fabric_headers()
 
 
 def create(url, body):
-    """Fail loudly with the emulator's error, not a KeyError three lines later.
+    """Fail loudly with the target's error, not a KeyError three lines later.
     Display names are unique per workspace, so a second run on a dirty stack
-    lands here — see Cleanup in the tutorial."""
-    r = S.post(url, headers=H, json=body)
-    assert r.status_code in (200, 201, 202), f"{url} -> {r.status_code} {r.text}"
-    return r.json()
+    lands here — see Cleanup in the tutorial.
+
+    `post_and_wait` because real Fabric creates a Warehouse ASYNCHRONOUSLY: 202
+    with an operation and no body, where a development stack answers 201 with the
+    item. Reading `.json()["id"]` off that 202 is a TypeError on a tenant and
+    nothing locally — found by running this against a real trial."""
+    return post_and_wait(url, body)
 
 
 ws = create(f"{FABRIC}/v1/workspaces", {"displayName": WORKSPACE_NAME})

--- a/examples/medallion-pyspark/reflect.py
+++ b/examples/medallion-pyspark/reflect.py
@@ -7,11 +7,17 @@ read-only, refreshed on every connect.
 import time
 
 import source_system as src
-from common import SQL_AUD, ensure_app, load, log, tds_connect, token
+from common import SQL_AUD, ensure_app, load, log, sync_sql_endpoint, tds_connect, token
 
 st = load()
 ensure_app(SQL_AUD, "Azure SQL")
 sql_tok = token(SQL_AUD)
+
+# Ask the endpoint to catch up with the Delta silver just wrote. Locally that is
+# the connect itself; on real Fabric it is refreshMetadata, because the endpoint
+# syncs asynchronously and a query can otherwise read a table that is not there
+# yet — or worse, an older version of one that is (docs/46).
+sync_sql_endpoint(st["lakehouse"])
 
 # The first connect makes the emulator create and start the per-item database on
 # the sidecar, which can be slow — retry until it is online.

--- a/python/fabric-target/fabric_target/__init__.py
+++ b/python/fabric-target/fabric_target/__init__.py
@@ -110,6 +110,29 @@ def _az_logged_in():
         return False
 
 
+class _TenantScoped:
+    """A TokenCredential that mints for ONE tenant, whatever the CLI's default is.
+
+    Thin on purpose: it forwards `tenant_id` and nothing else, so the underlying
+    chain keeps deciding WHICH credential answers. A caller that passes its own
+    tenant_id still wins, because a per-call intent is more specific than a
+    configured default.
+    """
+
+    def __init__(self, inner, tenant):
+        self._inner, self._tenant = inner, tenant
+
+    def get_token(self, *scopes, **kw):
+        kw.setdefault("tenant_id", self._tenant)
+        return self._inner.get_token(*scopes, **kw)
+
+    def get_token_info(self, *scopes, **kw):
+        # Newer azure-core clients prefer this; forwarding keeps the wrapper from
+        # silently downgrading a caller to the older shape.
+        kw.setdefault("tenant_id", self._tenant)
+        return self._inner.get_token_info(*scopes, **kw)
+
+
 class Target:
     def __init__(self, name):
         if name not in ("emulator", "real"):
@@ -202,7 +225,27 @@ class Target:
                     raise TargetError(
                         "real mode needs azure-identity: uv add 'fabric-target[real]'"
                     ) from e
-                self._credential = DefaultAzureCredential()
+                # AZURE_TENANT_ID MUST REACH THE az CLI PATH.
+                #
+                # DefaultAzureCredential does not forward it there: it accepts
+                # tenant hints for the browser, VS Code, shared-cache and
+                # workload-identity links and has no azure_cli_tenant_id. So a
+                # developer whose `az` default tenant is not the tenant they
+                # configured got tokens for the WRONG tenant, from the credential
+                # source docs/21 documents as the default — and Fabric answered
+                # `UserNotLicensed`, which reads as a licensing problem rather
+                # than a tenant one. Measured against a real trial: the capacity
+                # was listable with `az account get-access-token --tenant <id>`
+                # and invisible to this credential at the same moment.
+                #
+                # Baked in rather than passed per call, because callers hold the
+                # credential and call get_token(scope) themselves — notebookutils
+                # and the examples both do.
+                inner = DefaultAzureCredential(
+                    additionally_allowed_tenants=[self.tenant] if self.tenant else None)
+                self._credential = (_TenantScoped(inner, self.tenant)
+                                    if self.tenant and self.tenant != "organizations"
+                                    else inner)
         return self._credential
 
     # -- guards ------------------------------------------------------------

--- a/python/fabric-target/tests/test_fabric_target.py
+++ b/python/fabric-target/tests/test_fabric_target.py
@@ -9,7 +9,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import fabric_target
-from fabric_target import Target, TargetError, target
+from fabric_target import AccessToken, Target, TargetError, target
 from fabric_target.__main__ import main
 
 
@@ -284,3 +284,41 @@ def test_the_emulator_never_needs_a_capacity():
 def test_a_get_is_not_a_create(monkeypatch):
     t = _real(monkeypatch)
     t._complete_workspace_create("GET", t.api_root + "/workspaces", {})  # must not raise
+
+
+# --- the configured tenant must reach the az CLI path ------------------------
+# MEASURED, not argued: against a real trial, `az account get-access-token
+# --tenant <id>` listed the capacity while this credential could not see it, and
+# Fabric answered UserNotLicensed — which reads as a licensing problem rather than
+# a tenant one. DefaultAzureCredential takes tenant hints for the browser, VS
+# Code, shared-cache and workload-identity links, and has none for the CLI.
+
+class _RecordingCredential:
+    def __init__(self):
+        self.calls = []
+
+    def get_token(self, *scopes, **kw):
+        self.calls.append((scopes, kw))
+        return AccessToken("t", 0)
+
+
+def test_real_tokens_are_minted_for_the_configured_tenant(monkeypatch):
+    inner = _RecordingCredential()
+    scoped = fabric_target._TenantScoped(inner, "0ce8e0d2-1e14-4aab-a1f2-2d3c61e75e3c")
+    scoped.get_token("https://api.fabric.microsoft.com/.default")
+    assert inner.calls[0][1]["tenant_id"] == "0ce8e0d2-1e14-4aab-a1f2-2d3c61e75e3c"
+
+
+def test_a_caller_with_its_own_tenant_still_wins():
+    """Per-call intent is more specific than a configured default."""
+    inner = _RecordingCredential()
+    scoped = fabric_target._TenantScoped(inner, "configured")
+    scoped.get_token("scope/.default", tenant_id="explicit")
+    assert inner.calls[0][1]["tenant_id"] == "explicit"
+
+
+def test_the_emulator_credential_is_not_wrapped():
+    """Only real mode has a tenant the CLI might disagree with; the emulator's
+    credential already mints against the tenant it was constructed with."""
+    t = Target("emulator")
+    assert not isinstance(t.credential, fabric_target._TenantScoped)

--- a/python/tests/test_example_sql_endpoint.py
+++ b/python/tests/test_example_sql_endpoint.py
@@ -164,17 +164,23 @@ def test_emulator_addresses_the_item_by_id_over_plain_tds(monkeypatch, tmp_path)
     assert t.encrypt is False
 
 
-def test_tds_server_overrides_discovery_without_asking_the_api(monkeypatch, tmp_path):
+def test_tds_server_overrides_the_address_but_not_the_endpoint_id(monkeypatch, tmp_path):
     """The emulator advertises the port it LISTENS on, not the port Docker
     published it to, so a remapped isolated stack is the one case discovery gets
-    wrong. Fabric has no such distinction, which is why this is an override."""
-    lake = {"displayName": "contoso_lake", "type": "Lakehouse", "id": "lh-1"}
+    wrong. Fabric has no such distinction, which is why this is an override — of
+    the ADDRESS only. The endpoint id is a different fact and sync_sql_endpoint
+    needs it, so the typed route is still asked."""
+    lake = {"displayName": "contoso_lake", "type": "Lakehouse", "id": "lh-1",
+            "properties": {"sqlEndpointProperties": {
+                "connectionString": "localhost:1433", "provisioningStatus": "Success"}}}
     common = load_common(monkeypatch, tmp_path, "emulator", TDS_SERVER="localhost,11533")
     monkeypatch.setattr(common, "fabric_headers", lambda: {})
-    session = FakeSession({"/items/lh-1": lake})  # the typed route is NOT stubbed
+    session = FakeSession({"/items/lh-1": lake, "/lakehouses/lh-1": lake})
     monkeypatch.setattr(common, "S", session)
-    assert common.sql_endpoint("lh-1").server == "localhost,11533"
-    assert not any("lakehouses" in u for u in session.asked)
+    t = common.sql_endpoint("lh-1")
+    assert t.server == "localhost,11533"
+    assert t.endpoint_id is None  # the emulator has no SQLEndpoint item
+    assert any("lakehouses" in u for u in session.asked)
 
 
 def test_an_item_with_no_sql_endpoint_says_so(monkeypatch, tmp_path):
@@ -241,3 +247,54 @@ def test_the_notebook_runtime_is_wired_from_the_resolved_target(monkeypatch, tmp
     load_common(monkeypatch, tmp_path, "emulator", ENTRA_EMULATOR_URL="https://localhost:18443")
     assert os.environ["NOTEBOOKUTILS_ENTRA_URL"] == "https://localhost:18443"
     assert os.environ["NOTEBOOKUTILS_INSECURE"] == "1"
+
+
+# --- keeping the SQL endpoint in step with Delta -----------------------------
+# Two mechanisms, one for each target, and the emulator's absence of an endpoint
+# ID is the signal for which. dq_gate.py used to open a throwaway connection with
+# the comment "re-reflect whatever silver now holds" — true locally, a silent
+# no-op on real Fabric, where the endpoint syncs on its own schedule and the gate
+# would then pass on data it never rebuilt.
+
+def test_the_emulator_syncs_by_connecting(monkeypatch, tmp_path):
+    lake = {"displayName": "contoso_lake", "type": "Lakehouse", "id": "lh-1",
+            "properties": {"sqlEndpointProperties": {
+                "connectionString": "localhost:1433", "provisioningStatus": "Success"}}}
+    common = load_common(monkeypatch, tmp_path, "emulator")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    session = FakeSession({"/items/lh-1": lake, "/lakehouses/lh-1": lake})
+    monkeypatch.setattr(common, "S", session)
+
+    class FakeConn:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    connected = []
+    monkeypatch.setattr(common, "tds_connect", lambda i: connected.append(i) or FakeConn())
+    common.sync_sql_endpoint("lh-1")
+    assert connected == ["lh-1"]
+    assert not any("refreshMetadata" in u for u in session.asked)
+
+
+def test_real_syncs_with_refreshmetadata_on_the_endpoint_id(monkeypatch, tmp_path):
+    """Addressed by the SQLEndpoint item's own id, which is why that id being
+    reported at all is what selects this branch."""
+    lake = {**LAKEHOUSE_REAL}
+    common = load_common(monkeypatch, tmp_path, "real",
+                         FABRIC_WORKSPACE="ws", FABRIC_VAULT_URL="https://kv.vault.azure.net")
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    session = FakeSession({"/items/lh-1": lake, "/lakehouses/lh-1": lake})
+    posted = []
+
+    def post(url, **kw):
+        posted.append(url)
+        return FakeResponse({})
+
+    session.post = post
+    monkeypatch.setattr(common, "S", session)
+    monkeypatch.setattr(common._T, "poll_lro", lambda r, **k: r)
+    monkeypatch.setattr(common, "tds_connect", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("real mode must not sync by connecting")))
+    common.sync_sql_endpoint("lh-1")
+    assert posted and posted[0].endswith(
+        "/workspaces/ws-1/sqlEndpoints/37dc8a41-dea9-465d-b528-3e95043b2356/refreshMetadata"), posted

--- a/scripts/check_example_portability.py
+++ b/scripts/check_example_portability.py
@@ -71,9 +71,31 @@ KNOWN_PARTS = {
     "definition/model.tmdl",
     "definition/expressions.tmdl",
     "model.bim",
-    "data.json",  # the emulator's own import-data part, documented in doc 46
     "Spark.json",
     "SparkJobDefinitionV1.json",
+}
+
+# Part paths ONLY THE EMULATOR ACCEPTS, declared with what real Fabric needs
+# instead. These are reported on every run rather than hidden, because the entry
+# that used to live in KNOWN_PARTS above read:
+#
+#     "data.json",  # the emulator's own import-data part, documented in doc 46
+#
+# and doc 46 documented no such thing. A gate whose one job is "every definition
+# part is a path Fabric accepts" carried a silent exemption for the one path
+# Fabric rejects, justified by a citation that did not exist — so it reported
+# green over the least portable line in the examples. Listing them here keeps the
+# exemption true, visible, and countable; the count is what makes it a debt
+# rather than a decision.
+EMULATOR_ONLY_PARTS = {
+    "data.json": (
+        "the emulator's inline row snapshot for a semantic model (see "
+        "internal/api/datasets.go: \"rows are an inline data.json snapshot with "
+        "nothing behind them\"). Real Fabric has no such part: a model's data "
+        "comes from a partition — Direct Lake over OneLake Delta, or an import "
+        "partition whose M expression reads Sql.Database(<connectionString>, …). "
+        "Converting needs one of those to exist on BOTH targets; the emulator "
+        "evaluates Direct Lake today and inline data, not Sql.Database import"),
 }
 
 # A part path may also be a TMDL table file or a PBIP subpath, which are
@@ -223,27 +245,57 @@ def known_part(path):
     return path in KNOWN_PARTS or any(s.match(path) for s in PART_SHAPES)
 
 
-def check_definition_parts(problems):
-    """Every definition part path must be one Fabric actually accepts."""
+def check_emulator_only_parts(divergences):
+    """Find every USE of a declared emulator-only part path.
+
+    A SUBSTRING search, not the structural patterns below, and that is the point.
+    Those patterns recognise two shapes — a `"path": …, "payloadType": …` object
+    and `create_item(name, type, {"<path>": …})` — and semantic_model.py uses a
+    third: a local `part("data.json", data)` helper. So the whitelist that
+    exempted `data.json` was never even reached; the gate was silent about it for
+    a second, independent reason. For a fixed list this small, matching the
+    literal anywhere in an example is both sufficient and impossible to evade by
+    reshaping the call.
+    """
+    for f in python_files(EXAMPLES):
+        text = f.read_text()
+        for path, why in EMULATOR_ONLY_PARTS.items():
+            if f'"{path}"' in text or f"'{path}'" in text:
+                divergences.append((rel(f), path, why))
+
+
+def check_definition_parts(problems, divergences=None):
+    """Every definition part path must be one Fabric actually accepts.
+
+    A path in EMULATOR_ONLY_PARTS is recorded as a DIVERGENCE rather than a
+    violation: it is a declared debt with a stated reason, and the run says so out
+    loud every time instead of a comment saying so once.
+    """
     for f in python_files(EXAMPLES):
         text = f.read_text()
         for pat in (PART_KEY, PART_DICT):
             for m in pat.finditer(text):
                 path = m.group(1)
+                if path in EMULATOR_ONLY_PARTS:
+                    if divergences is not None:
+                        divergences.append((rel(f), path, EMULATOR_ONLY_PARTS[path]))
+                    continue
                 if not known_part(path):
                     problems.append(
                         f"{rel(f)} writes a definition part {path!r}, which is not a "
                         f"Fabric source-format path. See docs/46-artifact-persistence.md; "
-                        f"add it to KNOWN_PARTS only with a reference to the contract.")
+                        f"add it to KNOWN_PARTS only with a reference to the contract, or "
+                        f"to EMULATOR_ONLY_PARTS with what real Fabric needs instead.")
 
 
 def main():
-    problems = []
+    problems, divergences = [], []
     check_no_pinned_target(problems)
     check_no_emulator_only_leaks(problems)
     check_definition_folders(problems)
     check_resolver_uses_the_contract(problems)
-    check_definition_parts(problems)
+    check_definition_parts(problems, divergences)
+    check_emulator_only_parts(divergences)
 
     examples = sorted(d.name for d in EXAMPLES.iterdir()
                       if d.is_dir() and (d / "README.md").exists())
@@ -258,6 +310,15 @@ def main():
         return 1
     print("every example resolves its target through the contract, and every "
           "definition part uses a Fabric source-format path")
+    if divergences:
+        # Printed on every green run on purpose. This is the one thing the
+        # examples still do that real Fabric would reject, and a debt nobody
+        # reads is a debt nobody pays.
+        print(f"\nDECLARED emulator-only definition parts ({len(divergences)} use(s)) — "
+              f"these do NOT survive FABRIC_TARGET=real:")
+        for where, path, why in divergences:
+            print(f"  {where} writes {path!r}")
+            print(f"      {why}")
     return 0
 
 


### PR DESCRIPTION
Items 1–4 of the audit, in one PR. Item 5 is blocked and I say why at the end.

## 1. The gate stops lying about `data.json`

It carried `"data.json",  # the emulator's own import-data part, documented in doc 46` — and doc 46 documented no such thing. A gate whose one job is "every definition part is a path Fabric accepts" held a silent exemption for the one path Fabric rejects, with a citation that did not exist.

Worse, the exemption was never even reached: the two structural patterns match `"path": …, "payloadType": …` and `create_item(name, type, {"<path>": …})`, and `semantic_model.py` uses a third shape — a local `part("data.json", data)` helper. So the gate was silent for two independent reasons.

Now `EMULATOR_ONLY_PARTS` declares it with what real Fabric needs instead, a substring scan finds every use regardless of call shape, and the run prints all 6 uses on every green build. A debt nobody reads is a debt nobody pays.

## 2. `semantic_model.py` — investigated, not converted

Real Fabric takes a model's data from a partition: Direct Lake over OneLake Delta, or an import partition whose M reads `Sql.Database(<connectionString>, …)`. The emulator evaluates Direct Lake and inline data, **not** `Sql.Database` import — and locally the warehouse's gold tables are not Delta in OneLake, so Direct Lake has nothing to read. Converting therefore needs emulator work first, and guessing at it would produce a green local test proving nothing about a tenant. Documented in docs/46 and printed by the gate rather than left to be discovered.

## 3. The SQL endpoint sync is explicit

`dq_gate.py` opened a throwaway connection commented "re-reflect whatever silver now holds". True locally — the emulator reflects on connect — and a **silent no-op on real Fabric**, where the analytics endpoint syncs on its own schedule. The gate would have passed on data it never rebuilt: a wrong answer with a plausible shape.

`sync_sql_endpoint()` picks the mechanism the target actually has: connect locally, `POST …/sqlEndpoints/{id}/refreshMetadata` on real. The selector is whether the target reports an endpoint id at all — the emulator has no `SQLEndpoint` item, so it reports none. `reflect.py` uses it too, for the same reason.

## 4. `star_silver` is a Notebook definition

The transform moves to `definitions/star-silver.Notebook/` in both advanced examples; the step submits `RunNotebook` and asserts against the tables.

It needed one thing silver did not: its assertions depend on quantities that exist only inside the transform — how many phone keys were shared by more than one POS customer, how many ERP and web accounts arrived — and `compare.py` asserts on them across the pair. A notebook cannot return those through a job, because real Fabric exposes no exit value for a REST-submitted run. The tempting channel would have been emulator-only. So the notebook writes them as **one Delta row** (`silver_resolution_metrics`): portable by construction, inspectable afterwards, and something real teams materialise anyway.

## Verified

`e2e/medallion-advanced` **23/23 exit 0**, with both transforms running as notebook jobs and every number unchanged: 168,800 source records → 129,526 identities (35,376 multi-source, 18,000 web-only, 11,526 erp-only), 10 ambiguous phone keys, 213,562 web order lines. 540 python tests, lint, parity and portability gates clean.

## 5. Blocked, with the evidence

`az` is authenticated as `calvin@odeoncg.ai` (tenant `2882b6f0-…`), and `GET /v1/capacities` returns **`UserNotLicensed`**. The token minted fine; Fabric refused the identity — so this login is not the account holding the trial, or it has no Fabric licence. Nothing in this PR can fix that: it needs `az login` as the account that created the trial, which is also the only account that can assign a workspace to trial capacity.