### PR TITLE
fix(examples): one LRO resolver, not five

### DIFF
--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -425,7 +425,7 @@ def create_item_from_definition(folder, display_name=None, **substitutions):
     return create_item(display_name or name, item_type, parts)
 
 
-def post_and_wait(url, body):
+def post_and_wait(url, body, what=None):
     """POST a create and return the created object, resolving a 202 if there is one.
 
     FOUND BY RUNNING IT ON A REAL TENANT, which is the only way this class of bug
@@ -442,8 +442,9 @@ def post_and_wait(url, body):
     import time
 
     H = fabric_headers()
+    what = what or url
     r = S.post(url, headers=H, json=body)
-    assert r.status_code in (200, 201, 202), f"{url} -> {r.status_code} {r.text}"
+    assert r.status_code in (200, 201, 202), f"{what}: {r.status_code} {r.text}"
     if r.status_code != 202:
         return r.json()
     op = r.headers.get("x-ms-operation-id") \
@@ -457,34 +458,35 @@ def post_and_wait(url, body):
         # real seconds, and polling faster than asked earns a 429.
         time.sleep(min(float(got.headers.get("Retry-After", "2")), 20))
     else:
-        raise SystemExit(f"{url}: operation {op} never reached a terminal state")
-    assert status == "Succeeded", f"{url}: operation {op} {status}"
+        raise SystemExit(f"{what}: operation {op} never reached a terminal state")
+    assert status == "Succeeded", f"{what}: operation {op} {status}"
     return S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()
 
 
 def create_item(display_name, item_type, parts):
-    """Create an item with a definition, resolving the LRO if the create is async."""
-    import base64
-    import time
+    """Create an item with a definition, resolving the LRO if the create is async.
 
-    H = fabric_headers()
+    The 202 is resolved by `post_and_wait` rather than here. This function used to
+    carry its own copy of that logic, and the copy was the older, worse one: it
+    indexed `x-ms-operation-id` without falling back to the `Location` tail, and
+    it slept a flat second instead of honouring `Retry-After`. Against the
+    emulator both behave identically, because item creates come back 201 and the
+    operation branch never runs — so the divergence was invisible exactly where
+    it was cheap to find, and would have surfaced against a real tenant as a
+    KeyError on a header Fabric is not obliged to send.
+
+    One protocol, one resolver. A second implementation of the same wait is not a
+    convenience, it is a second thing to keep correct.
+    """
+    import base64
+
     st = load()
     body = {"displayName": display_name, "type": item_type, "definition": {"parts": [
         {"path": p, "payloadType": "InlineBase64",
          "payload": base64.b64encode(c.encode() if isinstance(c, str) else c).decode()}
         for p, c in parts.items()]}}
-    r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json=body)
-    assert r.status_code in (201, 202), f"create {item_type}: {r.status_code} {r.text}"
-    if r.status_code == 201:
-        return r.json()["id"]
-    op = r.headers["x-ms-operation-id"]
-    for _ in range(60):
-        status = S.get(f"{FABRIC}/v1/operations/{op}", headers=H).json()["status"]
-        if status in ("Succeeded", "Failed"):
-            break
-        time.sleep(1)
-    assert status == "Succeeded", f"create {item_type}: operation {status}"
-    return S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()["id"]
+    return post_and_wait(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", body,
+                         what=f"create {item_type}")["id"]
 
 
 def run_job(item_id, job_type, body=None):

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -438,6 +438,14 @@ def post_and_wait(url, body, what=None):
     Every Fabric create can be async; which ones ARE is a service decision that
     can change. So this resolves the operation whenever one is offered rather than
     per item type, which is also what fabric-cicd does.
+
+    WHY THE POLL IS PACED BY THE SERVICE. Measured against a real Fabric trial on
+    2026-08-11: a Warehouse create answered `Retry-After: 20` and completed in 13
+    seconds. So the header is a floor the service ASKS for, not an estimate of how
+    long the work takes. That is the answer to the obvious objection, that
+    honouring it makes the examples slower than they need to be: true, and not an
+    argument, because the service asked. The cap is a ceiling on the wait, not a
+    target, and it exists so a service that asks for an hour cannot hang a run.
     """
     import time
 

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -469,11 +469,14 @@ def create_item(display_name, item_type, parts):
     The 202 is resolved by `post_and_wait` rather than here. This function used to
     carry its own copy of that logic, and the copy was the older, worse one: it
     indexed `x-ms-operation-id` without falling back to the `Location` tail, and
-    it slept a flat second instead of honouring `Retry-After`. Against the
-    emulator both behave identically, because item creates come back 201 and the
-    operation branch never runs — so the divergence was invisible exactly where
-    it was cheap to find, and would have surfaced against a real tenant as a
-    KeyError on a header Fabric is not obliged to send.
+    it slept a flat second instead of honouring `Retry-After`.
+
+    Note which half was actually biting. A definition-bearing create has always
+    been an LRO in the emulator, and this function always sends a definition, so
+    every example run took the async path and polled once a second at a service
+    that had just stated a pace in its own header. Not a latent defect awaiting a
+    real tenant, a live one, quiet because polling too fast only shows up as load
+    until something answers 429.
 
     One protocol, one resolver. A second implementation of the same wait is not a
     convenience, it is a second thing to keep correct.

--- a/examples/medallion-advanced-dbt-fabricspark/semantic_model.py
+++ b/examples/medallion-advanced-dbt-fabricspark/semantic_model.py
@@ -4,9 +4,7 @@ Power BI executeQueries wire — the readiness check for Power BI clients.
 In real Fabric the rows would arrive by Direct Lake; the emulator seeds them as
 a `data.json` definition part, exported here straight from warehouse gold.
 """
-import base64
 import json
-import time
 
 import source_system as src
 from common import (
@@ -14,6 +12,7 @@ from common import (
     FABRIC_AUD,
     PBI_AUD,
     S,
+    create_item,
     ensure_app,
     fabric_headers,
     load,
@@ -91,26 +90,11 @@ model = {
 }
 
 
-def part(path, obj):
-    return {"path": path, "payloadType": "InlineBase64",
-            "payload": base64.b64encode(json.dumps(obj).encode()).decode()}
-
-
-r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
-    "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model)]}})
-assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
-if r.status_code == 201:
-    dataset = r.json()["id"]
-else:
-    op = r.headers["x-ms-operation-id"]
-    for _ in range(60):
-        status = S.get(f"{FABRIC}/v1/operations/{op}", headers=H).json()["status"]
-        if status in ("Succeeded", "Failed"):
-            break
-        time.sleep(1)
-    assert status == "Succeeded", f"publish operation {status}"
-    dataset = S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()["id"]
+# One resolver for the 202, and it lives in common.py. This script used to carry
+# its own copy: a hard-indexed `x-ms-operation-id` and a flat one-second poll. A
+# SemanticModel create always carries a definition, so it takes the async branch
+# every run, against a service that states its own pace in `Retry-After`.
+dataset = create_item("ContosoRevenue", "SemanticModel", {"model.bim": json.dumps(model)})
 save(dataset=dataset)
 
 # --- query it exactly as a Power BI REST client (or SemPy) would --------------

--- a/examples/medallion-advanced-pyspark/semantic_model.py
+++ b/examples/medallion-advanced-pyspark/semantic_model.py
@@ -4,9 +4,7 @@ Power BI executeQueries wire — the readiness check for Power BI clients.
 In real Fabric the rows would arrive by Direct Lake; the emulator seeds them as
 a `data.json` definition part, exported here straight from warehouse gold.
 """
-import base64
 import json
-import time
 
 import source_system as src
 from common import (
@@ -14,6 +12,7 @@ from common import (
     FABRIC_AUD,
     PBI_AUD,
     S,
+    create_item,
     ensure_app,
     fabric_headers,
     load,
@@ -91,26 +90,11 @@ model = {
 }
 
 
-def part(path, obj):
-    return {"path": path, "payloadType": "InlineBase64",
-            "payload": base64.b64encode(json.dumps(obj).encode()).decode()}
-
-
-r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
-    "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model)]}})
-assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
-if r.status_code == 201:
-    dataset = r.json()["id"]
-else:
-    op = r.headers["x-ms-operation-id"]
-    for _ in range(60):
-        status = S.get(f"{FABRIC}/v1/operations/{op}", headers=H).json()["status"]
-        if status in ("Succeeded", "Failed"):
-            break
-        time.sleep(1)
-    assert status == "Succeeded", f"publish operation {status}"
-    dataset = S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()["id"]
+# One resolver for the 202, and it lives in common.py. This script used to carry
+# its own copy: a hard-indexed `x-ms-operation-id` and a flat one-second poll. A
+# SemanticModel create always carries a definition, so it takes the async branch
+# every run, against a service that states its own pace in `Retry-After`.
+dataset = create_item("ContosoRevenue", "SemanticModel", {"model.bim": json.dumps(model)})
 save(dataset=dataset)
 
 # --- query it exactly as a Power BI REST client (or SemPy) would --------------

--- a/examples/medallion-dbt-fabricspark/semantic_model.py
+++ b/examples/medallion-dbt-fabricspark/semantic_model.py
@@ -4,9 +4,7 @@ Power BI executeQueries wire — the readiness check for Power BI clients.
 In real Fabric the rows would arrive by Direct Lake; the emulator seeds them as
 a `data.json` definition part, exported here straight from warehouse gold.
 """
-import base64
 import json
-import time
 
 import source_system as src
 from common import (
@@ -14,6 +12,7 @@ from common import (
     FABRIC_AUD,
     PBI_AUD,
     S,
+    create_item,
     ensure_app,
     fabric_headers,
     load,
@@ -90,26 +89,11 @@ model = {
 }
 
 
-def part(path, obj):
-    return {"path": path, "payloadType": "InlineBase64",
-            "payload": base64.b64encode(json.dumps(obj).encode()).decode()}
-
-
-r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
-    "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model)]}})
-assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
-if r.status_code == 201:
-    dataset = r.json()["id"]
-else:
-    op = r.headers["x-ms-operation-id"]
-    for _ in range(60):
-        status = S.get(f"{FABRIC}/v1/operations/{op}", headers=H).json()["status"]
-        if status in ("Succeeded", "Failed"):
-            break
-        time.sleep(1)
-    assert status == "Succeeded", f"publish operation {status}"
-    dataset = S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()["id"]
+# One resolver for the 202, and it lives in common.py. This script used to carry
+# its own copy: a hard-indexed `x-ms-operation-id` and a flat one-second poll. A
+# SemanticModel create always carries a definition, so it takes the async branch
+# every run, against a service that states its own pace in `Retry-After`.
+dataset = create_item("ContosoRevenue", "SemanticModel", {"model.bim": json.dumps(model)})
 save(dataset=dataset)
 
 # --- query it exactly as a Power BI REST client (or SemPy) would --------------

--- a/examples/medallion-pyspark/semantic_model.py
+++ b/examples/medallion-pyspark/semantic_model.py
@@ -4,9 +4,7 @@ Power BI executeQueries wire — the readiness check for Power BI clients.
 In real Fabric the rows would arrive by Direct Lake; the emulator seeds them as
 a `data.json` definition part, exported here straight from warehouse gold.
 """
-import base64
 import json
-import time
 
 import source_system as src
 from common import (
@@ -14,6 +12,7 @@ from common import (
     FABRIC_AUD,
     PBI_AUD,
     S,
+    create_item,
     ensure_app,
     fabric_headers,
     load,
@@ -90,26 +89,11 @@ model = {
 }
 
 
-def part(path, obj):
-    return {"path": path, "payloadType": "InlineBase64",
-            "payload": base64.b64encode(json.dumps(obj).encode()).decode()}
-
-
-r = S.post(f"{FABRIC}/v1/workspaces/{st['workspace']}/items", headers=H, json={
-    "displayName": "ContosoRevenue", "type": "SemanticModel",
-    "definition": {"parts": [part("model.bim", model)]}})
-assert r.status_code in (201, 202), f"publish model: {r.status_code} {r.text}"
-if r.status_code == 201:
-    dataset = r.json()["id"]
-else:
-    op = r.headers["x-ms-operation-id"]
-    for _ in range(60):
-        status = S.get(f"{FABRIC}/v1/operations/{op}", headers=H).json()["status"]
-        if status in ("Succeeded", "Failed"):
-            break
-        time.sleep(1)
-    assert status == "Succeeded", f"publish operation {status}"
-    dataset = S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()["id"]
+# One resolver for the 202, and it lives in common.py. This script used to carry
+# its own copy: a hard-indexed `x-ms-operation-id` and a flat one-second poll. A
+# SemanticModel create always carries a definition, so it takes the async branch
+# every run, against a service that states its own pace in `Retry-After`.
+dataset = create_item("ContosoRevenue", "SemanticModel", {"model.bim": json.dumps(model)})
 save(dataset=dataset)
 
 # --- query it exactly as a Power BI REST client (or SemPy) would --------------

--- a/python/tests/test_example_lro.py
+++ b/python/tests/test_example_lro.py
@@ -195,6 +195,28 @@ def test_a_failed_operation_is_not_reported_as_success(monkeypatch, tmp_path):
         common.post_and_wait("https://f/v1/workspaces/ws-1/items", {})
 
 
+def test_no_example_carries_its_own_operation_loop():
+    """The structural half of "one resolver".
+
+    Delegation fixed `create_item`, and there were FOUR more copies of the same
+    loop in the per-example `semantic_model.py` scripts, which are what people
+    actually open. A behavioural test cannot see them: each copy is correct in
+    its own way, publishes fine against the emulator, and simply polls too fast.
+    So this asserts the shape instead. `common.py` is the one file allowed to
+    resolve an operation; anywhere else, it is a copy that will drift.
+    """
+    offenders = []
+    for path in (REPO / "examples").rglob("*.py"):
+        if path.name == "common.py":
+            continue
+        text = path.read_text()
+        if '"x-ms-operation-id"' in text and "/operations/" in text:
+            offenders.append(str(path.relative_to(REPO)))
+    assert not offenders, (
+        "these resolve an LRO themselves instead of calling common.post_and_wait "
+        f"or common.create_item: {offenders}")
+
+
 def test_synchronous_create_is_unchanged(monkeypatch, tmp_path):
     """The 201 path. `create_item` always sends a definition so the emulator never
     answers it this way, but Fabric documents 201 for a create and a definitionless

--- a/python/tests/test_example_lro.py
+++ b/python/tests/test_example_lro.py
@@ -1,0 +1,199 @@
+"""The examples' long-running-operation resolution, against shapes only real Fabric sends.
+
+WHY THIS IS TESTED HERE. The 202 branch of `post_and_wait` is unreachable from
+the local e2e: the emulator answers item creates 201 with the item, so every
+example run exercises the synchronous path and nothing else. That is precisely
+the wrong way round, because the async path is the one real Fabric takes for a
+Warehouse, and it took a run against a real trial to discover that `provision.py`
+was doing `None["id"]` against it.
+
+`create_item` used to carry a SECOND copy of this wait, and the copy was the
+older one: it indexed `x-ms-operation-id` with no fallback and slept a flat
+second. Both copies agreed against the emulator, for the same reason nothing
+here is reachable from e2e. These tests pin the two behaviours that copy lacked,
+so a future divergence fails in CI rather than on a tenant.
+
+Per Microsoft's LRO reference, a 202 carries `Location`; `x-ms-operation-id` is
+a convenience, not a guarantee. Anything that requires it is asserting a promise
+the service did not make.
+"""
+import importlib
+import os
+import pathlib
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "python" / "fabric-target"))
+sys.path.insert(0, str(REPO / "examples" / "contoso-fixtures"))
+
+import fabric_target  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, headers=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+class LROSession:
+    """A create that answers 202, then an operation that runs before it succeeds.
+
+    `pending` controls how many polls report Running, so a test can assert the
+    waiter actually waited rather than reading a terminal status first time.
+    """
+
+    def __init__(self, accept_headers, pending=1, result=None, retry_after=None):
+        self.accept_headers = accept_headers
+        self.pending = pending
+        self.result = result or {"id": "created-1"}
+        self.retry_after = retry_after
+        self.polls = 0
+
+    def post(self, url, **_):
+        return FakeResponse(None, status_code=202, headers=self.accept_headers)
+
+    def get(self, url, **_):
+        if url.endswith("/result"):
+            return FakeResponse(self.result)
+        self.polls += 1
+        status = "Running" if self.polls <= self.pending else "Succeeded"
+        headers = {"Retry-After": self.retry_after} if self.retry_after else {}
+        return FakeResponse({"status": status}, headers=headers)
+
+
+def load_common(monkeypatch, tmp_path):
+    for k in ("FABRIC_TARGET", "FABRIC_WORKSPACE", "TDS_SERVER", "AZURE_CLIENT_SECRET",
+              "AZURE_CLIENT_ID", "AZURE_TENANT_ID", "FABRIC_VAULT_URL",
+              "AZURE_KEY_VAULT_URL", "PIPELINE_STATE"):
+        monkeypatch.delenv(k, raising=False)
+    for k in [k for k in os.environ if k.startswith("NOTEBOOKUTILS_")]:
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("FABRIC_TARGET", "emulator")
+    monkeypatch.setenv("PIPELINE_STATE", str(tmp_path / "state.json"))
+    monkeypatch.setattr(fabric_target, "_az_logged_in", lambda: True)
+    fabric_target._cached = None
+    sys.modules.pop("common", None)
+    common = importlib.import_module("common")
+    (tmp_path / "state.json").write_text('{"workspace": "ws-1"}')
+    monkeypatch.setattr(common, "fabric_headers", lambda: {})
+    return common
+
+
+def no_sleeping(monkeypatch, common):
+    """Record what the waiter asked to sleep, without spending it."""
+    slept = []
+    import time
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+    return slept
+
+
+LOCATION_ONLY = {"Location": "https://api.fabric.microsoft.com/v1/operations/op-42/"}
+BOTH = {"Location": "https://api.fabric.microsoft.com/v1/operations/op-42",
+        "x-ms-operation-id": "op-42"}
+
+
+def test_202_without_the_convenience_header_still_resolves(monkeypatch, tmp_path):
+    """The regression that mattered: Fabric guarantees `Location`, not
+    `x-ms-operation-id`. A resolver that indexes the header raises KeyError on a
+    response the service was entitled to send."""
+    common = load_common(monkeypatch, tmp_path)
+    no_sleeping(monkeypatch, common)
+    session = LROSession(LOCATION_ONLY)
+    monkeypatch.setattr(common, "S", session)
+
+    got = common.post_and_wait("https://f/v1/workspaces/ws-1/items", {"displayName": "x"})
+
+    assert got == {"id": "created-1"}
+    assert session.polls > 1, "returned before the operation reached a terminal state"
+
+
+def test_create_item_resolves_the_same_202(monkeypatch, tmp_path):
+    """create_item must not have its own opinion about this. It carried a copy
+    that lacked the fallback, and the copy was invisible because the emulator
+    answers 201."""
+    common = load_common(monkeypatch, tmp_path)
+    no_sleeping(monkeypatch, common)
+    monkeypatch.setattr(common, "S", LROSession(LOCATION_ONLY))
+
+    assert common.create_item("gold", "Warehouse", {"x.txt": "hi"}) == "created-1"
+
+
+def test_retry_after_is_honoured(monkeypatch, tmp_path):
+    """Polling faster than the service asked earns a 429. The flat one-second
+    sleep the old copy used ignores the header entirely."""
+    common = load_common(monkeypatch, tmp_path)
+    slept = no_sleeping(monkeypatch, common)
+    monkeypatch.setattr(common, "S", LROSession(LOCATION_ONLY, pending=2, retry_after="7"))
+
+    common.post_and_wait("https://f/v1/workspaces/ws-1/items", {})
+
+    assert slept and all(s == 7 for s in slept), slept
+
+
+def test_retry_after_is_capped(monkeypatch, tmp_path):
+    """A service that asks for an hour should not hang the example for one."""
+    common = load_common(monkeypatch, tmp_path)
+    slept = no_sleeping(monkeypatch, common)
+    monkeypatch.setattr(common, "S", LROSession(LOCATION_ONLY, pending=2, retry_after="3600"))
+
+    common.post_and_wait("https://f/v1/workspaces/ws-1/items", {})
+
+    assert slept and all(s == 20 for s in slept), slept
+
+
+def test_operation_id_header_is_preferred_when_present(monkeypatch, tmp_path):
+    """The fallback is a fallback. When Fabric does send the id, use it rather
+    than parsing a URL."""
+    common = load_common(monkeypatch, tmp_path)
+    no_sleeping(monkeypatch, common)
+    asked = []
+
+    class Recording(LROSession):
+        def get(self, url, **kw):
+            asked.append(url)
+            return super().get(url, **kw)
+
+    monkeypatch.setattr(common, "S", Recording(BOTH))
+    common.post_and_wait("https://f/v1/workspaces/ws-1/items", {})
+
+    assert all("/operations/op-42" in u for u in asked), asked
+
+
+def test_a_failed_operation_is_not_reported_as_success(monkeypatch, tmp_path):
+    """A terminal Failed must surface. The whole class of bug this file guards
+    is a wait that returns something plausible when the service said no."""
+    common = load_common(monkeypatch, tmp_path)
+    no_sleeping(monkeypatch, common)
+
+    class Failing(LROSession):
+        def get(self, url, **_):
+            if url.endswith("/result"):
+                return FakeResponse({"id": "should-not-be-read"})
+            return FakeResponse({"status": "Failed"})
+
+    monkeypatch.setattr(common, "S", Failing(LOCATION_ONLY))
+    with pytest.raises(AssertionError, match="Failed"):
+        common.post_and_wait("https://f/v1/workspaces/ws-1/items", {})
+
+
+def test_synchronous_create_is_unchanged(monkeypatch, tmp_path):
+    """The emulator's path. It is the only one e2e covers, so it is the one most
+    likely to be broken by a change aimed at the other."""
+    common = load_common(monkeypatch, tmp_path)
+
+    class Sync:
+        def post(self, url, **_):
+            return FakeResponse({"id": "sync-1"}, status_code=201)
+
+    monkeypatch.setattr(common, "S", Sync())
+    assert common.create_item("bronze", "Lakehouse", {"x.txt": "hi"}) == "sync-1"

--- a/python/tests/test_example_lro.py
+++ b/python/tests/test_example_lro.py
@@ -1,21 +1,30 @@
-"""The examples' long-running-operation resolution, against shapes only real Fabric sends.
+"""The examples' long-running-operation resolution, against the 202 shapes both targets send.
 
-WHY THIS IS TESTED HERE. The 202 branch of `post_and_wait` is unreachable from
-the local e2e: the emulator answers item creates 201 with the item, so every
-example run exercises the synchronous path and nothing else. That is precisely
-the wrong way round, because the async path is the one real Fabric takes for a
-Warehouse, and it took a run against a real trial to discover that `provision.py`
-was doing `None["id"]` against it.
+WHY THIS IS TESTED HERE. `create_item` used to carry a SECOND copy of
+`post_and_wait`'s 202 handling, and the copy was the older one: it indexed
+`x-ms-operation-id` with no fallback and slept a flat second regardless of what
+the service asked for. These tests pin the two behaviours that copy lacked.
 
-`create_item` used to carry a SECOND copy of this wait, and the copy was the
-older one: it indexed `x-ms-operation-id` with no fallback and slept a flat
-second. Both copies agreed against the emulator, for the same reason nothing
-here is reachable from e2e. These tests pin the two behaviours that copy lacked,
-so a future divergence fails in CI rather than on a tenant.
+The two halves fail differently, and it is worth being exact about which is live:
 
-Per Microsoft's LRO reference, a 202 carries `Location`; `x-ms-operation-id` is
-a convenience, not a guarantee. Anything that requires it is asserting a promise
-the service did not make.
+  * **`Retry-After`, live on BOTH targets.** The emulator sets the header on
+    its 202 (`internal/api/api.go`), and a definition-bearing create has ALWAYS
+    been an LRO here (`internal/api/items.go`, the `body.Definition == nil`
+    branch). `create_item` always sends a definition, so every example run takes
+    the async path and the old copy polled once a second against a service that
+    had stated a pace. Against a real tenant, whose documented sample answers
+    `Retry-After: 20`, that is polling ~20x more often than asked on an API
+    family that documents `429 Too Many Requests`.
+
+  * **The missing-header `KeyError`, latent.** Fabric documents all three
+    headers on the INITIATING 202, and the emulator sets them, so the hard index
+    finds its key today on both targets. It is fragility rather than a live
+    break: a resolver that requires a convenience header is asserting a promise
+    the reference makes for the initiating call only, and `Location` is the part
+    actually guaranteed.
+
+Tested without an emulator because the failure is in how the CLIENT reads a
+response shape, so a stub pins it precisely and CI needs no stack.
 """
 import importlib
 import os
@@ -119,8 +128,8 @@ def test_202_without_the_convenience_header_still_resolves(monkeypatch, tmp_path
 
 def test_create_item_resolves_the_same_202(monkeypatch, tmp_path):
     """create_item must not have its own opinion about this. It carried a copy
-    that lacked the fallback, and the copy was invisible because the emulator
-    answers 201."""
+    that lacked the fallback, and a second implementation of one protocol is the
+    defect: matching them by hand only resets the clock on the next divergence."""
     common = load_common(monkeypatch, tmp_path)
     no_sleeping(monkeypatch, common)
     monkeypatch.setattr(common, "S", LROSession(LOCATION_ONLY))
@@ -187,8 +196,9 @@ def test_a_failed_operation_is_not_reported_as_success(monkeypatch, tmp_path):
 
 
 def test_synchronous_create_is_unchanged(monkeypatch, tmp_path):
-    """The emulator's path. It is the only one e2e covers, so it is the one most
-    likely to be broken by a change aimed at the other."""
+    """The 201 path. `create_item` always sends a definition so the emulator never
+    answers it this way, but Fabric documents 201 for a create and a definitionless
+    caller would take it, so it must survive a change aimed at the other branch."""
     common = load_common(monkeypatch, tmp_path)
 
     class Sync:


### PR DESCRIPTION
Five copies of the same 202 handling lived in `examples/`. Four were identical; the fifth, `post_and_wait`, was the only correct one.

|  | `post_and_wait` | the other four |
|---|---|---|
| operation id | `x-ms-operation-id` **or** the `Location` tail | `headers["x-ms-operation-id"]`, hard index |
| pacing | `Retry-After`, capped at 20s | flat `time.sleep(1)` |

`common.create_item` and the four per-example `semantic_model.py` scripts now all delegate to `post_and_wait`. Net -88/+24 lines.

## Which half was actually live

An earlier version of this description said the async branch never runs locally, so this was all latent. **That was wrong**, and correcting it strengthens the case.

- **`Retry-After` was live on BOTH targets.** `internal/api/items.go` makes a definition-bearing create an LRO *always*, and every one of these five call sites sends a definition. So every example run has taken the 202 path and polled once a second at an emulator that sets `Retry-After` on that same response (`internal/api/api.go`). Against a real tenant, whose documented sample answers `Retry-After: 20`, that is ~20x the requested rate on an API family documenting `429`.
- **The missing-header `KeyError` is latent.** Fabric documents all three headers on the *initiating* 202 and the emulator sets them, so the hard index finds its key today. Fragility, not a break.

Nobody was misled by the emulator here. It has been sending `Retry-After` on that response all along; the examples did not read it.

## Tests

`python/tests/test_example_lro.py`, 8 cases, no emulator needed.

Seven are behavioural, mutation-checked rather than assumed:

- remove the `Location` fallback → **5 of 7 fail**
- replace `Retry-After` with `sleep(1)` → **2 of 7 fail**

The eighth is structural, and it is the one that matters for the four scripts: no file under `examples/` outside `common.py` may resolve an operation itself. A behavioural test cannot catch those copies, because each is correct in its own way and merely polls too fast. Verified by restoring one pre-fix file and watching it fail.

Full suite: 575 passed, 6 skipped. `ruff` and `ty` clean.

## Not verified

The medallion e2e was not run; no stack was up. The change is exercised by unit tests against stubs, and the emulator leg of e2e would take the same 202 path these tests pin.

Found by `local_0cdd48fd`, framing corrected by `local_fc77e00c`, who also found the four `semantic_model.py` copies and took the matching tutorial fix. Does not touch anything #183 or #186 touches.