### PR TITLE
docs: the tutorial taught a flat poll against a Retry-After it was given

### DIFF
--- a/docs/28-tutorial-end-to-end.md
+++ b/docs/28-tutorial-end-to-end.md
@@ -894,10 +894,23 @@ assert r.status_code in (201, 202), r.text
 dataset = None
 if r.status_code == 201:
     dataset = r.json()["id"]
-else:  # LRO: poll, then fetch the result
-    op = r.headers["x-ms-operation-id"]
-    while S.get(f"{FABRIC}/v1/operations/{op}", headers=H).json()["status"] not in ("Succeeded", "Failed"):
-        time.sleep(1)
+else:  # LRO: poll on the service's terms, then fetch the result
+    # x-ms-operation-id is documented on the 202, and Location carries the same
+    # id in its tail. Prefer the header, fall back to the URL: a client that
+    # hard-indexes one header raises KeyError the day a service sends only the
+    # other, and the failure looks nothing like its cause.
+    op = (r.headers.get("x-ms-operation-id")
+          or r.headers["Location"].rstrip("/").rsplit("/", 1)[-1])
+    while True:
+        got = S.get(f"{FABRIC}/v1/operations/{op}", headers=H)
+        if got.json()["status"] in ("Succeeded", "Failed"):
+            break
+        # SLEEP FOR AS LONG AS THE SERVICE ASKED. Retry-After is on the 202 and
+        # on every poll; Fabric's own sample returns 20. A flat sleep(1) polls a
+        # real tenant ~20x more often than requested, on an API family whose
+        # reference documents 429 Too Many Requests — and the emulator will not
+        # complain, because its clock finishes operations promptly either way.
+        time.sleep(min(float(got.headers.get("Retry-After", "2")), 20))
     dataset = S.get(f"{FABRIC}/v1/operations/{op}/result", headers=H).json()["id"]
 save(dataset=dataset)
 


### PR DESCRIPTION
`docs/28-tutorial-end-to-end.md` taught two habits worth unlearning, and a tutorial is **copy-paste surface** — it propagates further than a library does.

```python
op = r.headers["x-ms-operation-id"]                        # hard index, no fallback
while …["status"] not in ("Succeeded", "Failed"):
    time.sleep(1)                                          # flat, ignores Retry-After
```

Now: prefer the header, fall back to the `Location` tail, and **sleep for as long as the service asked**, capped at 20.

## Why the second one is the live half

Fabric's own sample returns `Retry-After: 20`. A flat `sleep(1)` polls a real tenant roughly twenty times more often than requested, on an API family whose reference documents `429 Too Many Requests` — with a `Retry-After` of its own that the same loop would ignore.

**And the emulator was already sending it.** `startOperation` sets `Retry-After` on the initiating 202 (`api.go:408`), and `internal/api/items.go:107` means a *definition-bearing* create has always been an LRO here — which is every create this tutorial makes. So the tutorial has been ignoring a header it was handed, on the default local path, since before any of this.

I got that wrong first and said so on #186: I claimed the emulator "could not have taught anyone to honour `Retry-After` because it never sent one". True of poll responses, false of the initiating 202, and the false half was the one that mattered. `local_eb00472c` caught it; I verified before accepting. The comment stating a definition-bearing create is always an LRO is one **I wrote myself** in #174.

## The hard index is fragility, not a live break

All three headers are documented on the initiating 202 and the emulator sets them, so the index finds its key today on both targets. It is graded as fragility — but a tutorial that models hard-indexing one header teaches readers to write code that breaks the day a service sends only the other, and that failure looks nothing like its cause.

## Scope

Docs only. The same pattern lives in five code files:

- `examples/contoso-fixtures/common.py:480` — being fixed in #187 by `local_eb00472c`
- `examples/medallion-{pyspark,dbt-fabricspark,advanced-pyspark,advanced-dbt-fabricspark}/semantic_model.py`

I found the four `semantic_model.py` copies while checking whether this was isolated, verified one in full as the identical shape, and reported them rather than editing: `examples/` is not mine, and whether four near-identical scripts want four edits or a shared helper is a structural call for whoever owns them. **Fixing only `common.py` would leave four copies in the files people actually read**, since those are the per-example entry points.

`make check` green.