### PR TITLE
fix: the operation state was missing three documented fields

### DIFF
--- a/internal/api/items.go
+++ b/internal/api/items.go
@@ -3,8 +3,10 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/calvinchengx/fabric-emulator/internal/auth"
 	"github.com/calvinchengx/fabric-emulator/internal/store"
@@ -226,7 +228,18 @@ func (a *API) deleteItem(w http.ResponseWriter, r *http.Request, p *auth.Princip
 type operationBody struct {
 	ID     string `json:"id"`
 	Status string `json:"status"`
-	Error  *struct {
+	// The three fields Fabric's OperationState documents and this emulator did
+	// not send. A client rendering progress, or logging when an operation
+	// started, saw nothing locally and real values on a tenant — a divergence
+	// that only surfaces in production, which is the worst place to find one.
+	//
+	// `id` above is NOT in the documented shape. It is kept because removing a
+	// field clients here may already read would be a gratuitous break, and an
+	// extra field is harmless where a missing one is not.
+	CreatedTimeUtc     string `json:"createdTimeUtc"`
+	LastUpdatedTimeUtc string `json:"lastUpdatedTimeUtc"`
+	PercentComplete    int    `json:"percentComplete"`
+	Error              *struct {
 		ErrorCode string `json:"errorCode"`
 		Message   string `json:"message"`
 	} `json:"error,omitempty"`
@@ -238,16 +251,34 @@ func (a *API) getOperation(w http.ResponseWriter, r *http.Request, p *auth.Princ
 		writeErr(w, http.StatusNotFound, "OperationNotFound", "No such operation.")
 		return
 	}
-	body := operationBody{ID: op.ID, Status: op.StatusAt(a.Store.Now())}
+	now := a.Store.Now()
+	body := operationBody{
+		ID:                 op.ID,
+		Status:             op.StatusAt(now),
+		CreatedTimeUtc:     time.Unix(op.CreatedAt, 0).UTC().Format(time.RFC3339),
+		LastUpdatedTimeUtc: time.Unix(op.LastUpdatedAt(now), 0).UTC().Format(time.RFC3339),
+		PercentComplete:    op.PercentCompleteAt(now),
+	}
 	if body.Status == store.OpFailed {
 		body.Error = &struct {
 			ErrorCode string `json:"errorCode"`
 			Message   string `json:"message"`
 		}{ErrorCode: op.FailWith, Message: "The operation failed."}
 	}
-	if body.Status == store.OpSucceeded && op.ResultRef != "" {
-		loc := "https://" + r.Host + "/v1/operations/" + op.ID + "/result"
-		w.Header().Set("Location", loc)
+	// The polling headers, per the documented samples. `x-ms-operation-id` is on
+	// every poll; `Location` MOVES — it names the state URL while the operation
+	// runs and the RESULT URL once it succeeds, which is how a client following
+	// Location alone reaches the result without constructing a URL. Retry-After
+	// appears only while there is still something to wait for; the completed
+	// sample carries none, and sending one would tell a finished client to sleep.
+	w.Header().Set("x-ms-operation-id", op.ID)
+	base := "https://" + r.Host + "/v1/operations/" + op.ID
+	switch {
+	case body.Status == store.OpSucceeded && op.ResultRef != "":
+		w.Header().Set("Location", base+"/result")
+	case body.Status == store.OpNotStarted || body.Status == store.OpRunning:
+		w.Header().Set("Location", base)
+		w.Header().Set("Retry-After", fmt.Sprintf("%d", a.RetryAfterSeconds))
 	}
 	writeJSON(w, http.StatusOK, body)
 }

--- a/internal/api/items.go
+++ b/internal/api/items.go
@@ -224,6 +224,19 @@ func (a *API) deleteItem(w http.ResponseWriter, r *http.Request, p *auth.Princip
 
 // ---- operations ----
 
+// fabricOperationTime is .NET's round-trip format on a Kind=Unspecified
+// DateTime: 7 fractional digits and NO trailing `Z`.
+//
+// MEASURED against a real tenant on 2026-08-11, and it is NOT what the schema
+// suggests — `string (date-time)` reads as RFC3339, which is what this emulator
+// sent first. A client with a strict parser that accepts `2026-08-11T07:23:41Z`
+// rejects `2026-08-11T07:23:41.3765432`, so it would pass here and fail there.
+//
+// The emulator's clock is second-granular, so the fraction is always seven
+// zeros. That is the right kind of inaccuracy: the SHAPE a client parses is
+// exact and only the precision it carries is coarser.
+const fabricOperationTime = "2006-01-02T15:04:05.0000000"
+
 // operationBody is the poll response.
 type operationBody struct {
 	ID     string `json:"id"`
@@ -238,7 +251,10 @@ type operationBody struct {
 	// extra field is harmless where a missing one is not.
 	CreatedTimeUtc     string `json:"createdTimeUtc"`
 	LastUpdatedTimeUtc string `json:"lastUpdatedTimeUtc"`
-	PercentComplete    int    `json:"percentComplete"`
+	// A POINTER so it can be null, which is what a tenant sends while the
+	// operation runs. No omitempty: the key is always present, only its value
+	// varies. See Operation.PercentCompleteAt.
+	PercentComplete *int `json:"percentComplete"`
 	Error              *struct {
 		ErrorCode string `json:"errorCode"`
 		Message   string `json:"message"`
@@ -255,8 +271,8 @@ func (a *API) getOperation(w http.ResponseWriter, r *http.Request, p *auth.Princ
 	body := operationBody{
 		ID:                 op.ID,
 		Status:             op.StatusAt(now),
-		CreatedTimeUtc:     time.Unix(op.CreatedAt, 0).UTC().Format(time.RFC3339),
-		LastUpdatedTimeUtc: time.Unix(op.LastUpdatedAt(now), 0).UTC().Format(time.RFC3339),
+		CreatedTimeUtc:     time.Unix(op.CreatedAt, 0).UTC().Format(fabricOperationTime),
+		LastUpdatedTimeUtc: time.Unix(op.LastUpdatedAt(now), 0).UTC().Format(fabricOperationTime),
 		PercentComplete:    op.PercentCompleteAt(now),
 	}
 	if body.Status == store.OpFailed {

--- a/internal/api/items.go
+++ b/internal/api/items.go
@@ -234,15 +234,22 @@ func (a *API) deleteItem(w http.ResponseWriter, r *http.Request, p *auth.Princip
 // here and fails there.
 //
 // The width VARIES: `…07:49:13.5612398` is 7 digits and `…08:00:43.654668` is
-// 6, from the same tenant minutes apart. So this is System.Text.Json's trimming
-// rule, not .NET's fixed-width round-trip "O" — a distinction that matters,
-// because a fixed `.0000000` emitter passes a test asserting exactly 7 digits
-// while a tenant sending 6 fails it. Go's `9`s trim; its `0`s pad.
+// 6, from the same tenant minutes apart. Go's `9`s trim; its `0`s pad.
 //
-// Our clock is second-granular, so every zero trims and we emit no fractional
+// The 6-digit sample is the WITNESS for trimming, and it settles the rule
+// without appealing to any documentation about .NET: a fixed-width emitter
+// would have written `.6546680` for that instant. Only trimming produces six
+// digits. That matters because a fixed `.0000000` emitter passes a test
+// asserting exactly 7 while a tenant sending 6 fails it — code and test wrong
+// together, green together.
+//
+// Our clock is second-granular, so every digit trims and we emit no fractional
 // part at all. That is the HONEST rendering of the precision we actually have,
-// and it is a shape the tenant genuinely produces on a whole second — rather
-// than seven fabricated zeros that claim sub-second resolution we do not carry.
+// rather than seven fabricated zeros claiming sub-second resolution we do not
+// carry. ONE STEP OF THIS IS STILL INFERENCE and is marked as such: the samples
+// witness trimming inside a non-zero fraction, not the whole-second case where
+// the decimal point itself disappears. That follows from the same rule, and a
+// tenant timestamp landing on an exact second would witness it directly.
 const fabricOperationTime = "2006-01-02T15:04:05.9999999"
 
 // operationBody is the poll response.

--- a/internal/api/items.go
+++ b/internal/api/items.go
@@ -224,18 +224,26 @@ func (a *API) deleteItem(w http.ResponseWriter, r *http.Request, p *auth.Princip
 
 // ---- operations ----
 
-// fabricOperationTime is .NET's round-trip format on a Kind=Unspecified
-// DateTime: 7 fractional digits and NO trailing `Z`.
+// fabricOperationTime renders a timestamp the way a tenant does: ISO 8601 with
+// up to 7 fractional digits, TRAILING ZEROS TRIMMED, and NO `Z`.
 //
-// MEASURED against a real tenant on 2026-08-11, and it is NOT what the schema
-// suggests — `string (date-time)` reads as RFC3339, which is what this emulator
-// sent first. A client with a strict parser that accepts `2026-08-11T07:23:41Z`
-// rejects `2026-08-11T07:23:41.3765432`, so it would pass here and fail there.
+// MEASURED against a real tenant on 2026-08-11 by local_0cdd48fd, and it is NOT
+// what the schema suggests — `string (date-time)` reads as RFC3339, which is
+// what this emulator sent first. A strict parser that accepts
+// `2026-08-11T07:23:41Z` rejects `2026-08-11T07:49:13.5612398`, so it passes
+// here and fails there.
 //
-// The emulator's clock is second-granular, so the fraction is always seven
-// zeros. That is the right kind of inaccuracy: the SHAPE a client parses is
-// exact and only the precision it carries is coarser.
-const fabricOperationTime = "2006-01-02T15:04:05.0000000"
+// The width VARIES: `…07:49:13.5612398` is 7 digits and `…08:00:43.654668` is
+// 6, from the same tenant minutes apart. So this is System.Text.Json's trimming
+// rule, not .NET's fixed-width round-trip "O" — a distinction that matters,
+// because a fixed `.0000000` emitter passes a test asserting exactly 7 digits
+// while a tenant sending 6 fails it. Go's `9`s trim; its `0`s pad.
+//
+// Our clock is second-granular, so every zero trims and we emit no fractional
+// part at all. That is the HONEST rendering of the precision we actually have,
+// and it is a shape the tenant genuinely produces on a whole second — rather
+// than seven fabricated zeros that claim sub-second resolution we do not carry.
+const fabricOperationTime = "2006-01-02T15:04:05.9999999"
 
 // operationBody is the poll response.
 type operationBody struct {
@@ -255,10 +263,30 @@ type operationBody struct {
 	// operation runs. No omitempty: the key is always present, only its value
 	// varies. See Operation.PercentCompleteAt.
 	PercentComplete *int `json:"percentComplete"`
-	Error              *struct {
-		ErrorCode string `json:"errorCode"`
-		Message   string `json:"message"`
-	} `json:"error,omitempty"`
+	// NOT omitempty. A tenant sends `"error": null` on every non-failed poll,
+	// and a client doing `body["error"]` tells a null apart from a missing key
+	// the hard way.
+	Error *operationError `json:"error"`
+	// Undocumented in the reference and present on EVERY tenant response —
+	// Running, Succeeded and Failed — null in all three samples. So the keys are
+	// measured and their semantics are not: emitting null is what the evidence
+	// supports, and inventing a value would be the fabrication this whole PR is
+	// about. A client reading `resultContentType` to decide how to parse the
+	// result at least finds the key.
+	BlobInfoID        *string `json:"blobInfoId"`
+	ResultContentType *string `json:"resultContentType"`
+}
+
+// operationError is the operation's own error shape, which is NARROWER than the
+// documented ErrorResponse: measured on a failed SemanticModel create, it
+// carries errorCode, message and isRetriable, with no moreDetails,
+// relatedResource or requestId.
+type operationError struct {
+	ErrorCode string `json:"errorCode"`
+	Message   string `json:"message"`
+	// Measured present and false. A client deciding whether to retry has
+	// nothing to read locally without it.
+	IsRetriable bool `json:"isRetriable"`
 }
 
 func (a *API) getOperation(w http.ResponseWriter, r *http.Request, p *auth.Principal) {
@@ -276,10 +304,7 @@ func (a *API) getOperation(w http.ResponseWriter, r *http.Request, p *auth.Princ
 		PercentComplete:    op.PercentCompleteAt(now),
 	}
 	if body.Status == store.OpFailed {
-		body.Error = &struct {
-			ErrorCode string `json:"errorCode"`
-			Message   string `json:"message"`
-		}{ErrorCode: op.FailWith, Message: "The operation failed."}
+		body.Error = &operationError{ErrorCode: op.FailWith, Message: "The operation failed."}
 	}
 	// The polling headers, per the documented samples. `x-ms-operation-id` is on
 	// every poll; `Location` MOVES — it names the state URL while the operation

--- a/internal/api/operationstate_test.go
+++ b/internal/api/operationstate_test.go
@@ -50,36 +50,74 @@ func TestOperationStateCarriesEveryDocumentedField(t *testing.T) {
 		}
 	}
 	// NOT RFC3339, though `string (date-time)` reads that way and this test
-	// asserted it first. A tenant sends .NET round-trip: 7 fractional digits,
-	// no `Z`.
+	// asserted it first. A tenant sends ISO 8601 with up to 7 fractional
+	// digits, trailing zeros trimmed, and no `Z`.
 	//
 	// The pattern is written out LITERALLY rather than built from
 	// fabricOperationTime. Parsing with the same constant the handler formats
 	// with is self-referential — it passes for any layout the two share, which
 	// is every layout. Asked the wrong way it proves nothing; this asks whether
 	// the bytes match what a tenant sent. See [[assertions-one-level-off]].
-	shape := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}$`)
+	//
+	// The fraction is OPTIONAL and its width is 1-7, because the tenant's width
+	// varies: `…07:49:13.5612398` and `…08:00:43.654668`, minutes apart. An
+	// earlier version of this line demanded exactly 7 — which our own emitter
+	// satisfied and a tenant sending 6 would not. A test can be wrong in the
+	// emulator's favour just as easily as the code can.
+	shape := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,7})?$`)
 	for _, field := range []string{"createdTimeUtc", "lastUpdatedTimeUtc"} {
 		s, _ := body[field].(string)
 		if !shape.MatchString(s) {
-			t.Errorf("%s = %q, want the measured tenant shape 2026-08-11T07:23:41.3765432 "+
-				"(7 fractional digits, no trailing Z)", field, s)
+			t.Errorf("%s = %q, want the measured tenant shape (ISO 8601, up to 7 "+
+				"fractional digits with trailing zeros trimmed, no trailing Z)", field, s)
 		}
 		if _, err := time.Parse(fabricOperationTime, s); err != nil {
 			t.Errorf("%s = %q does not round-trip through the handler's own layout: %v", field, s, err)
 		}
 	}
+
+	// Undocumented, and on every tenant response including the terminal one.
+	for _, field := range []string{"error", "blobInfoId", "resultContentType"} {
+		v, ok := body[field]
+		if !ok {
+			t.Errorf("%s key is absent; a tenant sends it with a null value on every poll", field)
+		}
+		if v != nil {
+			t.Errorf("%s = %v on a running operation, want null", field, v)
+		}
+	}
 }
 
-// percentComplete is null while running and 100 once terminal, and NEVER an
-// intermediate value — measured on a real tenant, not inferred from the schema.
+// The tenant's own fractional widths must parse. This is the assertion that
+// would have caught a fixed-width `.0000000` emitter paired with a `\d{7}`
+// expectation — both wrong, and green together.
+func TestMeasuredTenantTimestampsParse(t *testing.T) {
+	shape := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,7})?$`)
+	// Captured 2026-08-11 by local_0cdd48fd: a Warehouse create and a failed
+	// SemanticModel create.
+	for _, s := range []string{
+		"2026-08-11T07:49:13.5612398", // 7 digits
+		"2026-08-11T08:00:43.654668",  // 6 digits, from the same tenant
+		"2026-08-11T08:00:43.7910071",
+	} {
+		if !shape.MatchString(s) {
+			t.Errorf("measured tenant timestamp %q does not match the asserted shape", s)
+		}
+		if _, err := time.Parse(fabricOperationTime, s); err != nil {
+			t.Errorf("measured tenant timestamp %q does not parse with the handler's layout: %v", s, err)
+		}
+	}
+}
+
+// percentComplete is 100 ON SUCCESS ONLY — null while running AND on failure —
+// and never an intermediate value. All three measured on a real tenant.
 //
 // This test previously asserted only `< 100` while running, which an
 // interpolated 47 satisfies. The assertion was one level off the property that
 // mattered: it checked that progress and status did not contradict each other,
 // when the real question was whether the emulator emits a quantity Fabric
 // publishes at all. See [[assertions-one-level-off]].
-func TestPercentCompleteIsNullUntilTerminalNeverIntermediate(t *testing.T) {
+func TestPercentCompleteIs100OnlyOnSuccess(t *testing.T) {
 	a, st := newAPI(t)
 	now := st.Now()
 
@@ -112,15 +150,25 @@ func TestPercentCompleteIsNullUntilTerminalNeverIntermediate(t *testing.T) {
 		t.Errorf("succeeded operation = %v at %v, want Succeeded at 100", b["status"], b["percentComplete"])
 	}
 
-	// A failed operation stopped progressing too. This half is NOT measured —
-	// only the succeeded case is — so it is asserted as the choice made, and
-	// changing it needs a tenant reading rather than an argument.
+	// A FAILED operation is null, not 100 — measured, and the opposite of what
+	// this test asserted first. 100 there would let a client branching on
+	// `percentComplete == 100` read a failure as a completion.
 	_, b = pollOperation(t, a, failed.ID)
-	if b["status"] != "Failed" || b["percentComplete"] != float64(100) {
-		t.Errorf("failed operation = %v at %v, want Failed at 100", b["status"], b["percentComplete"])
+	if b["status"] != "Failed" {
+		t.Errorf("failed operation status = %v, want Failed", b["status"])
 	}
-	if b["error"] == nil {
-		t.Error("a failed operation carries no error object")
+	if b["percentComplete"] != nil {
+		t.Errorf("failed operation percentComplete = %v, want null — 100 only ever means Succeeded",
+			b["percentComplete"])
+	}
+	errObj, _ := b["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("a failed operation carries no error object")
+	}
+	// isRetriable is measured present on the tenant's failure. A client with no
+	// way to read it locally cannot exercise its own retry decision.
+	if _, ok := errObj["isRetriable"]; !ok {
+		t.Error("the error object has no isRetriable; a tenant sends it")
 	}
 }
 
@@ -145,6 +193,10 @@ func TestPercentCompleteNeverTakesAnIntermediateValue(t *testing.T) {
 		case float64:
 			if pc != 100 {
 				t.Errorf("t+%ds: percentComplete = %v — Fabric emits only null or 100", tick, pc)
+			}
+			if b["status"] != "Succeeded" {
+				t.Errorf("t+%ds: percentComplete = 100 with status %v; 100 means Succeeded and nothing else",
+					tick, b["status"])
 			}
 		default:
 			t.Errorf("t+%ds: percentComplete = %T(%v), want null or a number", tick, pc, pc)

--- a/internal/api/operationstate_test.go
+++ b/internal/api/operationstate_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+)
+
+// Fabric's OperationState is documented as {status, createdTimeUtc,
+// lastUpdatedTimeUtc, percentComplete, error}. This emulator sent only
+// {id, status, error}, so a client rendering progress or logging a start time
+// saw NOTHING locally and real values on a tenant — the divergence that only
+// shows up in production.
+//
+// See docs/49-async-outcome-audit.md.
+
+func pollOperation(t *testing.T, a *API, id string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "https://api.fabric.microsoft.com/v1/operations/"+id, nil)
+	r.SetPathValue("oid", id)
+	a.getOperation(w, r, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("poll status = %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	return w, body
+}
+
+func TestOperationStateCarriesEveryDocumentedField(t *testing.T) {
+	a, st := newAPI(t)
+	now := st.Now()
+	op := &store.Operation{Kind: "AuditProbe", CompleteAt: now + 100}
+	if err := st.CreateOperation(op); err != nil {
+		t.Fatal(err)
+	}
+
+	_, body := pollOperation(t, a, op.ID)
+	for _, field := range []string{"status", "createdTimeUtc", "lastUpdatedTimeUtc", "percentComplete"} {
+		if _, ok := body[field]; !ok {
+			t.Errorf("%s is missing — the documented OperationState carries it", field)
+		}
+	}
+	// Times are RFC3339, which is what `string (date-time)` means and what a
+	// client will try to parse.
+	for _, field := range []string{"createdTimeUtc", "lastUpdatedTimeUtc"} {
+		s, _ := body[field].(string)
+		if _, err := time.Parse(time.RFC3339, s); err != nil {
+			t.Errorf("%s = %q is not RFC3339: %v", field, s, err)
+		}
+	}
+}
+
+// percentComplete must be DERIVED from the same clock the status is, or the two
+// disagree — "Succeeded" at 40%, or "Running" at 100%, both of which a progress
+// UI would render as a stuck or lying bar.
+func TestPercentCompleteAgreesWithStatus(t *testing.T) {
+	a, st := newAPI(t)
+	now := st.Now()
+
+	running := &store.Operation{Kind: "AuditProbe", CompleteAt: now + 1000}
+	done := &store.Operation{Kind: "AuditProbe", CompleteAt: now}
+	failed := &store.Operation{Kind: "AuditProbe", CompleteAt: now, FailWith: "OperationFailed"}
+	for _, op := range []*store.Operation{running, done, failed} {
+		if err := st.CreateOperation(op); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, b := pollOperation(t, a, running.ID)
+	if b["status"] == "Succeeded" {
+		t.Fatal("the probe completed too early to test the running case")
+	}
+	if pc := b["percentComplete"].(float64); pc >= 100 {
+		t.Errorf("a running operation reports %v%% — status and progress disagree", pc)
+	}
+
+	_, b = pollOperation(t, a, done.ID)
+	if b["status"] != "Succeeded" || b["percentComplete"].(float64) != 100 {
+		t.Errorf("succeeded operation = %v at %v%%, want Succeeded at 100", b["status"], b["percentComplete"])
+	}
+
+	// A failed operation stopped progressing too. The status says which
+	// outcome; percentComplete says only that it is no longer moving.
+	_, b = pollOperation(t, a, failed.ID)
+	if b["status"] != "Failed" || b["percentComplete"].(float64) != 100 {
+		t.Errorf("failed operation = %v at %v%%, want Failed at 100", b["status"], b["percentComplete"])
+	}
+	if b["error"] == nil {
+		t.Error("a failed operation carries no error object")
+	}
+}
+
+// Location MOVES: the state URL while running, the RESULT URL once succeeded.
+// That is how a client following Location alone reaches the result without
+// building a URL, and it is the documented behaviour in both samples.
+func TestPollingHeadersFollowTheDocumentedSamples(t *testing.T) {
+	a, st := newAPI(t)
+	a.RetryAfterSeconds = 11
+	now := st.Now()
+
+	running := &store.Operation{Kind: "AuditProbe", CompleteAt: now + 1000, ResultRef: "item-1"}
+	done := &store.Operation{Kind: "CreateItem", CompleteAt: now, ResultRef: "item-1"}
+	noResult := &store.Operation{Kind: "CommitToGit", CompleteAt: now}
+	for _, op := range []*store.Operation{running, done, noResult} {
+		if err := st.CreateOperation(op); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w, _ := pollOperation(t, a, running.ID)
+	if got := w.Header().Get("x-ms-operation-id"); got != running.ID {
+		t.Errorf("running: x-ms-operation-id = %q, want %q", got, running.ID)
+	}
+	if got, want := w.Header().Get("Location"), "/v1/operations/"+running.ID; !hasSuffix(got, want) {
+		t.Errorf("running: Location = %q, want it to end in %q (the STATE url)", got, want)
+	}
+	if got := w.Header().Get("Retry-After"); got != "11" {
+		t.Errorf("running: Retry-After = %q, want the configured 11 — a client has to know how long to sleep", got)
+	}
+
+	w, _ = pollOperation(t, a, done.ID)
+	if got, want := w.Header().Get("Location"), "/v1/operations/"+done.ID+"/result"; !hasSuffix(got, want) {
+		t.Errorf("succeeded: Location = %q, want it to end in %q (the RESULT url)", got, want)
+	}
+	if got := w.Header().Get("Retry-After"); got != "" {
+		t.Errorf("succeeded: Retry-After = %q, want none — telling a finished client to sleep is wrong", got)
+	}
+
+	// An operation with no result has nowhere to point once done; the
+	// documented shape is simply no Location, not a dangling one.
+	w, _ = pollOperation(t, a, noResult.ID)
+	if got := w.Header().Get("Location"); got != "" {
+		t.Errorf("resultless operation: Location = %q, want none", got)
+	}
+	if got := w.Header().Get("x-ms-operation-id"); got != noResult.ID {
+		t.Errorf("resultless operation: x-ms-operation-id = %q", got)
+	}
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/internal/api/operationstate_test.go
+++ b/internal/api/operationstate_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -48,20 +49,37 @@ func TestOperationStateCarriesEveryDocumentedField(t *testing.T) {
 			t.Errorf("%s is missing — the documented OperationState carries it", field)
 		}
 	}
-	// Times are RFC3339, which is what `string (date-time)` means and what a
-	// client will try to parse.
+	// NOT RFC3339, though `string (date-time)` reads that way and this test
+	// asserted it first. A tenant sends .NET round-trip: 7 fractional digits,
+	// no `Z`.
+	//
+	// The pattern is written out LITERALLY rather than built from
+	// fabricOperationTime. Parsing with the same constant the handler formats
+	// with is self-referential — it passes for any layout the two share, which
+	// is every layout. Asked the wrong way it proves nothing; this asks whether
+	// the bytes match what a tenant sent. See [[assertions-one-level-off]].
+	shape := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}$`)
 	for _, field := range []string{"createdTimeUtc", "lastUpdatedTimeUtc"} {
 		s, _ := body[field].(string)
-		if _, err := time.Parse(time.RFC3339, s); err != nil {
-			t.Errorf("%s = %q is not RFC3339: %v", field, s, err)
+		if !shape.MatchString(s) {
+			t.Errorf("%s = %q, want the measured tenant shape 2026-08-11T07:23:41.3765432 "+
+				"(7 fractional digits, no trailing Z)", field, s)
+		}
+		if _, err := time.Parse(fabricOperationTime, s); err != nil {
+			t.Errorf("%s = %q does not round-trip through the handler's own layout: %v", field, s, err)
 		}
 	}
 }
 
-// percentComplete must be DERIVED from the same clock the status is, or the two
-// disagree — "Succeeded" at 40%, or "Running" at 100%, both of which a progress
-// UI would render as a stuck or lying bar.
-func TestPercentCompleteAgreesWithStatus(t *testing.T) {
+// percentComplete is null while running and 100 once terminal, and NEVER an
+// intermediate value — measured on a real tenant, not inferred from the schema.
+//
+// This test previously asserted only `< 100` while running, which an
+// interpolated 47 satisfies. The assertion was one level off the property that
+// mattered: it checked that progress and status did not contradict each other,
+// when the real question was whether the emulator emits a quantity Fabric
+// publishes at all. See [[assertions-one-level-off]].
+func TestPercentCompleteIsNullUntilTerminalNeverIntermediate(t *testing.T) {
 	a, st := newAPI(t)
 	now := st.Now()
 
@@ -78,23 +96,60 @@ func TestPercentCompleteAgreesWithStatus(t *testing.T) {
 	if b["status"] == "Succeeded" {
 		t.Fatal("the probe completed too early to test the running case")
 	}
-	if pc := b["percentComplete"].(float64); pc >= 100 {
-		t.Errorf("a running operation reports %v%% — status and progress disagree", pc)
+	// The KEY must be present and its VALUE null. A missing key and a null are
+	// different wires, and a client doing `body["percentComplete"]` in Python
+	// tells them apart the hard way.
+	pc, ok := b["percentComplete"]
+	if !ok {
+		t.Error("running: percentComplete key is absent; a tenant sends the key with a null value")
+	}
+	if pc != nil {
+		t.Errorf("running: percentComplete = %v, want null — a tenant publishes no intermediate figure", pc)
 	}
 
 	_, b = pollOperation(t, a, done.ID)
-	if b["status"] != "Succeeded" || b["percentComplete"].(float64) != 100 {
-		t.Errorf("succeeded operation = %v at %v%%, want Succeeded at 100", b["status"], b["percentComplete"])
+	if b["status"] != "Succeeded" || b["percentComplete"] != float64(100) {
+		t.Errorf("succeeded operation = %v at %v, want Succeeded at 100", b["status"], b["percentComplete"])
 	}
 
-	// A failed operation stopped progressing too. The status says which
-	// outcome; percentComplete says only that it is no longer moving.
+	// A failed operation stopped progressing too. This half is NOT measured —
+	// only the succeeded case is — so it is asserted as the choice made, and
+	// changing it needs a tenant reading rather than an argument.
 	_, b = pollOperation(t, a, failed.ID)
-	if b["status"] != "Failed" || b["percentComplete"].(float64) != 100 {
-		t.Errorf("failed operation = %v at %v%%, want Failed at 100", b["status"], b["percentComplete"])
+	if b["status"] != "Failed" || b["percentComplete"] != float64(100) {
+		t.Errorf("failed operation = %v at %v, want Failed at 100", b["status"], b["percentComplete"])
 	}
 	if b["error"] == nil {
 		t.Error("a failed operation carries no error object")
+	}
+}
+
+// The interpolation this replaced would pass every assertion above except this
+// one: it is the test that pins the ABSENCE of intermediate values, by polling
+// across the whole span rather than at one instant.
+func TestPercentCompleteNeverTakesAnIntermediateValue(t *testing.T) {
+	a, st := newAPI(t)
+	st.Clock.Freeze()
+	op := &store.Operation{Kind: "AuditProbe", CompleteAt: st.Now() + 10}
+	if err := st.CreateOperation(op); err != nil {
+		t.Fatal(err)
+	}
+
+	for tick := int64(0); tick <= 10; tick++ {
+		_, b := pollOperation(t, a, op.ID)
+		switch pc := b["percentComplete"].(type) {
+		case nil:
+			if b["status"] == "Succeeded" {
+				t.Errorf("t+%ds: Succeeded with a null percentComplete", tick)
+			}
+		case float64:
+			if pc != 100 {
+				t.Errorf("t+%ds: percentComplete = %v — Fabric emits only null or 100", tick, pc)
+			}
+		default:
+			t.Errorf("t+%ds: percentComplete = %T(%v), want null or a number", tick, pc, pc)
+		}
+		st.Clock.Advance(1)
 	}
 }
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -93,6 +93,48 @@ type Operation struct {
 	FailWith   string // non-empty forces Failed with this errorCode
 }
 
+// PercentCompleteAt derives operation progress from the SAME clock the status
+// comes from, so the two can never disagree.
+//
+// Fabric documents `percentComplete` as an integer 0-100 on every operation
+// state, and the emulator returned none. A client rendering progress therefore
+// saw nothing locally and a real number on a tenant — the shape of divergence
+// that only shows up in production.
+//
+// It is COMPUTED, not faked: the emulator knows when the operation was created
+// and when its clock completes it, so the fraction between them is a real
+// answer rather than a plausible-looking constant. A terminal operation is 100
+// whether it succeeded or failed — the work stopped progressing either way, and
+// the status field is what says which.
+func (o Operation) PercentCompleteAt(now int64) int {
+	if now >= o.CompleteAt {
+		return 100
+	}
+	span := o.CompleteAt - o.CreatedAt
+	if span <= 0 {
+		return 0
+	}
+	done := int((now - o.CreatedAt) * 100 / span)
+	if done < 0 {
+		return 0
+	}
+	if done > 100 {
+		return 100
+	}
+	return done
+}
+
+// LastUpdatedAt is when this operation's state last CHANGED, which for a
+// clock-derived operation is its completion once complete, and its creation
+// before that. Reporting `now` instead would make every poll look like a fresh
+// update and defeat the field's purpose.
+func (o Operation) LastUpdatedAt(now int64) int64 {
+	if now >= o.CompleteAt {
+		return o.CompleteAt
+	}
+	return o.CreatedAt
+}
+
 // StatusAt derives the wire status at the given clock time.
 func (o Operation) StatusAt(now int64) string {
 	if now < o.CompleteAt {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -96,9 +96,17 @@ type Operation struct {
 // PercentCompleteAt reports progress the way a tenant does, which is NOT a
 // progress bar. nil means "no figure", i.e. a JSON null.
 //
-// MEASURED against real Fabric on 2026-08-11 (Warehouse create, by
-// local_0cdd48fd): percentComplete is `null` for the whole time the operation
-// runs and `100` once it has succeeded. It never takes an intermediate value.
+// MEASURED against real Fabric on 2026-08-11 by local_0cdd48fd, twice: a
+// Warehouse create that succeeded, and a SemanticModel create that failed
+// asynchronously. percentComplete is `100` ON SUCCESS AND NULL EVERYWHERE ELSE
+// — running, and failed. It never takes an intermediate value.
+//
+// The failed case was my inference and it was WRONG. I argued 100 because the
+// work stopped progressing either way and `status` is the field that says
+// which. The tenant does not do that, and the reason it does not is the better
+// argument: a client branching on `percentComplete == 100` would read a failure
+// as a completion. A sound-sounding inference in the fabricated-success
+// direction is exactly the kind this repo keeps having to undo.
 //
 // The first version of this function interpolated between CreatedAt and
 // CompleteAt and returned figures like 47. Every one of those is a number real
@@ -109,12 +117,9 @@ type Operation struct {
 // at null against Fabric, and its null-handling branch would never once execute
 // locally. That is the emulator-green/tenant-broken direction.
 func (o Operation) PercentCompleteAt(now int64) *int {
-	if now < o.CompleteAt {
+	if o.StatusAt(now) != OpSucceeded {
 		return nil
 	}
-	// 100-on-success is the measured half. A FAILED operation was not measured;
-	// 100 is the smaller inference — it stopped progressing, and `status` is the
-	// field that says which way — than inventing a separate figure for it.
 	done := 100
 	return &done
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -93,35 +93,30 @@ type Operation struct {
 	FailWith   string // non-empty forces Failed with this errorCode
 }
 
-// PercentCompleteAt derives operation progress from the SAME clock the status
-// comes from, so the two can never disagree.
+// PercentCompleteAt reports progress the way a tenant does, which is NOT a
+// progress bar. nil means "no figure", i.e. a JSON null.
 //
-// Fabric documents `percentComplete` as an integer 0-100 on every operation
-// state, and the emulator returned none. A client rendering progress therefore
-// saw nothing locally and a real number on a tenant — the shape of divergence
-// that only shows up in production.
+// MEASURED against real Fabric on 2026-08-11 (Warehouse create, by
+// local_0cdd48fd): percentComplete is `null` for the whole time the operation
+// runs and `100` once it has succeeded. It never takes an intermediate value.
 //
-// It is COMPUTED, not faked: the emulator knows when the operation was created
-// and when its clock completes it, so the fraction between them is a real
-// answer rather than a plausible-looking constant. A terminal operation is 100
-// whether it succeeded or failed — the work stopped progressing either way, and
-// the status field is what says which.
-func (o Operation) PercentCompleteAt(now int64) int {
-	if now >= o.CompleteAt {
-		return 100
+// The first version of this function interpolated between CreatedAt and
+// CompleteAt and returned figures like 47. Every one of those is a number real
+// Fabric does not send, and the comment defending it — "COMPUTED, not faked" —
+// was answering the wrong question: the value was honestly derived from this
+// emulator's clock and still wrong, because the tenant does not publish that
+// quantity at all. A client rendering a bar would animate smoothly here and sit
+// at null against Fabric, and its null-handling branch would never once execute
+// locally. That is the emulator-green/tenant-broken direction.
+func (o Operation) PercentCompleteAt(now int64) *int {
+	if now < o.CompleteAt {
+		return nil
 	}
-	span := o.CompleteAt - o.CreatedAt
-	if span <= 0 {
-		return 0
-	}
-	done := int((now - o.CreatedAt) * 100 / span)
-	if done < 0 {
-		return 0
-	}
-	if done > 100 {
-		return 100
-	}
-	return done
+	// 100-on-success is the measured half. A FAILED operation was not measured;
+	// 100 is the smaller inference — it stopped progressing, and `status` is the
+	// field that says which way — than inventing a separate figure for it.
+	done := 100
+	return &done
 }
 
 // LastUpdatedAt is when this operation's state last CHANGED, which for a


### PR DESCRIPTION
Found by turning the sweep rule inward. #184 audits which APIs *answer* 202; this fixes the contract they all poll **through** — including the three surfaces #173/#174/#180 just made async.

## The gap

[Get Operation State](https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-state) documents `OperationState` as:

| field | emulator sent |
|---|---|
| `status` | ✅ |
| `error` | ✅ |
| `createdTimeUtc` | ❌ |
| `lastUpdatedTimeUtc` | ❌ |
| `percentComplete` | ❌ |

And the poll response should carry `Location`, `x-ms-operation-id` and `Retry-After`. The emulator set `Location` only on success and never sent the other two.

So a client following the documented flow — sleeping for `Retry-After`, rendering `percentComplete`, logging when the operation started — got **nothing locally and real values on a tenant**. Same family as everything else this week: local green proving nothing about the tenant.

## Computed, not faked

All three are derivable from the emulator's own clock, so none of them is a plausible-looking constant:

- `percentComplete` is the fraction between `CreatedAt` and `CompleteAt`, from the **same clock the status comes from** — so the two can never disagree. A test asserts exactly that, because "Succeeded at 40%" or "Running at 100%" would render as a stuck or lying progress bar.
- `lastUpdatedTimeUtc` is when the state last **changed** — completion once complete, creation before that. Returning `now` would make every poll look like a fresh update and defeat the field.
- A **failed** operation is 100: the work stopped progressing either way, and `status` is what says which outcome.

`id` is kept even though the documented shape has no such field — removing something clients here may already read would be a gratuitous break, and an extra field is harmless where a missing one is not.

## Location moves, and that is the point

The two documented samples differ, and the difference is load-bearing:

```
running:    Location: …/v1/operations/{id}          Retry-After: 20
succeeded:  Location: …/v1/operations/{id}/result   (no Retry-After)
```

That is how a client following `Location` alone reaches the result without constructing a URL. `Retry-After` appears only while there is still something to wait for — telling a finished client to sleep is wrong. An operation with **no** result (`commitToGit`) gets no Location rather than a dangling one, and that case is asserted too.

## Verification

Three tests: every documented field present and the timestamps parseable as RFC3339; progress agreeing with status across running/succeeded/failed; and the headers following both samples including the resultless case.

Mutation-tested, and one attempt was invalid so I redid it: making `percentComplete` a constant `100` turns it red, and so does stopping `Location` moving to `/result` — the subtle one, since every other assertion still passes. My first attempt at a second mutant deleted the `Retry-After` line, which failed to compile on an unused import; a mutation that does not build proves nothing, so I replaced it with one that does.

`make check`, `go vet`, `gofmt` and all Go suites green.