### PR TITLE
fix: twelve Fabric activity types were reporting success having run nothing

### DIFF
--- a/internal/api/azurehdinsightactivity.go
+++ b/internal/api/azurehdinsightactivity.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/calvinchengx/fabric-emulator/internal/pipeline"
+)
+
+// hdinsightPrograms maps the program an `AzureHDInsight` activity names to the
+// ADF discriminator this emulator already reasons about.
+//
+// Fabric merges ADF's five HDInsight activity types into ONE — the
+// DataPipelineActivityTypes table describes `AzureHDInsight` as "Runs various
+// programs (Hive, Pig, MapReduce, Streaming, Spark)". A name alias would
+// therefore be wrong in the most dangerous way available: it would send a Hive
+// script to whichever single handler was chosen, and the Spark agent computes
+// Spark SQL, not HiveQL. The overlap between two dialects is not the guarantee.
+//
+// So the program decides, and four of the five keep the refusals they already
+// have with their causes intact.
+var hdinsightPrograms = map[string]string{
+	"spark":     "HDInsightSpark",
+	"hive":      "HDInsightHive",
+	"pig":       "HDInsightPig",
+	"mapreduce": "HDInsightMapReduce",
+	"streaming": "HDInsightStreaming",
+}
+
+// azureHDInsightActivity routes Fabric's single HDInsight activity to the
+// program it actually names.
+func (e *pipelineExecutor) azureHDInsightActivity(
+	act pipeline.Activity,
+	tp map[string]json.RawMessage,
+	resolve func(json.RawMessage) (any, error),
+) (map[string]any, error) {
+	program, err := hdinsightProgram(tp, resolve)
+	if err != nil {
+		return nil, fmt.Errorf("HDInsight activity %q: %w", act.Name, err)
+	}
+	adf, ok := hdinsightPrograms[strings.ToLower(program)]
+	if !ok {
+		return nil, fmt.Errorf("HDInsight activity %q names program %q, which is not one of "+
+			"the five this activity type covers (%s). Refused rather than run: guessing which "+
+			"engine an unknown program wants is how a script gets executed under the wrong "+
+			"semantics and reported as the right one", act.Name, program, knownHDInsightPrograms())
+	}
+	if adf == "HDInsightSpark" {
+		return e.hdinsightSparkActivity(act, tp, resolve)
+	}
+	// The other four are refused with the cause already written for their ADF
+	// discriminator, so a Fabric-authored pipeline gets the same honest answer
+	// an ADF-authored one does rather than a fabricated success.
+	cause, ok := unrunnableActivities[adf]
+	if !ok {
+		return nil, fmt.Errorf("HDInsight activity %q: program %q is not implemented", act.Name, program)
+	}
+	return nil, unrunnableRefusal(pipeline.Activity{Name: act.Name, Type: adf}, cause)
+}
+
+// hdinsightProgram reads the program name. Fabric's own designer writes it as
+// `type` inside typeProperties; `program` is accepted as the other spelling
+// seen in the wild. Absent, it cannot be guessed.
+func hdinsightProgram(tp map[string]json.RawMessage, resolve func(json.RawMessage) (any, error)) (string, error) {
+	for _, key := range []string{"type", "program", "programType"} {
+		raw, ok := tp[key]
+		if !ok || len(raw) == 0 {
+			continue
+		}
+		v, err := resolve(raw)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", key, err)
+		}
+		if s := fmt.Sprint(v); v != nil && s != "" {
+			return s, nil
+		}
+	}
+	return "", fmt.Errorf("typeProperties names no program, so which of %s to run is unknown. "+
+		"This activity covers five different engines and picking one would be a guess",
+		knownHDInsightPrograms())
+}
+
+func knownHDInsightPrograms() string {
+	names := make([]string, 0, len(hdinsightPrograms))
+	for n := range hdinsightPrograms {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/internal/api/fabricactivitytypes.go
+++ b/internal/api/fabricactivitytypes.go
@@ -1,0 +1,62 @@
+package api
+
+// fabricActivityTypes is Fabric's OWN list of data-pipeline activity type
+// discriminators — the `DataPipelineActivityTypes` table in:
+//
+//	https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/datapipeline-definition
+//
+// THIS IS THE ORACLE, AND NAMING THE WRONG ONE IS WHAT CAUSED THE BUG IT
+// EXISTS TO PREVENT. unrunnableactivities.go previously recorded its oracle as
+// "ADF's published schema", and the dispatch was diffed against that. Fabric
+// renames several of ADF's discriminators and merges others, so twelve Fabric
+// names matched nothing in the dispatch and fell to its default — which
+// returns {"status":"Succeeded"}. A Fabric-authored pipeline was told its Spark
+// job ran, its email sent, its semantic model refreshed, having done none of it.
+//
+// A type name is part of the wire contract exactly as a response code is. Both
+// were checked against the wrong document, which is why the fix is a list with
+// its source attached and a test that walks it, rather than twelve more cases.
+//
+// Nothing here is invented: every entry is transcribed from that table. ADF
+// names the emulator also accepts (HDInsightHive, AzureFunctionActivity,
+// RunNotebook, …) are deliberately ABSENT — they are not Fabric's vocabulary,
+// they are compatibility with the other authoring surface, and mixing the two
+// lists is the mistake being corrected.
+var fabricActivityTypes = []string{
+	"AppendVariable",
+	"AzureFunction",
+	"AzureHDInsight",
+	"AzureMLExecutePipeline",
+	"Copy",
+	"Custom",
+	"DataLakeAnalyticsScope",
+	"DatabricksNotebook",
+	"Delete",
+	"Email",
+	"ExecutePipeline",
+	"ExecuteSSISPackage",
+	"Fail",
+	"Filter",
+	"ForEach",
+	"GetMetadata",
+	"IfCondition",
+	"InvokeCopyJob",
+	"InvokePipeline",
+	"KustoQueryLanguage",
+	"Lookup",
+	"MicrosoftTeams",
+	"Office365Email",
+	"PBISemanticModelRefresh",
+	"RefreshDataFlow",
+	"Script",
+	"SetVariable",
+	"SparkJobDefinition",
+	"SqlServerStoredProcedure",
+	"Switch",
+	"Teams",
+	"TridentNotebook",
+	"Until",
+	"Wait",
+	"WebActivity",
+	"WebHook",
+}

--- a/internal/api/fabricactivitytypes_test.go
+++ b/internal/api/fabricactivitytypes_test.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/pipeline"
+)
+
+// THE STRUCTURAL TEST. Every activity type Fabric documents must produce a real
+// outcome — run, or be refused by name — and never the dispatch default, which
+// answers {"status":"Succeeded"} and would report work that never happened.
+//
+// It walks fabricActivityTypes rather than asserting a hand-written list of
+// cases, so the next rename in Fabric's table fails HERE instead of silently
+// becoming a fabricated success. That is the whole point: the previous bug was
+// not twelve mistakes, it was one missing check repeated twelve times.
+//
+// The probe is deliberately empty typeProperties. A type that needs real
+// properties may legitimately fail on them — that is a real outcome and passes
+// this test. What must NOT happen is the success stub.
+func TestEveryDocumentedFabricActivityTypeIsHandled(t *testing.T) {
+	e := &pipelineExecutor{a: &API{}, wid: "ws"}
+	resolve := func(raw json.RawMessage) (any, error) {
+		if len(raw) == 0 {
+			return nil, nil
+		}
+		var v any
+		_ = json.Unmarshal(raw, &v)
+		return v, nil
+	}
+
+	var fabricated []string
+	for _, typ := range fabricActivityTypes {
+		if handledByInterpreter[typ] {
+			continue // control flow never reaches the executor
+		}
+		act := pipeline.Activity{Name: "probe", Type: typ, TypeProperties: json.RawMessage(`{}`)}
+		out, err := func() (out map[string]any, err error) {
+			defer func() {
+				// A panic is a bug, but it is NOT a fabricated success, which
+				// is what this test is about. Recorded as handled and left for
+				// whatever test covers that type properly.
+				if r := recover(); r != nil {
+					out, err = nil, nil
+				}
+			}()
+			return e.Execute(act, resolve)
+		}()
+		if err != nil {
+			continue // refused or failed by name — a real outcome
+		}
+		if out != nil && out["status"] == "Succeeded" && out["activityType"] == typ {
+			fabricated = append(fabricated, typ)
+		}
+	}
+
+	if len(fabricated) > 0 {
+		t.Fatalf(`%d Fabric activity types fall to the dispatch default and are reported
+Succeeded having run nothing:
+
+  %s
+
+Each must either RUN or be refused BY NAME. If Fabric has added a type, add it
+to fabricActivityTypes (from the DataPipelineActivityTypes table) and then give
+it an outcome — adding it to the list alone will keep this test red, which is
+intended.`, len(fabricated), strings.Join(fabricated, "\n  "))
+	}
+}
+
+// handledByInterpreter are the control-flow types internal/pipeline executes
+// itself, so they never reach the Executor at all. Listed explicitly rather
+// than skipped by guesswork, because a type wrongly assumed to be control flow
+// would be exempted from the check above and could then fabricate freely.
+var handledByInterpreter = map[string]bool{
+	"AppendVariable": true,
+	"Fail":           true,
+	"Filter":         true,
+	"ForEach":        true,
+	"IfCondition":    true,
+	"SetVariable":    true,
+	"Switch":         true,
+	"Until":          true,
+	"Wait":           true,
+}
+
+// The interpreter list must stay true: anything claimed as control flow has to
+// be a case in internal/pipeline, or the exemption above is a hole.
+func TestInterpreterExemptionsAreReal(t *testing.T) {
+	for typ := range handledByInterpreter {
+		p, err := pipeline.Parse([]byte(`{"properties":{"activities":[
+			{"name":"a","type":"` + typ + `","typeProperties":{}}]}}`))
+		if err != nil {
+			t.Fatalf("%s: %v", typ, err)
+		}
+		// A nil Executor is the assertion: if the interpreter delegated this
+		// type, it would dereference nil and panic. Reaching a result at all
+		// proves it handled the type itself.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("%s is exempted as control flow but was delegated to the Executor", typ)
+				}
+			}()
+			_ = p.Run(nil, nil)
+		}()
+	}
+}
+
+// The three true renames must route to the SAME behaviour as the ADF name the
+// emulator already handled, not to a refusal — otherwise "handled" would be
+// satisfied by refusing everything, which passes the structural test while
+// losing real capability.
+func TestFabricRenamesReachTheSameBehaviourAsTheirADFNames(t *testing.T) {
+	e := &pipelineExecutor{a: &API{}, wid: "ws"}
+	resolve := func(raw json.RawMessage) (any, error) { return nil, nil }
+	for _, pair := range []struct{ fabric, adf string }{
+		{"AzureFunction", "AzureFunctionActivity"},
+		{"KustoQueryLanguage", "AzureDataExplorerCommand"},
+		{"RefreshDataFlow", "RefreshDataflow"},
+	} {
+		probe := func(typ string) string {
+			act := pipeline.Activity{Name: "p", Type: typ, TypeProperties: json.RawMessage(`{}`)}
+			_, err := e.Execute(act, resolve)
+			if err == nil {
+				return "<no error>"
+			}
+			// Strip the activity type, which legitimately differs, and compare
+			// what the handler actually said.
+			return strings.ReplaceAll(err.Error(), typ, "<TYPE>")
+		}
+		if got, want := probe(pair.fabric), probe(pair.adf); got != want {
+			t.Errorf("%s took a different path from %s:\n  fabric: %s\n  adf:    %s",
+				pair.fabric, pair.adf, got, want)
+		}
+	}
+}
+
+// AzureHDInsight is one Fabric type over five programs, so it must dispatch on
+// typeProperties. Aliasing it by name would send a Hive script to whichever
+// single handler was picked — the failure unrunnableactivities.go exists for.
+func TestAzureHDInsightDispatchesOnItsProgram(t *testing.T) {
+	e := &pipelineExecutor{a: &API{}, wid: "ws"}
+	resolve := func(raw json.RawMessage) (any, error) {
+		var v any
+		_ = json.Unmarshal(raw, &v)
+		return v, nil
+	}
+	run := func(props string) error {
+		act := pipeline.Activity{Name: "p", Type: "AzureHDInsight", TypeProperties: json.RawMessage(props)}
+		_, err := e.Execute(act, resolve)
+		return err
+	}
+	// Each non-Spark program is refused under ITS OWN name, carrying the cause
+	// already written for that engine.
+	for program, adf := range map[string]string{
+		"Hive": "HDInsightHive", "Pig": "HDInsightPig",
+		"MapReduce": "HDInsightMapReduce", "Streaming": "HDInsightStreaming",
+	} {
+		err := run(`{"type":"` + program + `"}`)
+		if err == nil {
+			t.Fatalf("%s was not refused", program)
+		}
+		if !strings.Contains(err.Error(), adf) {
+			t.Errorf("%s refused without naming %s: %v", program, adf, err)
+		}
+	}
+	// A missing program is refused rather than guessed.
+	if err := run(`{}`); err == nil || !strings.Contains(err.Error(), "names no program") {
+		t.Errorf("a programless HDInsight activity should be refused, got %v", err)
+	}
+	// An unknown program is refused rather than routed anywhere.
+	if err := run(`{"type":"Nonsense"}`); err == nil || !strings.Contains(err.Error(), "not one of") {
+		t.Errorf("an unknown program should be refused, got %v", err)
+	}
+}
+
+// Every refusal must name the activity and say why. A refusal a reader cannot
+// act on is only marginally better than the fabricated success it replaced.
+func TestNewRefusalsExplainThemselves(t *testing.T) {
+	e := &pipelineExecutor{a: &API{}, wid: "ws"}
+	resolve := func(raw json.RawMessage) (any, error) { return nil, nil }
+	for _, typ := range []string{
+		"Teams", "MicrosoftTeams", "Office365Email", "Email",
+		"DataLakeAnalyticsScope", "SparkJobDefinition", "InvokeCopyJob",
+		"PBISemanticModelRefresh",
+	} {
+		act := pipeline.Activity{Name: "notify", Type: typ, TypeProperties: json.RawMessage(`{}`)}
+		_, err := e.Execute(act, resolve)
+		if err == nil {
+			t.Errorf("%s did not fail", typ)
+			continue
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "notify") || !strings.Contains(msg, typ) {
+			t.Errorf("%s: refusal names neither the activity nor the type: %s", typ, msg)
+		}
+		if !strings.Contains(msg, "Inactive") {
+			t.Errorf("%s: refusal does not tell the reader how to skip the step: %s", typ, msg)
+		}
+	}
+	// The two that are wiring-not-boundary must say so, or a reader will file
+	// them as permanently unsupported.
+	for _, typ := range []string{"SparkJobDefinition", "InvokeCopyJob"} {
+		act := pipeline.Activity{Name: "x", Type: typ, TypeProperties: json.RawMessage(`{}`)}
+		_, err := e.Execute(act, resolve)
+		if err == nil || !strings.Contains(err.Error(), "THE EMULATOR CAN DO THIS") {
+			t.Errorf("%s should state that the capability exists: %v", typ, err)
+		}
+	}
+}

--- a/internal/api/pipelines.go
+++ b/internal/api/pipelines.go
@@ -252,7 +252,7 @@ func (e *pipelineExecutor) Execute(act pipeline.Activity, resolve func(json.RawM
 		// resolveDatabaseRef accepts alongside the other reference keys.
 		return e.storedProcedureActivity(act, tp, resolve)
 
-	case "RefreshDataflow", "ExecuteDataFlow", "ExecutePowerQueryTemplate":
+	case "RefreshDataflow", "RefreshDataFlow", "ExecuteDataFlow", "ExecutePowerQueryTemplate":
 		// Dataflow Gen2 is the proprietary Power Query M engine — honestly
 		// unimplemented (mirrors the Livy/Airflow stance), so the activity
 		// fails loudly rather than pretending.
@@ -280,13 +280,24 @@ func (e *pipelineExecutor) Execute(act pipeline.Activity, resolve func(json.RawM
 		// what is real and what is refused by name.
 		return e.hdinsightSparkActivity(act, tp, resolve)
 
+	case "AzureHDInsight":
+		// Fabric collapses ADF's five HDInsight discriminators into ONE type
+		// whose table entry reads "Runs various programs (Hive, Pig, MapReduce,
+		// Streaming, Spark)". So this is NOT a rename and must not be aliased
+		// by name: the program lives in typeProperties, and routing a Hive
+		// script into the Spark agent would compute different semantics and
+		// report them as Hive — precisely what unrunnableactivities.go exists
+		// to prevent. Dispatch on the program, and refuse the four this
+		// emulator cannot run under their own names.
+		return e.azureHDInsightActivity(act, tp, resolve)
+
 	case "Validation":
 		// Really waits for the data: real OneLake paths, real sizes, and the
 		// virtual clock for the timeout. See validationactivity.go — an
 		// always-passing Validation is worse than none.
 		return e.validationActivity(act, tp, resolve)
 
-	case "AzureDataExplorerCommand":
+	case "AzureDataExplorerCommand", "KustoQueryLanguage":
 		// A real control command on the real Kusto engine behind Eventhouse,
 		// through the same relay helpers the KQL data plane uses. See
 		// adxcommandactivity.go.
@@ -299,7 +310,7 @@ func (e *pipelineExecutor) Execute(act pipeline.Activity, resolve func(json.RawM
 		// reported Succeeded; see azuremlactivity.go.
 		return e.azureMLActivity(act)
 
-	case "AzureFunctionActivity":
+	case "AzureFunctionActivity", "AzureFunction":
 		// A real call to a function endpoint over the same HTTP core as Web;
 		// the function key travels as x-functions-key, which is how ADF
 		// authenticates the call.

--- a/internal/api/unrunnableactivities.go
+++ b/internal/api/unrunnableactivities.go
@@ -27,8 +27,24 @@ import (
 // is the deliverable; running an approximation and calling it the real thing
 // would be the failure.
 //
-// ORACLE for every entry: ADF's published schema, its discriminator and the
-// required fields quoted in each cause.
+// ORACLE, and this line was WRONG in a way that cost twelve fabricated
+// successes. It used to read "ADF's published schema" full stop, and the
+// dispatch was diffed against exactly that. ADF's schema is the oracle for the
+// ADF discriminators below and for the fields quoted in each cause — it is NOT
+// the oracle for what Fabric sends. Fabric renames several types and merges
+// five HDInsight ones into a single AzureHDInsight, so twelve of its names
+// matched nothing here and fell to the dispatch default.
+//
+// Fabric's own list is the DataPipelineActivityTypes table, transcribed in
+// fabricactivitytypes.go and walked by a test. Add to BOTH when adding a type:
+// the ADF name for compatibility, the Fabric name because that is what arrives.
+// dataLakeAnalyticsCause is shared by ADF's DataLakeAnalyticsU-SQL and
+// Fabric's DataLakeAnalyticsScope — the same activity under two names.
+const dataLakeAnalyticsCause = "runs a U-SQL/Scope script on Azure Data Lake Analytics. U-SQL is a " +
+	"language of its own (SQL with inline C#), the emulator hosts no Data Lake Analytics " +
+	"account, and AZURE HAS RETIRED THE SERVICE — so there is nothing to call and " +
+	"nothing left to be faithful to"
+
 var unrunnableActivities = map[string]string{
 	"HDInsightHive": "runs a HiveQL script (scriptPath in a storage linked service) on an " +
 		"HDInsight cluster. The Spark agent executes Python statements and routes SQL to " +
@@ -52,16 +68,69 @@ var unrunnableActivities = map[string]string{
 		"behind FABRIC_CUSTOM_ACTIVITY — that gate covers a command the caller wrote, not a " +
 		"MapReduce runtime the emulator would have to supply around it",
 
-	"DataLakeAnalyticsU-SQL": "runs a U-SQL script on Azure Data Lake Analytics. U-SQL is a " +
-		"language of its own (SQL with inline C#), the emulator hosts no Data Lake Analytics " +
-		"account, and AZURE HAS RETIRED THE SERVICE — so there is nothing to call and " +
-		"nothing left to be faithful to",
+	"DataLakeAnalyticsU-SQL": dataLakeAnalyticsCause,
 
 	"ExecuteSSISPackage": "runs an SSIS package on an Azure-SSIS integration runtime, named " +
 		"by packageLocation and reached through connectVia. The emulator hosts no " +
 		"integration runtime and does not interpret the SSIS package format; a package's " +
 		"work is defined inside the package, so there is nothing here to read and nothing " +
 		"to run it with",
+
+	// --- Fabric's own names, added after diffing its DataPipelineActivityTypes
+	// table rather than ADF's schema. Every one of these was reporting
+	// Succeeded having done nothing.
+
+	// Fabric's spelling of the ADF DataLakeAnalyticsU-SQL activity above. The
+	// SAME cause is reused rather than restated: two texts for one refusal
+	// drift, and the second copy is the one nobody updates.
+	"DataLakeAnalyticsScope": dataLakeAnalyticsCause,
+
+	// The four notification types. They are grouped because the objection is
+	// identical and worth stating once: each one's whole purpose is a SIDE
+	// EFFECT LEAVING THE MACHINE. There is no local approximation of "a message
+	// arrived in a channel", and a pipeline that branches on a notification
+	// having been sent is exactly the case a fabricated success misleads.
+	"Teams": "posts a message to a Teams channel or chat. The emulator has no Teams tenant " +
+		"and no Graph credentials, and the activity's only observable effect is off-machine — " +
+		"there is nothing local that could stand in for a message having been delivered",
+
+	"MicrosoftTeams": "posts a message to Microsoft Teams. Fabric documents this alongside " +
+		"`Teams` as a separate discriminator, so both are refused: an author who picked either " +
+		"spelling gets the same honest answer rather than one of them silently succeeding",
+
+	"Office365Email": "sends an email through Office 365. The emulator has no mailbox, no " +
+		"SMTP path and no Graph credentials; delivery is the entire point of the activity and " +
+		"none of it can happen here",
+
+	"Email": "sends an email notification. Fabric lists this beside `Office365Email` as its " +
+		"own discriminator, and it is refused for the same reason — the effect is delivery to " +
+		"somewhere the emulator cannot reach",
+
+	// These two are DIFFERENT in kind from every other entry, and the difference
+	// is stated so nobody reads them as permanent: the emulator ALREADY RUNS
+	// both item types through the jobs API (`sparkjob` for a Spark Job
+	// Definition, `Execute` for a Copy job). What is missing is only the
+	// activity-side wiring — resolve the referenced item, submit the job,
+	// gate the activity on its outcome.
+	//
+	// They are refused rather than left in the default because a refusal is
+	// honest and reversible while a fabricated success is neither: today the
+	// activity claims a Spark job ran. Refusing is strictly better and strictly
+	// worse than running them, which is the next increment.
+	"SparkJobDefinition": "runs a Spark Job Definition item. THE EMULATOR CAN DO THIS — the " +
+		"item type executes through the jobs API (jobType `sparkjob`) — but the pipeline " +
+		"activity is not yet wired to submit that job, so it is refused rather than reported " +
+		"as having run. Wiring it is the next increment, not a boundary",
+
+	"InvokeCopyJob": "invokes a Copy job item. THE EMULATOR CAN DO THIS — a Copy job executes " +
+		"through the jobs API (jobType `Execute`) and really moves bytes on its OneLake legs — " +
+		"but the pipeline activity is not yet wired to submit that job. Refused rather than " +
+		"reported as having run; wiring it is the next increment, not a boundary",
+
+	"PBISemanticModelRefresh": "refreshes a Power BI semantic model. The emulator stores and " +
+		"evaluates models but does not implement the refresh pipeline that reloads a model's " +
+		"data from its sources, so a success here would claim the model now holds data it " +
+		"does not",
 }
 
 // unrunnableRefusal is the shared message. The tail is the same for all six on

--- a/internal/api/unrunnableactivities_test.go
+++ b/internal/api/unrunnableactivities_test.go
@@ -108,8 +108,27 @@ func TestTheStubStillAnswersForConnectorLeaves(t *testing.T) {
 // activity — it would fall to the stub again with no test failing.
 func TestUnrunnableRefusalsCoverTheDiff(t *testing.T) {
 	want := map[string]bool{
+		// From ADF's discriminators, the original diff.
 		"HDInsightHive": true, "HDInsightPig": true, "HDInsightMapReduce": true,
 		"HDInsightStreaming": true, "DataLakeAnalyticsU-SQL": true, "ExecuteSSISPackage": true,
+
+		// From FABRIC's DataPipelineActivityTypes table — a second diff against
+		// a different document, because the first one used ADF's schema and
+		// Fabric renames several types. Each of these was reaching the stub and
+		// being reported Succeeded having run nothing.
+		"DataLakeAnalyticsScope": true, // Fabric's name for DataLakeAnalyticsU-SQL
+
+		// Notification activities: the effect is delivery off-machine, so there
+		// is no local approximation of "the message arrived".
+		"Teams": true, "MicrosoftTeams": true, "Office365Email": true, "Email": true,
+
+		"PBISemanticModelRefresh": true,
+
+		// TEMPORARY, and different in kind from every other entry: the emulator
+		// already RUNS both item types through the jobs API, and only the
+		// activity-side wiring is missing. When that lands these two must be
+		// REMOVED from the map, and this test is what will demand it.
+		"SparkJobDefinition": true, "InvokeCopyJob": true,
 	}
 	for name := range want {
 		if _, ok := unrunnableActivities[name]; !ok {


### PR DESCRIPTION
Found by `local_87220308`, verified and extended here. **This is the fabricated-success class**: a Fabric-authored pipeline was told its Spark job ran, its email sent, its semantic model refreshed — having done none of it. Downstream activities then consume the effect.

## The cause is a citation, not a typo

`unrunnableactivities.go` recorded its provenance in writing:

> *ORACLE for every entry: ADF's published schema*

The dispatch was diffed against exactly that. **Fabric renames several of ADF's discriminators and merges five HDInsight ones into a single type**, so twelve Fabric names matched nothing and fell to the default, which returns `{"status":"Succeeded"}`.

A type name is part of the wire contract exactly as a response code is. Both were checked against the wrong document — the same shape as #173/#174, one level down.

## Twelve, not ten

`local_87220308` reported ten. Diffing all 36 rows of Fabric's [`DataPipelineActivityTypes` table](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/datapipeline-definition) found two more: **`Email`** and **`MicrosoftTeams`**, which sit beside `Office365Email` and `Teams` as separate discriminators.

Worth noting what is *not* an oracle: the per-activity Learn pages are UI walkthroughs with no discriminator, [Activity overview](https://learn.microsoft.com/en-us/fabric/data-factory/activity-overview) lists display names only, and there is no `developer.microsoft.com` schema for pipeline-content (404). That REST article is the only published source.

## Not all renames — the distinction changes the fix

| kind | types | treatment |
|---|---|---|
| true renames | `AzureFunction`, `KustoQueryLanguage`, `RefreshDataFlow`, `DataLakeAnalyticsScope` | route to the existing handler/refusal |
| one type, five programs | `AzureHDInsight` | dispatch on `typeProperties` |
| effect leaves the machine | `Teams`, `MicrosoftTeams`, `Office365Email`, `Email` | refused by name |
| not implemented | `PBISemanticModelRefresh` | refused by name |
| **wiring missing, capability present** | `SparkJobDefinition`, `InvokeCopyJob` | refused **for now**, and the refusal says so |

**`AzureHDInsight` must not be aliased by name.** Its table entry reads *"Runs various programs (Hive, Pig, MapReduce, Streaming, Spark)"* — one Fabric type over five ADF ones. Aliasing it would send a Hive script to whichever handler was picked, and the Spark agent computes Spark SQL, not HiveQL. It dispatches on the program and the four non-Spark ones keep their existing causes.

**`SparkJobDefinition` and `InvokeCopyJob` are deliberately partial.** The emulator already runs both item types through the jobs API (`sparkjob`, `Execute`); only the activity-side wiring is missing. I refused them rather than half-build a submit-and-await under time pressure — a refusal is honest and reversible, a fabricated success is neither. Both refusals say **"THE EMULATOR CAN DO THIS"** in as many words, a test asserts they say it, and the guard test marks them TEMPORARY so removing them is demanded when the wiring lands.

## The part that stops recurrence

`fabricActivityTypes` transcribes Fabric's 36 with the source URL, and `TestEveryDocumentedFabricActivityTypeIsHandled` walks it, failing on any type that reaches the success stub. **The previous bug was not twelve mistakes; it was one missing check repeated twelve times.**

Written test-first: it failed listing exactly those twelve before any fix.

Three supporting tests guard the ways this could be satisfied dishonestly: renames must reach the *same* behaviour as their ADF name (so "handled" cannot be met by refusing everything), HDInsight must dispatch per program, and every refusal must name the activity and tell the reader how to skip it.

I also corrected `unrunnableactivities.go`'s oracle line, because leaving it would invite the identical mistake.

## One correction to my own analysis

I first classified `DataLakeAnalyticsScope` as a new refusal. It is a **rename** — the map already held ADF's `DataLakeAnalyticsU-SQL`, and my extraction regex `[A-Za-z]+` excluded the hyphen so it never appeared in my diff. The two now share one cause rather than carrying two texts that would drift.

`make check` green, all Go suites green, `gofmt`/`vet` clean.