### PR TITLE
feat: the variable types a tenant accepts, and the two it refuses

### DIFF
--- a/docs/48-variable-libraries.md
+++ b/docs/48-variable-libraries.md
@@ -165,12 +165,68 @@ The library's own type list, read off the New-variable dropdown (2026-08-10):
 |---|---|---|---|
 | `String` | Basic | `String` | captured |
 | `Guid` | Basic | `String` | **captured** |
-| `DateTime` | Basic | `String` | article |
-| `Integer` | Basic | `Int` | article |
-| `Boolean` | Basic | `Bool` | article |
-| `Number` | Basic | *(unsupported in pipelines)* | article |
+| `DateTime` | Basic | `String` | **captured** |
+| `Integer` | Basic | `Int` | **captured** |
+| `Boolean` | Basic | `Bool` | **captured** |
+| `Number` | Basic | *(unsupported in pipelines)* | **captured** |
 | `Item reference` (preview) | Other | **`Object`** | **captured** |
-| `Connection reference` (preview) | Other | `Object`, presumed | not captured |
+| `Connection reference` (preview) | Other | `Object`, presumed | **value captured**, pipeline `type` still not |
+
+### The library's type list, captured with a control (2026-08-11)
+
+The remaining rows above were filled by creating one library carrying a variable
+of each candidate type **plus one deliberate nonsense type**, and reading the
+failed operation:
+
+```
+InvalidVariableType: The variable type 'TotallyMadeUpType' is not supported.
+```
+
+The control is the load-bearing part. Sending only plausible types and watching
+them succeed proves nothing — a create that ignores `type` accepts those too,
+and `getDefinition` would echo our own guesses back as if the tenant had
+confirmed them. The published schema cannot settle it either: it constrains
+`type` to `^[A-Za-z][A-Za-z0-9]{0,63}$` and declares `value: true` (any JSON).
+
+Stored values, read back with `getDefinition`:
+
+```json
+{"name": "aDateTime",  "note": "", "type": "DateTime",  "value": "2026-08-11T00:00:00Z"},
+{"name": "anInteger",  "note": "", "type": "Integer",   "value": 42},
+{"name": "aBoolean",   "note": "", "type": "Boolean",   "value": true},
+{"name": "aNumber",    "note": "", "type": "Number",    "value": 1.5},
+{"name": "aConnection","note": "", "type": "ConnectionReference",
+ "value": {"connectionId": "7feee8f6-0545-4647-a24f-c6f98693aea5"}}
+```
+
+`Integer` and `Boolean` are stored as JSON number and JSON bool, not strings —
+so a resolver passing values through unchanged is right for these as it is for
+`Guid`. `Number` is accepted by the **library** even though pipelines cannot
+consume it; the two vocabularies are separate, and this is the library's list.
+
+### A connection reference is a GUID, and it is checked
+
+`ConnectionReference`'s value is `{"connectionId": "<guid>"}`, and the tenant
+**verifies the connection resolves** at definition-write time. A made-up id is
+refused:
+
+```
+InvalidContent (issue: InvalidValueOrTypeMismatch)
+Item content cannot be used (ReferencedEntityNotFoundOrAccessDenied)
+```
+
+This does **not** contradict [Binding is by name, with no GUID
+anywhere](#binding-is-by-name-with-no-guid-anywhere) — that result is about the
+*pipeline's reference to the library*, which remains `libraryName` +
+`variableName`. What this adds is the other half of 47's split: the reference is
+environment-invariant, and here is a **value** that is environment-bound as
+hard as a value can be. A library carrying a connection reference cannot be
+promoted between workspaces unchanged; the id must exist on the far side, or a
+value set must override it per environment.
+
+`ItemReference` behaves the same way — its value is `{itemId, workspaceId}`.
+The pattern is that Fabric's *reference-typed values* are GUID pairs while its
+*bindings* are names.
 
 Two of these are worth calling out because a reasonable person would guess them
 wrong:

--- a/internal/api/items.go
+++ b/internal/api/items.go
@@ -79,6 +79,10 @@ func (a *API) createItem(w http.ResponseWriter, r *http.Request, p *auth.Princip
 	if body.Definition != nil {
 		parts = body.Definition.Parts
 	}
+	if code, msg := a.definitionRejection(body.Type, parts); msg != "" {
+		writeErr(w, http.StatusBadRequest, code, msg)
+		return
+	}
 	if err := a.Store.CreateItem(it, parts); err != nil {
 		// The pre-check above catches the ordinary case; this is the
 		// concurrent-create race the DB constraint closes.

--- a/internal/api/variablelibrary.go
+++ b/internal/api/variablelibrary.go
@@ -98,3 +98,66 @@ func (a *API) resolveLibraryVariables(wid string, refs map[string]pipeline.Libra
 	}
 	return out, nil
 }
+
+// definitionRejection reports the error code and message a real tenant answers
+// when a definition is structurally fine but semantically wrong, or "" to
+// accept.
+//
+// MEASURED 2026-08-11. Creating a VariableLibrary on a trial tenant, two
+// separate rejections came back that the emulator had no opinion about:
+//
+//	InvalidVariableType
+//	  The variable type 'TotallyMadeUpType' is not supported.
+//
+//	InvalidContent (issue: InvalidValueOrTypeMismatch)
+//	  Item content cannot be used (ReferencedEntityNotFoundOrAccessDenied)
+//	  — a ConnectionReference naming a connection id that does not exist.
+//
+// Both are the direction that ships: the emulator accepted either payload
+// silently, so a library written against it deploys and fails. The second one
+// matters more than it looks, because a ConnectionReference's value is a GUID
+// (docs/48) — promoting a library between workspaces carries an id that must
+// exist on the far side, and nothing local said so.
+func (a *API) definitionRejection(itemType string, parts []store.DefinitionPart) (string, string) {
+	if itemType != "VariableLibrary" || len(parts) == 0 {
+		return "", ""
+	}
+	files := make(map[string][]byte, len(parts))
+	for _, p := range parts {
+		raw, err := base64.StdEncoding.DecodeString(p.Payload)
+		if err != nil {
+			// Not this check's business: an undecodable part is caught where
+			// definitions are read, and reporting it as a variable-type problem
+			// would send the reader to the wrong file.
+			return "", ""
+		}
+		files[p.Path] = raw
+	}
+	lib, err := varlib.Parse(files)
+	if err != nil {
+		return "", ""
+	}
+	if err := lib.ValidateTypes(); err != nil {
+		return "InvalidVariableType", capitalise(err.Error()) + "."
+	}
+	for _, v := range lib.Variables {
+		if v.Type != "ConnectionReference" {
+			continue
+		}
+		val, _ := v.Value.(map[string]any)
+		id, _ := val["connectionId"].(string)
+		if _, err := a.Store.GetConnection(id); err != nil {
+			return "InvalidContent",
+				"Item content cannot be used (ReferencedEntityNotFoundOrAccessDenied)."
+		}
+	}
+	return "", ""
+}
+
+// capitalise upper-cases the first letter, so a Go error reads as a sentence.
+func capitalise(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/internal/api/variablelibrary_types_test.go
+++ b/internal/api/variablelibrary_types_test.go
@@ -1,0 +1,140 @@
+package api
+
+// What a real tenant refuses in a VariableLibrary definition.
+//
+// MEASURED 2026-08-11 against a Fabric trial. Both rejections below were
+// produced by POSTing the payload and reading the failed operation, not
+// inferred from a schema — the published schema for variables.json constrains
+// `type` only to `^[A-Za-z][A-Za-z0-9]{0,63}$` and declares `value: true` (any
+// JSON), so it cannot answer either question.
+//
+// WHY THE NONSENSE TYPE IS THE LOAD-BEARING CASE. Sending only plausible types
+// and watching them succeed would have proved nothing: a create that ignores
+// `type` entirely accepts them too, and a round-trip would echo our own guesses
+// back as if the tenant had confirmed them. The tenant naming
+// `TotallyMadeUpType` and nothing else is what makes the acceptance of the
+// others evidence. Any probe for "is this validated" needs a control that must
+// fail.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+)
+
+// varLibBody builds a createItem payload carrying one variables.json.
+func varLibBody(t *testing.T, name string, variables ...map[string]any) string {
+	t.Helper()
+	doc, err := json.Marshal(map[string]any{"variables": variables})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"displayName": name, "type": "VariableLibrary",
+		"definition": map[string]any{"parts": []map[string]any{{
+			"path": "variables.json", "payloadType": "InlineBase64",
+			"payload": base64.StdEncoding.EncodeToString(doc),
+		}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+func TestVariableLibraryRefusesATypeTheTenantRefuses(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+
+	// The eight types a tenant accepted, in one library. Values are the shapes
+	// it stored them as, read back with getDefinition: Integer is a JSON
+	// number, Boolean a JSON bool, DateTime a string, and ConnectionReference
+	// an object carrying a connection id.
+	conn := &store.Connection{DisplayName: "kv", ConnectivityType: "ShareableCloud"}
+	if err := st.CreateConnection(conn); err != nil {
+		t.Fatal(err)
+	}
+	ok := varLibBody(t, "accepted",
+		map[string]any{"name": "s", "type": "String", "value": "x"},
+		map[string]any{"name": "g", "type": "Guid", "value": "11111111-2222-3333-4444-555555555555"},
+		map[string]any{"name": "d", "type": "DateTime", "value": "2026-08-11T00:00:00Z"},
+		map[string]any{"name": "i", "type": "Integer", "value": 42},
+		map[string]any{"name": "n", "type": "Number", "value": 1.5},
+		map[string]any{"name": "b", "type": "Boolean", "value": true},
+		map[string]any{"name": "ir", "type": "ItemReference",
+			"value": map[string]any{"itemId": "a", "workspaceId": ws.ID}},
+		map[string]any{"name": "cr", "type": "ConnectionReference",
+			"value": map[string]any{"connectionId": conn.ID}},
+	)
+	// 201 or 202: createItem is an LRO surface, so a success is whichever the
+	// stack is configured for. What matters here is that it is not a rejection.
+	if w := do(a.createItem, admin, "POST", ok, map[string]string{"wid": ws.ID}); w.Code >= 300 {
+		t.Fatalf("every tenant-accepted type = %d %s", w.Code, w.Body.Bytes())
+	}
+
+	// The control. Without this the case above is vacuous.
+	bad := varLibBody(t, "rejected",
+		map[string]any{"name": "s", "type": "String", "value": "x"},
+		map[string]any{"name": "junk", "type": "TotallyMadeUpType", "value": "x"},
+	)
+	w := do(a.createItem, admin, "POST", bad, map[string]string{"wid": ws.ID})
+	if w.Code != http.StatusBadRequest || errorCode(t, w) != "InvalidVariableType" {
+		t.Fatalf("nonsense type = %d %s; want 400 InvalidVariableType", w.Code, w.Body.Bytes())
+	}
+	// The message names the offending type: "not supported" alone would leave a
+	// reader diffing eight declarations by hand.
+	if body := w.Body.String(); !containsAll(body, "TotallyMadeUpType", "not supported") {
+		t.Errorf("message does not name the type: %s", body)
+	}
+}
+
+// A ConnectionReference's value is a GUID, and the tenant checks it resolves.
+// That is the half that makes a library environment-BOUND: promoting one
+// between workspaces carries an id that must exist on the far side.
+func TestVariableLibraryRefusesAConnectionThatDoesNotExist(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+
+	dangling := varLibBody(t, "dangling",
+		map[string]any{"name": "cr", "type": "ConnectionReference",
+			"value": map[string]any{"connectionId": "00000000-1111-2222-3333-444444444444"}},
+	)
+	w := do(a.createItem, admin, "POST", dangling, map[string]string{"wid": ws.ID})
+	if w.Code != http.StatusBadRequest || errorCode(t, w) != "InvalidContent" {
+		t.Fatalf("dangling connectionId = %d %s; want 400 InvalidContent",
+			w.Code, w.Body.Bytes())
+	}
+
+	// The same library with a connection that exists is accepted — so the
+	// refusal above is about resolution, not about the shape.
+	conn := &store.Connection{DisplayName: "real", ConnectivityType: "ShareableCloud"}
+	if err := st.CreateConnection(conn); err != nil {
+		t.Fatal(err)
+	}
+	good := varLibBody(t, "resolvable",
+		map[string]any{"name": "cr", "type": "ConnectionReference",
+			"value": map[string]any{"connectionId": conn.ID}},
+	)
+	if w := do(a.createItem, admin, "POST", good, map[string]string{"wid": ws.ID}); w.Code >= 300 {
+		t.Fatalf("resolvable connectionId = %d %s", w.Code, w.Body.Bytes())
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/varlib/varlib.go
+++ b/internal/varlib/varlib.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 )
 
@@ -38,6 +39,36 @@ type Variable struct {
 	Type  string `json:"type"`
 	Note  string `json:"note,omitempty"`
 	Value any    `json:"value"`
+}
+
+// VariableTypes is the set a real tenant accepts, MEASURED 2026-08-11 by
+// creating a VariableLibrary carrying one variable of each candidate type plus
+// one deliberate nonsense type. The tenant named the nonsense one and nothing
+// else:
+//
+//	InvalidVariableType: The variable type 'TotallyMadeUpType' is not supported.
+//
+// That rejection is what makes the acceptances mean something. Without a
+// negative control the create could have been ignoring `type` entirely, and a
+// round-trip would only have echoed our own guesses back — the emulator did
+// exactly that until this list existed.
+//
+// `Number` is accepted by the LIBRARY even though the pipeline integration
+// article says pipelines cannot consume it; the two vocabularies are separate
+// (docs/48), so this is the library's list and not the pipeline's.
+var VariableTypes = []string{
+	"String", "Integer", "Number", "Boolean", "DateTime", "Guid",
+	"ItemReference", "ConnectionReference",
+}
+
+// ValidateTypes reports the first unsupported variable type, tenant-style.
+func (l *Library) ValidateTypes() error {
+	for _, v := range l.Variables {
+		if !slices.Contains(VariableTypes, v.Type) {
+			return fmt.Errorf("the variable type %q is not supported", v.Type)
+		}
+	}
+	return nil
 }
 
 // override is one entry of a value set's variableOverrides.


### PR DESCRIPTION
Closes the two rows `docs/48` left open, both measured against a real Fabric
trial on 2026-08-11 rather than taken from the integration article.

### The control is the point

I created one VariableLibrary carrying a variable of each candidate type **plus
one deliberate nonsense type**. The tenant named the nonsense one and nothing
else:

```
InvalidVariableType: The variable type 'TotallyMadeUpType' is not supported.
```

Without that, the run proves nothing — a create that ignores `type` accepts
plausible types too, and `getDefinition` would echo my own guesses back as if
the tenant had confirmed them. The published schema cannot settle it either: it
constrains `type` to `^[A-Za-z][A-Za-z0-9]{0,63}$` and declares `value: true`.

`DateTime`, `Integer`, `Boolean` and `Number` are now **captured** rather than
`article`, with their stored value shapes: `Integer` is a JSON number and
`Boolean` a JSON bool, so passing them through unchanged is correct for the same
reason it is for `Guid`.

### A connection reference is a GUID, and Fabric checks it

```json
{"name": "aConnection", "type": "ConnectionReference",
 "value": {"connectionId": "7feee8f6-…"}}
```

A made-up id is refused:

```
InvalidContent (issue: InvalidValueOrTypeMismatch)
Item content cannot be used (ReferencedEntityNotFoundOrAccessDenied)
```

This does **not** contradict *"Binding is by name, with no GUID anywhere"* — that
result is about the pipeline's reference to the library, which is still
`libraryName` + `variableName`. It is the other half of 47's split: the
reference is environment-invariant, and this is a **value** that is
environment-bound as hard as a value can be. A library carrying a connection
reference cannot be promoted between workspaces unchanged.

### What the emulator did before

Nothing. `Type` was a bare string, never checked, and a `connectionId` was never
resolved — so both payloads were accepted silently and would fail on deploy. The
same permissive direction as the rest of this week's findings.

Now both are refused, with the tenant's own error codes. Each test carries the
negative control, and I verified they fail without the change:

```
nonsense type = 202 ; want 400 InvalidVariableType
dangling connectionId = 202 ; want 400 InvalidContent
```

`go test ./internal/...` exit 0, `make check` exit 0. Both tenant probes were
deleted after capture.

### Not answered

`Connection reference`'s **pipeline** `type` is still uncaptured — that needs
the pipeline designer, not the API, and the table says so rather than guessing
`Object`.