### PR TITLE
docs: v0.21.0's wheels were published by hand, and why

### DIFF
--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -170,6 +170,27 @@ divergence on every green run.
 - **The Sail e2e no longer hangs**: it ends on its own budget rather than the
   job's, taking a leg that was being cancelled at 25 minutes down to 1m33s.
 
+## The fixture wheels were published by hand
+
+Stated because a consumer cannot see it from the release page. This tag's
+`Published wheels` job **failed**: `examples/contoso-fixtures` requires
+`fabric-emulator-notebookutils`, whose uv path source does not survive into wheel
+metadata, and no wheel was built for the shim — so the release's own smoke install
+could not resolve the set. The same failure skipped the dispatch that tells
+`contoso-data-platform` a release shipped.
+
+The fix runs the wheel builder on **every PR** rather than only from
+`release.yml`, which is why nothing caught it: a check that runs only on tags
+cannot fail the change that breaks it. That fix landed after this tag, so CI could
+not rebuild the wheels at this ref.
+
+The four wheels attached here were therefore built **from this tag's tree** with
+only the build script replaced, stamped `0.21.0` the same way the job stamps it,
+and verified by downloading them back from this release and importing every
+package from `site-packages` in a clean environment. Their contents are this
+tag's; only the tool that packaged them was newer. From the next release the job
+publishes them again.
+
 ## Purview Data Map is green
 
 Graded on a `pyapacheatlas` witness, which is a third-party client rather than


### PR DESCRIPTION
v0.21.0's `Published wheels` job failed (`No solution found … Because fabric-emulator-notebookutils was not found`), and #189's fix landed after the tag, so CI could not rebuild the wheels at that ref.

Calvin's call was to build them at the tag with only the build script replaced and upload manually, which is done: four wheels stamped `0.21.0`, verified by downloading them back from the release and importing every package from `site-packages` in a clean venv.

This adds the disclosure to the notes, because a consumer cannot tell from the release page that the artifacts were not CI-built. It also records the root cause worth remembering: the wheel builder ran only from `release.yml`, so a check that runs on tags alone could not fail the change that broke it.