### PR TITLE
Warehouse parity: Fabric's collation, and the CREATE TABLE restrictions it enforces

### DIFF
--- a/docs/29-tsql-parity.md
+++ b/docs/29-tsql-parity.md
@@ -570,3 +570,40 @@ unless the variable is set (a nil `TraceFunc` costs one nil check per message).
 [nested]: https://learn.microsoft.com/en-us/sql/t-sql/queries/nested-common-table-expression?view=fabric&preserve-view=true
 [ident]: https://learn.microsoft.com/en-us/fabric/data-warehouse/identity
 [i318]: https://github.com/microsoft/dbt-fabric/issues/318
+
+## Measured against a real tenant, 2026-08-11
+
+Everything above was derived from what dbt-fabric emits and what SQL Server
+accepts. These are the divergences a real Fabric Warehouse produced when the same
+statements were sent to it, and they all point the dangerous way: **SQL Server
+accepts more than Fabric does**, so a model built here could fail there.
+
+| Statement | Real Fabric | Vanilla SQL Server | Now |
+|---|---|---|---|
+| `information_schema.tables` (lowercase) | `Invalid object name` | 12 rows | refused, because per-item databases are created `COLLATE Latin1_General_100_BIN2_UTF8` |
+| `INT IDENTITY(1,1)` | "Identity column must be of data type BIGINT" | accepted | refused by name (`internal/tsql/createtable.go`) |
+| `PRIMARY KEY` in `CREATE TABLE` | "not supported in the CREATE TABLE statement" | accepted | refused by name |
+| `PRIMARY KEY … NOT ENFORCED` inline | same refusal | accepted | refused by name |
+| CTAS · `SELECT INTO` · nested CTE · `varchar(max)` · `MERGE` · `#temp` · `sys.tables` | all accepted | accepted | unchanged |
+
+**The collation is the one that mattered.** A Fabric Warehouse reports
+`Latin1_General_100_BIN2_UTF8` — documented by Microsoft as "The default -
+case-sensitive (CS) collation" — while `CREATE DATABASE [x]` on the emulator's
+SQL Server inherited `SQL_Latin1_General_CP1_CI_AS`, case-INsensitive. So every
+identifier casing mistake passed locally and failed on a tenant, and no amount of
+reading the code would show it. Per-item databases now carry Fabric's collation,
+and `collationType` is honoured from a Warehouse's `creationPayload` and reported
+on `GET /warehouses/{id}` (both values Fabric offers).
+
+Verified after the change: `e2e/medallion` 11/11, with **dbt-fabric's gold build
+green against a case-sensitive warehouse** — the adapter emits correctly-cased
+SQL, which is unsurprising once you notice Fabric has always been case-sensitive.
+Measured in the container: both per-item databases report
+`Latin1_General_100_BIN2_UTF8`, `INFORMATION_SCHEMA.TABLES` returns 6 and
+`information_schema.tables` is now an invalid object name — the tenant's answer,
+locally.
+
+**The two dialect adaptations are not portability debt.** Real Fabric accepts
+CTAS natively *and* `SELECT INTO`, and accepts the nested CTE dbt-fabric wraps
+every test body in. T6 and T8 exist because the emulator's backend is vanilla SQL
+Server, not because Fabric is short of anything.

--- a/internal/api/kql.go
+++ b/internal/api/kql.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/calvinchengx/fabric-emulator/internal/auth"
 	"github.com/calvinchengx/fabric-emulator/internal/store"
+	"github.com/calvinchengx/fabric-emulator/internal/tds"
 )
 
 // KustoAudience is the Entra resource a Kusto/Eventhouse token carries —
@@ -437,11 +438,13 @@ func (a *API) typedItemProperties(r *http.Request, it *store.Item) map[string]an
 		// See warehouse_endpoint.go. Nil rather than an empty string when no SQL
 		// endpoint is running: a property that is present but blank reads as "the
 		// warehouse has no address", which is a different claim from "this build
-		// serves no SQL".
+		// serves no SQL". The collation is reported either way, because it is a
+		// property of the warehouse rather than of the endpoint serving it.
+		props := map[string]any{"collationType": a.warehouseCollation(it.ID)}
 		if cs := a.warehouseConnectionString(r); cs != "" {
-			return map[string]any{"connectionString": cs}
+			props["connectionString"] = cs
 		}
-		return nil
+		return props
 	case "Lakehouse":
 		// The SQL analytics endpoint: the read-only T-SQL surface over the
 		// lakehouse's Delta tables. It is the same TDS listener a Warehouse
@@ -523,6 +526,19 @@ func (a *API) applyCreationPayload(it *store.Item, payload map[string]any) {
 		return v
 	}
 	switch it.Type {
+	case "Warehouse":
+		// Fabric offers exactly two collations and defaults to the case-SENSITIVE
+		// one. Recording the default explicitly rather than leaving the property
+		// absent is deliberate: `collationType` is a documented part of a
+		// Warehouse's properties, and a consumer that reads it to decide how to
+		// quote identifiers must get an answer here too. An unrecognised value is
+		// ignored rather than stored, so the report and the database's actual
+		// COLLATE clause cannot disagree (internal/tds/collation.go).
+		collation := tds.CollationCaseSensitive
+		if c := str("collationType"); tds.ValidCollation(c) {
+			collation = c
+		}
+		_ = a.Store.SetItemProperties(it.ID, map[string]string{store.PropCollationType: collation})
 	case "KQLDatabase":
 		props := map[string]string{propDatabaseType: "ReadWrite"}
 		for _, key := range []string{propParentEventhouse, propDatabaseType, propStoragePeriod} {

--- a/internal/api/warehouse_endpoint.go
+++ b/internal/api/warehouse_endpoint.go
@@ -31,6 +31,9 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+	"github.com/calvinchengx/fabric-emulator/internal/tds"
 )
 
 // warehouseConnectionString returns the host:port a SQL client should dial to
@@ -69,4 +72,18 @@ func SQLPortOf(addr string) string {
 		return addr
 	}
 	return ""
+}
+
+// warehouseCollation reports the collation a warehouse's database was created
+// with, defaulting to Fabric's own default when nothing was declared. Never
+// blank: a consumer reading this to decide how to quote an identifier needs an
+// answer, and "absent" would make case-sensitivity look like a local quirk
+// rather than the documented default it is.
+func (a *API) warehouseCollation(itemID string) string {
+	if props, err := a.Store.ItemProperties(itemID); err == nil {
+		if c := props[store.PropCollationType]; tds.ValidCollation(c) {
+			return c
+		}
+	}
+	return tds.CollationCaseSensitive
 }

--- a/internal/api/warehouse_endpoint_test.go
+++ b/internal/api/warehouse_endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/calvinchengx/fabric-emulator/internal/store"
+	"github.com/calvinchengx/fabric-emulator/internal/tds"
 )
 
 func TestSQLPortOf(t *testing.T) {
@@ -103,8 +104,18 @@ func TestWarehouseReportsNoConnectionStringWithoutASQLEndpoint(t *testing.T) {
 	}
 
 	body := getItemBody(t, a, "localhost:9443", ws.ID, wh.ID)
-	if props, ok := body["properties"]; ok {
-		t.Fatalf("a warehouse with no SQL endpoint advertised properties: %v", props)
+	props, _ := body["properties"].(map[string]any)
+	if cs, present := props["connectionString"]; present {
+		t.Fatalf("a warehouse with no SQL endpoint advertised an address: %v", cs)
+	}
+	// It DOES still report its collation, and that is not a weakening of the
+	// assertion above: the collation is a property of the warehouse, not of the
+	// endpoint serving it, and real Fabric reports it either way. Asserting it
+	// here keeps the two claims separate — "no address" must not quietly become
+	// "no properties", which is what this test said before there was a second one.
+	if props["collationType"] != tds.CollationCaseSensitive {
+		t.Errorf("collationType = %v, want Fabric's default %q",
+			props["collationType"], tds.CollationCaseSensitive)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -149,6 +149,15 @@ func New(cfg *config.Config, jwksClient *http.Client) (*Server, error) {
 				return nil, err
 			}
 			s.TDS.Backend = be
+			// A Warehouse's own collationType decides how its database is created.
+			// The backend cannot read the store (import direction), so it asks.
+			be.CollationOf = func(database string) string {
+				props, err := st.ItemProperties(database)
+				if err != nil {
+					return ""
+				}
+				return props[store.PropCollationType]
+			}
 			// Route each connection by item type (Lakehouse = read-only analytics
 			// endpoint, Warehouse = read-write), each into its own database, with
 			// workspace RBAC enforced for the token's principal.

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -136,6 +136,16 @@ func (s *Store) SetDefinition(itemID string, parts []DefinitionPart) error {
 	return err
 }
 
+// PropCollationType is the Warehouse property naming its database collation.
+//
+// It lives in `store` rather than `api` because two packages need the same
+// string: the API stores it from `creationPayload`, and the server hands the TDS
+// backend a lookup so `CREATE DATABASE` gets the right COLLATE clause. A literal
+// duplicated across that boundary is a silent divergence waiting for a typo —
+// the database would be created with Fabric's default while the API reported
+// what the caller asked for.
+const PropCollationType = "collationType"
+
 // SetItemProperties upserts typed properties on an item — the values Fabric
 // returns under an item's "properties" object (a KQLDatabase's
 // parentEventhouseItemId, for instance). Empty values delete the key so a

--- a/internal/tds/collation.go
+++ b/internal/tds/collation.go
@@ -1,0 +1,56 @@
+package tds
+
+// The collation a per-item database is created with, and why it is not the
+// server's.
+//
+// MEASURED ON A REAL TENANT, 2026-08-11. A Fabric Warehouse reports
+// `Latin1_General_100_BIN2_UTF8` as its database collation, and Microsoft's own
+// Get Warehouse reference documents that value as "The default - case-sensitive
+// (CS) collation". BIN2 is a BINARY collation: identifier and data comparisons
+// are case- AND accent-sensitive.
+//
+// The emulator's backend is a SQL Server container whose server collation is
+// `SQL_Latin1_General_CP1_CI_AS` — case-INSENSITIVE — and `CREATE DATABASE [x]`
+// with no COLLATE clause inherits it. So every per-item database was
+// case-insensitive while the thing it stands in for is case-sensitive, and the
+// divergence pointed the dangerous way:
+//
+//	SELECT ... FROM information_schema.tables   -- 12 rows here, on a tenant:
+//	                                            -- "Invalid object name"
+//
+// Green locally, broken in production, and undiscoverable by reading code. That
+// asymmetry is worth more than the convenience of a forgiving default: a casing
+// mistake should fail on the developer's machine, which is the only place it is
+// cheap to fix.
+//
+// Fabric offers exactly two collations at create time, so those are the only two
+// this accepts — an unrecognised value must not be silently coerced into the
+// default, because "we ignored your collation" is how a case-sensitivity bug gets
+// re-introduced by configuration.
+const (
+	// CollationCaseSensitive is Fabric's default: binary, case- and
+	// accent-sensitive, UTF-8.
+	CollationCaseSensitive = "Latin1_General_100_BIN2_UTF8"
+	// CollationCaseInsensitive is the opt-in Fabric documents on
+	// Warehouse creationPayload.collationType.
+	CollationCaseInsensitive = "Latin1_General_100_CI_AS_KS_WS_SC_UTF8"
+)
+
+// ValidCollation reports whether `c` is one Fabric actually offers.
+func ValidCollation(c string) bool {
+	return c == CollationCaseSensitive || c == CollationCaseInsensitive
+}
+
+// collationFor resolves the collation to create `database` with: whatever the
+// item declared, else Fabric's default. An unknown declared value falls back to
+// the default rather than reaching the DDL, because an invalid COLLATE clause
+// fails the CREATE DATABASE outright and a warehouse that cannot be created is a
+// worse answer than one created case-sensitive.
+func (b *sqlServerBackend) collationFor(database string) string {
+	if b.CollationOf != nil {
+		if c := b.CollationOf(database); ValidCollation(c) {
+			return c
+		}
+	}
+	return CollationCaseSensitive
+}

--- a/internal/tds/collation_test.go
+++ b/internal/tds/collation_test.go
@@ -1,0 +1,57 @@
+package tds
+
+import (
+	"strings"
+	"testing"
+)
+
+// The whole point of collation.go: a per-item database must be created with
+// Fabric's collation, not the SQL Server container's. Measured on a real tenant
+// 2026-08-11 — the warehouse reports Latin1_General_100_BIN2_UTF8 (case-SENSITIVE)
+// while the emulator's server collation is SQL_Latin1_General_CP1_CI_AS, so
+// `information_schema.tables` lowercase worked here and was an invalid object
+// name there.
+func TestDatabasesAreCreatedWithFabricsCollation(t *testing.T) {
+	b := &sqlServerBackend{}
+	if got := b.collationFor("any"); got != CollationCaseSensitive {
+		t.Fatalf("default collation = %q, want Fabric's %q", got, CollationCaseSensitive)
+	}
+}
+
+func TestADeclaredCollationIsHonoured(t *testing.T) {
+	b := &sqlServerBackend{CollationOf: func(string) string { return CollationCaseInsensitive }}
+	if got := b.collationFor("wh"); got != CollationCaseInsensitive {
+		t.Fatalf("declared collation ignored: %q", got)
+	}
+}
+
+// An unrecognised value must not reach the DDL: an invalid COLLATE clause fails
+// CREATE DATABASE outright, and a warehouse that cannot be created is a worse
+// answer than one created case-sensitive.
+func TestAnUnknownCollationFallsBackRatherThanFailingTheCreate(t *testing.T) {
+	for _, bad := range []string{"", "Latin1_General_CI_AS", "'; DROP DATABASE x --", "utf8mb4_general_ci"} {
+		b := &sqlServerBackend{CollationOf: func(string) string { return bad }}
+		if got := b.collationFor("wh"); got != CollationCaseSensitive {
+			t.Errorf("collationFor(%q) = %q, want the default", bad, got)
+		}
+	}
+}
+
+// The COLLATE clause is interpolated into DDL, so only values from the fixed set
+// may ever reach it — checked here rather than trusted, because collationFor is
+// the only thing standing between CollationOf and a CREATE DATABASE statement.
+func TestOnlyFabricsTwoCollationsAreValid(t *testing.T) {
+	if !ValidCollation(CollationCaseSensitive) || !ValidCollation(CollationCaseInsensitive) {
+		t.Fatal("Fabric's own two collations must validate")
+	}
+	for _, bad := range []string{"", "SQL_Latin1_General_CP1_CI_AS", "Latin1_General_100_BIN2"} {
+		if ValidCollation(bad) {
+			t.Errorf("ValidCollation(%q) = true", bad)
+		}
+	}
+	for _, c := range []string{CollationCaseSensitive, CollationCaseInsensitive} {
+		if strings.ContainsAny(c, " ;'\"[]-") {
+			t.Errorf("collation %q contains a character that is unsafe to interpolate", c)
+		}
+	}
+}

--- a/internal/tds/sqlserver.go
+++ b/internal/tds/sqlserver.go
@@ -58,6 +58,12 @@ type sqlServerBackend struct {
 	base  *msdsn.Config // base config for per-database pools (nil in tests)
 	mu    sync.Mutex
 	pools map[string]*sql.DB
+	// CollationOf returns the collation an item's database must be created
+	// with — the Warehouse `collationType` the caller declared, or "" for
+	// Fabric's default. A function rather than a value because the answer is
+	// per item and lives in the store, which this package must not import.
+	// Nil means every database gets Fabric's default (see collation.go).
+	CollationOf func(database string) string
 }
 
 // NewSQLServerBackend opens a pooled connection to a SQL Server DSN, e.g.
@@ -110,8 +116,11 @@ func (b *sqlServerBackend) EnsureDatabase(ctx context.Context, database string) 
 	if !safeDBName(database) {
 		return fmt.Errorf("unsafe database name %q", database)
 	}
+	// COLLATE is not optional here: without it the database inherits the
+	// server's case-INSENSITIVE collation while Fabric's is case-sensitive, so
+	// a casing mistake passes locally and fails on a tenant (collation.go).
 	_, err := b.db.ExecContext(ctx,
-		"IF DB_ID('"+database+"') IS NULL CREATE DATABASE ["+database+"]")
+		"IF DB_ID('"+database+"') IS NULL CREATE DATABASE ["+database+"] COLLATE "+b.collationFor(database))
 	return err
 }
 

--- a/internal/tsql/createtable.go
+++ b/internal/tsql/createtable.go
@@ -1,0 +1,110 @@
+package tsql
+
+// CREATE TABLE restrictions Fabric Warehouse enforces and SQL Server does not.
+//
+// MEASURED AGAINST A REAL TENANT, 2026-08-11, on a Fabric Warehouse:
+//
+//	CREATE TABLE dbo.t (id INT IDENTITY(1,1), n INT)
+//	  -> "Identity column 'id' must be of data type BIGINT."
+//	CREATE TABLE dbo.t (id INT NOT NULL PRIMARY KEY)
+//	  -> "The PRIMARY KEY keyword is not supported in the CREATE TABLE statement…"
+//	CREATE TABLE dbo.t (id INT NOT NULL,
+//	                    CONSTRAINT pk PRIMARY KEY NONCLUSTERED (id) NOT ENFORCED)
+//	  -> the same refusal: NOT ENFORCED does not buy an inline constraint either;
+//	     Fabric wants ALTER TABLE … ADD CONSTRAINT.
+//
+// The emulator's backend is a SQL Server container, which accepts all three. That
+// is the dangerous direction — a model using any of them builds locally and fails
+// on the tenant it was written for — and it is the direction an emulator must
+// close, because the alternative is that its users discover Fabric's restrictions
+// in production.
+//
+// This REFUSES rather than rewrites. A rewrite would have to invent semantics
+// Fabric does not have: dropping IDENTITY changes what the table does, and
+// hoisting an inline PRIMARY KEY into an ALTER TABLE changes what the statement
+// is. The author has to make that call, and a refusal that quotes the tenant's
+// own message is the shortest path to them making it.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// checkCreateTableRestrictions refuses a CREATE TABLE that Fabric Warehouse
+// would refuse. It looks at TOKENS rather than raw text so a column called
+// `identity_provider`, a string literal containing "PRIMARY KEY", or a comment
+// cannot trigger it.
+func checkCreateTableRestrictions(toks []Token) error {
+	if !startsCreateTable(toks) {
+		return nil
+	}
+	for i, t := range toks {
+		if t.Kind != Word {
+			continue
+		}
+		switch strings.ToUpper(t.Text) {
+		case "IDENTITY":
+			// Fabric allows IDENTITY only on BIGINT. The type precedes the
+			// keyword: `id BIGINT IDENTITY(1,1)`.
+			if ty := previousTypeName(toks, i); ty != "" && ty != "BIGINT" {
+				return fmt.Errorf(
+					"Fabric Warehouse restriction: an IDENTITY column must be BIGINT, "+
+						"not %s — the tenant answers \"Identity column must be of data "+
+						"type BIGINT\". Change the type, or drop IDENTITY and generate "+
+						"the key yourself", ty)
+			}
+		case "PRIMARY":
+			if i+1 < len(toks) && strings.EqualFold(nextWord(toks, i), "KEY") {
+				return fmt.Errorf(
+					"Fabric Warehouse restriction: PRIMARY KEY is not supported in " +
+						"CREATE TABLE — not even NOT ENFORCED. Create the table, then " +
+						"ALTER TABLE … ADD CONSTRAINT … PRIMARY KEY NONCLUSTERED (…) " +
+						"NOT ENFORCED")
+			}
+		}
+	}
+	return nil
+}
+
+// startsCreateTable reports whether the token stream begins a CREATE TABLE.
+// Deliberately narrow: CREATE TABLE only, so CREATE VIEW/PROC/INDEX pass through.
+func startsCreateTable(toks []Token) bool {
+	var seen []string
+	for _, t := range toks {
+		if t.Kind != Word {
+			continue
+		}
+		seen = append(seen, strings.ToUpper(t.Text))
+		if len(seen) == 2 {
+			break
+		}
+	}
+	return len(seen) == 2 && seen[0] == "CREATE" && seen[1] == "TABLE"
+}
+
+// previousTypeName returns the identifier immediately before position i, upper
+// cased — the column's declared type when i is an IDENTITY keyword. Empty when
+// there is no preceding identifier.
+func previousTypeName(toks []Token, i int) string {
+	for j := i - 1; j >= 0; j-- {
+		if toks[j].Kind == Word {
+			return strings.ToUpper(toks[j].Text)
+		}
+	}
+	return ""
+}
+
+// nextWord returns the next Word token's text after position i, skipping
+// whitespace and comments — `PRIMARY /* c */ KEY` is still a PRIMARY KEY.
+func nextWord(toks []Token, i int) string {
+	for j := i + 1; j < len(toks); j++ {
+		if toks[j].Trivia() {
+			continue
+		}
+		if toks[j].Kind == Word {
+			return toks[j].Text
+		}
+		return ""
+	}
+	return ""
+}

--- a/internal/tsql/createtable_test.go
+++ b/internal/tsql/createtable_test.go
@@ -1,0 +1,52 @@
+package tsql
+
+import "strings"
+import "testing"
+
+// Each case is a statement a real Fabric Warehouse REFUSED on 2026-08-11, with
+// the tenant's own message quoted in createtable.go. SQL Server accepts all of
+// them, which is why the emulator has to say no itself: otherwise the model
+// builds locally and fails on the tenant it was written for.
+func TestFabricCreateTableRestrictionsAreRefused(t *testing.T) {
+	for _, tc := range []struct{ name, sql, want string }{
+		{"INT IDENTITY", "CREATE TABLE dbo.t (id INT IDENTITY(1,1), n INT)", "must be BIGINT"},
+		{"SMALLINT IDENTITY", "CREATE TABLE t (id SMALLINT IDENTITY(1,1))", "must be BIGINT"},
+		{"inline PRIMARY KEY", "CREATE TABLE dbo.t (id INT NOT NULL PRIMARY KEY)", "PRIMARY KEY is not supported"},
+		{"NOT ENFORCED PRIMARY KEY",
+			"CREATE TABLE dbo.t (id INT NOT NULL, CONSTRAINT pk PRIMARY KEY NONCLUSTERED (id) NOT ENFORCED)",
+			"PRIMARY KEY is not supported"},
+		{"PRIMARY KEY split by a comment",
+			"CREATE TABLE t (id INT PRIMARY /* sneaky */ KEY)", "PRIMARY KEY is not supported"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Adapt(tc.sql)
+			if err == nil {
+				t.Fatalf("accepted a statement Fabric refuses: %s", tc.sql)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error does not name the restriction: %v", err)
+			}
+		})
+	}
+}
+
+// The refusal must not fire on statements Fabric accepts — a gate that blocks
+// legal DDL is worse than none, because the workaround is to stop using the gate.
+func TestLegalCreateTablesArePassedThrough(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE dbo.t (id BIGINT IDENTITY(1,1), n INT)", // BIGINT is allowed
+		"CREATE TABLE dbo.t (n INT, s VARCHAR(100))",
+		// A column whose NAME contains the keyword: token-level matching, not text.
+		"CREATE TABLE dbo.t (identity_provider VARCHAR(50), primary_contact VARCHAR(50))",
+		// The words inside a string literal and a comment.
+		"CREATE TABLE dbo.t (s VARCHAR(50) DEFAULT 'PRIMARY KEY') -- IDENTITY(1,1)",
+		// Not a CREATE TABLE at all.
+		"CREATE VIEW v AS SELECT 1 AS n",
+		"ALTER TABLE dbo.t ADD CONSTRAINT pk PRIMARY KEY NONCLUSTERED (id) NOT ENFORCED",
+		"SELECT 1",
+	} {
+		if _, _, err := Adapt(sql); err != nil {
+			t.Errorf("refused a statement Fabric accepts: %s\n  %v", sql, err)
+		}
+	}
+}

--- a/internal/tsql/ctas.go
+++ b/internal/tsql/ctas.go
@@ -210,6 +210,15 @@ func Adapt(sql string) (out string, changed bool, err error) {
 // compose: CTAS first — it produces an ordinary query — then nested-CTE
 // flattening over the result.
 func adaptStatement(sql string) (out string, changed bool, err error) {
+	// Refusals first: a statement Fabric would reject must not be rewritten into
+	// one it would accept. Rewriting first and checking after would let the
+	// adapter launder a restriction — the emulator would run something the tenant
+	// never would, which is the failure this whole file exists to avoid.
+	if toks, terr := Tokenize(sql); terr == nil {
+		if rerr := checkCreateTableRestrictions(toks); rerr != nil {
+			return sql, false, rerr
+		}
+	}
 	out, changed, err = RewriteCTAS(sql)
 	if err != nil {
 		return sql, false, err


### PR DESCRIPTION
Answering "is gold fully compatible?" by sending statements to a real Fabric Warehouse instead of reasoning about them. 9 of 13 accepted; the four refusals are this PR.

## The one that matters: collation

A real Warehouse reports `Latin1_General_100_BIN2_UTF8` — Microsoft's own Get Warehouse reference documents that value as "The default - case-sensitive (CS) collation". The emulator's `CREATE DATABASE [x]` had no `COLLATE` clause, so every per-item database inherited the container's `SQL_Latin1_General_CP1_CI_AS`, case-**in**sensitive.

```
SELECT COUNT(*) FROM information_schema.tables   -- emulator: 12   tenant: Invalid object name
```

Green locally, broken on a tenant, and undiscoverable by reading code. Per-item databases now carry Fabric's collation, `collationType` is honoured from a Warehouse's `creationPayload`, and it is reported on `GET /warehouses/{id}` — always, because the collation is a property of the warehouse rather than of the endpoint serving it.

Unknown collation values fall back to the default rather than reaching the DDL: an invalid `COLLATE` clause fails `CREATE DATABASE` outright, and a warehouse that cannot be created is a worse answer than one created case-sensitive. Only Fabric's two documented values ever reach the interpolated DDL, asserted in a test alongside a character-safety check.

## Three CREATE TABLE restrictions, refused by name

`INT IDENTITY(1,1)` ("Identity column must be of data type BIGINT"), `PRIMARY KEY` in `CREATE TABLE`, and the same inline constraint with `NOT ENFORCED` — all accepted by SQL Server, all refused by the tenant. Refused rather than rewritten, because a rewrite would invent semantics Fabric does not have: dropping IDENTITY changes what the table does, and hoisting a constraint into `ALTER TABLE` changes what the statement is. Token-level matching, so `identity_provider`, `'PRIMARY KEY'` in a literal, and `-- IDENTITY(1,1)` in a comment all pass.

Refusals run **before** the CTAS/CTE rewrites: rewriting first would let the adapter launder a restriction into something the emulator runs and a tenant never would.

## What was already fine

Real Fabric accepts CTAS natively *and* `SELECT INTO`, plus the nested CTE dbt-fabric wraps every test body in, `varchar(max)`, `MERGE` and `#temp`. So T6 and T8 are artefacts of the emulator's vanilla-SQL-Server backend, not portability debt.

## Verified

- **`e2e/medallion` 11/11 exit 0**, with dbt-fabric's gold build green against a case-sensitive warehouse — the adapter emits correctly-cased SQL, unsurprising once you notice Fabric has always been case-sensitive.
- **Measured in the container**, not assumed: both per-item databases report `Latin1_General_100_BIN2_UTF8`; `INFORMATION_SCHEMA.TABLES` returns 6 and `information_schema.tables` is now an invalid object name — the tenant's answer, locally.
- All Go suites, lint, and the new unit tests for the collation resolver and the CREATE TABLE refusals.
- One existing test narrowed: `TestWarehouseReportsNoConnectionStringWithoutASQLEndpoint` asserted a warehouse with no endpoint reports *no properties at all*, which was only true while `connectionString` was the sole property. It now asserts no **address** and that the collation is still reported — keeping the two claims separate instead of letting "no address" mean "no properties".