### PR TITLE
docs: v0.22.0 notes carry #182 as a behaviour change

### DIFF
--- a/docs/release-notes/v0.22.0.md
+++ b/docs/release-notes/v0.22.0.md
@@ -2,6 +2,20 @@
 
 The range starts at `571abfa` (#182), the first commit after the `v0.21.0` tag.
 
+## Behaviour changes — read this one before upgrading
+
+- **Spark job definition and Invoke copy job activities now run.** v0.21.0
+  refused both by name, with a message stating the capability existed and only
+  the wiring was missing. That wiring landed: `InvokeCopyJob` moves real bytes
+  through the same executor a direct Copy job run uses, and
+  `SparkJobDefinition` submits a real job and drives it to its actual outcome
+  when a Spark agent is attached. With **no** engine attached the job is
+  submitted and left Pending and the activity says so, rather than reporting
+  success.
+
+  **If you pinned v0.21.0 and designed around the refusal — skipping the
+  activity, or marking it Inactive — those steps now execute.**
+
 ## Fixes found by running it
 
 - **OneLake has two hosts and the examples used one.** Landing bytes went to


### PR DESCRIPTION
#182 is the commit the v0.22.0 range starts at and it had no entry, which is the one gap that matters here: it is a **behaviour change**, not a new feature.

v0.21.0 did not merely lack these two activities. It **refused them by name**, and the refusal message said the capability existed and only the wiring was missing. That is a message people act on — the reasonable response is to skip the activity or mark it Inactive and move on. Anyone who did that and pinned v0.21.0 now has steps that execute on upgrade.

So the entry leads with the refusal it replaces rather than with the capability, and says plainly what changes for someone who designed around it.

It also keeps the honest half: with **no** Spark agent attached, `SparkJobDefinition` submits the job, leaves it Pending, and **errors**. It does not report success. That is the whole reason #182 exists — the dispatch default used to return `{"status":"Succeeded"}` for twelve documented activity types, so a pipeline could claim it ran a Spark job having done nothing. Reporting a fabricated success from the *fix* would have been the same defect wearing a better name.

Drafted while #182 was in flight and reviewed by local_87220308, who approved the framing as written. Held until #183 landed `docs/release-notes/v0.22.0.md`, so this is purely additive to that file.