### PR TITLE
fix: three shapes real Fabric requires and the emulator accepted without

### DIFF
--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -169,12 +169,6 @@ divergence on every green run.
   create and then rejects every item in it, so the resolver refuses instead.
 - **The Sail e2e no longer hangs**: it ends on its own budget rather than the
   job's, taking a leg that was being cancelled at 25 minutes down to 1m33s.
-- **OneLake has two hosts and the examples used one.** Landing bytes went to
-  `{control-plane}/onelake/…`, which is the emulator's own routing spelled out,
-  so it 404'd on a tenant; and a blob-shaped `PUT` aimed at the DFS host earns
-  `IncorrectEndpointError`. `delta-rs` wants `onelake.dfs`, a raw upload wants
-  `onelake.blob`, and `common.py` now resolves both per target. Nothing local
-  distinguished them, which is why this survived hundreds of green local runs.
 
 ## Purview Data Map is green
 

--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -169,6 +169,12 @@ divergence on every green run.
   create and then rejects every item in it, so the resolver refuses instead.
 - **The Sail e2e no longer hangs**: it ends on its own budget rather than the
   job's, taking a leg that was being cancelled at 25 minutes down to 1m33s.
+- **OneLake has two hosts and the examples used one.** Landing bytes went to
+  `{control-plane}/onelake/…`, which is the emulator's own routing spelled out,
+  so it 404'd on a tenant; and a blob-shaped `PUT` aimed at the DFS host earns
+  `IncorrectEndpointError`. `delta-rs` wants `onelake.dfs`, a raw upload wants
+  `onelake.blob`, and `common.py` now resolves both per target. Nothing local
+  distinguished them, which is why this survived hundreds of green local runs.
 
 ## Purview Data Map is green
 

--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -1,8 +1,18 @@
 # v0.21.0
 
-**XMLA works.** Thirty-one commits, and the theme is a surface that this
-repository spent months calling infeasible, then deferred on cost, and has now
-implemented and proved with two of Microsoft's own clients.
+**XMLA works, and a real Fabric tenant graded the emulator.** Eighty-eight
+commits in two batches.
+
+The first implemented a surface this repository spent months calling infeasible,
+then deferred on cost, and proved with two of Microsoft's own clients.
+
+The second was measured against **a real Fabric trial**, not against
+documentation: an unmodified example provisioned a live workspace, and the
+attempt found bugs no amount of reading would have. Warehouse collation, twelve
+pipeline activities that reported success having run nothing, the SQL analytics
+endpoint as a real item, semantic models that read their own gold, and a
+credential that ignored the tenant it was told to use. Variable libraries landed
+alongside, with three consumers driving them.
 
 Also here: the Purview Data Map goes green on an independent witness, four
 code-scanning fixes, and `./data` becomes the default state directory.
@@ -58,6 +68,92 @@ tables, columns, relationships, partitions, Direct Lake migration) are **not**
 implemented. The parity row and [docs/32](https://github.com/calvinchengx/fabric-emulator/blob/main/docs/32-xmla-plan.md)
 carry the detail.
 
+## Graded against a real tenant
+
+Every claim in this section is a measurement against a live Fabric trial, and
+each one was invisible to local testing.
+
+**Warehouse collation.** A Fabric Warehouse reports
+`Latin1_General_100_BIN2_UTF8` — Microsoft documents it as "The default -
+case-sensitive (CS) collation". The emulator's `CREATE DATABASE` inherited the
+container's `..._CI_AS`, case-**in**sensitive, so
+`select … from information_schema.tables` returned rows here and
+`Invalid object name` on a tenant. Per-item databases now carry Fabric's
+collation, and `collationType` is honoured from a Warehouse's `creationPayload`
+and reported on read. **A model with an identifier-casing mistake now fails on
+the developer's machine**, which is the only place it is cheap to fix.
+
+**Three `CREATE TABLE` restrictions**, refused by name because the tenant
+refuses them and vanilla SQL Server does not: `INT IDENTITY` (Fabric requires
+BIGINT), `PRIMARY KEY` in `CREATE TABLE`, and the same constraint inline with
+`NOT ENFORCED`. Refused rather than rewritten — dropping IDENTITY changes what a
+table does.
+
+**The SQL analytics endpoint is an item.** A lakehouse leaves a `SQLEndpoint`
+item carrying its display name and its own id, and that id is what
+`sqlEndpointProperties.id` reports. So
+`POST …/sqlEndpoints/{id}/refreshMetadata` works — the lever a client uses when
+the endpoint has not caught up with Delta. This reverses an earlier decision
+that omitted the field: the honest fix was not to withhold the id but to have
+the item.
+
+**Twelve pipeline activity types reported success having run nothing.** The
+dispatch had been diffed against **ADF's** schema rather than Fabric's, and
+Fabric renames several — so a Fabric-authored pipeline got a fabricated success
+where an ADF-authored one got real work. Six were capability already present
+under a different spelling. A structural test now walks Fabric's own documented
+type list against the dispatch, so the next rename fails a test instead.
+
+**Long-running operations, twice.** `getDefinition` and `createItem` can both
+answer 202 on a tenant where the emulator always answered 200/201 —
+`FABRIC_FORCE_LRO` produces both, so a client's poll path is testable locally
+rather than discovered in production.
+
+**Properties a tenant returns and this did not:** a lakehouse's
+`oneLakeTablesPath` / `oneLakeFilesPath`, a warehouse's `connectionInfo` and
+`creationMode`.
+
+## Variable libraries
+
+Pipelines resolve `@pipeline().libraryVariables.<alias>` against the workspace's
+Variable Library and its active value set. The pipeline-side reference binds
+**by name** with no GUID anywhere, so a pipeline consuming library variables is
+environment-invariant by construction; `activeValueSetName` is an item property
+rather than definition content, so a git branch cannot carry the choice of
+environment. Three consumers drive it: pipelines, the `notebookutils` shim, and
+Microsoft's own `fabric-cicd`.
+
+## The examples are target-agnostic
+
+All four medallion examples now run against either target by environment alone,
+with **no step refusing** and nothing emulator-only in what they publish:
+
+- secrets read through `notebookutils.credentials.getSecret`, the brokered path
+  a notebook actually has;
+- SQL addresses **discovered** per item, never configured — the emulator
+  advertises them the way a tenant does;
+- transforms living in Notebook **definitions** submitted as `RunNotebook` jobs,
+  so the emulator's agent and a Fabric pool run the same cells;
+- semantic models reading gold through a **Direct Lake** partition instead of an
+  inline `data.json` snapshot the emulator alone understands.
+
+`scripts/check_example_portability.py` enforces it and prints any remaining
+divergence on every green run.
+
+## Fixes found by running it
+
+- **`AZURE_TENANT_ID` never reached the `az` CLI credential.**
+  `DefaultAzureCredential` has no tenant hint for the CLI, so a developer whose
+  `az` default tenant differed got tokens for the wrong one and Fabric answered
+  `UserNotLicensed` — a tenant problem wearing a licensing error. Fixed in
+  `fabric_target` and in the `notebookutils` shim, which had the same gap.
+- **A Warehouse create is asynchronous on a tenant**, so an example that read
+  `.json()["id"]` off the 202 failed three calls past its cause.
+- **`FABRIC_CAPACITY_ID`**: a workspace created with no capacity accepts the
+  create and then rejects every item in it, so the resolver refuses instead.
+- **The Sail e2e no longer hangs**: it ends on its own budget rather than the
+  job's, taking a leg that was being cancelled at 25 minutes down to 1m33s.
+
 ## Purview Data Map is green
 
 Graded on a `pyapacheatlas` witness, which is a third-party client rather than
@@ -109,4 +205,13 @@ empty explicitly. If you run the **image**, note it bakes
 override back to empty as this repository's compose file does, or the store
 fails to open `/data`.
 
-Nothing else on the REST or Spark surfaces changed.
+**Warehouse databases are now created case-sensitive**, matching Fabric's
+default. If your T-SQL or dbt models reference an object in the wrong case, they
+worked before and will now fail — which is what a tenant does. `dbt-fabric`
+itself is unaffected: its generated SQL is correctly cased, verified by a full
+`dbt build` against a case-sensitive warehouse.
+
+**Twelve pipeline activity types no longer report a fabricated success.** A
+pipeline that appeared to succeed while running nothing will now either run for
+real or refuse by name. That is a behaviour change in the direction of the truth,
+and a pipeline depending on the old silence will start failing.

--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -120,8 +120,24 @@ Variable Library and its active value set. The pipeline-side reference binds
 **by name** with no GUID anywhere, so a pipeline consuming library variables is
 environment-invariant by construction; `activeValueSetName` is an item property
 rather than definition content, so a git branch cannot carry the choice of
-environment. Three consumers drive it: pipelines, the `notebookutils` shim, and
-Microsoft's own `fabric-cicd`.
+environment.
+
+Two consumers are implemented — **data pipelines** and **notebooks**
+(`notebookutils.variableLibrary`) — and a third, **user data functions**, gets the
+documented client shape so a function body is testable, though the emulator has
+no UDF runtime and the item itself does not execute. The remaining three are
+blocked upstream rather than unbuilt: shortcut assignment is UI-only with no REST
+surface, Copy job parameterises the connection id this emulator refuses for
+external endpoints, and Dataflow Gen2 has no Power Query M engine to resolve
+into. Ceilings and citations are in `docs/48-variable-libraries.md`.
+
+The surface is **witnessed by Microsoft's own `fabric-cicd`**, which publishes the
+library and the pipeline referencing it from a git-shaped repository and activates
+a value set. It is a witness rather than a consumer — it never resolves
+`@pipeline().libraryVariables.<alias>` at runtime — and it found a real interop
+defect on its first run: it sends `/VariableLibraries/` while the REST reference
+documents `variableLibraries`, and Go's ServeMux is case-sensitive where ASP.NET
+is not.
 
 ## The examples are target-agnostic
 

--- a/docs/release-notes/v0.22.0.md
+++ b/docs/release-notes/v0.22.0.md
@@ -1,0 +1,14 @@
+# v0.22.0
+
+The range starts at `571abfa` (#182), the first commit after the `v0.21.0` tag.
+
+## Fixes found by running it
+
+- **OneLake has two hosts and the examples used one.** Landing bytes went to
+  `{control-plane}/onelake/…`, which is the emulator's own routing spelled out,
+  so it 404'd on a tenant; and a blob-shaped `PUT` aimed at the DFS host earns
+  `IncorrectEndpointError: Operation not supported on the specified endpoint`.
+  `delta-rs` wants `onelake.dfs`, a raw upload wants `onelake.blob`, and
+  `common.py` now resolves both per target. The emulator serves both shapes on
+  one surface, so nothing local distinguished them — this survived hundreds of
+  green local runs before a tenant saw it.

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -88,6 +88,33 @@ SPARK_REMOTE = os.environ.get("SPARK_REMOTE", "sc://localhost:50051")
 # which is a different integration rather than a different endpoint.
 OM_URL = os.environ.get("OM_URL", "http://localhost:8585")
 
+# The RUNTIME OneLake address — where bytes are actually PUT and read.
+#
+# NOT the same thing as the OneLake host written into a DEFINITION, and the two
+# looking alike is the trap. A Direct Lake expression names
+# `onelake.dfs.fabric.microsoft.com` literally on both targets, because the
+# emulator parses ids out of it and never fetches it. An HTTP PUT has to go to an
+# address that answers.
+#
+# The emulator serves the DFS surface under a `/onelake` path prefix on its own
+# origin; real OneLake is a separate host with no prefix. extract_load.py built
+# this as `{control-plane}/onelake/...`, which is the emulator's shape spelled out
+# — so it 404'd on a tenant. Measured 2026-08-11, after the step had passed
+# locally hundreds of times.
+ONELAKE = _T.onelake_url + ("/onelake" if _T.is_emulator else "")
+
+# ...and OneLake serves TWO protocols on TWO hosts, which is the second half of
+# the same trap. `onelake.dfs.…` speaks ADLS Gen2 (create/append/flush) and
+# `onelake.blob.…` speaks the Blob API (a single PUT with `x-ms-blob-type`).
+# Sending a blob-shaped PUT to the DFS host earns
+# `IncorrectEndpointError: Operation not supported on the specified endpoint` —
+# measured, one iteration after the 404 above. The emulator serves both shapes on
+# one surface, so nothing local distinguishes them.
+#
+# delta-rs wants the DFS endpoint (ONELAKE); a raw upload wants this one.
+ONELAKE_BLOB = (ONELAKE if _T.is_emulator
+                else _T.onelake_url.replace("//onelake.dfs.", "//onelake.blob."))
+
 FABRIC_AUD = "https://api.fabric.microsoft.com"
 STORAGE_AUD = "https://storage.azure.com"
 SQL_AUD = "https://database.windows.net"
@@ -201,7 +228,9 @@ def storage_options():
     opts = {
         "azure_storage_account_name": "onelake",
         "azure_storage_token": token(STORAGE_AUD),
-        "azure_endpoint": f"{_T.onelake_url}/onelake",
+        # ONELAKE, not a hand-built suffix: the `/onelake` prefix is the
+        # emulator's routing and must not reach a tenant.
+        "azure_endpoint": ONELAKE,
     }
     if _T.onelake_url.startswith("http://"):
         opts["azure_allow_http"] = "true"

--- a/examples/fab-driven/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/fab-driven/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -7,9 +7,13 @@
         "typeProperties": {
           "source": {
             "type": "DelimitedTextSource",
-            "rootFolder": "Files",
-            "folderPath": "landing",
-            "fileName": "customers.csv",
+            "storeSettings": {
+              "type": "LakehouseReadSettings",
+              "recursive": true
+            },
+            "formatSettings": {
+              "type": "DelimitedTextReadSettings"
+            },
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -19,13 +23,27 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "location": {
+                  "type": "LakehouseLocation",
+                  "rootFolder": "Files",
+                  "folderPath": "landing",
+                  "fileName": "customers.csv"
+                },
+                "columnDelimiter": ",",
+                "escapeChar": "\\",
+                "firstRowAsHeader": true,
+                "quoteChar": "\""
+              },
+              "type": "DelimitedText",
+              "annotations": [],
+              "schema": []
             }
           },
           "sink": {
             "type": "LakehouseTableSink",
             "tableActionOption": "Overwrite",
-            "table": "bronze_customers",
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -35,7 +53,14 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "table": "bronze_customers",
+                "rootFolder": "Tables"
+              },
+              "type": "LakehouseTable",
+              "annotations": [],
+              "schema": []
             }
           }
         }

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -35,7 +35,12 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "rootFolder": "Tables",
+                "table": "bronze_customers"
+              },
+              "type": "LakehouseTable"
             }
           }
         }
@@ -44,7 +49,8 @@
         "name": "IngestOrders",
         "type": "TridentNotebook",
         "typeProperties": {
-          "notebookId": "{{NOTEBOOK_ID}}"
+          "notebookId": "{{NOTEBOOK_ID}}",
+          "workspaceId": "{{WORKSPACE_ID}}"
         }
       }
     ]

--- a/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -7,9 +7,13 @@
         "typeProperties": {
           "source": {
             "type": "DelimitedTextSource",
-            "rootFolder": "Files",
-            "folderPath": "{{LANDING_DIR}}",
-            "fileName": "customers.csv",
+            "storeSettings": {
+              "type": "LakehouseReadSettings",
+              "recursive": true
+            },
+            "formatSettings": {
+              "type": "DelimitedTextReadSettings"
+            },
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -19,13 +23,27 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "location": {
+                  "type": "LakehouseLocation",
+                  "rootFolder": "Files",
+                  "folderPath": "{{LANDING_DIR}}",
+                  "fileName": "customers.csv"
+                },
+                "columnDelimiter": ",",
+                "escapeChar": "\\",
+                "firstRowAsHeader": true,
+                "quoteChar": "\""
+              },
+              "type": "DelimitedText",
+              "annotations": [],
+              "schema": []
             }
           },
           "sink": {
             "type": "LakehouseTableSink",
             "tableActionOption": "Overwrite",
-            "table": "bronze_customers",
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -40,7 +58,9 @@
                 "rootFolder": "Tables",
                 "table": "bronze_customers"
               },
-              "type": "LakehouseTable"
+              "type": "LakehouseTable",
+              "annotations": [],
+              "schema": []
             }
           }
         }

--- a/examples/medallion-advanced-dbt-fabricspark/extract_load.py
+++ b/examples/medallion-advanced-dbt-fabricspark/extract_load.py
@@ -18,7 +18,7 @@ import datetime
 import notebookutils
 import source_system as src
 from common import (
-    FABRIC,
+    ONELAKE_BLOB,
     STORAGE_AUD,
     VAULT_AUD,
     S,
@@ -47,7 +47,7 @@ today = datetime.date.today().isoformat()
 
 for name, blob in src.export(api_key).items():
     path = f"Files/landing/contoso_pos/{today}/{name}"
-    r = S.put(f"{FABRIC}/onelake/{st['workspace']}/{st['lakehouse']}/{path}",
+    r = S.put(f"{ONELAKE_BLOB}/{st['workspace']}/{st['lakehouse']}/{path}",
               data=blob, headers={"Authorization": "Bearer " + st_tok,
                                   "x-ms-blob-type": "BlockBlob"})
     assert r.status_code in (200, 201), f"land {path}: {r.status_code} {r.text}"

--- a/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -35,7 +35,12 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "rootFolder": "Tables",
+                "table": "bronze_customers"
+              },
+              "type": "LakehouseTable"
             }
           }
         }
@@ -44,7 +49,8 @@
         "name": "IngestOrders",
         "type": "TridentNotebook",
         "typeProperties": {
-          "notebookId": "{{NOTEBOOK_ID}}"
+          "notebookId": "{{NOTEBOOK_ID}}",
+          "workspaceId": "{{WORKSPACE_ID}}"
         }
       }
     ]

--- a/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-advanced-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -7,9 +7,13 @@
         "typeProperties": {
           "source": {
             "type": "DelimitedTextSource",
-            "rootFolder": "Files",
-            "folderPath": "{{LANDING_DIR}}",
-            "fileName": "customers.csv",
+            "storeSettings": {
+              "type": "LakehouseReadSettings",
+              "recursive": true
+            },
+            "formatSettings": {
+              "type": "DelimitedTextReadSettings"
+            },
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -19,13 +23,27 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "location": {
+                  "type": "LakehouseLocation",
+                  "rootFolder": "Files",
+                  "folderPath": "{{LANDING_DIR}}",
+                  "fileName": "customers.csv"
+                },
+                "columnDelimiter": ",",
+                "escapeChar": "\\",
+                "firstRowAsHeader": true,
+                "quoteChar": "\""
+              },
+              "type": "DelimitedText",
+              "annotations": [],
+              "schema": []
             }
           },
           "sink": {
             "type": "LakehouseTableSink",
             "tableActionOption": "Overwrite",
-            "table": "bronze_customers",
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -40,7 +58,9 @@
                 "rootFolder": "Tables",
                 "table": "bronze_customers"
               },
-              "type": "LakehouseTable"
+              "type": "LakehouseTable",
+              "annotations": [],
+              "schema": []
             }
           }
         }

--- a/examples/medallion-advanced-pyspark/extract_load.py
+++ b/examples/medallion-advanced-pyspark/extract_load.py
@@ -18,7 +18,7 @@ import datetime
 import notebookutils
 import source_system as src
 from common import (
-    FABRIC,
+    ONELAKE_BLOB,
     STORAGE_AUD,
     VAULT_AUD,
     S,
@@ -47,7 +47,7 @@ today = datetime.date.today().isoformat()
 
 for name, blob in src.export(api_key).items():
     path = f"Files/landing/contoso_pos/{today}/{name}"
-    r = S.put(f"{FABRIC}/onelake/{st['workspace']}/{st['lakehouse']}/{path}",
+    r = S.put(f"{ONELAKE_BLOB}/{st['workspace']}/{st['lakehouse']}/{path}",
               data=blob, headers={"Authorization": "Bearer " + st_tok,
                                   "x-ms-blob-type": "BlockBlob"})
     assert r.status_code in (200, 201), f"land {path}: {r.status_code} {r.text}"

--- a/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -35,7 +35,12 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "rootFolder": "Tables",
+                "table": "bronze_customers"
+              },
+              "type": "LakehouseTable"
             }
           }
         }
@@ -44,7 +49,8 @@
         "name": "IngestOrders",
         "type": "TridentNotebook",
         "typeProperties": {
-          "notebookId": "{{NOTEBOOK_ID}}"
+          "notebookId": "{{NOTEBOOK_ID}}",
+          "workspaceId": "{{WORKSPACE_ID}}"
         }
       }
     ]

--- a/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-dbt-fabricspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -7,9 +7,13 @@
         "typeProperties": {
           "source": {
             "type": "DelimitedTextSource",
-            "rootFolder": "Files",
-            "folderPath": "{{LANDING_DIR}}",
-            "fileName": "customers.csv",
+            "storeSettings": {
+              "type": "LakehouseReadSettings",
+              "recursive": true
+            },
+            "formatSettings": {
+              "type": "DelimitedTextReadSettings"
+            },
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -19,13 +23,27 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "location": {
+                  "type": "LakehouseLocation",
+                  "rootFolder": "Files",
+                  "folderPath": "{{LANDING_DIR}}",
+                  "fileName": "customers.csv"
+                },
+                "columnDelimiter": ",",
+                "escapeChar": "\\",
+                "firstRowAsHeader": true,
+                "quoteChar": "\""
+              },
+              "type": "DelimitedText",
+              "annotations": [],
+              "schema": []
             }
           },
           "sink": {
             "type": "LakehouseTableSink",
             "tableActionOption": "Overwrite",
-            "table": "bronze_customers",
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -40,7 +58,9 @@
                 "rootFolder": "Tables",
                 "table": "bronze_customers"
               },
-              "type": "LakehouseTable"
+              "type": "LakehouseTable",
+              "annotations": [],
+              "schema": []
             }
           }
         }

--- a/examples/medallion-dbt-fabricspark/extract_load.py
+++ b/examples/medallion-dbt-fabricspark/extract_load.py
@@ -18,7 +18,7 @@ import datetime
 import notebookutils
 import source_system as src
 from common import (
-    FABRIC,
+    ONELAKE_BLOB,
     STORAGE_AUD,
     VAULT_AUD,
     S,
@@ -47,7 +47,7 @@ today = datetime.date.today().isoformat()
 
 for name, blob in src.export(api_key).items():
     path = f"Files/landing/contoso_pos/{today}/{name}"
-    r = S.put(f"{FABRIC}/onelake/{st['workspace']}/{st['lakehouse']}/{path}",
+    r = S.put(f"{ONELAKE_BLOB}/{st['workspace']}/{st['lakehouse']}/{path}",
               data=blob, headers={"Authorization": "Bearer " + st_tok,
                                   "x-ms-blob-type": "BlockBlob"})
     assert r.status_code in (200, 201), f"land {path}: {r.status_code} {r.text}"

--- a/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -35,7 +35,12 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "rootFolder": "Tables",
+                "table": "bronze_customers"
+              },
+              "type": "LakehouseTable"
             }
           }
         }
@@ -44,7 +49,8 @@
         "name": "IngestOrders",
         "type": "TridentNotebook",
         "typeProperties": {
-          "notebookId": "{{NOTEBOOK_ID}}"
+          "notebookId": "{{NOTEBOOK_ID}}",
+          "workspaceId": "{{WORKSPACE_ID}}"
         }
       }
     ]

--- a/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
+++ b/examples/medallion-pyspark/definitions/bronze-ingest.DataPipeline/pipeline-content.json
@@ -7,9 +7,13 @@
         "typeProperties": {
           "source": {
             "type": "DelimitedTextSource",
-            "rootFolder": "Files",
-            "folderPath": "{{LANDING_DIR}}",
-            "fileName": "customers.csv",
+            "storeSettings": {
+              "type": "LakehouseReadSettings",
+              "recursive": true
+            },
+            "formatSettings": {
+              "type": "DelimitedTextReadSettings"
+            },
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -19,13 +23,27 @@
                     "artifactId": "{{LAKEHOUSE_ID}}"
                   }
                 }
-              }
+              },
+              "typeProperties": {
+                "location": {
+                  "type": "LakehouseLocation",
+                  "rootFolder": "Files",
+                  "folderPath": "{{LANDING_DIR}}",
+                  "fileName": "customers.csv"
+                },
+                "columnDelimiter": ",",
+                "escapeChar": "\\",
+                "firstRowAsHeader": true,
+                "quoteChar": "\""
+              },
+              "type": "DelimitedText",
+              "annotations": [],
+              "schema": []
             }
           },
           "sink": {
             "type": "LakehouseTableSink",
             "tableActionOption": "Overwrite",
-            "table": "bronze_customers",
             "datasetSettings": {
               "linkedService": {
                 "properties": {
@@ -40,7 +58,9 @@
                 "rootFolder": "Tables",
                 "table": "bronze_customers"
               },
-              "type": "LakehouseTable"
+              "type": "LakehouseTable",
+              "annotations": [],
+              "schema": []
             }
           }
         }

--- a/examples/medallion-pyspark/extract_load.py
+++ b/examples/medallion-pyspark/extract_load.py
@@ -18,7 +18,7 @@ import datetime
 import notebookutils
 import source_system as src
 from common import (
-    FABRIC,
+    ONELAKE_BLOB,
     STORAGE_AUD,
     VAULT_AUD,
     S,
@@ -47,7 +47,7 @@ today = datetime.date.today().isoformat()
 
 for name, blob in src.export(api_key).items():
     path = f"Files/landing/contoso_pos/{today}/{name}"
-    r = S.put(f"{FABRIC}/onelake/{st['workspace']}/{st['lakehouse']}/{path}",
+    r = S.put(f"{ONELAKE_BLOB}/{st['workspace']}/{st['lakehouse']}/{path}",
               data=blob, headers={"Authorization": "Bearer " + st_tok,
                                   "x-ms-blob-type": "BlockBlob"})
     assert r.status_code in (200, 201), f"land {path}: {r.status_code} {r.text}"

--- a/internal/api/pipelines.go
+++ b/internal/api/pipelines.go
@@ -718,6 +718,18 @@ func (e *pipelineExecutor) resolveLoc(side string, raw json.RawMessage, resolve 
 		if err != nil || v == nil {
 			return "", err
 		}
+		// Only a SCALAR addresses anything. Fabric's dataset model reuses names
+		// this lookup wants for things that are not names: `datasetSettings.schema`
+		// is a COLUMN LIST, not a namespace, and `annotations`/`structure` are
+		// arrays too. Flattening the scopes puts them in reach, and fmt.Sprint
+		// would happily render `[]` — which is how a tenant-shaped Copy landed its
+		// bytes at `Tables/[]/bronze_customers` and still reported Succeeded.
+		// A composite here means "this key does not mean what the caller thinks",
+		// so it reads as absent rather than as the string "[]".
+		switch v.(type) {
+		case []any, map[string]any:
+			return "", nil
+		}
 		return fmt.Sprint(v), nil
 	}
 

--- a/internal/api/pipelines_test.go
+++ b/internal/api/pipelines_test.go
@@ -1273,6 +1273,70 @@ func TestCopyFilesRootFolderAddressing(t *testing.T) {
 	}
 }
 
+// TestCopyTenantDatasetShapeLandsWhereItSays: the FULL dataset model real Fabric
+// requires — `datasetSettings.type` with `typeProperties.location` and the
+// format properties beside it — addresses the same bytes as the shapes above.
+//
+// MEASURED, 2026-08-11. A tenant rejects the abbreviated source the emulator was
+// happy with:
+//
+//	ErrorCode=InvalidParameter, HybridDeliveryException
+//	The value of the property 'formatProperties' is invalid:
+//	'Value cannot be null. Parameter name: formatProperties'
+//
+// So the examples have to carry the full shape, and the emulator has to run it.
+//
+// WHY THIS ASSERTS THE PATH AND NOT THE STATUS. The first version of this case
+// passed on `Completed` while the bytes went to `Tables/[]/bronze_customers`:
+// flattening the scopes brought `datasetSettings.schema` into reach of the
+// `schema` lookup, and in Fabric's dataset model that key is a COLUMN LIST, not
+// a namespace. fmt.Sprint rendered the empty array as `[]` and it became a path
+// segment. Nothing failed — the activity reported Succeeded, the job Completed,
+// and the table simply was not where anyone would look for it. A status
+// assertion cannot see that; a path assertion is the whole test.
+func TestCopyTenantDatasetShapeLandsWhereItSays(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	lh := seedLakehouse(t, st, ws.ID, "lake")
+	payload := []byte("id,name\n1,ada\n")
+	seedFile(t, st, ws.ID, lh.ID, "Files/landing/customers.csv", payload)
+
+	ls := `"linkedService":{"properties":{"type":"Lakehouse",
+      "typeProperties":{"workspaceId":"` + ws.ID + `","artifactId":"` + lh.ID + `"}}}`
+	content := `{"properties":{"activities":[
+      {"name":"IngestCustomers","type":"Copy","typeProperties":{
+        "source":{"type":"DelimitedTextSource",
+          "storeSettings":{"type":"LakehouseReadSettings","recursive":true},
+          "formatSettings":{"type":"DelimitedTextReadSettings"},
+          "datasetSettings":{"type":"DelimitedText","annotations":[],"schema":[],
+            "typeProperties":{
+              "location":{"type":"LakehouseLocation","fileName":"customers.csv",
+                "folderPath":"landing"},
+              "columnDelimiter":",","escapeChar":"\\","firstRowAsHeader":true,
+              "quoteChar":"\""},
+            ` + ls + `}},
+        "sink":{"type":"LakehouseTableSink","tableActionOption":"Overwrite",
+          "datasetSettings":{"type":"LakehouseTable","annotations":[],"schema":[],
+            "typeProperties":{"table":"bronze_customers"},
+            ` + ls + `}}
+      }}]}}`
+	pl := createPipeline(t, st, ws.ID, content)
+	_, jid := runJob(t, a, ws.ID, pl.ID, "jobType=Pipeline", "{}")
+	if s := awaitJob(t, a, ws.ID, pl.ID, jid); s != "Completed" {
+		t.Fatalf("job status = %s", s)
+	}
+	_, runs := activityRuns(t, a, ws.ID, pl.ID, jid)
+	lineage := runs[0]["output"].(map[string]any)["lineage"].(map[string]any)
+	if lineage["targetPath"] != "Tables/bronze_customers" {
+		t.Errorf("targetPath = %v, want Tables/bronze_customers — an empty "+
+			"column list became a namespace", lineage["targetPath"])
+	}
+	if lineage["sourcePath"] != "Files/landing/customers.csv" {
+		t.Errorf("sourcePath = %v, want Files/landing/customers.csv",
+			lineage["sourcePath"])
+	}
+}
+
 // TestCopyRejectsUnsupportedLoudly: the emulator must refuse what it cannot
 // honour by name, never accept the payload and quietly do something else.
 func TestCopyRejectsUnsupportedLoudly(t *testing.T) {


### PR DESCRIPTION
Everything here was measured against a real Fabric trial tenant on 2026-08-11,
running `examples/medallion-pyspark` unchanged with `FABRIC_TARGET=real`. Every
one of these passed locally hundreds of times first.

### 1. OneLake is a different host, and serves DFS and Blob on different names

The examples built their OneLake URL from the control-plane host with the
emulator's `/onelake` prefix, which a tenant answers with `404`. Sending a
blob-shaped `PUT` (`x-ms-blob-type`) to the DFS endpoint earns
`IncorrectEndpointError` — `onelake.dfs.fabric.microsoft.com` and
`onelake.blob.fabric.microsoft.com` are not interchangeable. `common.py` now
resolves both, and each caller uses the one its API speaks.

### 2. Copy's dataset model

A tenant refuses the abbreviated source the emulator was happy with:

```
ErrorCode=InvalidParameter, HybridDeliveryException
The value of the property 'formatProperties' is invalid:
'Value cannot be null. Parameter name: formatProperties'
```

The source's `location` and its format properties (`columnDelimiter`,
`firstRowAsHeader`, `quoteChar`, `escapeChar`) now sit on a `DelimitedText`
dataset, and the sink's `table` on its `LakehouseTable` dataset. Two earlier
errors in the same sequence came from the same abbreviation — `Invalid Trident
lakehouse root folder Files` (no `rootFolder`) and `Empty table name is not
allowed in lakehouse` (table named on the sink, not the dataset) — plus
`'WorkspaceId' cannot be null` on the notebook activity.

### 3. A dataset's column list became a path segment

Feeding the emulator the full shape above ran, reported `Succeeded`, and wrote
to `Tables/[]/bronze_customers`.

`resolveLoc` flattens the Copy side's nested scopes into one lookup, which puts
`datasetSettings.schema` in reach of the `schema` key. In Fabric's dataset model
that is a **column list**, not a namespace; `fmt.Sprint` rendered the empty array
as `[]` and it became a path segment. `annotations` and `structure` are arrays on
the same object and would corrupt any key they collided with, so the fix is
general: a composite value reads as absent, never as its Go rendering.

Its test asserts the **path**, not the status — the first version passed on
`Completed` while the bytes were in the wrong place. Nothing failed: the activity
said Succeeded, the job said Completed, and the table simply was not where anyone
would look for it.

---

Medallion e2e green (exit 0, Copy landing 102,000 rows in
`Tables/bronze_customers`), `make check` green, `go test ./internal/...` green.

Supersedes #185, which carried the third fix alone. The reshaped examples carry
`schema: []`, so they need that fix to land where they say — separating them
would have produced a PR that was green only because another merged first.

---

## Also in this PR: two tenant-measured Copy fixes

**Copy's dataset model.** A tenant refuses the abbreviated source: `ErrorCode=InvalidParameter, HybridDeliveryException — The value of the property 'formatProperties' is invalid: 'Value cannot be null.'` The source's `location` and format properties (`columnDelimiter`, `firstRowAsHeader`, `quoteChar`, `escapeChar`) now sit on a `DelimitedText` dataset and the sink's `table` on its `LakehouseTable` dataset. Two earlier errors in the same sequence had the same cause: `Invalid Trident lakehouse root folder Files` and `Empty table name is not allowed in lakehouse`.

**A dataset's column list became a path segment.** Feeding the emulator that full shape ran, reported `Succeeded`, and wrote to `Tables/[]/bronze_customers`. `resolveLoc` flattens the Copy side's nested scopes into one lookup, which brings `datasetSettings.schema` in reach of the `schema` key — in Fabric's dataset model that is a **column list**, not a namespace, and `fmt.Sprint` rendered the empty array as `[]`. `annotations` and `structure` are arrays on the same object, so the fix is general: a composite value reads as absent, never as its Go rendering.

**The test asserts the PATH, not the status.** With the fix stashed:

```
--- FAIL: TestCopyTenantDatasetShapeLandsWhereItSays
    pipelines_test.go:1331: targetPath = Tables/[]/bronze_customers,
        want Tables/bronze_customers — an empty column list became a namespace
```

With it restored, `ok github.com/calvinchengx/fabric-emulator/internal/api`. An earlier version of that test asserted `Completed` and passed while the bytes were in the wrong place — which is the whole lesson of this pair: a green emulator run was not evidence the example was portable, and here it was not evidence the example was correct against the emulator either.

## Attribution

The OneLake dfs-vs-blob split, the Copy dataset model and the `[]`-path bug were **measured by session local_0cdd48fd against Calvin's Fabric trial on 2026-08-11**. I committed the OneLake work from a shared worktree believing it was mine and it was not; the measurements are theirs.
