### PR TITLE
fix: a dataset's column list became a path segment

### DIFF
--- a/internal/api/pipelines.go
+++ b/internal/api/pipelines.go
@@ -729,6 +729,18 @@ func (e *pipelineExecutor) resolveLoc(side string, raw json.RawMessage, resolve 
 		if err != nil || v == nil {
 			return "", err
 		}
+		// Only a SCALAR addresses anything. Fabric's dataset model reuses names
+		// this lookup wants for things that are not names: `datasetSettings.schema`
+		// is a COLUMN LIST, not a namespace, and `annotations`/`structure` are
+		// arrays too. Flattening the scopes puts them in reach, and fmt.Sprint
+		// would happily render `[]` — which is how a tenant-shaped Copy landed its
+		// bytes at `Tables/[]/bronze_customers` and still reported Succeeded.
+		// A composite here means "this key does not mean what the caller thinks",
+		// so it reads as absent rather than as the string "[]".
+		switch v.(type) {
+		case []any, map[string]any:
+			return "", nil
+		}
 		return fmt.Sprint(v), nil
 	}
 

--- a/internal/api/pipelines_test.go
+++ b/internal/api/pipelines_test.go
@@ -1273,6 +1273,70 @@ func TestCopyFilesRootFolderAddressing(t *testing.T) {
 	}
 }
 
+// TestCopyTenantDatasetShapeLandsWhereItSays: the FULL dataset model real Fabric
+// requires — `datasetSettings.type` with `typeProperties.location` and the
+// format properties beside it — addresses the same bytes as the shapes above.
+//
+// MEASURED, 2026-08-11. A tenant rejects the abbreviated source the emulator was
+// happy with:
+//
+//	ErrorCode=InvalidParameter, HybridDeliveryException
+//	The value of the property 'formatProperties' is invalid:
+//	'Value cannot be null. Parameter name: formatProperties'
+//
+// So the examples have to carry the full shape, and the emulator has to run it.
+//
+// WHY THIS ASSERTS THE PATH AND NOT THE STATUS. The first version of this case
+// passed on `Completed` while the bytes went to `Tables/[]/bronze_customers`:
+// flattening the scopes brought `datasetSettings.schema` into reach of the
+// `schema` lookup, and in Fabric's dataset model that key is a COLUMN LIST, not
+// a namespace. fmt.Sprint rendered the empty array as `[]` and it became a path
+// segment. Nothing failed — the activity reported Succeeded, the job Completed,
+// and the table simply was not where anyone would look for it. A status
+// assertion cannot see that; a path assertion is the whole test.
+func TestCopyTenantDatasetShapeLandsWhereItSays(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	lh := seedLakehouse(t, st, ws.ID, "lake")
+	payload := []byte("id,name\n1,ada\n")
+	seedFile(t, st, ws.ID, lh.ID, "Files/landing/customers.csv", payload)
+
+	ls := `"linkedService":{"properties":{"type":"Lakehouse",
+      "typeProperties":{"workspaceId":"` + ws.ID + `","artifactId":"` + lh.ID + `"}}}`
+	content := `{"properties":{"activities":[
+      {"name":"IngestCustomers","type":"Copy","typeProperties":{
+        "source":{"type":"DelimitedTextSource",
+          "storeSettings":{"type":"LakehouseReadSettings","recursive":true},
+          "formatSettings":{"type":"DelimitedTextReadSettings"},
+          "datasetSettings":{"type":"DelimitedText","annotations":[],"schema":[],
+            "typeProperties":{
+              "location":{"type":"LakehouseLocation","fileName":"customers.csv",
+                "folderPath":"landing"},
+              "columnDelimiter":",","escapeChar":"\\","firstRowAsHeader":true,
+              "quoteChar":"\""},
+            ` + ls + `}},
+        "sink":{"type":"LakehouseTableSink","tableActionOption":"Overwrite",
+          "datasetSettings":{"type":"LakehouseTable","annotations":[],"schema":[],
+            "typeProperties":{"table":"bronze_customers"},
+            ` + ls + `}}
+      }}]}}`
+	pl := createPipeline(t, st, ws.ID, content)
+	_, jid := runJob(t, a, ws.ID, pl.ID, "jobType=Pipeline", "{}")
+	if s := awaitJob(t, a, ws.ID, pl.ID, jid); s != "Completed" {
+		t.Fatalf("job status = %s", s)
+	}
+	_, runs := activityRuns(t, a, ws.ID, pl.ID, jid)
+	lineage := runs[0]["output"].(map[string]any)["lineage"].(map[string]any)
+	if lineage["targetPath"] != "Tables/bronze_customers" {
+		t.Errorf("targetPath = %v, want Tables/bronze_customers — an empty "+
+			"column list became a namespace", lineage["targetPath"])
+	}
+	if lineage["sourcePath"] != "Files/landing/customers.csv" {
+		t.Errorf("sourcePath = %v, want Files/landing/customers.csv",
+			lineage["sourcePath"])
+	}
+}
+
 // TestCopyRejectsUnsupportedLoudly: the emulator must refuse what it cannot
 // honour by name, never accept the payload and quietly do something else.
 func TestCopyRejectsUnsupportedLoudly(t *testing.T) {


### PR DESCRIPTION
Found while reshaping the medallion Copy activities to the dataset model a real
Fabric tenant requires:

```
ErrorCode=InvalidParameter, HybridDeliveryException
The value of the property 'formatProperties' is invalid:
'Value cannot be null. Parameter name: formatProperties'
```

Feeding the emulator that full shape ran, reported `Succeeded` — and wrote to
`Tables/[]/bronze_customers`.

`resolveLoc` flattens the Copy side's nested scopes into one lookup, which puts
`datasetSettings.schema` in reach of the `schema` key. In Fabric's dataset model
that is a **column list**, not a namespace; `fmt.Sprint` rendered the empty array
as `[]` and it became a path segment. `annotations` and `structure` are arrays on
the same object and would corrupt any key they collided with, so the fix is
general: a composite value reads as absent, never as its Go rendering.

The test asserts the **path**, not the status — the first version of it passed on
`Completed` while the bytes were in the wrong place.

Reshaping the four examples' pipeline definitions into this dataset model follows
once #183 lands, to keep those four files in one PR.