### PR TITLE
fix: end the Sail e2e on its own terms instead of the job's budget

### DIFF
--- a/docker/python-runtime/Dockerfile
+++ b/docker/python-runtime/Dockerfile
@@ -9,3 +9,10 @@ COPY python/ ./python/
 RUN uv sync --frozen --no-install-project --group "${UV_GROUP}"
 
 ENV PATH="/app/.venv/bin:${PATH}"
+# Every driver on this image writes its progress to a pipe, where python
+# block-buffers stdout: the e2e/sail driver's twenty prints all carried ONE
+# timestamp, flushed at exit, so a run killed mid-flight printed nothing at all
+# and its 24 minutes of silence said nothing about where it stopped. Progress is
+# only worth printing if a hang can be located by it. Last, so the uv layer
+# above stays cached for all 18 stacks built from this file.
+ENV PYTHONUNBUFFERED=1

--- a/docker/spark-agent/Dockerfile
+++ b/docker/spark-agent/Dockerfile
@@ -26,6 +26,12 @@ COPY python/ ./python/
 RUN uv sync --frozen --no-install-project --group sail-delta
 
 ENV PATH="/app/.venv/bin:${PATH}"
+# Same reason as docker/python-runtime, and set here too because the two images
+# are required to share one preamble (python/tests/test_spark_agent_packaging.py):
+# this agent also writes its progress to a pipe, where python block-buffers
+# stdout, so a run killed mid-flight prints nothing and its silence locates
+# nothing.
+ENV PYTHONUNBUFFERED=1
 
 # Runnable with no command and no mount — the whole repair. Everything the
 # agent still needs is environment (SPARK_REMOTE, the Entra and storage

--- a/docs/20-lakesail-engine.md
+++ b/docs/20-lakesail-engine.md
@@ -113,6 +113,18 @@ touches; every claim below is CI-verified against the emulator:
 - **Concurrent overwrite conflicts are rejected** at the Delta-log commit
   boundary: the executable two-session probe observes one successful writer
   and one transaction failure through OneLake's conditional create contract.
+  The loser fails **fast, not eventually** — worth stating because a hung
+  `sail` job was once read as an unbounded commit retry, and it is not one.
+  Sail commits under `for attempt_number in 1..=total_retries`
+  (`crates/sail-delta-lake/src/transaction/mod.rs`, v0.6.6), and an overwrite
+  is neither a table creation nor a blind append, so its
+  `effective_max_retries` is **0**: one attempt, then `MaxCommitAttempts`.
+  Measured at 50 ms from conflict to both sessions closed. The emulator's half
+  of that contract is Azure's own code — a Put Blob carrying `If-None-Match: *`
+  against an existing commit answers **409 `BlobAlreadyExists`**
+  (`internal/onelake/blob.go`), which object_store maps to `AlreadyExists` and
+  does not retry, 409 being a client error outside its retry policy. Terminal
+  on both sides.
 - **No streaming** (`readStream`/`writeStream` absent), `cache()`/`persist()`
   are no-ops, no Java/Scala UDFs (Python/Pandas/Arrow UDFs all work), some
   catalog calls missing (`cacheTable`, `refreshTable`, …).
@@ -121,6 +133,59 @@ touches; every claim below is CI-verified against the emulator:
   SP's Storage token covers everything the e2es do.
 - Session timeout defaults to 900s — our composes set
   `SAIL_SPARK__SESSION_TIMEOUT_SECS=3600`.
+
+## The 24-minute hang, and why one is legible now
+
+The `sail` job once produced no output for 24 of its 25 minutes and was
+reported as **CANCELLED**. That is worse than a failure: a cancelled check
+reads as infrastructure noise, so it was rerun rather than investigated, the
+rerun went green, and nothing was learned.
+
+**The cause was in the client, not in Delta, Sail or the emulator.** The
+concurrent-writer probe stops its two extra Spark Connect sessions, and
+`SparkSession.stop()` calls `client.close()`, whose first act is
+`ExecutePlanResponseReattachableIterator.shutdown()` — which is **process-wide,
+not per session**. It takes a class-level lock, hands the class-level release
+thread pool to `ThreadPoolExecutor.shutdown()` (`wait=True` by default), and
+holds the lock until the pool drains. Every new query in the process builds one
+of those iterators, and its `__init__` takes that same class lock. So one worker
+thread's `stop()` blocks the main session's next query — which is precisely
+where the CI log falls silent — for as long as the outstanding `ReleaseExecute`
+RPCs take to retry, an interval pyspark's own retry policy is documented to let
+run "at least 10 minutes". A **losing** writer is the case that leaves one
+outstanding, because its execution ends in an error that submits `_release_all`
+just as the session is torn down: hence intermittent, and hence only on the run
+where the race actually collided.
+
+Measured, not inferred: driving the shipped pyspark classes with no server at
+all, one thread inside `shutdown()` blocks another thread's
+`_get_or_create_release_thread_pool()` for the full drain. `e2e/sail/driver.py`
+now calls `session.client.release_session()` instead — the same `ReleaseSession`
+RPC, so Sail still logs the removal, and no shared state is touched.
+
+Two things had to be untangled before that was findable, and they are worth
+keeping regardless. Three guards, in the order they fire:
+
+1. **The driver prints as it happens.** It did not before. Python
+   block-buffers stdout to a pipe, so in the run that *passed* all twenty of
+   the driver's lines carry one timestamp, flushed at exit — meaning a killed
+   run prints nothing at all, and its silence locates nothing.
+   `PYTHONUNBUFFERED=1` in `docker/python-runtime/Dockerfile` fixes this for
+   every driver built on that image, not just this one.
+2. **A stuck step ends the run and names itself.** Every Spark Connect call is
+   a gRPC round trip with no deadline, so nothing in the driver is bounded on
+   its own. `e2e/sail/driver.py` names each step, heartbeats every 30 s, and
+   after `SAIL_E2E_STEP_BUDGET` (180 s; steps take under a second in practice)
+   prints what it was waiting on, dumps **every thread's** stack, and exits 1.
+   Set the budget to a fraction of a second to watch it fire — a watchdog that
+   cannot be made to fire is not evidence of anything, and the first draft of
+   this one could not be.
+3. **A stack that hangs before the driver can speak** — a stalled build, a Sail
+   that never listens — hits `SAIL_E2E_BUDGET` (900 s) in `e2e/sail/run.py`,
+   which then dumps the driver, sail and emulator logs.
+
+All three exist so the job **fails**, inside its budget, with the failing step
+named. None of them changes what the suite asserts.
 
 ## Running it (user-facing)
 

--- a/e2e/livy/client.py
+++ b/e2e/livy/client.py
@@ -32,7 +32,9 @@ def http(method, url, body=None, token=None, form=False):
     if token:
         headers["Authorization"] = "Bearer " + token
     req = urllib.request.Request(url, data=data, method=method, headers=headers)
-    with urllib.request.urlopen(req) as r:
+    # Timed, like every other wait in this suite: an untimed urlopen is the one
+    # way a bounded poll loop still hangs for a whole CI job (see e2e/sail).
+    with urllib.request.urlopen(req, timeout=60) as r:
         raw = r.read()
         return r.status, (json.loads(raw) if raw else {})
 
@@ -321,7 +323,7 @@ def main():
         f"{FABRIC}/{ws['id']}/{lake['id']}/Files/batch.py", data=script, method="PUT",
         headers={"Host": "onelake.blob.fabric.microsoft.com", "Authorization": "Bearer " + storage_token,
                  "x-ms-blob-type": "BlockBlob"})
-    with urllib.request.urlopen(put) as r:
+    with urllib.request.urlopen(put, timeout=60) as r:
         assert r.status in (200, 201), r.status
 
     _, b = http("POST", f"{base}/batches", {"file": f"{ws['id']}/{lake['id']}/Files/batch.py"}, token=token)

--- a/e2e/notebook-driven/client.py
+++ b/e2e/notebook-driven/client.py
@@ -75,7 +75,9 @@ def req(method, url, body=None, token=None, form=False):
     if token:
         headers["Authorization"] = "Bearer " + token
     r = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(r) as resp:
+    # Timed, like every other wait in this suite: an untimed urlopen is the one
+    # way a bounded poll loop still hangs for a whole CI job (see e2e/sail).
+    with urllib.request.urlopen(r, timeout=60) as resp:
         raw = resp.read()
         return resp.status, resp.headers, (json.loads(raw) if raw else {})
 
@@ -225,7 +227,7 @@ assert any(n.endswith(".parquet") for n in names), f"no Parquet under {TABLE_DIR
 
 r = urllib.request.Request(f"http://{ACCT}/{ws}/{urllib.parse.quote(commits[0])}",
                            headers={"Authorization": "Bearer " + sft})
-with urllib.request.urlopen(r) as resp:
+with urllib.request.urlopen(r, timeout=60) as resp:
     commit = resp.read().decode()
 # The log is the table's own account of what was written; a stray .parquet on
 # disk is not part of the table.

--- a/e2e/sail/docker-compose.yml
+++ b/e2e/sail/docker-compose.yml
@@ -75,4 +75,8 @@ services:
       SPARK_REMOTE: "sc://sail:50051"
       FABRIC: "http://fabric-emulator"
       ENTRA: "http://entra-emulator:8443"
+      # Per-step hang budget for driver.py's watchdog. Overridable so the guard
+      # itself can be exercised (set it to a fraction of a second and the run
+      # must die naming the step it was in, not pass anyway).
+      SAIL_E2E_STEP_BUDGET: "${SAIL_E2E_STEP_BUDGET:-180}"
     command: python /driver.py

--- a/e2e/sail/driver.py
+++ b/e2e/sail/driver.py
@@ -7,8 +7,10 @@ Data plane: Sail executes the plans; its object_store speaks the az:// +
 endpoint-override recipe to the emulator's Blob surface, including the
 If-None-Match conditional PUT every Delta commit needs.
 """
+import faulthandler
 import json
 import os
+import sys
 import threading
 import time
 import urllib.error
@@ -19,6 +21,70 @@ from concurrent.futures import ThreadPoolExecutor
 FABRIC = os.environ["FABRIC"]
 ENTRA = os.environ["ENTRA"]
 TENANT = "6f89cf12-978b-4d23-ac18-9ef0c127cf87"
+
+# --- hang budget ------------------------------------------------------------
+#
+# This suite hung once for its CI job's entire 25-minute budget and was reported
+# as CANCELLED. That is worse than a failure: a cancelled check reads as
+# infrastructure noise, so it gets rerun rather than investigated — which is
+# what happened, and the rerun went green.
+#
+# Two things have to be true for the next hang to be legible, and neither was.
+# Progress must be visible AS IT HAPPENS: python block-buffers stdout to a pipe,
+# so in the run that PASSED all twenty prints below carry a single timestamp,
+# flushed at exit — a killed run prints nothing, and the silence locates
+# nothing. `PYTHONUNBUFFERED=1` in docker/python-runtime/Dockerfile fixes that
+# for every driver on that image. And a stuck step must end the run itself,
+# naming what it was waiting on, well inside the job's budget: every Spark
+# Connect call below is a gRPC round trip with no deadline, so nothing here is
+# bounded on its own.
+#
+# Steps take well under a second in practice, including on a cold CI runner, so
+# the budget is loose enough to never fire on slowness alone.
+STEP_BUDGET = float(os.environ.get("SAIL_E2E_STEP_BUDGET", "180"))
+HEARTBEAT = 30.0
+
+_progress = threading.Lock()
+_step = "startup"
+_step_began = time.monotonic()
+
+
+def step(name):
+    """Name the operation now in flight, and restart its budget."""
+    global _step, _step_began
+    with _progress:
+        _step, _step_began = name, time.monotonic()
+    print(f"--> {name}", flush=True)
+
+
+def _watchdog():
+    next_beat = HEARTBEAT
+    while True:
+        time.sleep(1.0)
+        with _progress:
+            name, elapsed = _step, time.monotonic() - _step_began
+        # The budget is checked BEFORE the heartbeat gate, and not after it: a
+        # `continue` for "nothing to report yet" also skipped the budget, so any
+        # budget under one heartbeat was unreachable and the guard passed a run
+        # it was set to kill. A watchdog that cannot be made to fire is not
+        # evidence of anything.
+        if elapsed > STEP_BUDGET:
+            print(f"\nHUNG: {elapsed:.0f}s with no progress, waiting on: {name}",
+                  flush=True)
+            # Every thread, so a stuck concurrent writer is as visible as a
+            # stuck main thread. gRPC drops the GIL while it waits, so this
+            # thread still runs when the others are blocked on the wire.
+            faulthandler.dump_traceback()
+            sys.stderr.flush()
+            os._exit(1)
+        if elapsed < next_beat:  # a new step started; re-arm the heartbeat
+            next_beat = HEARTBEAT
+            continue
+        print(f"    still {name} ({elapsed:.0f}s)", flush=True)
+        next_beat = elapsed + HEARTBEAT
+
+
+threading.Thread(target=_watchdog, daemon=True).start()
 
 
 def post_json(url, body, token=None):
@@ -43,6 +109,7 @@ def entra_token(scope):
 
 
 # --- control plane: a workspace and a lakehouse to write into ---
+step("control plane: mint token, create workspace + lakehouse")
 fabric_token = entra_token("https://api.fabric.microsoft.com/.default")
 ws = post_json(f"{FABRIC}/v1/workspaces", {"displayName": "sailws"}, fabric_token)
 post_json(f"{FABRIC}/v1/workspaces/{ws['id']}/lakehouses", {"displayName": "lake"}, fabric_token)
@@ -51,6 +118,7 @@ print(f"workspace: {ws['id']}")
 # --- data plane: PySpark over Spark Connect to Sail ---
 from pyspark.sql import SparkSession  # noqa: E402
 
+step("connect to sail over Spark Connect")
 for attempt in range(30):  # sail may still be starting
     try:
         spark = SparkSession.builder.remote(os.environ["SPARK_REMOTE"]).getOrCreate()
@@ -68,6 +136,7 @@ url = "az://sailws/lake.Lakehouse/Tables/events"
 # asks the server for spark.sql.session.localRelationSizeLimit and chokes on
 # Sail 0.6.6's "3GB" string. VALUES keeps everything server-side (and is the
 # better engine witness anyway).
+step("delta write (overwrite, 3 rows)")
 df = spark.sql(
     "SELECT * FROM VALUES (1,'signup','eu'), (2,'purchase','us'), (3,'signup','us')"
     " AS t(id, kind, region)"
@@ -75,6 +144,7 @@ df = spark.sql(
 df.write.format("delta").mode("overwrite").save(url)
 print("delta write OK")
 
+step("sql over delta")
 back = spark.read.format("delta").load(url)
 back.createOrReplaceTempView("events")
 rows = spark.sql("SELECT kind, COUNT(*) AS n FROM events GROUP BY kind ORDER BY kind").collect()
@@ -83,6 +153,7 @@ assert got == {"purchase": 1, "signup": 2}, got
 print(f"sql over delta OK: {got}")
 
 # Append — a second Delta commit exercises the conditional-PUT log protocol.
+step("delta append")
 spark.sql("SELECT * FROM VALUES (4,'purchase','eu') AS t(id, kind, region)") \
     .write.format("delta").mode("append").save(url)
 n = spark.read.format("delta").load(url).count()
@@ -93,6 +164,7 @@ print("delta append OK (4 rows)")
 
 # Time travel by version. (The SQL `VERSION AS OF` form also works — see
 # docs/engine-matrix.md; an earlier comment here called it a Sail gap.)
+step("time travel (versionAsOf 0)")
 v0 = spark.read.format("delta").option("versionAsOf", 0).load(url).count()
 assert v0 == 3, v0
 print("time travel OK (versionAsOf 0 -> 3 rows)")
@@ -100,6 +172,7 @@ print("time travel OK (versionAsOf 0 -> 3 rows)")
 # MERGE INTO (copy-on-write): update one row, insert another. Finding: Sail
 # resolves path-based delta.`az://…` for READS but not as a MERGE target —
 # the target must be a catalog table, so register the location first.
+step("MERGE INTO (copy-on-write, via registered table)")
 spark.sql(f"CREATE TABLE events_t USING delta LOCATION '{url}'")
 spark.sql("""
     MERGE INTO events_t AS t
@@ -116,6 +189,7 @@ print("MERGE INTO OK (update + insert, via registered table)")
 # notebooks use). Sail parses container@account.dfs.fabric.microsoft.com and
 # the endpoint override redirects the requests to the emulator — if this
 # holds, no abfss->az shim is needed anywhere.
+step("abfss:// (Fabric Hadoop URL form)")
 abfss = "abfss://sailws@onelake.dfs.fabric.microsoft.com/lake.Lakehouse/Tables/abfss_probe"
 spark.sql("SELECT * FROM VALUES (1,'x') AS t(id, v)") \
     .write.format("delta").mode("overwrite").save(abfss)
@@ -125,6 +199,7 @@ print("abfss:// (Fabric Hadoop form) OK — no shim needed")
 # --- executable compatibility boundary -------------------------------------
 
 def expect_unavailable(name, operation):
+    step(f"compatibility probe: {name}")
     try:
         operation()
     except Exception as error:
@@ -151,6 +226,7 @@ def start_stream():
 expect_unavailable("Structured Streaming execution", start_stream)
 expect_unavailable("OPTIMIZE", lambda: spark.sql("OPTIMIZE events_t").collect())
 expect_unavailable("VACUUM", lambda: spark.sql("VACUUM events_t RETAIN 168 HOURS").collect())
+step("compatibility probe: change data feed")
 cdf_probe = (spark.read.format("delta").option("readChangeFeed", "true")
              .option("startingVersion", 0).load(url))
 cdf_probe.collect()
@@ -179,7 +255,16 @@ print("known divergence confirmed: CDF options are accepted but return a normal 
 # race lives in a window too small to hit reliably, make the interleaving an
 # input rather than sampling for it — or, where you cannot, assert the property
 # that survives every interleaving instead of the one you hoped to observe.
+#
+# The retry side of this is Sail's, and it is bounded: sail-delta-lake 0.6.6
+# commits under `for attempt_number in 1..=total_retries`
+# (crates/sail-delta-lake/src/transaction/mod.rs), and an overwrite is neither a
+# creation nor a blind append, so its `effective_max_retries` is 0 — one
+# attempt, then `MaxCommitAttempts`. The loser fails in milliseconds. Nothing
+# here can spin; what it can do is block, since every call below is a gRPC round
+# trip with no deadline, which is what `step()` exists to bound.
 conflict_url = "az://sailws/lake.Lakehouse/Tables/concurrent_probe"
+step("seed the concurrent-writer table")
 spark.range(1).write.format("delta").mode("overwrite").save(conflict_url)
 storage_token = entra_token("https://storage.azure.com/.default")
 
@@ -205,6 +290,7 @@ def delta_log_versions(table):
     return found
 
 
+step("read _delta_log versions before the race")
 before = delta_log_versions("concurrent_probe")
 assert before, "the seed commit is missing; the probe below would prove nothing"
 barrier = threading.Barrier(2)
@@ -219,11 +305,43 @@ def concurrent_overwrite(value):
     except Exception as error:
         return f"rejected:{type(error).__name__}"
     finally:
-        session.stop()
+        # Release the session on the SERVER, and deliberately NOT session.stop().
+        #
+        # This is what hung the job. stop() calls client.close(), whose first act
+        # is ExecutePlanResponseReattachableIterator.shutdown() — and that is
+        # PROCESS-WIDE, not per session. It takes a CLASS-level lock, hands the
+        # CLASS-level release thread pool to ThreadPoolExecutor.shutdown()
+        # (wait=True by default), and holds the lock until the pool drains. Every
+        # new query in this process builds one of those iterators, and its
+        # __init__ takes the same class lock — so one worker's stop() blocks the
+        # MAIN session's next query for as long as the drain takes.
+        #
+        # What is draining is outstanding ReleaseExecute RPCs under the Connect
+        # retry policy, whose own comment says the retry count is chosen "so that
+        # the maximum tolerated wait is guaranteed to be at least 10 minutes"
+        # (pyspark/sql/connect/client/retries.py, DefaultPolicy). A losing writer
+        # is exactly the case that leaves one outstanding: its execution ends in
+        # an error, which submits _release_all right as the session is torn down.
+        # That is the intermittency, and the CI log is its shape — both sessions
+        # released, then 24 minutes of nothing, because no request ever reached
+        # Sail again.
+        #
+        # release_session() sends the same ReleaseSession RPC (so Sail still logs
+        # the removal) and touches no shared state. It can still retry on its own
+        # thread; the step watchdog above bounds that. Best-effort like the
+        # stop() it replaces — this is teardown, and a failure here must not be
+        # mistaken for the race's verdict — but said out loud, not swallowed.
+        try:
+            session.client.release_session()
+        except Exception as teardown_error:  # noqa: BLE001
+            print(f"note: releasing the writer session failed: {teardown_error!r}",
+                  flush=True)
 
 
+step("race two overwrite writers on one Delta version")
 with ThreadPoolExecutor(max_workers=2) as executor:
     outcomes = list(executor.map(concurrent_overwrite, (100, 200)))
+step("read _delta_log versions after the race")
 committed = outcomes.count("committed")
 rejected = sum(outcome.startswith("rejected:") for outcome in outcomes)
 after = delta_log_versions("concurrent_probe")
@@ -241,6 +359,7 @@ assert len(new_versions) == committed, (outcomes, before, after)
 # would stop at.
 assert after == list(range(len(after))), after
 # The surviving table is one writer's full overwrite, not a blend of both.
+step("read back the table the race left behind")
 rows = spark.read.format("delta").load(conflict_url).collect()
 assert len(rows) == 10, rows
 assert {row[0] for row in rows} in ({v for v in range(100, 110)}, {v for v in range(200, 210)}), rows
@@ -253,6 +372,7 @@ else:
 
 # The engine's writes are real bytes in OneLake: read the first Delta commit
 # back through the Blob surface ourselves (same account-prefixed path form).
+step("read the delta log through the Blob surface")
 req = urllib.request.Request(
     f"{FABRIC}/onelake/{ws['id']}/lake.Lakehouse/Tables/events/_delta_log/"
     "00000000000000000000.json",
@@ -276,6 +396,7 @@ print("delta log readable through the Blob surface (protocol + metaData present)
 # TestConcurrentDeltaCommitRace pins the same mechanism at unit level; this
 # pins it end-to-end, through the Blob surface a real client reaches, with the
 # token a real client mints.
+step("put-if-absent against an existing commit (expect 409)")
 conflict_probe = urllib.request.Request(
     f"{FABRIC}/onelake/{ws['id']}/lake.Lakehouse/Tables/events/_delta_log/"
     "00000000000000000000.json",

--- a/e2e/sail/run.py
+++ b/e2e/sail/run.py
@@ -15,17 +15,43 @@ if os.environ.get("FABRIC_COVERAGE"):
     COMPOSE += ["-f", os.path.join(os.path.dirname(DIR), "docker-compose.coverage.yml")]
 
 
-def compose(*args, check=False):
-    return subprocess.run(COMPOSE + list(args), check=check)
+# The CI job that runs this has a 25-minute budget, and a run that eats all of
+# it is reported as CANCELLED — which reads as infrastructure noise and gets
+# rerun rather than investigated. So the suite must always end on its own terms
+# first. driver.py's per-step watchdog is the primary guard and names what it
+# was waiting on; this is the backstop for a stack that hangs before the driver
+# can say anything at all — a build that stalls, or sail never listening.
+#
+# THE BUDGETS MUST ADD UP, and the first draft of this did not: 900 up + 120 ps
+# + 3x120 logs + 300 down is 28 minutes, so the guard could itself be cancelled
+# at 25 and prove nothing. Every path below has a ceiling and they sum on
+# purpose — 600 + 60 + 3x60 + 180 = 17 minutes, against a job budget of 25 and a
+# normal run of about one. Change one number and re-add them.
+BUDGET = float(os.environ.get("SAIL_E2E_BUDGET", "600"))
+DIAGNOSTIC = 60.0
+TEARDOWN = 180.0
+
+
+def compose(*args, check=False, timeout=None):
+    return subprocess.run(COMPOSE + list(args), check=check, timeout=timeout)
 
 
 try:
-    rc = compose("up", "--build", "--abort-on-container-exit",
-                 "--exit-code-from", "driver").returncode
+    try:
+        rc = compose("up", "--build", "--abort-on-container-exit",
+                     "--exit-code-from", "driver", timeout=BUDGET).returncode
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(f"\n==== TIMEOUT: the stack did not finish in {BUDGET:.0f}s ====\n")
+        compose("ps", timeout=DIAGNOSTIC)
+        rc = 1
     if rc != 0:
-        for svc in ("sail", "fabric-emulator"):
+        # driver first: its own output is the only thing that says how far the
+        # run got, and on the timeout path `up` was killed mid-stream.
+        for svc in ("driver", "sail", "fabric-emulator"):
             sys.stderr.write(f"\n==== {svc} log ====\n")
-            compose("logs", svc)
+            compose("logs", svc, timeout=DIAGNOSTIC)
     sys.exit(rc)
 finally:
-    compose("down", "-v")
+    # Timed as well: the whole point is that nothing here can consume the job's
+    # budget, and a diagnostic or a teardown hangs as readily as the run does.
+    compose("down", "-v", timeout=TEARDOWN)

--- a/e2e/spark/job.py
+++ b/e2e/spark/job.py
@@ -30,7 +30,9 @@ def _req(method, url, body=None, token=None, form=False):
     if token:
         headers["Authorization"] = "Bearer " + token
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req) as r:
+    # Timed, like every other wait in this suite: an untimed urlopen is the one
+    # way a bounded poll loop still hangs for a whole CI job (see e2e/sail).
+    with urllib.request.urlopen(req, timeout=60) as r:
         raw = r.read()
         return json.loads(raw) if raw else {}
 


### PR DESCRIPTION
**Adopted work, not mine.** This was authored by the session behind ledger entry `local_1b160431`, which has been silent since Aug 10 19:33 while its fix sat uncommitted in the shared checkout. `local_7cab3362` disclaimed it explicitly; `local_87220308` and I agreed I would adopt it, since I hold the freshest measurement. I applied the 8 files unchanged onto current main and verified them — I did not rewrite the diagnosis, and the analysis below is the author's.

Committed from a worktree off `origin/main`; the shared checkout was never used and still sits at `e40388b` with its files intact.

## Why now

The hang **fired on main** at `796d5df`: 67 success + 1 cancelled, the Sail e2e killed at **25m15s against a 25-minute budget**. I re-ran it and main went green 68/68 with the e2e step genuinely executed, which is exactly the trap the author names below — a cancelled check reads as infrastructure noise, so it gets rerun rather than investigated.

One datum I can add: it reproduced on a **push-event** run, where `ci.yml` sets `cancel-in-progress: false`. So concurrency is excluded as a cause, which supports the client-side diagnosis rather than a scheduling one.

## The cause is in pyspark, not Delta, Sail or the emulator

`SparkSession.stop()` calls `client.close()`, whose first act is `ExecutePlanResponseReattachableIterator.shutdown()` — **process-wide, not per session**. It takes a class-level lock, hands the class-level release pool to `ThreadPoolExecutor.shutdown()` (`wait=True`), and holds the lock until the pool drains. Every new query builds one of those iterators and its `__init__` takes that same lock. So a worker thread's `stop()` blocks the **main** session's next query — precisely where the log falls silent — for as long as outstanding `ReleaseExecute` retries take, which pyspark's own policy lets run "at least 10 minutes".

A **losing** writer is what leaves one outstanding, which is why it is intermittent and only bites when the race actually collides. Measured by driving the shipped pyspark classes with no server at all.

Fix: `session.client.release_session()` instead of `session.stop()`.

## Defence in depth, because the last hang said nothing

- `PYTHONUNBUFFERED=1` in the shared python image. In the run that *passed*, all twenty driver prints carried one timestamp, flushed at exit — so a killed run printed nothing and its silence located nothing.
- A per-step watchdog that names what it was waiting on. Note the author's own correction in the comments: the budget check sits *before* the heartbeat gate, because a `continue` for "nothing to report yet" also skipped the budget, making any budget under one heartbeat unreachable. A watchdog that cannot be made to fire is not evidence.
- Timeouts on `compose up/ps/logs/down`, and on the previously untimed `urlopen` calls in the livy, notebook-driven and spark suites.
- **The budgets sum under the job budget on purpose**: 600 + 60 + 3×60 + 180 = 17 minutes against a 25-minute job. The first draft summed to 28, so the guard could itself be cancelled and prove nothing. Change one number and re-add them.

## Also in docs/20

The Delta side is recorded as measured rather than assumed: the losing writer fails **fast, not eventually** — `effective_max_retries` is 0 for a non-blind-append overwrite, so one attempt then `MaxCommitAttempts`, 50 ms from conflict to both sessions closed. The emulator's half is Azure's own contract: `If-None-Match: *` against an existing commit answers 409 `BlobAlreadyExists`, which object_store does not retry. Terminal on both sides, so an unbounded commit retry was never the explanation.

## Verification

`make check` green, all five touched python files compile, compose config valid. The author reported 26 runs before the fix with no hang reproduced and 20 after, plus `make check` and the spark/livy/notebook-driven suites green locally. **I have not independently reproduced the 26/20 run counts** — CI is the next real test, and this PR is where the fix first gets exercised by the job that was hanging.