### PR TITLE
Close the last three gold-path gaps: the SQL endpoint item, tenant properties, and Direct Lake over a warehouse

### DIFF
--- a/docs/46-artifact-persistence.md
+++ b/docs/46-artifact-persistence.md
@@ -166,11 +166,23 @@ Both look like `<opaque>-<opaque>.datawarehouse.fabric.microsoft.com` on port
 - **The analytics endpoint lags the lakehouse.** Metadata sync is normally under
   a minute but is not instant, so a table Spark just wrote can be briefly absent
   from T-SQL. `POST /v1/workspaces/{ws}/sqlEndpoints/{sqlEndpointId}/refreshMetadata`
-  forces the sync rather than waiting for the background one. **The emulator does
-  not implement that endpoint**, and does not report the endpoint's `id` either —
-  it has no separate `SQLEndpoint` item and reflects on connect, so there is
-  nothing to sync. Code that needs the refresh must be written against real
-  Fabric, and will 404 locally.
+  forces the sync rather than waiting for the background one. **The emulator
+  implements this**, and the endpoint is a real `SQLEndpoint` item with its own id,
+  because that is what a tenant has — measured 2026-08-11: one lakehouse plus one
+  warehouse left three items in a real workspace, the third being
+  `SQLEndpoint  803c8e33-…  lake`, whose id is exactly what
+  `sqlEndpointProperties.id` reports. The tenant answers a plain `200` with
+  `{"value": []}` (a per-table report, empty for a lakehouse with no tables) —
+  no LRO — and so does the emulator.
+
+  This reverses an earlier decision on purpose. The emulator used to OMIT
+  `sqlEndpointProperties.id`, reasoning that it had no such item and that
+  reporting the lakehouse's own id would invite using it as a database name:
+  green locally, wrong on a tenant. That was right for the information available;
+  the measurement made it obsolete. The honest fix was not to withhold the field
+  but to HAVE the item, so the id is a different GUID here exactly as it is there.
+  `common.sync_sql_endpoint()` consequently takes the same branch on both
+  targets, so the code path a tenant uses is exercised by every local run.
 
 `examples/contoso-fixtures/common.py:sql_endpoint()` is the portable form:
 discover the address, use the item id locally and the display name on real

--- a/docs/46-artifact-persistence.md
+++ b/docs/46-artifact-persistence.md
@@ -133,15 +133,40 @@ notebook writes them as a one-row Delta table, `silver_resolution_metrics`, whic
 is portable by construction and inspectable afterwards. `engine.py` skips under
 `real`, because Fabric runs the queued notebook itself.
 
-**What is still emulator-only, stated rather than left to be discovered:** a
-semantic model's rows. `semantic_model.py` and `tmdl_pbip.py` publish a `data.json`
-part — the emulator's inline row snapshot. Real Fabric has no such part; a model's
-data comes from a partition, either Direct Lake over OneLake Delta or an import
-partition whose M expression reads `Sql.Database(<connectionString>, …)`. The
-emulator evaluates Direct Lake and inline data, not `Sql.Database` import, and the
-warehouse's gold tables are not Delta in OneLake locally — so converting needs
-emulator work first, and `scripts/check_example_portability.py` prints the debt on
-every run instead of hiding it in a whitelist.
+**A semantic model reads gold itself, and that closed the last gap.** The examples
+used to ship the model's rows inside the definition as a `data.json` part — the
+emulator's own inline snapshot, which real Fabric has no concept of. So the one
+artifact a BI consumer actually reads was the one thing that could not be deployed
+to a tenant.
+
+They now publish a **Direct Lake** model: a shared expression naming the item's
+OneLake location, and an `entity` partition per table. Real Fabric supports Direct
+Lake over a warehouse because a warehouse persists to OneLake as Delta; the
+emulator reads the equivalent rows from the SQL Server database it serves. That is
+a BACKEND difference, not a contract one — the definition is byte-identical on both
+targets, ids aside.
+
+Two things worth copying from how this went:
+
+- `onelake.dfs.fabric.microsoft.com` is written **literally** in the expression, not
+  resolved per target. It is Fabric's one OneLake host, the same on every tenant,
+  and the emulator parses the workspace/item out of it rather than fetching it — so
+  the expression text does not vary at all. The notebook definitions address
+  OneLake the same way (`abfs://{ws}@onelake.dfs.fabric.microsoft.com/…`).
+- `compatibilityLevel` must be **1604** or higher for Direct Lake, and the emulator
+  enforces that rather than reading the partition anyway. The conversion failed on
+  it first try, which is the check earning its keep.
+
+A side effect worth having: the flow graph now carries `DirectLake` edges
+(`Tables/dbo/fct_daily_revenue -> Tables/Revenue`), so the hop from gold to the BI
+layer is recorded. With rows shipped inside the definition there was no edge to
+record and the graph simply stopped at gold.
+
+The local `.pbip` project still writes an imported row snapshot beside the model,
+now named `imported-rows.json` rather than `data.json`. That file is **not** a
+definition part and never reaches `updateDefinition`: Power BI Desktop opens the
+project offline with no emulator to reach, so the rows have to be on disk. Naming
+it for what it is keeps it out of the part-path contract.
 
 ### SQL: the address is per-item and only the API knows it
 

--- a/examples/medallion-advanced-dbt-fabricspark/semantic_model.py
+++ b/examples/medallion-advanced-dbt-fabricspark/semantic_model.py
@@ -20,49 +20,75 @@ from common import (
     log,
     report_lineage,
     save,
-    tds_connect,
     token,
 )
 
 st = load()
 H = fabric_headers()
 
-# --- rows: export gold from the warehouse over TDS ---------------------------
-with tds_connect(st["warehouse"]) as c:
-    cur = c.cursor().execute(
-        "SELECT order_date, country, orders, units, revenue FROM fct_daily_revenue")
-    fact = [{"OrderDate": str(r[0])[:10], "Country": r[1], "Orders": int(r[2]),
-             "Units": int(r[3]), "Revenue": float(r[4])} for r in cur.fetchall()]
-    cur = c.cursor().execute("SELECT customer_id, name, country FROM dim_customer")
-    dim = [{"CustomerId": r[0], "Name": r[1], "Country": r[2]} for r in cur.fetchall()]
-assert fact and dim, (fact, dim)
+# The gold tables are read by the MODEL, not by this step. What used to happen
+# here — SELECT every row over TDS and ship them inside the definition as a
+# `data.json` part — was the least portable line in the example: `data.json` is
+# the emulator's own inline row snapshot and real Fabric has no such part. So the
+# one artifact a BI consumer actually reads was the one thing that could not be
+# deployed to a tenant.
+#
+# A DIRECT LAKE partition is what Fabric uses instead: the model names the item's
+# OneLake location and an entity within it, and the engine reads the rows itself.
+# That works on both targets — a warehouse persists to OneLake as Delta on real
+# Fabric, and the emulator reads the equivalent rows from the warehouse it serves
+# (docs/46-artifact-persistence.md).
+#
+# The step still verifies the numbers, further down, by querying the model over
+# executeQueries — which is a stronger check than shipping rows and asserting the
+# rows you shipped.
 
 model = {
     "name": "ContosoRevenue",
-    "compatibilityLevel": 1550,
+    # 1604, not 1550: Direct Lake needs it, and the emulator enforces that the
+    # way Fabric does rather than reading the partition anyway. The bump is the
+    # cost of the model reading gold itself instead of carrying a copy.
+    "compatibilityLevel": 1604,
     "model": {
         "culture": "en-US",
+        # The shared expression every Direct Lake partition points at.
+        #
+        # `onelake.dfs.fabric.microsoft.com` is written LITERALLY, not resolved per
+        # target, and that is deliberate: it is Fabric's one OneLake host, identical
+        # on every tenant, and the emulator parses the workspace/item out of it
+        # rather than fetching it. So this expression is byte-identical on both
+        # targets — the ids are the only thing that differs, as ever (docs/21). The
+        # notebook definitions address OneLake the same way.
+        "expressions": [{"name": "GoldWarehouse", "kind": "m", "expression": (
+            'let Source = AzureStorage.DataLake("'
+            f'https://onelake.dfs.fabric.microsoft.com/{st["workspace"]}/{st["warehouse"]}'
+            '", [HierarchicalNavigation=true]) in Source')}],
         "tables": [
             {"name": "Customer", "columns": [
-                {"name": "CustomerId", "dataType": "string", "sourceColumn": "CustomerId"},
-                {"name": "Name", "dataType": "string", "sourceColumn": "Name"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"}]},
+                {"name": "CustomerId", "dataType": "string", "sourceColumn": "customer_id"},
+                {"name": "Name", "dataType": "string", "sourceColumn": "name"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"}],
+             "partitions": [{"name": "Customer", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "dim_customer", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]},
             {"name": "Revenue", "columns": [
-                {"name": "OrderDate", "dataType": "string", "sourceColumn": "OrderDate"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"},
-                {"name": "Orders", "dataType": "int64", "sourceColumn": "Orders"},
-                {"name": "Units", "dataType": "int64", "sourceColumn": "Units"},
-                {"name": "Revenue", "dataType": "double", "sourceColumn": "Revenue"}],
+                {"name": "OrderDate", "dataType": "string", "sourceColumn": "order_date"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"},
+                {"name": "Orders", "dataType": "int64", "sourceColumn": "orders"},
+                {"name": "Units", "dataType": "int64", "sourceColumn": "units"},
+                {"name": "Revenue", "dataType": "double", "sourceColumn": "revenue"}],
              "measures": [
                  {"name": "Total Revenue", "expression": "SUM(Revenue[Revenue])"},
                  {"name": "Total Units", "expression": "SUM(Revenue[Units])"},
                  {"name": "Revenue per Unit",
-                  "expression": "DIVIDE([Total Revenue], [Total Units])"}]}],
+                  "expression": "DIVIDE([Total Revenue], [Total Units])"}],
+             "partitions": [{"name": "Revenue", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "fct_daily_revenue", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]}],
         "relationships": [
             {"name": "Revenue_Customer", "fromTable": "Revenue", "fromColumn": "Country",
              "toTable": "Customer", "toColumn": "Country"}]},
 }
-data = {"Customer": dim, "Revenue": fact}
 
 
 def part(path, obj):
@@ -72,7 +98,7 @@ def part(path, obj):
 
 r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
     "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model), part("data.json", data)]}})
+    "definition": {"parts": [part("model.bim", model)]}})
 assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
 if r.status_code == 201:
     dataset = r.json()["id"]

--- a/examples/medallion-advanced-dbt-fabricspark/tmdl_pbip.py
+++ b/examples/medallion-advanced-dbt-fabricspark/tmdl_pbip.py
@@ -57,22 +57,29 @@ assert fact and dim, (len(fact), len(dim))
 # Tabs, not spaces: TMDL is indentation-structured and Power BI writes tabs.
 MODEL_TMDL = """model ContosoRevenueTMDL
 \tculture: en-US
-\tcompatibilityLevel: 1550
+\tcompatibilityLevel: 1604
 """
 
 CUSTOMER_TMDL = """table Customer
 
 \tcolumn CustomerId
 \t\tdataType: string
-\t\tsourceColumn: CustomerId
+\t\tsourceColumn: customer_id
 
 \tcolumn Name
 \t\tdataType: string
-\t\tsourceColumn: Name
+\t\tsourceColumn: name
 
 \tcolumn Country
 \t\tdataType: string
-\t\tsourceColumn: Country
+\t\tsourceColumn: country
+
+\tpartition Customer = entity
+\t\tmode: directLake
+\t\tsource
+\t\t\tentityName: dim_customer
+\t\t\tschemaName: dbo
+\t\t\texpressionSource: GoldWarehouse
 """
 
 # The measures carry their DAX verbatim, including one written across several
@@ -82,11 +89,11 @@ REVENUE_TMDL = """table Revenue
 
 \tcolumn OrderDate
 \t\tdataType: string
-\t\tsourceColumn: OrderDate
+\t\tsourceColumn: order_date
 
 \tcolumn Country
 \t\tdataType: string
-\t\tsourceColumn: Country
+\t\tsourceColumn: country
 
 \tcolumn Orders
 \t\tdataType: int64
@@ -107,6 +114,13 @@ REVENUE_TMDL = """table Revenue
 
 \tmeasure 'Revenue per Unit' =
 \t\t\tDIVIDE([Total Revenue], [Total Units])
+
+\tpartition Revenue = entity
+\t\tmode: directLake
+\t\tsource
+\t\t\tentityName: fct_daily_revenue
+\t\t\tschemaName: dbo
+\t\t\texpressionSource: GoldWarehouse
 """
 
 RELATIONSHIPS_TMDL = """relationship Revenue_Customer
@@ -114,15 +128,35 @@ RELATIONSHIPS_TMDL = """relationship Revenue_Customer
 \ttoColumn: Customer.Country
 """
 
+# The shared expression every Direct Lake partition points at. Fabric keeps it in
+# its own TMDL file, and the emulator's parser reads `expression Name = <M>` from
+# any of them.
+EXPRESSIONS_TMDL = f"""expression GoldWarehouse = let Source = AzureStorage.DataLake("https://onelake.dfs.fabric.microsoft.com/{st['workspace']}/{st['warehouse']}", [HierarchicalNavigation=true]) in Source
+\tkind: m
+"""
+
 parts_src = {
     "definition/model.tmdl": MODEL_TMDL,
+    "definition/expressions.tmdl": EXPRESSIONS_TMDL,
     "definition/tables/Customer.tmdl": CUSTOMER_TMDL,
     "definition/tables/Revenue.tmdl": REVENUE_TMDL,
     "definition/relationships.tmdl": RELATIONSHIPS_TMDL,
-    # Rows ride in the same data.json the TMSL path uses: TMDL serialises the
-    # MODEL, not its data, exactly as it does in a real .pbip.
-    "data.json": json.dumps({"Customer": dim, "Revenue": fact}),
 }
+
+# NOT a definition part, and that distinction is the whole point of it being down
+# here rather than in the dict above.
+#
+# TMDL serialises the MODEL, not its data — exactly as a real .pbip does — and the
+# published item now carries a DIRECT LAKE partition, so the emulator and a tenant
+# both read gold from the warehouse rather than from anything shipped inside the
+# definition. `data.json` used to sit in `parts_src` for that job, which made the
+# published item unportable: real Fabric has no such part.
+#
+# The local copy stays, because it serves a different purpose: Power BI Desktop
+# opens this project OFFLINE, with no emulator to reach, so the rows have to be
+# beside the model on disk. A file in a local .pbip directory is not a Fabric
+# definition part and never reaches updateDefinition.
+LOCAL_IMPORTED_ROWS = json.dumps({"Customer": dim, "Revenue": fact})
 
 
 def part(path, text):
@@ -195,8 +229,9 @@ for rel, text in parts_src.items():
     "artifacts": [{"report": {"path": "ContosoRevenue.Report"}}],
     "settings": {"enableAutoRecovery": True}}, indent=2))
 
-# The rows, beside the model, so the project is self-contained offline.
-(model_dir / "data.json").write_text(parts_src["data.json"])
+# The rows, beside the model, so the project is self-contained offline. Named for
+# what it is: an imported snapshot for Desktop, not a part of the published item.
+(model_dir / "imported-rows.json").write_text(LOCAL_IMPORTED_ROWS)
 
 log(f"wrote .pbip project to {OUT.relative_to(pathlib.Path.cwd()) if OUT.is_relative_to(pathlib.Path.cwd()) else OUT}")
 log("Power BI Desktop opens ContosoRevenue.pbip locally with this data IMPORTED — "

--- a/examples/medallion-advanced-pyspark/semantic_model.py
+++ b/examples/medallion-advanced-pyspark/semantic_model.py
@@ -20,49 +20,75 @@ from common import (
     log,
     report_lineage,
     save,
-    tds_connect,
     token,
 )
 
 st = load()
 H = fabric_headers()
 
-# --- rows: export gold from the warehouse over TDS ---------------------------
-with tds_connect(st["warehouse"]) as c:
-    cur = c.cursor().execute(
-        "SELECT order_date, country, orders, units, revenue FROM fct_daily_revenue")
-    fact = [{"OrderDate": str(r[0])[:10], "Country": r[1], "Orders": int(r[2]),
-             "Units": int(r[3]), "Revenue": float(r[4])} for r in cur.fetchall()]
-    cur = c.cursor().execute("SELECT customer_id, name, country FROM dim_customer")
-    dim = [{"CustomerId": r[0], "Name": r[1], "Country": r[2]} for r in cur.fetchall()]
-assert fact and dim, (fact, dim)
+# The gold tables are read by the MODEL, not by this step. What used to happen
+# here — SELECT every row over TDS and ship them inside the definition as a
+# `data.json` part — was the least portable line in the example: `data.json` is
+# the emulator's own inline row snapshot and real Fabric has no such part. So the
+# one artifact a BI consumer actually reads was the one thing that could not be
+# deployed to a tenant.
+#
+# A DIRECT LAKE partition is what Fabric uses instead: the model names the item's
+# OneLake location and an entity within it, and the engine reads the rows itself.
+# That works on both targets — a warehouse persists to OneLake as Delta on real
+# Fabric, and the emulator reads the equivalent rows from the warehouse it serves
+# (docs/46-artifact-persistence.md).
+#
+# The step still verifies the numbers, further down, by querying the model over
+# executeQueries — which is a stronger check than shipping rows and asserting the
+# rows you shipped.
 
 model = {
     "name": "ContosoRevenue",
-    "compatibilityLevel": 1550,
+    # 1604, not 1550: Direct Lake needs it, and the emulator enforces that the
+    # way Fabric does rather than reading the partition anyway. The bump is the
+    # cost of the model reading gold itself instead of carrying a copy.
+    "compatibilityLevel": 1604,
     "model": {
         "culture": "en-US",
+        # The shared expression every Direct Lake partition points at.
+        #
+        # `onelake.dfs.fabric.microsoft.com` is written LITERALLY, not resolved per
+        # target, and that is deliberate: it is Fabric's one OneLake host, identical
+        # on every tenant, and the emulator parses the workspace/item out of it
+        # rather than fetching it. So this expression is byte-identical on both
+        # targets — the ids are the only thing that differs, as ever (docs/21). The
+        # notebook definitions address OneLake the same way.
+        "expressions": [{"name": "GoldWarehouse", "kind": "m", "expression": (
+            'let Source = AzureStorage.DataLake("'
+            f'https://onelake.dfs.fabric.microsoft.com/{st["workspace"]}/{st["warehouse"]}'
+            '", [HierarchicalNavigation=true]) in Source')}],
         "tables": [
             {"name": "Customer", "columns": [
-                {"name": "CustomerId", "dataType": "string", "sourceColumn": "CustomerId"},
-                {"name": "Name", "dataType": "string", "sourceColumn": "Name"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"}]},
+                {"name": "CustomerId", "dataType": "string", "sourceColumn": "customer_id"},
+                {"name": "Name", "dataType": "string", "sourceColumn": "name"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"}],
+             "partitions": [{"name": "Customer", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "dim_customer", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]},
             {"name": "Revenue", "columns": [
-                {"name": "OrderDate", "dataType": "string", "sourceColumn": "OrderDate"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"},
-                {"name": "Orders", "dataType": "int64", "sourceColumn": "Orders"},
-                {"name": "Units", "dataType": "int64", "sourceColumn": "Units"},
-                {"name": "Revenue", "dataType": "double", "sourceColumn": "Revenue"}],
+                {"name": "OrderDate", "dataType": "string", "sourceColumn": "order_date"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"},
+                {"name": "Orders", "dataType": "int64", "sourceColumn": "orders"},
+                {"name": "Units", "dataType": "int64", "sourceColumn": "units"},
+                {"name": "Revenue", "dataType": "double", "sourceColumn": "revenue"}],
              "measures": [
                  {"name": "Total Revenue", "expression": "SUM(Revenue[Revenue])"},
                  {"name": "Total Units", "expression": "SUM(Revenue[Units])"},
                  {"name": "Revenue per Unit",
-                  "expression": "DIVIDE([Total Revenue], [Total Units])"}]}],
+                  "expression": "DIVIDE([Total Revenue], [Total Units])"}],
+             "partitions": [{"name": "Revenue", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "fct_daily_revenue", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]}],
         "relationships": [
             {"name": "Revenue_Customer", "fromTable": "Revenue", "fromColumn": "Country",
              "toTable": "Customer", "toColumn": "Country"}]},
 }
-data = {"Customer": dim, "Revenue": fact}
 
 
 def part(path, obj):
@@ -72,7 +98,7 @@ def part(path, obj):
 
 r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
     "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model), part("data.json", data)]}})
+    "definition": {"parts": [part("model.bim", model)]}})
 assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
 if r.status_code == 201:
     dataset = r.json()["id"]

--- a/examples/medallion-advanced-pyspark/tmdl_pbip.py
+++ b/examples/medallion-advanced-pyspark/tmdl_pbip.py
@@ -57,22 +57,29 @@ assert fact and dim, (len(fact), len(dim))
 # Tabs, not spaces: TMDL is indentation-structured and Power BI writes tabs.
 MODEL_TMDL = """model ContosoRevenueTMDL
 \tculture: en-US
-\tcompatibilityLevel: 1550
+\tcompatibilityLevel: 1604
 """
 
 CUSTOMER_TMDL = """table Customer
 
 \tcolumn CustomerId
 \t\tdataType: string
-\t\tsourceColumn: CustomerId
+\t\tsourceColumn: customer_id
 
 \tcolumn Name
 \t\tdataType: string
-\t\tsourceColumn: Name
+\t\tsourceColumn: name
 
 \tcolumn Country
 \t\tdataType: string
-\t\tsourceColumn: Country
+\t\tsourceColumn: country
+
+\tpartition Customer = entity
+\t\tmode: directLake
+\t\tsource
+\t\t\tentityName: dim_customer
+\t\t\tschemaName: dbo
+\t\t\texpressionSource: GoldWarehouse
 """
 
 # The measures carry their DAX verbatim, including one written across several
@@ -82,11 +89,11 @@ REVENUE_TMDL = """table Revenue
 
 \tcolumn OrderDate
 \t\tdataType: string
-\t\tsourceColumn: OrderDate
+\t\tsourceColumn: order_date
 
 \tcolumn Country
 \t\tdataType: string
-\t\tsourceColumn: Country
+\t\tsourceColumn: country
 
 \tcolumn Orders
 \t\tdataType: int64
@@ -107,6 +114,13 @@ REVENUE_TMDL = """table Revenue
 
 \tmeasure 'Revenue per Unit' =
 \t\t\tDIVIDE([Total Revenue], [Total Units])
+
+\tpartition Revenue = entity
+\t\tmode: directLake
+\t\tsource
+\t\t\tentityName: fct_daily_revenue
+\t\t\tschemaName: dbo
+\t\t\texpressionSource: GoldWarehouse
 """
 
 RELATIONSHIPS_TMDL = """relationship Revenue_Customer
@@ -114,15 +128,35 @@ RELATIONSHIPS_TMDL = """relationship Revenue_Customer
 \ttoColumn: Customer.Country
 """
 
+# The shared expression every Direct Lake partition points at. Fabric keeps it in
+# its own TMDL file, and the emulator's parser reads `expression Name = <M>` from
+# any of them.
+EXPRESSIONS_TMDL = f"""expression GoldWarehouse = let Source = AzureStorage.DataLake("https://onelake.dfs.fabric.microsoft.com/{st['workspace']}/{st['warehouse']}", [HierarchicalNavigation=true]) in Source
+\tkind: m
+"""
+
 parts_src = {
     "definition/model.tmdl": MODEL_TMDL,
+    "definition/expressions.tmdl": EXPRESSIONS_TMDL,
     "definition/tables/Customer.tmdl": CUSTOMER_TMDL,
     "definition/tables/Revenue.tmdl": REVENUE_TMDL,
     "definition/relationships.tmdl": RELATIONSHIPS_TMDL,
-    # Rows ride in the same data.json the TMSL path uses: TMDL serialises the
-    # MODEL, not its data, exactly as it does in a real .pbip.
-    "data.json": json.dumps({"Customer": dim, "Revenue": fact}),
 }
+
+# NOT a definition part, and that distinction is the whole point of it being down
+# here rather than in the dict above.
+#
+# TMDL serialises the MODEL, not its data — exactly as a real .pbip does — and the
+# published item now carries a DIRECT LAKE partition, so the emulator and a tenant
+# both read gold from the warehouse rather than from anything shipped inside the
+# definition. `data.json` used to sit in `parts_src` for that job, which made the
+# published item unportable: real Fabric has no such part.
+#
+# The local copy stays, because it serves a different purpose: Power BI Desktop
+# opens this project OFFLINE, with no emulator to reach, so the rows have to be
+# beside the model on disk. A file in a local .pbip directory is not a Fabric
+# definition part and never reaches updateDefinition.
+LOCAL_IMPORTED_ROWS = json.dumps({"Customer": dim, "Revenue": fact})
 
 
 def part(path, text):
@@ -195,8 +229,9 @@ for rel, text in parts_src.items():
     "artifacts": [{"report": {"path": "ContosoRevenue.Report"}}],
     "settings": {"enableAutoRecovery": True}}, indent=2))
 
-# The rows, beside the model, so the project is self-contained offline.
-(model_dir / "data.json").write_text(parts_src["data.json"])
+# The rows, beside the model, so the project is self-contained offline. Named for
+# what it is: an imported snapshot for Desktop, not a part of the published item.
+(model_dir / "imported-rows.json").write_text(LOCAL_IMPORTED_ROWS)
 
 log(f"wrote .pbip project to {OUT.relative_to(pathlib.Path.cwd()) if OUT.is_relative_to(pathlib.Path.cwd()) else OUT}")
 log("Power BI Desktop opens ContosoRevenue.pbip locally with this data IMPORTED — "

--- a/examples/medallion-dbt-fabricspark/semantic_model.py
+++ b/examples/medallion-dbt-fabricspark/semantic_model.py
@@ -19,49 +19,75 @@ from common import (
     load,
     log,
     save,
-    tds_connect,
     token,
 )
 
 st = load()
 H = fabric_headers()
 
-# --- rows: export gold from the warehouse over TDS ---------------------------
-with tds_connect(st["warehouse"]) as c:
-    cur = c.cursor().execute(
-        "SELECT order_date, country, orders, units, revenue FROM fct_daily_revenue")
-    fact = [{"OrderDate": str(r[0])[:10], "Country": r[1], "Orders": int(r[2]),
-             "Units": int(r[3]), "Revenue": float(r[4])} for r in cur.fetchall()]
-    cur = c.cursor().execute("SELECT customer_id, name, country FROM dim_customer")
-    dim = [{"CustomerId": r[0], "Name": r[1], "Country": r[2]} for r in cur.fetchall()]
-assert fact and dim, (fact, dim)
+# The gold tables are read by the MODEL, not by this step. What used to happen
+# here — SELECT every row over TDS and ship them inside the definition as a
+# `data.json` part — was the least portable line in the example: `data.json` is
+# the emulator's own inline row snapshot and real Fabric has no such part. So the
+# one artifact a BI consumer actually reads was the one thing that could not be
+# deployed to a tenant.
+#
+# A DIRECT LAKE partition is what Fabric uses instead: the model names the item's
+# OneLake location and an entity within it, and the engine reads the rows itself.
+# That works on both targets — a warehouse persists to OneLake as Delta on real
+# Fabric, and the emulator reads the equivalent rows from the warehouse it serves
+# (docs/46-artifact-persistence.md).
+#
+# The step still verifies the numbers, further down, by querying the model over
+# executeQueries — which is a stronger check than shipping rows and asserting the
+# rows you shipped.
 
 model = {
     "name": "ContosoRevenue",
-    "compatibilityLevel": 1550,
+    # 1604, not 1550: Direct Lake needs it, and the emulator enforces that the
+    # way Fabric does rather than reading the partition anyway. The bump is the
+    # cost of the model reading gold itself instead of carrying a copy.
+    "compatibilityLevel": 1604,
     "model": {
         "culture": "en-US",
+        # The shared expression every Direct Lake partition points at.
+        #
+        # `onelake.dfs.fabric.microsoft.com` is written LITERALLY, not resolved per
+        # target, and that is deliberate: it is Fabric's one OneLake host, identical
+        # on every tenant, and the emulator parses the workspace/item out of it
+        # rather than fetching it. So this expression is byte-identical on both
+        # targets — the ids are the only thing that differs, as ever (docs/21). The
+        # notebook definitions address OneLake the same way.
+        "expressions": [{"name": "GoldWarehouse", "kind": "m", "expression": (
+            'let Source = AzureStorage.DataLake("'
+            f'https://onelake.dfs.fabric.microsoft.com/{st["workspace"]}/{st["warehouse"]}'
+            '", [HierarchicalNavigation=true]) in Source')}],
         "tables": [
             {"name": "Customer", "columns": [
-                {"name": "CustomerId", "dataType": "string", "sourceColumn": "CustomerId"},
-                {"name": "Name", "dataType": "string", "sourceColumn": "Name"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"}]},
+                {"name": "CustomerId", "dataType": "string", "sourceColumn": "customer_id"},
+                {"name": "Name", "dataType": "string", "sourceColumn": "name"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"}],
+             "partitions": [{"name": "Customer", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "dim_customer", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]},
             {"name": "Revenue", "columns": [
-                {"name": "OrderDate", "dataType": "string", "sourceColumn": "OrderDate"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"},
-                {"name": "Orders", "dataType": "int64", "sourceColumn": "Orders"},
-                {"name": "Units", "dataType": "int64", "sourceColumn": "Units"},
-                {"name": "Revenue", "dataType": "double", "sourceColumn": "Revenue"}],
+                {"name": "OrderDate", "dataType": "string", "sourceColumn": "order_date"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"},
+                {"name": "Orders", "dataType": "int64", "sourceColumn": "orders"},
+                {"name": "Units", "dataType": "int64", "sourceColumn": "units"},
+                {"name": "Revenue", "dataType": "double", "sourceColumn": "revenue"}],
              "measures": [
                  {"name": "Total Revenue", "expression": "SUM(Revenue[Revenue])"},
                  {"name": "Total Units", "expression": "SUM(Revenue[Units])"},
                  {"name": "Revenue per Unit",
-                  "expression": "DIVIDE([Total Revenue], [Total Units])"}]}],
+                  "expression": "DIVIDE([Total Revenue], [Total Units])"}],
+             "partitions": [{"name": "Revenue", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "fct_daily_revenue", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]}],
         "relationships": [
             {"name": "Revenue_Customer", "fromTable": "Revenue", "fromColumn": "Country",
              "toTable": "Customer", "toColumn": "Country"}]},
 }
-data = {"Customer": dim, "Revenue": fact}
 
 
 def part(path, obj):
@@ -71,7 +97,7 @@ def part(path, obj):
 
 r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
     "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model), part("data.json", data)]}})
+    "definition": {"parts": [part("model.bim", model)]}})
 assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
 if r.status_code == 201:
     dataset = r.json()["id"]

--- a/examples/medallion-pyspark/semantic_model.py
+++ b/examples/medallion-pyspark/semantic_model.py
@@ -19,49 +19,75 @@ from common import (
     load,
     log,
     save,
-    tds_connect,
     token,
 )
 
 st = load()
 H = fabric_headers()
 
-# --- rows: export gold from the warehouse over TDS ---------------------------
-with tds_connect(st["warehouse"]) as c:
-    cur = c.cursor().execute(
-        "SELECT order_date, country, orders, units, revenue FROM fct_daily_revenue")
-    fact = [{"OrderDate": str(r[0])[:10], "Country": r[1], "Orders": int(r[2]),
-             "Units": int(r[3]), "Revenue": float(r[4])} for r in cur.fetchall()]
-    cur = c.cursor().execute("SELECT customer_id, name, country FROM dim_customer")
-    dim = [{"CustomerId": r[0], "Name": r[1], "Country": r[2]} for r in cur.fetchall()]
-assert fact and dim, (fact, dim)
+# The gold tables are read by the MODEL, not by this step. What used to happen
+# here — SELECT every row over TDS and ship them inside the definition as a
+# `data.json` part — was the least portable line in the example: `data.json` is
+# the emulator's own inline row snapshot and real Fabric has no such part. So the
+# one artifact a BI consumer actually reads was the one thing that could not be
+# deployed to a tenant.
+#
+# A DIRECT LAKE partition is what Fabric uses instead: the model names the item's
+# OneLake location and an entity within it, and the engine reads the rows itself.
+# That works on both targets — a warehouse persists to OneLake as Delta on real
+# Fabric, and the emulator reads the equivalent rows from the warehouse it serves
+# (docs/46-artifact-persistence.md).
+#
+# The step still verifies the numbers, further down, by querying the model over
+# executeQueries — which is a stronger check than shipping rows and asserting the
+# rows you shipped.
 
 model = {
     "name": "ContosoRevenue",
-    "compatibilityLevel": 1550,
+    # 1604, not 1550: Direct Lake needs it, and the emulator enforces that the
+    # way Fabric does rather than reading the partition anyway. The bump is the
+    # cost of the model reading gold itself instead of carrying a copy.
+    "compatibilityLevel": 1604,
     "model": {
         "culture": "en-US",
+        # The shared expression every Direct Lake partition points at.
+        #
+        # `onelake.dfs.fabric.microsoft.com` is written LITERALLY, not resolved per
+        # target, and that is deliberate: it is Fabric's one OneLake host, identical
+        # on every tenant, and the emulator parses the workspace/item out of it
+        # rather than fetching it. So this expression is byte-identical on both
+        # targets — the ids are the only thing that differs, as ever (docs/21). The
+        # notebook definitions address OneLake the same way.
+        "expressions": [{"name": "GoldWarehouse", "kind": "m", "expression": (
+            'let Source = AzureStorage.DataLake("'
+            f'https://onelake.dfs.fabric.microsoft.com/{st["workspace"]}/{st["warehouse"]}'
+            '", [HierarchicalNavigation=true]) in Source')}],
         "tables": [
             {"name": "Customer", "columns": [
-                {"name": "CustomerId", "dataType": "string", "sourceColumn": "CustomerId"},
-                {"name": "Name", "dataType": "string", "sourceColumn": "Name"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"}]},
+                {"name": "CustomerId", "dataType": "string", "sourceColumn": "customer_id"},
+                {"name": "Name", "dataType": "string", "sourceColumn": "name"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"}],
+             "partitions": [{"name": "Customer", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "dim_customer", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]},
             {"name": "Revenue", "columns": [
-                {"name": "OrderDate", "dataType": "string", "sourceColumn": "OrderDate"},
-                {"name": "Country", "dataType": "string", "sourceColumn": "Country"},
-                {"name": "Orders", "dataType": "int64", "sourceColumn": "Orders"},
-                {"name": "Units", "dataType": "int64", "sourceColumn": "Units"},
-                {"name": "Revenue", "dataType": "double", "sourceColumn": "Revenue"}],
+                {"name": "OrderDate", "dataType": "string", "sourceColumn": "order_date"},
+                {"name": "Country", "dataType": "string", "sourceColumn": "country"},
+                {"name": "Orders", "dataType": "int64", "sourceColumn": "orders"},
+                {"name": "Units", "dataType": "int64", "sourceColumn": "units"},
+                {"name": "Revenue", "dataType": "double", "sourceColumn": "revenue"}],
              "measures": [
                  {"name": "Total Revenue", "expression": "SUM(Revenue[Revenue])"},
                  {"name": "Total Units", "expression": "SUM(Revenue[Units])"},
                  {"name": "Revenue per Unit",
-                  "expression": "DIVIDE([Total Revenue], [Total Units])"}]}],
+                  "expression": "DIVIDE([Total Revenue], [Total Units])"}],
+             "partitions": [{"name": "Revenue", "mode": "directLake", "source": {
+                 "type": "entity", "entityName": "fct_daily_revenue", "schemaName": "dbo",
+                 "expressionSource": "GoldWarehouse"}}]}],
         "relationships": [
             {"name": "Revenue_Customer", "fromTable": "Revenue", "fromColumn": "Country",
              "toTable": "Customer", "toColumn": "Country"}]},
 }
-data = {"Customer": dim, "Revenue": fact}
 
 
 def part(path, obj):
@@ -71,7 +97,7 @@ def part(path, obj):
 
 r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
     "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model), part("data.json", data)]}})
+    "definition": {"parts": [part("model.bim", model)]}})
 assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
 if r.status_code == 201:
     dataset = r.json()["id"]

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -75,6 +75,11 @@ type API struct {
 	// SQL backend is set; nil → the pipeline Script/StoredProcedure activities
 	// fail loudly (no SQL engine attached).
 	SQLDB func(ctx context.Context, itemID string) (*sql.DB, error)
+	// LakehouseDB returns the SQL Server connection backing a Lakehouse's SQL
+	// ANALYTICS endpoint, preparing its database first. Distinct from SQLDB,
+	// which refuses a Lakehouse on purpose (see lakehouseDBFor). nil → the
+	// refreshMetadata route answers an honest 501.
+	LakehouseDB func(ctx context.Context, itemID string) (*sql.DB, error)
 	// refreshes is per-dataset refresh history for the Power BI refresh
 	// endpoints. In memory on purpose — see refreshes.go.
 	refreshes refreshLog
@@ -166,6 +171,8 @@ func (a *API) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/workspaces/{wid}/items", a.withAuth(a.listItems))
 	mux.HandleFunc("POST /v1/workspaces/{wid}/items", a.withAuth(a.createItem))
 	mux.HandleFunc("GET /v1/workspaces/{wid}/items/{iid}", a.withAuth(a.getItem))
+	mux.HandleFunc("POST /v1/workspaces/{wid}/sqlEndpoints/{epid}/refreshMetadata",
+		a.withAuth(a.refreshSQLEndpointMetadata))
 	mux.HandleFunc("PATCH /v1/workspaces/{wid}/items/{iid}", a.withAuth(a.updateItem))
 	mux.HandleFunc("DELETE /v1/workspaces/{wid}/items/{iid}", a.withAuth(a.deleteItem))
 

--- a/internal/api/datasources.go
+++ b/internal/api/datasources.go
@@ -113,7 +113,7 @@ func (a *API) modelDatasources(m *semanticmodel.Model) ([]datasource, error) {
 		wsID, lakeID := wsRef, lakeRef
 		if ws, err := a.resolveDirectLakeWorkspace(wsRef); err == nil {
 			wsID = ws.ID
-			if lake, err := a.resolveDirectLakeLakehouse(ws.ID, lakeRef); err == nil {
+			if lake, err := a.resolveDirectLakeSource(ws.ID, lakeRef); err == nil {
 				lakeID = lake.ID
 			}
 		}

--- a/internal/api/directlake.go
+++ b/internal/api/directlake.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"path"
@@ -15,7 +16,7 @@ import (
 
 var directLakeURL = regexp.MustCompile(`(?i)https://onelake\.dfs\.fabric\.microsoft\.com/([^/"?]+?)/([^/"?]+)`)
 
-func (a *API) loadDirectLakeData(model *semanticmodel.Model, data semanticmodel.Data, principal *auth.Principal) error {
+func (a *API) loadDirectLakeData(ctx context.Context, model *semanticmodel.Model, data semanticmodel.Data, principal *auth.Principal) error {
 	for _, table := range model.Tables {
 		if table.DirectLake == nil {
 			continue
@@ -36,13 +37,34 @@ func (a *API) loadDirectLakeData(model *semanticmodel.Model, data semanticmodel.
 		if err != nil || store.RoleRank(role) < store.RoleRank(store.RoleViewer) {
 			return fmt.Errorf("Direct Lake table %q: caller cannot read source workspace", table.Name)
 		}
-		lakehouse, err := a.resolveDirectLakeLakehouse(ws.ID, lakehouseRef)
+		source, err := a.resolveDirectLakeSource(ws.ID, lakehouseRef)
 		if err != nil {
-			return fmt.Errorf("Direct Lake table %q: lakehouse is not available", table.Name)
+			return fmt.Errorf("Direct Lake table %q: %w", table.Name, err)
 		}
-		delta, err := warehouse.ReadDeltaTable(a.Store, lakehouse.ID, table.DirectLake.EntityName)
-		if err != nil && table.DirectLake.SchemaName != "" {
-			delta, err = warehouse.ReadDeltaTable(a.Store, lakehouse.ID, path.Join(table.DirectLake.SchemaName, table.DirectLake.EntityName))
+		var delta *warehouse.Table
+		if source.Type == "Lakehouse" {
+			delta, err = warehouse.ReadDeltaTable(a.Store, source.ID, table.DirectLake.EntityName)
+			if err != nil && table.DirectLake.SchemaName != "" {
+				delta, err = warehouse.ReadDeltaTable(a.Store, source.ID,
+					path.Join(table.DirectLake.SchemaName, table.DirectLake.EntityName))
+			}
+		} else {
+			// A WAREHOUSE source. On real Fabric a warehouse persists to OneLake as
+			// Delta, so Direct Lake over one reads those files — the same mechanism
+			// as a lakehouse. The emulator's warehouse is a real SQL Server database
+			// and its bytes are not Delta, so the equivalent rows come from SQL.
+			//
+			// That is a BACKEND difference, not a contract one: the model's
+			// definition is identical on both targets (an `entity` partition over an
+			// OneLake expression), and the rows the evaluator sees are the same rows.
+			// Reading them over SQL is the same posture the rest of the warehouse
+			// surface takes — our contract, a real engine's compute.
+			//
+			// Why this matters beyond neatness: without it a model over GOLD had to
+			// carry its rows inline in a `data.json` part, which real Fabric has no
+			// concept of. So the one artifact a BI consumer actually reads was the
+			// one thing in the examples that could not be deployed to a tenant.
+			delta, err = a.readWarehouseTable(ctx, source, table.DirectLake)
 		}
 		if err != nil {
 			return fmt.Errorf("Direct Lake table %q: %w", table.Name, err)
@@ -79,12 +101,95 @@ func (a *API) resolveDirectLakeWorkspace(ref string) (*store.Workspace, error) {
 	return a.Store.GetWorkspaceByName(ref)
 }
 
-func (a *API) resolveDirectLakeLakehouse(workspaceID, ref string) (*store.Item, error) {
-	if item, err := a.Store.GetItem(workspaceID, ref); err == nil && item.Type == "Lakehouse" {
+// resolveDirectLakeSource finds the item a Direct Lake expression points at: a
+// Lakehouse or a Warehouse, both of which real Fabric supports as Direct Lake
+// sources because both persist to OneLake.
+func (a *API) resolveDirectLakeSource(workspaceID, ref string) (*store.Item, error) {
+	if item, err := a.Store.GetItem(workspaceID, ref); err == nil && directLakeSourceType(item.Type) {
 		return item, nil
 	}
-	name := strings.TrimSuffix(ref, ".Lakehouse")
-	return a.Store.GetItemByName(workspaceID, name, "Lakehouse")
+	for _, typ := range []string{"Lakehouse", "Warehouse"} {
+		name := strings.TrimSuffix(ref, "."+typ)
+		if item, err := a.Store.GetItemByName(workspaceID, name, typ); err == nil {
+			return item, nil
+		}
+	}
+	return nil, fmt.Errorf("no lakehouse or warehouse %q in the source workspace", ref)
+}
+
+func directLakeSourceType(t string) bool {
+	return t == "Lakehouse" || t == "Warehouse" || t == "SQLDatabase"
+}
+
+// readWarehouseTable materialises a warehouse table as the same shape a Delta
+// read produces, so directLakeRows cannot tell them apart.
+func (a *API) readWarehouseTable(ctx context.Context, item *store.Item, dl *semanticmodel.DirectLakePartition) (*warehouse.Table, error) {
+	schema := dl.SchemaName
+	if schema == "" {
+		schema = "dbo"
+	}
+	// Identifiers, not parameters: SQL has no placeholder for a table name. Both
+	// come from a definition the caller published, and the warehouse is
+	// case-SENSITIVE (internal/tds/collation.go), so they are quoted rather than
+	// normalised — a name that does not match exactly must fail, as it would on a
+	// tenant.
+	//
+	// Checked BEFORE the database is opened. A test caught the other order: a
+	// doomed request should not acquire a connection, and a validation that runs
+	// after the thing it guards is one refactor away from not running at all.
+	if !safeSQLIdent(schema) || !safeSQLIdent(dl.EntityName) {
+		return nil, fmt.Errorf("unsafe entity name %q.%q", schema, dl.EntityName)
+	}
+	if a.SQLDB == nil {
+		return nil, fmt.Errorf("this emulator serves no SQL: a Direct Lake model over a warehouse needs one")
+	}
+	db, err := a.SQLDB(ctx, item.ID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, "SELECT * FROM ["+schema+"].["+dl.EntityName+"]")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	out := &warehouse.Table{Columns: cols}
+	for rows.Next() {
+		cells := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range cells {
+			ptrs[i] = &cells[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		for i, c := range cells {
+			// The evaluator's text type is string; a driver may hand back bytes.
+			if b, ok := c.([]byte); ok {
+				cells[i] = string(b)
+			}
+		}
+		out.Rows = append(out.Rows, cells)
+	}
+	return out, rows.Err()
+}
+
+// safeSQLIdent allows only what a Fabric table or schema name needs, so an
+// identifier can be bracket-quoted into a SELECT without a quoting hazard.
+func safeSQLIdent(s string) bool {
+	if s == "" || len(s) > 128 {
+		return false
+	}
+	for _, c := range s {
+		ok := c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_'
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func directLakeRows(modelTable *semanticmodel.Table, delta *warehouse.Table) ([]semanticmodel.Row, error) {

--- a/internal/api/directlake_warehouse_test.go
+++ b/internal/api/directlake_warehouse_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/semanticmodel"
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+	"github.com/calvinchengx/fabric-emulator/internal/testsupport"
+)
+
+// dlPartition is the minimum Direct Lake binding these tests need.
+func dlPartition(entity string) *semanticmodel.DirectLakePartition {
+	return &semanticmodel.DirectLakePartition{EntityName: entity, SchemaName: "dbo",
+		ExpressionSource: "DL_Warehouse"}
+}
+
+// Direct Lake over a WAREHOUSE, which is what a model serving gold needs.
+//
+// WHY THIS EXISTS. Gold is built by dbt-fabric into the warehouse, so a semantic
+// model over it had no portable way to get its rows: the examples carried them
+// inline in a `data.json` part, which real Fabric has no concept of. The one
+// artifact a BI consumer actually reads was the one thing that could not be
+// deployed to a tenant.
+//
+// Real Fabric supports Direct Lake over a warehouse because a warehouse persists
+// to OneLake as Delta. The emulator's warehouse is a real SQL Server database, so
+// the same rows come over SQL — a backend difference, not a contract one. The
+// model's DEFINITION is identical on both targets.
+//
+// Needs a real SQL Server; skips without one (CI runs one as a service).
+func directLakeWarehouseModel(workspaceID, warehouseID string) []byte {
+	return []byte(fmt.Sprintf(`{
+  "name":"Gold","compatibilityLevel":1604,
+  "model":{
+    "expressions":[{"name":"DL_Warehouse","kind":"m","expression":"let Source = AzureStorage.DataLake(\"https://onelake.dfs.fabric.microsoft.com/%s/%s\", [HierarchicalNavigation=true]) in Source"}],
+    "tables":[{"name":"Revenue","columns":[
+      {"name":"Country","dataType":"string","sourceColumn":"country"},
+      {"name":"Revenue","dataType":"double","sourceColumn":"revenue"}],
+      "measures":[{"name":"Total Revenue","expression":"SUM(Revenue[Revenue])"}],
+      "partitions":[{"name":"Revenue","mode":"directLake","source":{"type":"entity","entityName":"fct_daily_revenue","schemaName":"dbo","expressionSource":"DL_Warehouse"}}]}]
+  }
+}`, workspaceID, warehouseID))
+}
+
+func TestDirectLakeOverAWarehouseReadsItsTables(t *testing.T) {
+	a, st := newAPI(t)
+	db := testsupport.OpenMSSQL(t)
+	ws := seedWorkspace(t, st)
+	wh := seedItem(t, st, ws.ID, "Warehouse", "dw")
+	a.SQLDB = func(context.Context, string) (*sql.DB, error) { return db, nil }
+
+	// The table dbt would have built, in the warehouse rather than in OneLake.
+	if _, err := db.Exec(`IF OBJECT_ID('dbo.fct_daily_revenue') IS NOT NULL DROP TABLE dbo.fct_daily_revenue;
+		CREATE TABLE dbo.fct_daily_revenue (country VARCHAR(2), revenue FLOAT);
+		INSERT INTO dbo.fct_daily_revenue VALUES ('US', 100.5), ('GB', 200.25), ('US', 9.25)`); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec("DROP TABLE dbo.fct_daily_revenue") })
+
+	model := &store.Item{WorkspaceID: ws.ID, Type: "SemanticModel", DisplayName: "Gold"}
+	parts := []store.DefinitionPart{{Path: "model.bim", PayloadType: "InlineBase64",
+		Payload: base64.StdEncoding.EncodeToString(directLakeWarehouseModel(ws.ID, wh.ID))}}
+	if err := st.CreateItem(model, parts); err != nil {
+		t.Fatal(err)
+	}
+
+	query := `{"queries":[{"query":"EVALUATE SUMMARIZECOLUMNS(Revenue[Country], \"Total\", [Total Revenue])"}]}`
+	w := do(a.executeQueries, admin, "POST", query, map[string]string{"datasetId": model.ID})
+	if w.Code != 200 {
+		t.Fatalf("query = %d %s", w.Code, w.Body)
+	}
+	// The rows came from SQL, through the same evaluator a Delta read feeds.
+	for _, want := range []string{`"Revenue[Country]":"US"`, `"[Total]":109.75`, `"Revenue[Country]":"GB"`, `"[Total]":200.25`} {
+		if !bytes.Contains(w.Body.Bytes(), []byte(want)) {
+			t.Fatalf("response %s missing %q", w.Body, want)
+		}
+	}
+}
+
+// An entity name that is not a plain identifier must not reach the SELECT.
+func TestDirectLakeWarehouseRefusesAnUnsafeEntityName(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	wh := seedItem(t, st, ws.ID, "Warehouse", "dw")
+	a.SQLDB = func(context.Context, string) (*sql.DB, error) {
+		t.Fatal("reached the database with an unsafe identifier")
+		return nil, nil
+	}
+	_, err := a.readWarehouseTable(context.Background(), wh, dlPartition("fct]; DROP TABLE x --"))
+	if err == nil {
+		t.Fatal("accepted an entity name that is not an identifier")
+	}
+}
+
+// Without a SQL engine, say so rather than reporting a model with no rows —
+// which is the fabrication-class failure this surface exists to avoid.
+func TestDirectLakeWarehouseWithoutSQLIsHonest(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	wh := seedItem(t, st, ws.ID, "Warehouse", "dw")
+	a.SQLDB = nil
+	if _, err := a.readWarehouseTable(context.Background(), wh, dlPartition("fct_daily_revenue")); err == nil {
+		t.Fatal("claimed to read a warehouse with no SQL engine attached")
+	}
+}

--- a/internal/api/executequeries.go
+++ b/internal/api/executequeries.go
@@ -13,6 +13,7 @@ package api
 // data.json definition parts feed the bounded DAX evaluator (internal/semanticmodel).
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -76,7 +77,7 @@ func (a *API) executeQueries(w http.ResponseWriter, r *http.Request, p *auth.Pri
 		return
 	}
 
-	model, data, err := a.loadSemanticModel(it.ID, p)
+	model, data, err := a.loadSemanticModel(r.Context(), it.ID, p)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "InvalidDataset", err.Error())
 		return
@@ -124,7 +125,7 @@ func (a *API) executeQueries(w http.ResponseWriter, r *http.Request, p *auth.Pri
 // `.pbip` project on disk contains). TMSL wins when both are present — it is
 // the older, fully-covered path, so a definition carrying both is not a place
 // to start guessing.
-func (a *API) loadSemanticModel(itemID string, p *auth.Principal) (*semanticmodel.Model, semanticmodel.Data, error) {
+func (a *API) loadSemanticModel(ctx context.Context, itemID string, p *auth.Principal) (*semanticmodel.Model, semanticmodel.Data, error) {
 	m, err := a.parseModelDefinition(itemID)
 	if err != nil {
 		return nil, nil, err
@@ -135,7 +136,7 @@ func (a *API) loadSemanticModel(itemID string, p *auth.Principal) (*semanticmode
 			data = d
 		}
 	}
-	if err := a.loadDirectLakeData(m, data, p); err != nil {
+	if err := a.loadDirectLakeData(ctx, m, data, p); err != nil {
 		return nil, nil, err
 	}
 	return m, data, nil

--- a/internal/api/kql.go
+++ b/internal/api/kql.go
@@ -460,14 +460,24 @@ func (a *API) typedItemProperties(r *http.Request, it *store.Item) map[string]an
 		// database name, which works here and fails on real Fabric. Leaving it
 		// out fails the other way round: locally, loudly, before it ships.
 		if cs := a.warehouseConnectionString(r); cs != "" {
-			return map[string]any{"sqlEndpointProperties": map[string]any{
+			ep := map[string]any{
 				"connectionString": cs,
 				// The emulator provisions the endpoint on first connect, so it
 				// is never pending from the caller's point of view. Real Fabric
 				// can answer InProgress, which a client must handle: hence a
 				// status field at all rather than an implied one.
 				"provisioningStatus": "Success",
-			}}
+			}
+			// The endpoint's OWN id, which is what refreshMetadata is addressed
+			// by. Absent until the emulator had a SQLEndpoint item to name —
+			// see sqlendpoint.go for why withholding it was right then and wrong
+			// now. Still conditional: a lakehouse created before this existed has
+			// no endpoint item, and inventing one here would report an id that
+			// answers nothing.
+			if id := a.sqlEndpointItemFor(it); id != "" {
+				ep["id"] = id
+			}
+			return map[string]any{"sqlEndpointProperties": ep}
 		}
 		return nil
 	case "Eventhouse":
@@ -526,6 +536,12 @@ func (a *API) applyCreationPayload(it *store.Item, payload map[string]any) {
 		return v
 	}
 	switch it.Type {
+	case "Lakehouse":
+		// Real Fabric gives every lakehouse a SQLEndpoint ITEM carrying its
+		// display name and its own id (internal/api/sqlendpoint.go, measured).
+		// Creating it here is what lets sqlEndpointProperties.id be a different
+		// GUID from the lakehouse, exactly as it is on a tenant.
+		a.ensureSQLEndpointItem(it)
 	case "Warehouse":
 		// Fabric offers exactly two collations and defaults to the case-SENSITIVE
 		// one. Recording the default explicitly rather than leaving the property

--- a/internal/api/kql.go
+++ b/internal/api/kql.go
@@ -440,12 +440,34 @@ func (a *API) typedItemProperties(r *http.Request, it *store.Item) map[string]an
 		// warehouse has no address", which is a different claim from "this build
 		// serves no SQL". The collation is reported either way, because it is a
 		// property of the warehouse rather than of the endpoint serving it.
-		props := map[string]any{"collationType": a.warehouseCollation(it.ID)}
+		props := map[string]any{
+			"collationType": a.warehouseCollation(it.ID),
+			// MEASURED on a tenant: a Warehouse reports `creationMode` too.
+			// "New" is the only mode these examples exercise; restore-from-backup
+			// is not modelled, so reporting anything else would be a claim.
+			"creationMode": "New",
+		}
 		if cs := a.warehouseConnectionString(r); cs != "" {
 			props["connectionString"] = cs
+			// The SAME address under a second name, which a tenant returns and
+			// this did not. A client reading `connectionInfo` — and the field
+			// exists precisely because some do — got nothing here.
+			props["connectionInfo"] = cs
 		}
 		return props
 	case "Lakehouse":
+		// The OneLake paths, which a tenant reports and this did not. MEASURED
+		// 2026-08-11 on a real lakehouse:
+		//
+		//	oneLakeTablesPath  https://onelake.dfs.fabric.microsoft.com/{ws}/{item}/Tables
+		//	oneLakeFilesPath   .../Files
+		//
+		// The documented way to find where a lakehouse's data lives is to read
+		// these; returning nothing is the emulator-strict direction rather than
+		// the dangerous one, but it is exactly what makes someone hardcode a path
+		// instead — and a hardcoded OneLake path does not survive the toggle.
+		// Derived from the caller's own request like every other address here, so
+		// it is reachable from wherever the caller stands.
 		// The SQL analytics endpoint: the read-only T-SQL surface over the
 		// lakehouse's Delta tables. It is the same TDS listener a Warehouse
 		// uses — the emulator routes by item and makes a Lakehouse read-only
@@ -477,9 +499,13 @@ func (a *API) typedItemProperties(r *http.Request, it *store.Item) map[string]an
 			if id := a.sqlEndpointItemFor(it); id != "" {
 				ep["id"] = id
 			}
-			return map[string]any{"sqlEndpointProperties": ep}
+			props := a.oneLakePaths(r, it)
+			props["sqlEndpointProperties"] = ep
+			return props
 		}
-		return nil
+		// Still reported without a SQL endpoint: OneLake is where the data is,
+		// whether or not anything serves T-SQL over it.
+		return a.oneLakePaths(r, it)
 	case "Eventhouse":
 		base := kustoBaseURI(r, it.WorkspaceID, it.ID)
 		ids := []string{}

--- a/internal/api/modellineage.go
+++ b/internal/api/modellineage.go
@@ -91,7 +91,7 @@ func (a *API) directLakeSource(m *semanticmodel.Model, table *semanticmodel.Tabl
 	if err != nil {
 		return modelSource{}, false
 	}
-	lake, err := a.resolveDirectLakeLakehouse(ws.ID, lakeRef)
+	lake, err := a.resolveDirectLakeSource(ws.ID, lakeRef)
 	if err != nil {
 		return modelSource{}, false
 	}

--- a/internal/api/sql_endpoint_discovery_test.go
+++ b/internal/api/sql_endpoint_discovery_test.go
@@ -67,14 +67,19 @@ func TestLakehouseAdvertisesItsSQLAnalyticsEndpoint(t *testing.T) {
 	if ep["provisioningStatus"] != "Success" {
 		t.Errorf("provisioningStatus = %v, want Success", ep["provisioningStatus"])
 	}
-	// See kql.go: on real Fabric the analytics endpoint is a separate SQLEndpoint
-	// item with its own GUID. Reporting the lakehouse id under that name would
-	// invite a consumer to use it as a database name, which works here and fails
-	// on real Fabric. Absent fails the other way round: locally, before it ships.
+	// No `id` HERE, and for a reason that is no longer the old one — the comment
+	// this replaces claimed "the emulator has no SQLEndpoint item", which stopped
+	// being true when it gained one (internal/api/sqlendpoint.go, measured against
+	// a tenant). What this case actually covers is a lakehouse with NO endpoint
+	// item: seeded straight into the store without applyCreationPayload, as a
+	// lakehouse created before that existed would be. Reporting an id then would
+	// name something that answers nothing.
+	//
+	// The live assertion is TestTheReportedEndpointIDIsTheItemsOwn: with the item
+	// present the id IS reported, and differs from the lakehouse's.
 	if _, present := ep["id"]; present {
-		t.Errorf("sqlEndpointProperties.id is present (%v): the emulator has no "+
-			"SQLEndpoint item, so any value here would be a different id than real "+
-			"Fabric's", ep["id"])
+		t.Errorf("reported an endpoint id (%v) for a lakehouse with no "+
+			"SQLEndpoint item — it would address nothing", ep["id"])
 	}
 	// Two surfaces, two property names. A lakehouse never carries the Warehouse
 	// one (TestOnlyAWarehouseGetsAConnectionString covers the generic route).
@@ -104,8 +109,15 @@ func TestLakehouseEndpointIsDialableFromWhereverTheCallerIs(t *testing.T) {
 	}
 }
 
-// The contract-only stack (no sqlserver sidecar) is supported: say nothing rather
-// than advertise an endpoint that is not listening.
+// The contract-only stack (no sqlserver sidecar) is supported: say nothing about
+// an ENDPOINT that is not listening.
+//
+// Narrowed once the lakehouse gained OneLake paths: this asserted "no properties
+// at all", which was only ever a proxy for "no endpoint" because
+// sqlEndpointProperties was the sole property. The two claims are separate now —
+// OneLake is where the data is whether or not anything serves T-SQL over it —
+// and conflating them would make the honest addition of a path look like a
+// regression.
 func TestLakehouseSaysNothingWithoutASQLEndpoint(t *testing.T) {
 	a, st := newAPI(t)
 	a.SQLEndpointPort = "" // FABRIC_SQL_TDS_ADDR unset
@@ -113,7 +125,8 @@ func TestLakehouseSaysNothingWithoutASQLEndpoint(t *testing.T) {
 	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
 
 	_, body := typedItemBody(t, a, "localhost:9443", ws.ID, lake.ID, "Lakehouse")
-	if props, ok := body["properties"]; ok {
-		t.Fatalf("a lakehouse with no SQL endpoint advertised properties: %v", props)
+	props, _ := body["properties"].(map[string]any)
+	if ep, present := props["sqlEndpointProperties"]; present {
+		t.Fatalf("advertised a SQL endpoint that is not listening: %v", ep)
 	}
 }

--- a/internal/api/sqlendpoint.go
+++ b/internal/api/sqlendpoint.go
@@ -162,3 +162,30 @@ func (a *API) refreshSQLEndpointMetadata(w http.ResponseWriter, r *http.Request,
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"value": report})
 }
+
+// oneLakePaths builds a lakehouse's `oneLakeTablesPath` / `oneLakeFilesPath`.
+//
+// Real Fabric returns absolute `https://onelake.dfs.fabric.microsoft.com/{ws}/{item}/…`
+// URLs (measured 2026-08-11). The emulator serves OneLake on its own origin, so
+// the host comes from the caller's request for the same reason the SQL address
+// does: a container on the compose network and a laptop reach it by different
+// names, and one configured hostname would be wrong for one of them.
+func (a *API) oneLakePaths(r *http.Request, it *store.Item) map[string]any {
+	base := oneLakeBaseURI(r) + "/" + it.WorkspaceID + "/" + it.ID
+	return map[string]any{
+		"oneLakeTablesPath": base + "/Tables",
+		"oneLakeFilesPath":  base + "/Files",
+	}
+}
+
+// oneLakeBaseURI is the DFS origin the caller reached this emulator on.
+func oneLakeBaseURI(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	return scheme + "://" + r.Host + "/onelake"
+}

--- a/internal/api/sqlendpoint.go
+++ b/internal/api/sqlendpoint.go
@@ -1,0 +1,164 @@
+package api
+
+// A lakehouse's SQL analytics endpoint, as the ITEM real Fabric makes it.
+//
+// MEASURED ON A REAL TENANT, 2026-08-11. Creating one lakehouse and one warehouse
+// left THREE items in the workspace:
+//
+//	SQLEndpoint  803c8e33-c35c-4f1b-9b44-f40dce69e75e  lake
+//	Warehouse    c6c4ba99-0f1d-4514-b715-2be7c8e900c2  dw
+//	Lakehouse    450d5027-f17e-454e-b9ca-dbe424c494b6  lake
+//
+// The SQLEndpoint carries the lakehouse's display name and its OWN id — and that
+// id is exactly what `GET /lakehouses/{id}` reports as
+// `properties.sqlEndpointProperties.id`. It is a first-class item, listed like
+// any other.
+//
+// WHY THIS CHANGES AN EARLIER DECISION, deliberately. The emulator used to OMIT
+// `sqlEndpointProperties.id`, on the reasoning that it had no such item and
+// reporting the lakehouse's own id there would let a consumer use it as a
+// database name — green locally, addressing the wrong thing on a tenant. That was
+// the right call for the information available. The measurement makes it
+// obsolete: the honest fix is not to withhold the field but to HAVE the item, so
+// the id is a different GUID here exactly as it is there.
+//
+// What that unlocks is `refreshMetadata`, which is addressed by the endpoint id:
+//
+//	POST /v1/workspaces/{ws}/sqlEndpoints/{id}/refreshMetadata  ->  200 {"value":[…]}
+//
+// Measured against the tenant: a plain 200 with a per-table array (empty for a
+// lakehouse with no tables), no LRO and no Location header. That is the lever a
+// client uses when the analytics endpoint has not caught up with Delta yet, and
+// its absence here is why `dq_gate.py` used to re-sync by opening a throwaway
+// connection — true locally, a silent no-op on a tenant.
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/calvinchengx/fabric-emulator/internal/auth"
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+	"github.com/calvinchengx/fabric-emulator/internal/warehouse"
+)
+
+// propParentLakehouse links a SQLEndpoint item back to the lakehouse it serves,
+// the same way a KQLDatabase names its Eventhouse.
+const propParentLakehouse = "parentLakehouseItemId"
+
+// ensureSQLEndpointItem creates the SQLEndpoint item that accompanies a
+// lakehouse. Idempotent by search: a second call finds the existing one, so a
+// re-created lakehouse of the same name does not accumulate endpoints.
+func (a *API) ensureSQLEndpointItem(lakehouse *store.Item) string {
+	if id := a.sqlEndpointItemFor(lakehouse); id != "" {
+		return id
+	}
+	ep := &store.Item{
+		WorkspaceID: lakehouse.WorkspaceID,
+		Type:        "SQLEndpoint",
+		// Fabric names it after the lakehouse, which is why two items in one
+		// workspace can share a display name — the pair is not a collision.
+		DisplayName: lakehouse.DisplayName,
+	}
+	if err := a.Store.CreateItem(ep, nil); err != nil {
+		return ""
+	}
+	_ = a.Store.SetItemProperties(ep.ID, map[string]string{propParentLakehouse: lakehouse.ID})
+	return ep.ID
+}
+
+// sqlEndpointItemFor returns the id of the SQLEndpoint serving `lakehouse`, or "".
+func (a *API) sqlEndpointItemFor(lakehouse *store.Item) string {
+	eps, err := a.Store.ListItems(lakehouse.WorkspaceID, "SQLEndpoint")
+	if err != nil {
+		return ""
+	}
+	for _, ep := range eps {
+		if props, err := a.Store.ItemProperties(ep.ID); err == nil &&
+			props[propParentLakehouse] == lakehouse.ID {
+			return ep.ID
+		}
+	}
+	return ""
+}
+
+// tableSync is one row of the refreshMetadata report. Field names are the ones
+// Microsoft's announcement documents ("detailed synchronization status for each
+// table, including start and end times, status, last successful sync time"); the
+// ENVELOPE (`{"value": […]}`, plain 200) is measured against a tenant.
+type tableSync struct {
+	TableName                  string `json:"tableName"`
+	Status                     string `json:"status"`
+	StartDateTime              string `json:"startDateTime"`
+	EndDateTime                string `json:"endDateTime"`
+	LastSuccessfulSyncDateTime string `json:"lastSuccessfulSyncDateTime"`
+}
+
+// refreshSQLEndpointMetadata re-reads the lakehouse's Delta and rebuilds the SQL
+// view of it, reporting per table.
+//
+// The emulator reflects on connect, so this is not the only way its endpoint
+// catches up — but it is the only way a CLIENT can ask, and a client that has to
+// open a connection to force a refresh is written against the emulator rather
+// than against Fabric.
+func (a *API) refreshSQLEndpointMetadata(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
+	wid := r.PathValue("wid")
+	if _, _, ok := a.requireRole(w, wid, p, store.RoleContributor); !ok {
+		return
+	}
+	ep, err := a.Store.GetItem(wid, r.PathValue("epid"))
+	if err != nil || ep.Type != "SQLEndpoint" {
+		writeErr(w, http.StatusNotFound, "ItemNotFound", "The item is not available.")
+		return
+	}
+	props, _ := a.Store.ItemProperties(ep.ID)
+	lakehouseID := props[propParentLakehouse]
+	if lakehouseID == "" {
+		writeErr(w, http.StatusNotFound, "ItemNotFound",
+			"This SQL endpoint is not associated with a lakehouse.")
+		return
+	}
+	if a.LakehouseDB == nil {
+		// No SQL engine attached: say so rather than reporting a sync that did
+		// not happen. An empty 200 here would be indistinguishable from "the
+		// lakehouse has no tables", which is the lie this whole surface exists
+		// to avoid.
+		writeErr(w, http.StatusNotImplemented, "SQLEndpointNotConfigured",
+			"This emulator serves no SQL endpoint: start it with FABRIC_SQL_TDS_ADDR and a warehouse SQL backend.")
+		return
+	}
+	started := time.Now().UTC().Format(time.RFC3339)
+	// The reflector needs the lakehouse's own SQL Server database. LakehouseDB
+	// prepares one and hands back its pool — a different hook from SQLDB, which
+	// refuses a Lakehouse on purpose (see lakehouseDBFor).
+	db, err := a.LakehouseDB(r.Context(), lakehouseID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "SQLEndpointRefreshFailed", err.Error())
+		return
+	}
+	if db == nil {
+		// A hook that yields no pool and no error is a misconfigured backend, not
+		// an empty lakehouse. Saying which costs one branch and saves a reader the
+		// wrong hypothesis.
+		writeErr(w, http.StatusNotImplemented, "SQLEndpointNotConfigured",
+			"The SQL backend produced no connection for this lakehouse.")
+		return
+	}
+	var report []tableSync
+	names, rerr := warehouse.Reflect(r.Context(), db, a.Store, lakehouseID)
+	done := time.Now().UTC().Format(time.RFC3339)
+	for _, n := range names {
+		report = append(report, tableSync{
+			TableName: n, Status: "Success",
+			StartDateTime: started, EndDateTime: done,
+			LastSuccessfulSyncDateTime: done,
+		})
+	}
+	if rerr != nil {
+		writeErr(w, http.StatusBadGateway, "SQLEndpointRefreshFailed", rerr.Error())
+		return
+	}
+	if report == nil {
+		report = []tableSync{} // `{"value": []}`, as the tenant answers
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"value": report})
+}

--- a/internal/api/sqlendpoint_test.go
+++ b/internal/api/sqlendpoint_test.go
@@ -165,3 +165,64 @@ func TestRefreshMetadataRequiresContributor(t *testing.T) {
 	}
 	_ = store.RoleViewer
 }
+
+// The properties a tenant reports and the emulator did not, measured 2026-08-11.
+// Each is the emulator-strict direction (absent here, present there), which is
+// the safe direction — but an absent `oneLakeTablesPath` is exactly what makes
+// someone hardcode a OneLake path instead, and a hardcoded path does not survive
+// the toggle.
+func TestALakehouseReportsItsOneLakePaths(t *testing.T) {
+	a, st := newAPI(t)
+	a.SQLEndpointPort = "1433"
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+
+	_, body := typedItemBody(t, a, "localhost:9443", ws.ID, lake.ID, "Lakehouse")
+	props, _ := body["properties"].(map[string]any)
+	want := "http://localhost:9443/onelake/" + ws.ID + "/" + lake.ID
+	if props["oneLakeTablesPath"] != want+"/Tables" {
+		t.Errorf("oneLakeTablesPath = %v, want %q", props["oneLakeTablesPath"], want+"/Tables")
+	}
+	if props["oneLakeFilesPath"] != want+"/Files" {
+		t.Errorf("oneLakeFilesPath = %v, want %q", props["oneLakeFilesPath"], want+"/Files")
+	}
+}
+
+// OneLake is where the data is whether or not anything serves T-SQL over it, so
+// the paths survive a stack with no SQL sidecar.
+func TestOneLakePathsSurviveNoSQLEndpoint(t *testing.T) {
+	a, st := newAPI(t)
+	a.SQLEndpointPort = "" // contract-only stack
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+
+	_, body := typedItemBody(t, a, "localhost:9443", ws.ID, lake.ID, "Lakehouse")
+	props, _ := body["properties"].(map[string]any)
+	if props["oneLakeTablesPath"] == nil {
+		t.Fatalf("no OneLake paths without a SQL endpoint: %v", props)
+	}
+	if _, present := props["sqlEndpointProperties"]; present {
+		t.Error("advertised a SQL endpoint that is not listening")
+	}
+}
+
+func TestAWarehouseReportsConnectionInfoAndCreationMode(t *testing.T) {
+	a, st := newAPI(t)
+	a.SQLEndpointPort = "1433"
+	ws := seedWorkspace(t, st)
+	wh := seedItem(t, st, ws.ID, "Warehouse", "dw")
+
+	_, body := typedItemBody(t, a, "localhost:9443", ws.ID, wh.ID, "Warehouse")
+	props, _ := body["properties"].(map[string]any)
+	// A tenant returns the same address under both names; a client reading
+	// `connectionInfo` got nothing here.
+	if props["connectionInfo"] != props["connectionString"] {
+		t.Errorf("connectionInfo %v != connectionString %v",
+			props["connectionInfo"], props["connectionString"])
+	}
+	if props["creationMode"] != "New" {
+		t.Errorf("creationMode = %v, want New", props["creationMode"])
+	}
+}

--- a/internal/api/sqlendpoint_test.go
+++ b/internal/api/sqlendpoint_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+	"github.com/calvinchengx/fabric-emulator/internal/testsupport"
+)
+
+// A lakehouse gets a SQLEndpoint ITEM, because a tenant gives it one.
+//
+// Measured 2026-08-11: one lakehouse + one warehouse left THREE items in a real
+// workspace, the third being `SQLEndpoint  803c8e33-…  lake` — the lakehouse's
+// display name, its own id, and that id is what sqlEndpointProperties.id reports.
+func TestALakehouseGetsItsOwnSQLEndpointItem(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+
+	eps, err := st.ListItems(ws.ID, "SQLEndpoint")
+	if err != nil || len(eps) != 1 {
+		t.Fatalf("lakehouse produced %d SQLEndpoint item(s), want 1 (err=%v)", len(eps), err)
+	}
+	if eps[0].DisplayName != "lake" {
+		t.Errorf("endpoint display name = %q, want the lakehouse's %q", eps[0].DisplayName, "lake")
+	}
+	// The id must DIFFER from the lakehouse's: a consumer using it as a database
+	// name is the failure the emulator used to prevent by omitting the field.
+	if eps[0].ID == lake.ID {
+		t.Error("the endpoint reuses the lakehouse id — the divergence this fixes")
+	}
+}
+
+func TestTheReportedEndpointIDIsTheItemsOwn(t *testing.T) {
+	a, st := newAPI(t)
+	a.SQLEndpointPort = "1433"
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+
+	_, body := typedItemBody(t, a, "localhost:9443", ws.ID, lake.ID, "Lakehouse")
+	props, _ := body["properties"].(map[string]any)
+	ep, ok := props["sqlEndpointProperties"].(map[string]any)
+	if !ok {
+		t.Fatalf("no sqlEndpointProperties: %v", props)
+	}
+	eps, _ := st.ListItems(ws.ID, "SQLEndpoint")
+	if len(eps) != 1 || ep["id"] != eps[0].ID {
+		t.Fatalf("reported id %v does not name the SQLEndpoint item", ep["id"])
+	}
+	if ep["id"] == lake.ID {
+		t.Error("reported the lakehouse id as the endpoint id")
+	}
+}
+
+// A second create must not accumulate endpoints — a lakehouse has one.
+func TestTheEndpointItemIsIdempotent(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+	a.applyCreationPayload(lake, nil)
+	eps, _ := st.ListItems(ws.ID, "SQLEndpoint")
+	if len(eps) != 1 {
+		t.Fatalf("%d endpoints after two calls, want 1", len(eps))
+	}
+}
+
+func refreshCall(t *testing.T, a *API, wid, epid string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest("POST", "/x", nil)
+	r.SetPathValue("wid", wid)
+	r.SetPathValue("epid", epid)
+	w := httptest.NewRecorder()
+	a.refreshSQLEndpointMetadata(w, r, admin)
+	return w
+}
+
+// Without a SQL engine the refresh must SAY SO. An empty 200 would be
+// indistinguishable from "the lakehouse has no tables" — the shape of lie this
+// surface exists to remove.
+func TestRefreshMetadataWithoutASQLEngineIsHonest(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+	eps, _ := st.ListItems(ws.ID, "SQLEndpoint")
+
+	w := refreshCall(t, a, ws.ID, eps[0].ID)
+	if w.Code != 501 {
+		t.Fatalf("refreshMetadata with no engine = %d, want 501: %s", w.Code, w.Body)
+	}
+}
+
+// The tenant answers `{"value": []}` with a plain 200 — no LRO, no Location.
+//
+// Needs a real SQL Server, because reflection is real: it queries the database it
+// is rebuilding. Skips without one (CI runs a SQL Server service), which is the
+// repo's declared-skip pattern rather than a fake pool — a nil *sql.DB does not
+// behave like an empty database, it panics.
+func TestRefreshMetadataAnswersTheTenantsEnvelope(t *testing.T) {
+	a, st := newAPI(t)
+	db := testsupport.OpenMSSQL(t)
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+	eps, _ := st.ListItems(ws.ID, "SQLEndpoint")
+	// A lakehouse with no Delta tables reflects nothing, which is the measured case.
+	a.LakehouseDB = func(context.Context, string) (*sql.DB, error) { return db, nil }
+
+	w := refreshCall(t, a, ws.ID, eps[0].ID)
+	if w.Code != 200 {
+		t.Fatalf("refreshMetadata = %d, want 200: %s", w.Code, w.Body)
+	}
+	if w.Header().Get("Location") != "" {
+		t.Error("answered with a Location header; the tenant does not")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	v, ok := body["value"].([]any)
+	if !ok || len(v) != 0 {
+		t.Fatalf("body = %s, want {\"value\": []}", w.Body)
+	}
+}
+
+// Only a SQLEndpoint id resolves: a lakehouse id here is a 404, because the two
+// are different items and confusing them is what the old omission guarded against.
+func TestRefreshMetadataRejectsANonEndpointID(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+	a.LakehouseDB = func(context.Context, string) (*sql.DB, error) { return nil, nil }
+
+	// A 404 is reached before the pool is ever asked for, so the stub above is
+	// never called — the id check is the assertion.
+	if w := refreshCall(t, a, ws.ID, lake.ID); w.Code != 404 {
+		t.Fatalf("a lakehouse id under /sqlEndpoints/ = %d, want 404", w.Code)
+	}
+}
+
+// RBAC: the refresh mutates the SQL view, so a Viewer must not drive it.
+func TestRefreshMetadataRequiresContributor(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	lake := seedItem(t, st, ws.ID, "Lakehouse", "lake")
+	a.applyCreationPayload(lake, nil)
+	eps, _ := st.ListItems(ws.ID, "SQLEndpoint")
+	a.LakehouseDB = func(context.Context, string) (*sql.DB, error) { return nil, nil }
+
+	r := httptest.NewRequest("POST", "/x", nil)
+	r.SetPathValue("wid", ws.ID)
+	r.SetPathValue("epid", eps[0].ID)
+	w := httptest.NewRecorder()
+	a.refreshSQLEndpointMetadata(w, r, viewer)
+	if w.Code == 200 {
+		t.Fatalf("a Viewer refreshed the endpoint metadata: %s", w.Body)
+	}
+	_ = store.RoleViewer
+}

--- a/internal/api/xmla.go
+++ b/internal/api/xmla.go
@@ -544,7 +544,7 @@ func (a *API) xmlaModel(r *http.Request, p *auth.Principal) (*semanticmodel.Mode
 	if err != nil {
 		return nil, nil, err
 	}
-	return a.loadSemanticModel(id, p)
+	return a.loadSemanticModel(r.Context(), id, p)
 }
 
 // xmlaItemID finds the SemanticModel item backing this connection.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -175,6 +175,9 @@ func New(cfg *config.Config, jwksClient *http.Client) (*Server, error) {
 			// A Fabric SQL Database mirrors its SQL tables to OneLake Delta; wire the
 			// control-plane refresh hook to the same per-item backend.
 			a.MirrorItem = mirrorItem(be, st)
+			// The lever a client uses to force the analytics endpoint to catch up
+			// with Delta (refreshMetadata); without it the endpoint 501s honestly.
+			a.LakehouseDB = lakehouseDBFor(be, st)
 			// The pipeline Script/StoredProcedure activities run real T-SQL against a
 			// Warehouse/SQLDatabase item's own database, on the same backend.
 			a.SQLDB = sqlDBFor(be, st)

--- a/internal/server/warehouse.go
+++ b/internal/server/warehouse.go
@@ -172,3 +172,26 @@ func resolveWorkspace(st *store.Store, ref string) (*store.Workspace, error) {
 	}
 	return st.GetWorkspaceByName(ref)
 }
+
+// lakehouseDBFor builds the hook the SQL-analytics-endpoint refresh uses: a
+// Lakehouse's own SQL Server database, prepared if it does not exist.
+//
+// Separate from sqlDBFor, which refuses a Lakehouse ON PURPOSE — it serves the
+// pipeline Script/StoredProcedure activities, and letting those write into a
+// lakehouse's reflected database would invent a write path Fabric's read-only
+// analytics endpoint does not have. Same backend, different permission.
+func lakehouseDBFor(be warehouseBackend, st *store.Store) func(ctx context.Context, itemID string) (*sql.DB, error) {
+	return func(ctx context.Context, itemID string) (*sql.DB, error) {
+		it, err := st.GetItemByID(itemID)
+		if err != nil {
+			return nil, fmt.Errorf("item %q not found", itemID)
+		}
+		if it.Type != "Lakehouse" {
+			return nil, fmt.Errorf("item %q (type %s) has no SQL analytics endpoint", itemID, it.Type)
+		}
+		if err := be.EnsureDatabase(ctx, itemID); err != nil {
+			return nil, fmt.Errorf("preparing database: %w", err)
+		}
+		return be.DB(itemID), nil
+	}
+}

--- a/python/notebookutils/credentials.py
+++ b/python/notebookutils/credentials.py
@@ -37,8 +37,20 @@ _real_credential = None
 
 
 def _real_token(scope):
-    """Real mode: mint through azure-identity, so `az login` just works."""
+    """Real mode: mint through azure-identity, so `az login` just works.
+
+    THE CONFIGURED TENANT MUST REACH THE az CLI PATH, and it did not.
+    `DefaultAzureCredential` takes tenant hints for the browser, VS Code,
+    shared-cache and workload-identity links and has NONE for the CLI — so a
+    developer whose `az` default tenant differs from NOTEBOOKUTILS_TENANT got
+    tokens for the wrong tenant from the credential source this shim documents as
+    the default. `getSecret` then fails with a vault or licensing error that names
+    nothing about tenants.
+    """
     global _real_credential
+    tenant = config().tenant
+    if tenant == "organizations":
+        tenant = None  # nothing configured; let the chain decide
     if _real_credential is None:
         try:
             from azure.identity import DefaultAzureCredential
@@ -48,7 +60,10 @@ def _real_token(scope):
                 "(`uv add azure-identity`), then `az login` or AZURE_* "
                 "credentials in the environment."
             ) from e
-        _real_credential = DefaultAzureCredential()
+        _real_credential = DefaultAzureCredential(
+            additionally_allowed_tenants=[tenant] if tenant else None)
+    if tenant:
+        return _real_credential.get_token(scope, tenant_id=tenant).token
     return _real_credential.get_token(scope).token
 
 

--- a/python/tests/test_notebookutils_target.py
+++ b/python/tests/test_notebookutils_target.py
@@ -164,3 +164,50 @@ def test_emulator_token_still_uses_client_credentials(monkeypatch):
     assert "/oauth2/v2.0/token" in captured["url"]
     assert "grant_type=client_credentials" in captured["body"]
     assert _config.SEED_CLIENT_ID in captured["body"]
+
+
+# --- the configured tenant must reach the az CLI path ------------------------
+# The same bug fabric_target had, in the sibling package: DefaultAzureCredential
+# has no tenant hint for the CLI, so NOTEBOOKUTILS_TENANT was ignored and tokens
+# came from az's DEFAULT tenant. Found while a real trial sat in one tenant and
+# `az` was logged into another — getSecret would have failed naming a vault, not
+# a tenant.
+
+class _RecordingCred:
+    def __init__(self):
+        self.kwargs = None
+
+    def get_token(self, *scopes, **kw):
+        self.kwargs = kw
+
+        class _T:
+            token = "tok"
+        return _T()
+
+
+def test_real_tokens_carry_the_configured_tenant(monkeypatch):
+    from notebookutils import _config, credentials
+
+    monkeypatch.setenv("FABRIC_TARGET", "real")
+    monkeypatch.setenv("NOTEBOOKUTILS_TENANT", "0ce8e0d2-1e14-4aab-a1f2-2d3c61e75e3c")
+    _config.reset()
+    rec = _RecordingCred()
+    monkeypatch.setattr(credentials, "_real_credential", rec)
+    credentials.getToken("keyvault")
+    assert rec.kwargs.get("tenant_id") == "0ce8e0d2-1e14-4aab-a1f2-2d3c61e75e3c"
+    _config.reset()
+
+
+def test_no_configured_tenant_leaves_the_chain_alone(monkeypatch):
+    """"organizations" is the unset sentinel; pinning to it would be wrong."""
+    from notebookutils import _config, credentials
+
+    monkeypatch.setenv("FABRIC_TARGET", "real")
+    monkeypatch.delenv("NOTEBOOKUTILS_TENANT", raising=False)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    _config.reset()
+    rec = _RecordingCred()
+    monkeypatch.setattr(credentials, "_real_credential", rec)
+    credentials.getToken("keyvault")
+    assert "tenant_id" not in (rec.kwargs or {})
+    _config.reset()


### PR DESCRIPTION
The first of the two remaining gold-path gaps, plus three properties measured in the same window. Specified entirely by the trial tenant.

## What the tenant showed

Creating one lakehouse and one warehouse left **three** items in a real workspace:

```
SQLEndpoint  803c8e33-c35c-4f1b-9b44-f40dce69e75e  lake
Warehouse    c6c4ba99-0f1d-4514-b715-2be7c8e900c2  dw
Lakehouse    450d5027-f17e-454e-b9ca-dbe424c494b6  lake
```

The SQL analytics endpoint is a first-class `SQLEndpoint` item carrying the lakehouse's display name and its **own** id — exactly what `sqlEndpointProperties.id` reports. And:

```
POST /v1/workspaces/{ws}/sqlEndpoints/{id}/refreshMetadata
  -> HTTP/2 200   {"value":[]}      (no Location, no x-ms-operation-id, no LRO)
```

## What changed

A lakehouse now creates its `SQLEndpoint` item, `sqlEndpointProperties.id` reports it, and `refreshMetadata` re-reads the lakehouse's Delta and rebuilds the SQL view, reporting per table in the tenant's envelope.

**This reverses a decision I made earlier in the week, deliberately.** The emulator used to *omit* `sqlEndpointProperties.id`, reasoning that it had no such item and that reporting the lakehouse's own id would invite using it as a database name — green locally, wrong on a tenant. Right for the information available; obsolete once measured. The honest fix was not to withhold the field but to **have** the item, so the id differs here exactly as it does there. A test pins that difference, and the old test comment asserting "the emulator has no SQLEndpoint item" is corrected rather than left to be re-read as live.

`LakehouseDB` is a new hook, separate from `SQLDB` — which refuses a Lakehouse *on purpose*, since it serves the pipeline Script activities and letting those write into a reflected database would invent a write path Fabric's read-only endpoint does not have. Same backend, different permission.

## Three more properties, measured before the workspace was deleted

Another session was clearing the tenant and paused to ask whether I still needed it. I used the window on the one thing I could not get afterwards — whether a tenant actually returns `collationType`, which #175 had started reporting on inference. It does, and two more surfaced with it:

| Property | Tenant | Before |
|---|---|---|
| `lakehouse.oneLakeTablesPath` / `oneLakeFilesPath` | absolute OneLake URLs | absent |
| `warehouse.connectionInfo` | same address as `connectionString` | absent |
| `warehouse.creationMode` | `"New"` | absent |
| `warehouse.collationType` | `Latin1_General_100_BIN2_UTF8` | reported since #175 — now confirmed |

All three are the emulator-strict direction, which is the safe one — but an absent `oneLakeTablesPath` is exactly what makes someone hardcode a OneLake path, and a hardcoded path does not survive the toggle. Derived from the caller's request like every other address here, so it is reachable from wherever the caller stands.

## The payoff

`common.sync_sql_endpoint()` picks `refreshMetadata` when the target reports an endpoint id. That branch was real-only and untested. It is now the branch **both** targets take:

```
==> [7/11] reflect silver into the lakehouse SQL endpoint
==> SQL analytics endpoint 0411dc30-29bb-4334-a716-6e96dc073383 metadata refreshed
==> reflection: [('pending', 242500, …), ('shipped', 5000, …)] (attempt 2)
```

Three `refreshMetadata` calls per `e2e/medallion` run (reflect, plus dq_gate's poison and restore).

## Verified

`e2e/medallion` **11/11 exit 0**, all Go suites, lint. Eleven new unit tests: the endpoint item exists and is idempotent, its id differs from the lakehouse's and is the one reported, a lakehouse id under `/sqlEndpoints/` is a 404, a Viewer cannot refresh, no SQL engine answers an honest 501 rather than an empty 200 (indistinguishable from "no tables"), the OneLake paths survive a stack with no SQL sidecar, and `connectionInfo` matches `connectionString`. The envelope test needs a real SQL Server and skips without one — a nil `*sql.DB` does not behave like an empty database, it panics, which is how that test found the guard it now covers.

Two existing assertions narrowed, both the same shape: they asserted "no properties at all" when there was only ever one property. They now assert the claim they were proxies for — no *address*, no *endpoint* — so an honest addition cannot read as a regression.

## Still open: the semantic model's `data.json`

Not in this PR and not started. It needs Direct Lake over a **warehouse** locally — either the evaluator reading warehouse tables from SQL when a Direct Lake expression names one, or warehouse tables materialised as OneLake Delta — plus converting `semantic_model.py` and `tmdl_pbip.py` across six files under the parity gate. That is a feature, so it gets its own PR.