### PR TITLE
docs: v0.21.0 notes cover the whole unreleased range

### DIFF
--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -1,8 +1,18 @@
 # v0.21.0
 
-**XMLA works.** Thirty-one commits, and the theme is a surface that this
-repository spent months calling infeasible, then deferred on cost, and has now
-implemented and proved with two of Microsoft's own clients.
+**XMLA works, and a real Fabric tenant graded the emulator.** Eighty-eight
+commits in two batches.
+
+The first implemented a surface this repository spent months calling infeasible,
+then deferred on cost, and proved with two of Microsoft's own clients.
+
+The second was measured against **a real Fabric trial**, not against
+documentation: an unmodified example provisioned a live workspace, and the
+attempt found bugs no amount of reading would have. Warehouse collation, twelve
+pipeline activities that reported success having run nothing, the SQL analytics
+endpoint as a real item, semantic models that read their own gold, and a
+credential that ignored the tenant it was told to use. Variable libraries landed
+alongside, with three consumers driving them.
 
 Also here: the Purview Data Map goes green on an independent witness, four
 code-scanning fixes, and `./data` becomes the default state directory.
@@ -58,6 +68,92 @@ tables, columns, relationships, partitions, Direct Lake migration) are **not**
 implemented. The parity row and [docs/32](https://github.com/calvinchengx/fabric-emulator/blob/main/docs/32-xmla-plan.md)
 carry the detail.
 
+## Graded against a real tenant
+
+Every claim in this section is a measurement against a live Fabric trial, and
+each one was invisible to local testing.
+
+**Warehouse collation.** A Fabric Warehouse reports
+`Latin1_General_100_BIN2_UTF8` — Microsoft documents it as "The default -
+case-sensitive (CS) collation". The emulator's `CREATE DATABASE` inherited the
+container's `..._CI_AS`, case-**in**sensitive, so
+`select … from information_schema.tables` returned rows here and
+`Invalid object name` on a tenant. Per-item databases now carry Fabric's
+collation, and `collationType` is honoured from a Warehouse's `creationPayload`
+and reported on read. **A model with an identifier-casing mistake now fails on
+the developer's machine**, which is the only place it is cheap to fix.
+
+**Three `CREATE TABLE` restrictions**, refused by name because the tenant
+refuses them and vanilla SQL Server does not: `INT IDENTITY` (Fabric requires
+BIGINT), `PRIMARY KEY` in `CREATE TABLE`, and the same constraint inline with
+`NOT ENFORCED`. Refused rather than rewritten — dropping IDENTITY changes what a
+table does.
+
+**The SQL analytics endpoint is an item.** A lakehouse leaves a `SQLEndpoint`
+item carrying its display name and its own id, and that id is what
+`sqlEndpointProperties.id` reports. So
+`POST …/sqlEndpoints/{id}/refreshMetadata` works — the lever a client uses when
+the endpoint has not caught up with Delta. This reverses an earlier decision
+that omitted the field: the honest fix was not to withhold the id but to have
+the item.
+
+**Twelve pipeline activity types reported success having run nothing.** The
+dispatch had been diffed against **ADF's** schema rather than Fabric's, and
+Fabric renames several — so a Fabric-authored pipeline got a fabricated success
+where an ADF-authored one got real work. Six were capability already present
+under a different spelling. A structural test now walks Fabric's own documented
+type list against the dispatch, so the next rename fails a test instead.
+
+**Long-running operations, twice.** `getDefinition` and `createItem` can both
+answer 202 on a tenant where the emulator always answered 200/201 —
+`FABRIC_FORCE_LRO` produces both, so a client's poll path is testable locally
+rather than discovered in production.
+
+**Properties a tenant returns and this did not:** a lakehouse's
+`oneLakeTablesPath` / `oneLakeFilesPath`, a warehouse's `connectionInfo` and
+`creationMode`.
+
+## Variable libraries
+
+Pipelines resolve `@pipeline().libraryVariables.<alias>` against the workspace's
+Variable Library and its active value set. The pipeline-side reference binds
+**by name** with no GUID anywhere, so a pipeline consuming library variables is
+environment-invariant by construction; `activeValueSetName` is an item property
+rather than definition content, so a git branch cannot carry the choice of
+environment. Three consumers drive it: pipelines, the `notebookutils` shim, and
+Microsoft's own `fabric-cicd`.
+
+## The examples are target-agnostic
+
+All four medallion examples now run against either target by environment alone,
+with **no step refusing** and nothing emulator-only in what they publish:
+
+- secrets read through `notebookutils.credentials.getSecret`, the brokered path
+  a notebook actually has;
+- SQL addresses **discovered** per item, never configured — the emulator
+  advertises them the way a tenant does;
+- transforms living in Notebook **definitions** submitted as `RunNotebook` jobs,
+  so the emulator's agent and a Fabric pool run the same cells;
+- semantic models reading gold through a **Direct Lake** partition instead of an
+  inline `data.json` snapshot the emulator alone understands.
+
+`scripts/check_example_portability.py` enforces it and prints any remaining
+divergence on every green run.
+
+## Fixes found by running it
+
+- **`AZURE_TENANT_ID` never reached the `az` CLI credential.**
+  `DefaultAzureCredential` has no tenant hint for the CLI, so a developer whose
+  `az` default tenant differed got tokens for the wrong one and Fabric answered
+  `UserNotLicensed` — a tenant problem wearing a licensing error. Fixed in
+  `fabric_target` and in the `notebookutils` shim, which had the same gap.
+- **A Warehouse create is asynchronous on a tenant**, so an example that read
+  `.json()["id"]` off the 202 failed three calls past its cause.
+- **`FABRIC_CAPACITY_ID`**: a workspace created with no capacity accepts the
+  create and then rejects every item in it, so the resolver refuses instead.
+- **The Sail e2e no longer hangs**: it ends on its own budget rather than the
+  job's, taking a leg that was being cancelled at 25 minutes down to 1m33s.
+
 ## Purview Data Map is green
 
 Graded on a `pyapacheatlas` witness, which is a third-party client rather than
@@ -109,4 +205,13 @@ empty explicitly. If you run the **image**, note it bakes
 override back to empty as this repository's compose file does, or the store
 fails to open `/data`.
 
-Nothing else on the REST or Spark surfaces changed.
+**Warehouse databases are now created case-sensitive**, matching Fabric's
+default. If your T-SQL or dbt models reference an object in the wrong case, they
+worked before and will now fail — which is what a tenant does. `dbt-fabric`
+itself is unaffected: its generated SQL is correctly cased, verified by a full
+`dbt build` against a case-sensitive warehouse.
+
+**Twelve pipeline activity types no longer report a fabricated success.** A
+pipeline that appeared to succeed while running nothing will now either run for
+real or refuse by name. That is a behaviour change in the direction of the truth,
+and a pipeline depending on the old silence will start failing.

--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -120,8 +120,24 @@ Variable Library and its active value set. The pipeline-side reference binds
 **by name** with no GUID anywhere, so a pipeline consuming library variables is
 environment-invariant by construction; `activeValueSetName` is an item property
 rather than definition content, so a git branch cannot carry the choice of
-environment. Three consumers drive it: pipelines, the `notebookutils` shim, and
-Microsoft's own `fabric-cicd`.
+environment.
+
+Two consumers are implemented — **data pipelines** and **notebooks**
+(`notebookutils.variableLibrary`) — and a third, **user data functions**, gets the
+documented client shape so a function body is testable, though the emulator has
+no UDF runtime and the item itself does not execute. The remaining three are
+blocked upstream rather than unbuilt: shortcut assignment is UI-only with no REST
+surface, Copy job parameterises the connection id this emulator refuses for
+external endpoints, and Dataflow Gen2 has no Power Query M engine to resolve
+into. Ceilings and citations are in `docs/48-variable-libraries.md`.
+
+The surface is **witnessed by Microsoft's own `fabric-cicd`**, which publishes the
+library and the pipeline referencing it from a git-shaped repository and activates
+a value set. It is a witness rather than a consumer — it never resolves
+`@pipeline().libraryVariables.<alias>` at runtime — and it found a real interop
+defect on its first run: it sends `/VariableLibraries/` while the REST reference
+documents `variableLibraries`, and Go's ServeMux is case-sensitive where ASP.NET
+is not.
 
 ## The examples are target-agnostic
 


### PR DESCRIPTION
`v0.21.0` was never tagged, and 19 further PRs (#164–#180) landed after its notes were written — so main holds two batches under one unreleased version. Rather than invent a phantom version, the notes now describe what v0.21.0 actually contains.

Added sections: what a real Fabric tenant graded (collation, the CREATE TABLE restrictions, the SQL endpoint item and `refreshMetadata`, the twelve fabricated activity successes, the two LRO surfaces, the properties a tenant returns), variable libraries and their three consumers, the examples becoming target-agnostic, and the four fixes that only running it on a tenant could find.

**Upgrading gained two behaviour changes that will break someone**, which is the point of putting them there:

- warehouse databases are now created **case-sensitive**, matching Fabric's default, so T-SQL referencing an object in the wrong case now fails here as it does on a tenant (`dbt-fabric` itself is unaffected — verified with a full `dbt build` against a case-sensitive warehouse);
- twelve pipeline activity types no longer report a fabricated success, so a pipeline that appeared to succeed while running nothing will now run for real or refuse by name.

Docs only. No code.