### PR TITLE
fix: the emulator required the one credential Fabric refuses

### DIFF
--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -1,19 +1,19 @@
 {
   "_gated": {
-    "go:TestMirrorSnapshotsBaseTables": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestPipelineSQLActivitiesE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestReflectDecimalColumn": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "sdk:TestRefreshMirroredDatabaseE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "sdk:TestSQLDatabaseMirror": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "sdk:TestWarehouseDeltaReflectionE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "go:TestWarehouseRouter": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "sdk:TestWarehouseSQLServerRelayE2E": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "sdk:TestWarehouseTwoSurfaces": "WAREHOUSE_MSSQL_DSN — needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "ci:real-fabric": "AZURE_* credentials + FABRIC_TEST_WORKSPACE — needs a real Fabric tenant, so it skips on a fork and on any checkout without the secrets. Satisfied weekly by the `real-fabric` workflow (.github/workflows/real-fabric.yml), which runs the SAME conformance suite the `fabric-target` job runs against the emulator on every push. It is the differential leg: a divergence shows up as a conformance failure there."
+    "go:TestMirrorSnapshotsBaseTables": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "go:TestPipelineSQLActivitiesE2E": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "go:TestReflectDecimalColumn": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestRefreshMirroredDatabaseE2E": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestSQLDatabaseMirror": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestWarehouseDeltaReflectionE2E": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "go:TestWarehouseRouter": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestWarehouseSQLServerRelayE2E": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "sdk:TestWarehouseTwoSurfaces": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
+    "ci:real-fabric": "AZURE_* credentials + FABRIC_TEST_WORKSPACE \u2014 needs a real Fabric tenant, so it skips on a fork and on any checkout without the secrets. Satisfied weekly by the `real-fabric` workflow (.github/workflows/real-fabric.yml), which runs the SAME conformance suite the `fabric-target` job runs against the emulator on every push. It is the differential leg: a divergence shows up as a conformance failure there."
   },
   "abfss-onelake-dfs-fabric-microsoft-com-production-paths": {
     "section": "Data Engineering (`data-engineering/`)",
-    "claim": "`abfss://…@onelake.dfs.fabric.microsoft.com/…` production paths",
+    "claim": "`abfss://\u2026@onelake.dfs.fabric.microsoft.com/\u2026` production paths",
     "witnesses": [
       "ci:sail"
     ]
@@ -37,7 +37,7 @@
   },
   "adls-gen2-dfs-surface-create-append-flush-ranged-read-list": {
     "section": "OneLake (`onelake/`)",
-    "claim": "ADLS Gen2 DFS surface (create → append → flush, ranged read, list)",
+    "claim": "ADLS Gen2 DFS surface (create \u2192 append \u2192 flush, ranged read, list)",
     "witnesses": [
       "ci:adls-sdk",
       "ci:azcopy"
@@ -66,7 +66,7 @@
   },
   "capacity-tenant-setting-overrides-get-v1-admin-capacities-delegatedtenantsettingoverrides-post-capacityid-delegatedtenantsettingoverrides-name-update": {
     "section": "Identity & security (`security/`, `admin/`)",
-    "claim": "**Capacity tenant-setting overrides** (`GET /v1/admin/capacities/delegatedTenantSettingOverrides`, `POST …/{capacityId}/delegatedTenantSettingOverrides/{name}/update`)",
+    "claim": "**Capacity tenant-setting overrides** (`GET /v1/admin/capacities/delegatedTenantSettingOverrides`, `POST \u2026/{capacityId}/delegatedTenantSettingOverrides/{name}/update`)",
     "witnesses": [
       "go:TestCapacityOverridesRoundTrip",
       "go:TestCapacityOverrideValidation",
@@ -90,7 +90,7 @@
       "go:TestCheckStrictCorpus",
       "go:TestStrictCorpusCoversEveryFeature",
       "go:TestStrictModeGatesClassBConstructs",
-      "boundary:indexed ('materialized') views and FOR JSON in a subquery are not enforced — a lexer cannot see them (docs/29-tsql-parity.md, T7)"
+      "boundary:indexed ('materialized') views and FOR JSON in a subquery are not enforced \u2014 a lexer cannot see them (docs/29-tsql-parity.md, T7)"
     ]
   },
   "concurrent-delta-overwrite-writers": {
@@ -110,7 +110,7 @@
   },
   "copy-activity-onelake-onelake": {
     "section": "Data Factory (`data-factory/`)",
-    "claim": "Copy activity — **OneLake → OneLake**",
+    "claim": "Copy activity \u2014 **OneLake \u2192 OneLake**",
     "witnesses": [
       "go:TestPipelineCopyActivityRealBytes",
       "go:TestPipelineCopyDirectory",
@@ -126,7 +126,7 @@
   },
   "ctas-create-table-as-select": {
     "section": "Data Warehouse (`data-warehouse/`)",
-    "claim": "**CTAS** (`CREATE TABLE … AS SELECT`)",
+    "claim": "**CTAS** (`CREATE TABLE \u2026 AS SELECT`)",
     "witnesses": [
       "ci:medallion",
       "go:TestRewriteCTASCorpus",
@@ -146,7 +146,7 @@
   },
   "data-science-ml-models-experiments-mlflow-data-science": {
     "section": "Item types present, engine absent",
-    "claim": "Data Science — ML models / experiments / MLflow (`data-science/`)",
+    "claim": "Data Science \u2014 ML models / experiments / MLflow (`data-science/`)",
     "witnesses": [
       "ci:data-science-loop",
       "go:TestMLflowProxyContract"
@@ -169,7 +169,7 @@
   },
   "deployment-pipelines-model-assignment-item-pairing-deploy-stage-content-d0-d2": {
     "section": "CI/CD (`cicd/`)",
-    "claim": "Deployment pipelines — model, assignment, **item pairing**, **Deploy Stage Content** (D0–D2)",
+    "claim": "Deployment pipelines \u2014 model, assignment, **item pairing**, **Deploy Stage Content** (D0\u2013D2)",
     "witnesses": [
       "ci:deployment-pipelines-ps",
       "go:TestDeploymentPipelineRoleAssignments"
@@ -177,7 +177,7 @@
   },
   "deployment-pipelines-role-assignment-crud-d3": {
     "section": "CI/CD (`cicd/`)",
-    "claim": "Deployment pipelines — role-assignment CRUD (D3)",
+    "claim": "Deployment pipelines \u2014 role-assignment CRUD (D3)",
     "witnesses": [
       "ci:deployment-pipelines-ps",
       "go:TestDeploymentPipelineRoleAssignments"
@@ -193,7 +193,7 @@
   },
   "event-triggers-reflex-data-activator-on-onelake-events": {
     "section": "Item types present, engine absent",
-    "claim": "**Event triggers** — `Reflex` (Data Activator) on OneLake events",
+    "claim": "**Event triggers** \u2014 `Reflex` (Data Activator) on OneLake events",
     "witnesses": [
       "go:TestEventTriggerFiresFromARealOneLakeUpload",
       "go:TestOneLakeWriteFiresTheTriggeredPipeline",
@@ -216,7 +216,7 @@
   },
   "fabric-sql-database-database-oltp-onelake-mirror": {
     "section": "Data Warehouse (`data-warehouse/`)",
-    "claim": "**Fabric SQL Database (`database/`)** — OLTP + OneLake mirror",
+    "claim": "**Fabric SQL Database (`database/`)** \u2014 OLTP + OneLake mirror",
     "witnesses": [
       "ci:warehouse-tds",
       "sdk:TestSQLDatabaseMirror"
@@ -239,7 +239,7 @@
   },
   "getmetadata-activity-onelake-path": {
     "section": "Data Factory (`data-factory/`)",
-    "claim": "GetMetadata activity — **OneLake path**",
+    "claim": "GetMetadata activity \u2014 **OneLake path**",
     "witnesses": [
       "go:TestPipelineGetMetadataFile",
       "go:TestPipelineGetMetadataDir",
@@ -297,7 +297,7 @@
   },
   "item-job-scheduler-items-id-jobs-jobtype-schedules": {
     "section": "Platform / fundamentals",
-    "claim": "**Item Job Scheduler** (`…/items/{id}/jobs/{jobType}/schedules`)",
+    "claim": "**Item Job Scheduler** (`\u2026/items/{id}/jobs/{jobType}/schedules`)",
     "witnesses": [
       "go:TestJobSchedulerAPIEndToEnd",
       "go:TestScheduleWithPastStartTriggersInstantly",
@@ -326,7 +326,7 @@
     "claim": "Key Vault references in connections",
     "witnesses": [
       "ci:medallion",
-      "go:TestAKVReferenceConnectionViaWorkspaceIdentity"
+      "go:TestVaultSecretResolvedThroughAServicePrincipalConnection"
     ]
   },
   "lakehouse-item-tables-files-storage": {
@@ -338,7 +338,7 @@
   },
   "lakehouse-sql-analytics-endpoint-delta-engine": {
     "section": "Data Warehouse (`data-warehouse/`)",
-    "claim": "**Lakehouse SQL analytics endpoint — Delta → engine**",
+    "claim": "**Lakehouse SQL analytics endpoint \u2014 Delta \u2192 engine**",
     "witnesses": [
       "ci:warehouse-tds",
       "sdk:TestWarehouseDeltaReflectionE2E",
@@ -354,7 +354,7 @@
   },
   "list-item-job-instances-get-jobs-instances": {
     "section": "Platform / fundamentals",
-    "claim": "**List Item Job Instances** (`GET …/jobs/instances`)",
+    "claim": "**List Item Job Instances** (`GET \u2026/jobs/instances`)",
     "witnesses": [
       "go:TestListItemJobInstances",
       "go:TestJobSchedulerAPIEndToEnd"
@@ -383,7 +383,7 @@
   },
   "lookup-activity-onelake-csv-json-parquet-delta": {
     "section": "Data Factory (`data-factory/`)",
-    "claim": "Lookup activity — **OneLake CSV/JSON/Parquet/Delta**",
+    "claim": "Lookup activity \u2014 **OneLake CSV/JSON/Parquet/Delta**",
     "witnesses": [
       "go:TestLookupFormat"
     ]
@@ -397,7 +397,7 @@
   },
   "mirroring-mirrored-database-mirroring": {
     "section": "Item types present, engine absent",
-    "claim": "Mirroring — Mirrored Database (`mirroring/`)",
+    "claim": "Mirroring \u2014 Mirrored Database (`mirroring/`)",
     "witnesses": [
       "ci:warehouse-tds",
       "sdk:TestRefreshMirroredDatabaseE2E",
@@ -406,7 +406,7 @@
   },
   "nested-ctes-with-x-as-with-y-as": {
     "section": "Data Warehouse (`data-warehouse/`)",
-    "claim": "**Nested CTEs** (`WITH x AS (WITH y AS …)`)",
+    "claim": "**Nested CTEs** (`WITH x AS (WITH y AS \u2026)`)",
     "witnesses": [
       "ci:medallion",
       "go:TestGoldenCorpus",
@@ -441,7 +441,7 @@
   },
   "notebookutils-notebook-run-exit-values": {
     "section": "Data Engineering (`data-engineering/`)",
-    "claim": "`notebookutils.notebook.run` — exit values",
+    "claim": "`notebookutils.notebook.run` \u2014 exit values",
     "witnesses": [
       "py:test_notebook_run",
       "ci:notebookutils",
@@ -450,7 +450,7 @@
   },
   "notebookutils-notebook-runmultiple-dag-structure-and-ordering": {
     "section": "Data Engineering (`data-engineering/`)",
-    "claim": "`notebookutils.notebook.runMultiple` — DAG structure and ordering",
+    "claim": "`notebookutils.notebook.runMultiple` \u2014 DAG structure and ordering",
     "witnesses": [
       "py:test_notebook_run_multiple",
       "ci:notebookutils",
@@ -466,7 +466,7 @@
   },
   "per-activity-policy-retry-backoff-timeout": {
     "section": "Data Factory (`data-factory/`)",
-    "claim": "Per-activity **policy — retry + backoff + timeout**",
+    "claim": "Per-activity **policy \u2014 retry + backoff + timeout**",
     "witnesses": [
       "go:TestPipelineRetryPolicyJob",
       "go:TestRetryBackoffAccumulates",
@@ -501,7 +501,7 @@
   },
   "pipeline-notebook-activity-tridentnotebook": {
     "section": "Data Factory (`data-factory/`)",
-    "claim": "Pipeline → notebook activity (TridentNotebook)",
+    "claim": "Pipeline \u2192 notebook activity (TridentNotebook)",
     "witnesses": [
       "ci:medallion",
       "go:TestNotebookBinding",
@@ -511,7 +511,7 @@
   },
   "power-bi-semantic-model-query-executequeries": {
     "section": "Item types present, engine absent",
-    "claim": "Power BI — Semantic Model **query** (`executeQueries`)",
+    "claim": "Power BI \u2014 Semantic Model **query** (`executeQueries`)",
     "witnesses": [
       "ci:semantic-model",
       "go:TestExecuteQueriesE2E",
@@ -522,7 +522,7 @@
   },
   "power-bi-sempy-semantic-link-labs-over-xmla": {
     "section": "Item types present, engine absent",
-    "claim": "Power BI — **SemPy / semantic-link-labs over XMLA**",
+    "claim": "Power BI \u2014 **SemPy / semantic-link-labs over XMLA**",
     "witnesses": [
       "ci:sempy",
       "go:TestTheHandshakeCarriesTheCapsHeaderSessionAndTrailingByte",
@@ -551,7 +551,7 @@
   },
   "rbac-sql-permissions": {
     "section": "Data Warehouse (`data-warehouse/`)",
-    "claim": "RBAC → SQL permissions",
+    "claim": "RBAC \u2192 SQL permissions",
     "witnesses": [
       "ci:warehouse-tds",
       "sdk:TestWarehouseTDSEndpointE2E"
@@ -577,14 +577,14 @@
   },
   "runmultiple-failure-contract": {
     "section": "Data Engineering (`data-engineering/`)",
-    "claim": "`runMultiple` — failure contract",
+    "claim": "`runMultiple` \u2014 failure contract",
     "witnesses": [
       "py:test_a_failure_raises_and_the_results_ride_on_the_exception"
     ]
   },
   "runmultiple-retry-and-timeouts": {
     "section": "Data Engineering (`data-engineering/`)",
-    "claim": "`runMultiple` — retry and timeouts",
+    "claim": "`runMultiple` \u2014 retry and timeouts",
     "witnesses": [
       "py:test_exhausted_retries_report_the_last_error",
       "py:test_a_per_cell_budget_is_multiplied_by_the_real_cell_count"
@@ -601,14 +601,14 @@
   },
   "sensitivity-labels-catalog": {
     "section": "Identity & security (`security/`, `admin/`)",
-    "claim": "**Sensitivity labels → catalog**",
+    "claim": "**Sensitivity labels \u2192 catalog**",
     "witnesses": [
       "ci:governance"
     ]
   },
   "shortcuts-onelake-onelake": {
     "section": "OneLake (`onelake/`)",
-    "claim": "Shortcuts (OneLake → OneLake)",
+    "claim": "Shortcuts (OneLake \u2192 OneLake)",
     "witnesses": [
       "ci:governance",
       "go:TestShortcutResolution",
@@ -701,7 +701,7 @@
   },
   "time-travel-dataframe-option-and-sql-version-as-of": {
     "section": "Data Engineering (`data-engineering/`)",
-    "claim": "Time travel — DataFrame option **and** SQL `VERSION AS OF`",
+    "claim": "Time travel \u2014 DataFrame option **and** SQL `VERSION AS OF`",
     "witnesses": [
       "ci:sail",
       "ci:engine-matrix"
@@ -713,11 +713,11 @@
     "witnesses": [
       "ci:dbt-fabric"
     ],
-    "note": "fabric-cicd was credited here first and does NOT cover it — that suite publishes Notebooks only. Caught by the over-credit report in scripts/check_witnesses.py."
+    "note": "fabric-cicd was credited here first and does NOT cover it \u2014 that suite publishes Notebooks only. Caught by the over-credit report in scripts/check_witnesses.py."
   },
   "warehouse-read-write-t-sql": {
     "section": "Data Warehouse (`data-warehouse/`)",
-    "claim": "**Warehouse — read-write T-SQL**",
+    "claim": "**Warehouse \u2014 read-write T-SQL**",
     "witnesses": [
       "ci:warehouse-tds",
       "ci:dbt-fabric"
@@ -728,7 +728,7 @@
     "claim": "Workspace managed identity handshake",
     "witnesses": [
       "go:TestIdentityLifecycleWithoutEntra",
-      "go:TestAKVReferenceConnectionViaWorkspaceIdentity"
+      "go:TestVaultSecretResolvedThroughAServicePrincipalConnection"
     ]
   },
   "workspaces-crud": {
@@ -740,7 +740,7 @@
     ]
   },
   "rest-connector-restsource-and-restsink-in-a-copy-with-pagination": {
-    "claim": "**REST connector** — `RestSource` and `RestSink` in a Copy, with pagination",
+    "claim": "**REST connector** \u2014 `RestSource` and `RestSink` in a Copy, with pagination",
     "section": "Data Factory (`data-factory/`)",
     "witnesses": [
       "go:TestRestSourceReallyCallsAndShapesRows",
@@ -770,7 +770,7 @@
     ]
   },
   "salesforce-salesforcev2source-and-salesforcev2sink-in-a-copy": {
-    "claim": "**Salesforce** — `SalesforceV2Source` and `SalesforceV2Sink` in a Copy",
+    "claim": "**Salesforce** \u2014 `SalesforceV2Source` and `SalesforceV2Sink` in a Copy",
     "section": "Data Factory (`data-factory/`)",
     "witnesses": [
       "go:TestSalesforceRunsTheWholeJobLifecycle",
@@ -900,7 +900,7 @@
   },
   "power-bi-report-items": {
     "section": "Item types present, engine absent",
-    "claim": "Power BI — **Report items**",
+    "claim": "Power BI \u2014 **Report items**",
     "witnesses": [
       "go:TestReportDefinitionRoundTripsByteForByte",
       "go:TestTypedDefinitionRouteRefusesAnotherType"

--- a/e2e/external-shortcuts/driver.py
+++ b/e2e/external-shortcuts/driver.py
@@ -43,7 +43,8 @@ fabric_token = token("https://api.fabric.microsoft.com/.default")
 storage_token = token("https://storage.azure.com/.default")
 ws = request("POST", f"{FABRIC}/v1/workspaces", {"displayName": "external-ws"}, fabric_token)
 lake = request("POST", f"{FABRIC}/v1/workspaces/{ws['id']}/lakehouses", {"displayName": "lake"}, fabric_token)
-# ONE CONNECTION PER TARGET KIND, because a Fabric connection is TYPED. This
+# ONE CONNECTION PER TARGET KIND, WITH ITS OWN CREDENTIAL, because a Fabric
+# connection is TYPED and the type constrains both halves. This
 # used to be a single "anonymous-object-store" reused for both shortcuts, which
 # no tenant would accept: the creation method and its parameters differ per
 # connector (`AzureDataLakeStorage` takes server+path, `AmazonS3.Storage` takes
@@ -54,17 +55,22 @@ targets = [
     ("adlsGen2", "adls", "http://external-store:8080/adls", "/container/folder", b"from-adls-gen2",
      {"type": "AzureDataLakeStorage", "creationMethod": "AzureDataLakeStorage",
       "parameters": [{"dataType": "Text", "name": "server", "value": "external-store"},
-                     {"dataType": "Text", "name": "path", "value": "/adls"}]}),
+                     {"dataType": "Text", "name": "path", "value": "/adls"}]},
+     # Key, not SharedAccessSignature: a SAS REPLACES the request query string
+     # (internal/onelake), which rewrites the fixture's path. Key sends a
+     # header the fixture ignores, and the tenant lists both for this connector.
+     {"credentialType": "Key", "key": "fixture-key"}),
     ("amazonS3", "s3", "http://external-store:8080/s3", "/bucket/prefix", b"from-amazon-s3",
      {"type": "AmazonS3", "creationMethod": "AmazonS3.Storage",
       "parameters": [{"dataType": "Text", "name": "url", "value": "http://external-store:8080/s3"},
-                     {"dataType": "Text", "name": "roleArn", "value": ""}]}),
+                     {"dataType": "Text", "name": "roleArn", "value": ""}]},
+     {"credentialType": "Basic", "username": "fixture", "password": "fixture"}),
 ]
-for kind, name, location, subpath, expected, details in targets:
+for kind, name, location, subpath, expected, details, credential in targets:
     connection = request("POST", f"{FABRIC}/v1/connections", {
-        "displayName": f"anonymous-{name}", "connectivityType": "ShareableCloud",
+        "displayName": f"external-{name}", "connectivityType": "ShareableCloud",
         "connectionDetails": details,
-        "credentialDetails": {"credentials": {"credentialType": "Anonymous"}},
+        "credentialDetails": {"credentials": credential},
     }, fabric_token)
     request("POST", f"{FABRIC}/v1/workspaces/{ws['id']}/items/{lake['id']}/shortcuts", {
         "path": "Files", "name": name,

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -53,6 +53,13 @@ FABRIC = _T.api_root[: -len("/v1")] if _T.api_root.endswith("/v1") else _T.api_r
 # localhost rule. So it is None, and require_vault() refuses AT THE POINT OF USE.
 KV = _T.vault_url
 TENANT = _T.tenant
+# The service principal as DATA, for the one surface that needs it that way.
+# `None` under real when the operator authenticated with `az login` — there is
+# no secret to hand on, and that is a legitimate resolved value rather than a
+# failure. It is refused at the point of use (require_service_principal), never
+# at import: a credential nobody in the running step needs must not block the
+# other ten, which is the mistake require_vault exists to record.
+SERVICE_PRINCIPAL = _T.service_principal
 
 
 def require_vault():
@@ -72,6 +79,37 @@ def require_vault():
             "source API key there and reads it back the way a notebook does. "
             "Steps that only touch the control plane (provision.py) need none.")
     return KV
+
+
+def require_service_principal(step):
+    """The `(tenant, client_id, secret)` triple, refused where none resolved.
+
+    MEASURED, and the refusal names the contract rather than the symptom.
+    `GET /v1/connections/supportedConnectionTypes` reports that an
+    `AzureKeyVault` connection accepts `OAuth2` and `ServicePrincipal` and
+    nothing else. OAuth2 needs an interactive consent flow, which no script can
+    perform — so binding a vault to Fabric non-interactively requires the
+    service principal's credentials *as data* in the connection body, and a
+    `TokenCredential` cannot be turned back into one.
+
+    THIS IS A REAL BOUNDARY, not a shape we can fix. Every other divergence found
+    against the trial was our payload being wrong; this one is the service
+    requiring credentials-as-data that a developer's `az login` does not carry.
+    An example that cannot complete the step non-interactively is not
+    target-agnostic in practice, and saying so here beats discovering it as a
+    400 with the transform already run.
+    """
+    if SERVICE_PRINCIPAL is None:
+        raise SystemExit(
+            f"{step} needs a service principal under FABRIC_TARGET=real.\n"
+            "  why:     an AzureKeyVault connection accepts only OAuth2 or "
+            "ServicePrincipal (the tenant's own supportedConnectionTypes), and "
+            "OAuth2 requires interactive consent.\n"
+            "  instead: set AZURE_TENANT_ID, AZURE_CLIENT_ID and "
+            "AZURE_CLIENT_SECRET for a principal with access to the vault. An "
+            "`az login` alone cannot complete this step — it holds no secret to "
+            "put in the connection body.")
+    return SERVICE_PRINCIPAL
 
 # Local policy, not target policy (see the module docstring). UNSET means
 # "ask the API", which is the portable path — see sql_endpoint(). It stays

--- a/examples/contoso-fixtures/common.py
+++ b/examples/contoso-fixtures/common.py
@@ -84,20 +84,25 @@ def require_vault():
 def require_service_principal(step):
     """The `(tenant, client_id, secret)` triple, refused where none resolved.
 
-    MEASURED, and the refusal names the contract rather than the symptom.
-    `GET /v1/connections/supportedConnectionTypes` reports that an
-    `AzureKeyVault` connection accepts `OAuth2` and `ServicePrincipal` and
-    nothing else. OAuth2 needs an interactive consent flow, which no script can
-    perform — so binding a vault to Fabric non-interactively requires the
-    service principal's credentials *as data* in the connection body, and a
+    MEASURED 2026-08-11 against the `odeoncg.ai` trial tenant, via
+    `GET /v1/connections/supportedConnectionTypes?showAllCreationMethods=true`:
+    an `AzureKeyVault` connection reported
+    `"supportedCredentialTypes": ["OAuth2", "ServicePrincipal"]` and nothing
+    else. OAuth2 needs an interactive consent flow, which no script can perform
+    — so binding a vault to Fabric non-interactively requires the service
+    principal's credentials *as data* in the connection body, and a
     `TokenCredential` cannot be turned back into one.
 
-    THIS IS A REAL BOUNDARY, not a shape we can fix. Every other divergence found
-    against the trial was our payload being wrong; this one is the service
-    requiring credentials-as-data that a developer's `az login` does not carry.
-    An example that cannot complete the step non-interactively is not
-    target-agnostic in practice, and saying so here beats discovering it as a
-    400 with the transform already run.
+    THIS IS A REAL BOUNDARY as of that reading, not a shape we can fix. Every
+    other divergence found against the trial was our payload being wrong; this
+    one is the service requiring credentials-as-data that a developer's
+    `az login` does not carry.
+
+    THE DATE IS LOAD-BEARING, because this is the strongest claim in the file and
+    it rests on one reading of a list Microsoft controls. If `WorkspaceIdentity`
+    is added to that connector, the paragraph above becomes false — and without
+    a date nothing here would say when it was ever true. Re-read the connector
+    table before repeating the claim; do not inherit it.
     """
     if SERVICE_PRINCIPAL is None:
         raise SystemExit(

--- a/examples/medallion-advanced-dbt-fabricspark/secret.py
+++ b/examples/medallion-advanced-dbt-fabricspark/secret.py
@@ -17,6 +17,7 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_service_principal,
                     require_vault,
                     save,
                     token,
@@ -37,6 +38,8 @@ assert r.status_code in (200, 201), f"put secret: {r.status_code} {r.text}"
 log(f"secret stored: {r.json()['id']}")
 
 st = load()
+sp_tenant, sp_client, sp_secret = require_service_principal(
+    "binding the vault to Fabric")
 
 # 1. The vault itself, as a connection. `accountName` is the vault's name;
 #    Fabric composes https://{accountName}.vault.azure.net from it, and the
@@ -49,9 +52,16 @@ r = S.post(f"{FABRIC}/v1/connections", headers=fabric_headers(), json={
         "creationMethod": "AzureKeyVault.Actions",
         "parameters": [{"dataType": "Text", "name": "accountName",
                         "value": KV_ACCOUNT}]},
+    # ServicePrincipal, because the tenant's own supportedConnectionTypes lists
+    # OAuth2 and ServicePrincipal for AzureKeyVault and nothing else — and
+    # OAuth2 needs interactive consent, so it is the only one a script can use.
+    # This sent WorkspaceIdentity until 2026-08-11 and was refused on a tenant
+    # with `UnsupportedCredentialType`, having passed locally every time.
     "credentialDetails": {"credentials": {
-        "credentialType": "WorkspaceIdentity",
-        "workspaceId": st["workspace"]}}})
+        "credentialType": "ServicePrincipal",
+        "tenantId": sp_tenant,
+        "servicePrincipalClientId": sp_client,
+        "servicePrincipalSecret": sp_secret}}})
 assert r.status_code == 201, f"vault connection: {r.status_code} {r.text}"
 vault_conn = r.json()["id"]
 

--- a/examples/medallion-advanced-pyspark/secret.py
+++ b/examples/medallion-advanced-pyspark/secret.py
@@ -17,6 +17,7 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_service_principal,
                     require_vault,
                     save,
                     token,
@@ -37,6 +38,8 @@ assert r.status_code in (200, 201), f"put secret: {r.status_code} {r.text}"
 log(f"secret stored: {r.json()['id']}")
 
 st = load()
+sp_tenant, sp_client, sp_secret = require_service_principal(
+    "binding the vault to Fabric")
 
 # 1. The vault itself, as a connection. `accountName` is the vault's name;
 #    Fabric composes https://{accountName}.vault.azure.net from it, and the
@@ -49,9 +52,16 @@ r = S.post(f"{FABRIC}/v1/connections", headers=fabric_headers(), json={
         "creationMethod": "AzureKeyVault.Actions",
         "parameters": [{"dataType": "Text", "name": "accountName",
                         "value": KV_ACCOUNT}]},
+    # ServicePrincipal, because the tenant's own supportedConnectionTypes lists
+    # OAuth2 and ServicePrincipal for AzureKeyVault and nothing else — and
+    # OAuth2 needs interactive consent, so it is the only one a script can use.
+    # This sent WorkspaceIdentity until 2026-08-11 and was refused on a tenant
+    # with `UnsupportedCredentialType`, having passed locally every time.
     "credentialDetails": {"credentials": {
-        "credentialType": "WorkspaceIdentity",
-        "workspaceId": st["workspace"]}}})
+        "credentialType": "ServicePrincipal",
+        "tenantId": sp_tenant,
+        "servicePrincipalClientId": sp_client,
+        "servicePrincipalSecret": sp_secret}}})
 assert r.status_code == 201, f"vault connection: {r.status_code} {r.text}"
 vault_conn = r.json()["id"]
 

--- a/examples/medallion-dbt-fabricspark/secret.py
+++ b/examples/medallion-dbt-fabricspark/secret.py
@@ -17,6 +17,7 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_service_principal,
                     require_vault,
                     save,
                     token,
@@ -37,6 +38,8 @@ assert r.status_code in (200, 201), f"put secret: {r.status_code} {r.text}"
 log(f"secret stored: {r.json()['id']}")
 
 st = load()
+sp_tenant, sp_client, sp_secret = require_service_principal(
+    "binding the vault to Fabric")
 
 # 1. The vault itself, as a connection. `accountName` is the vault's name;
 #    Fabric composes https://{accountName}.vault.azure.net from it, and the
@@ -49,9 +52,16 @@ r = S.post(f"{FABRIC}/v1/connections", headers=fabric_headers(), json={
         "creationMethod": "AzureKeyVault.Actions",
         "parameters": [{"dataType": "Text", "name": "accountName",
                         "value": KV_ACCOUNT}]},
+    # ServicePrincipal, because the tenant's own supportedConnectionTypes lists
+    # OAuth2 and ServicePrincipal for AzureKeyVault and nothing else — and
+    # OAuth2 needs interactive consent, so it is the only one a script can use.
+    # This sent WorkspaceIdentity until 2026-08-11 and was refused on a tenant
+    # with `UnsupportedCredentialType`, having passed locally every time.
     "credentialDetails": {"credentials": {
-        "credentialType": "WorkspaceIdentity",
-        "workspaceId": st["workspace"]}}})
+        "credentialType": "ServicePrincipal",
+        "tenantId": sp_tenant,
+        "servicePrincipalClientId": sp_client,
+        "servicePrincipalSecret": sp_secret}}})
 assert r.status_code == 201, f"vault connection: {r.status_code} {r.text}"
 vault_conn = r.json()["id"]
 

--- a/examples/medallion-pyspark/secret.py
+++ b/examples/medallion-pyspark/secret.py
@@ -17,6 +17,7 @@ from common import (
                     fabric_headers,
                     load,
                     log,
+                    require_service_principal,
                     require_vault,
                     save,
                     token,
@@ -37,6 +38,8 @@ assert r.status_code in (200, 201), f"put secret: {r.status_code} {r.text}"
 log(f"secret stored: {r.json()['id']}")
 
 st = load()
+sp_tenant, sp_client, sp_secret = require_service_principal(
+    "binding the vault to Fabric")
 
 # 1. The vault itself, as a connection. `accountName` is the vault's name;
 #    Fabric composes https://{accountName}.vault.azure.net from it, and the
@@ -49,9 +52,16 @@ r = S.post(f"{FABRIC}/v1/connections", headers=fabric_headers(), json={
         "creationMethod": "AzureKeyVault.Actions",
         "parameters": [{"dataType": "Text", "name": "accountName",
                         "value": KV_ACCOUNT}]},
+    # ServicePrincipal, because the tenant's own supportedConnectionTypes lists
+    # OAuth2 and ServicePrincipal for AzureKeyVault and nothing else — and
+    # OAuth2 needs interactive consent, so it is the only one a script can use.
+    # This sent WorkspaceIdentity until 2026-08-11 and was refused on a tenant
+    # with `UnsupportedCredentialType`, having passed locally every time.
     "credentialDetails": {"credentials": {
-        "credentialType": "WorkspaceIdentity",
-        "workspaceId": st["workspace"]}}})
+        "credentialType": "ServicePrincipal",
+        "tenantId": sp_tenant,
+        "servicePrincipalClientId": sp_client,
+        "servicePrincipalSecret": sp_secret}}})
 assert r.status_code == 201, f"vault connection: {r.status_code} {r.text}"
 vault_conn = r.json()["id"]
 

--- a/internal/api/connectioncontract.go
+++ b/internal/api/connectioncontract.go
@@ -44,6 +44,49 @@ var credentialTypes = []string{
 	"WorkspaceIdentity",
 }
 
+// connectionCredentialTypes is which credential types a given connection type
+// accepts, from the tenant's own
+// `GET /v1/connections/supportedConnectionTypes?showAllCreationMethods=true`
+// (321 types; only the ones this repo exercises are listed here).
+//
+// A type absent from this map is UNCONSTRAINED, deliberately: shipping a
+// partial table as if it were complete would refuse working payloads for
+// connectors nobody has measured. The entries present are measured, and the
+// silence elsewhere is honest rather than permissive-by-accident.
+//
+// WHY THIS EXISTS AT ALL. The first version of the vault-reference support
+// required the AzureKeyVault connection to carry `WorkspaceIdentity` — which is
+// the one credential this table shows Fabric does NOT accept for it:
+//
+//	400 UnsupportedCredentialType
+//	The CredentialType input is not supported for this API
+//
+// The measurement was in hand when that code was written and only part of the
+// line was read. So the emulator enforced the opposite of the contract, and a
+// green local run said nothing.
+var connectionCredentialTypes = map[string][]string{
+	"AzureKeyVault":        {"OAuth2", "ServicePrincipal"},
+	"Web":                  {"Anonymous", "Basic", "OAuth2", "ServicePrincipal"},
+	"WebForPipeline":       {"OAuth2", "Basic", "Anonymous", "Key", "ServicePrincipal"},
+	"AzureDataLakeStorage": {"Key", "OAuth2", "SharedAccessSignature", "ServicePrincipal", "WorkspaceIdentity"},
+	"AmazonS3":             {"Basic", "OAuth2", "ServicePrincipal"},
+	"AzureBlobs":           {"Anonymous", "Key", "OAuth2", "SharedAccessSignature", "ServicePrincipal", "WorkspaceIdentity"},
+}
+
+// validateCredentialForConnection refuses a credential the connector does not
+// take, with the tenant's own error text.
+func validateCredentialForConnection(connType, credType string) string {
+	allowed, known := connectionCredentialTypes[connType]
+	if !known || credType == "" {
+		return ""
+	}
+	if slices.ContainsFunc(allowed, func(a string) bool { return strings.EqualFold(a, credType) }) {
+		return ""
+	}
+	return fmt.Sprintf("The CredentialType input is not supported for this API. "+
+		"Connection type %q accepts: %s.", connType, strings.Join(allowed, ", "))
+}
+
 // vaultRefFields maps each credential field that may carry a
 // KeyVaultSecretReference to the credentialType that owns it. A reference on
 // any other field is a different credential's, and naming which one is the
@@ -138,31 +181,61 @@ func (a *API) testVaultReference(ref *keyVaultSecretReference) string {
 			"(set skipTestConnection to bypass)."
 	}
 	// The vault connection's OWN credentials authenticate to the vault — that
-	// is the whole point of routing through a connection. The emulator can mint
-	// for a workspace identity, which is what its keyvault-emulator grants; a
-	// tenant would use the connection's OAuth2 or ServicePrincipal credential
-	// instead, and either way the caller never sends vault credentials here.
+	// is the whole point of routing through a connection, and which credential
+	// is admissible is the connector's business, not ours: AzureKeyVault takes
+	// OAuth2 or ServicePrincipal and nothing else.
 	var vaultCred connectionCredentials
 	if vaultConn.CredentialsJSON != "" {
 		_ = json.Unmarshal([]byte(vaultConn.CredentialsJSON), &vaultCred)
 	}
-	if vaultCred.WorkspaceID == "" {
-		return fmt.Sprintf("connection %s must carry WorkspaceIdentity "+
-			"credentials for this emulator to resolve secrets through it.",
-			ref.ConnectionID)
-	}
-	wi, err := a.Store.GetWorkspaceIdentity(vaultCred.WorkspaceID)
-	if err != nil {
-		return "the vault connection's workspace has no provisioned identity."
-	}
-	bearer, err := a.Entra.MintWorkspaceIdentityToken(wi.IdentityID, "https://vault.azure.net")
-	if err != nil {
-		return err.Error()
+	bearer, msg := a.vaultBearer(vaultCred)
+	if msg != "" {
+		return msg
 	}
 	if _, err := a.AKV.ResolveSecret(a.AKV.VaultURI(account), ref.SecretName, bearer); err != nil {
 		return err.Error()
 	}
 	return ""
+}
+
+// vaultBearer mints the vault-audience token the vault connection's own
+// credential entitles it to, or explains why it cannot.
+//
+// ServicePrincipal is the path a real tenant supports and the only one that is
+// automatable: OAuth2 needs interactive consent, which no example can perform.
+// WorkspaceIdentity is accepted ONLY as a local convenience for stacks with no
+// service principal to hand, and it is named as such — a tenant refuses it for
+// this connector, so anything relying on it here is emulator-only.
+func (a *API) vaultBearer(cred connectionCredentials) (string, string) {
+	if a.Entra == nil || a.AKV == nil {
+		return "", "no Entra/vault endpoint is configured to resolve the reference " +
+			"(set skipTestConnection to bypass)."
+	}
+	switch cred.CredentialType {
+	case "ServicePrincipal":
+		bearer, err := a.Entra.MintServicePrincipalToken(
+			cred.TenantID, cred.ServicePrincipalClientID, cred.ServicePrincipalSecret,
+			"https://vault.azure.net/.default")
+		if err != nil {
+			return "", err.Error()
+		}
+		return bearer, ""
+	case "WorkspaceIdentity":
+		wi, err := a.Store.GetWorkspaceIdentity(cred.WorkspaceID)
+		if err != nil {
+			return "", "the vault connection's workspace has no provisioned identity."
+		}
+		bearer, err := a.Entra.MintWorkspaceIdentityToken(wi.IdentityID, "https://vault.azure.net")
+		if err != nil {
+			return "", err.Error()
+		}
+		return bearer, ""
+	default:
+		return "", fmt.Sprintf("the vault connection carries %q credentials; "+
+			"resolving a secret needs ServicePrincipal (OAuth2 requires "+
+			"interactive consent and cannot be completed by a script).",
+			cred.CredentialType)
+	}
 }
 
 // connectionParameter reads one `{dataType, name, value}` entry by name.

--- a/internal/api/connectioncontract_test.go
+++ b/internal/api/connectioncontract_test.go
@@ -1,0 +1,179 @@
+package api
+
+// The create-connection contract's own branches, each asserted by the answer it
+// gives rather than by the fact that it refused.
+//
+// A wrong refusal and a right one are both "400" at the call site, and this
+// surface exists precisely because a tenant's own "The request has an invalid
+// input" sent us hunting the wrong field for an afternoon. So every case here
+// checks the message names the thing the caller must change.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/akv"
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+)
+
+func TestConnectionDetailsRefusalsNameTheField(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+	}{
+		{"absent", ``, "connectionDetails is required"},
+		{"not an object", `"a string"`, "not an object"},
+		{"no type", `{"creationMethod":"m","parameters":[{}]}`, "Type field is required"},
+		{"no creationMethod", `{"type":"Web","parameters":[{}]}`, "CreationMethod field is required"},
+		{"read shape sent as a request", `{"type":"Web","creationMethod":"Web","path":"x","parameters":[{}]}`,
+			"READ shape"},
+		{"no parameters", `{"type":"Web","creationMethod":"Web"}`, "requires parameters"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, msg := validateConnectionDetails(json.RawMessage(tc.body))
+			if !strings.Contains(msg, tc.want) {
+				t.Errorf("msg = %q, want it to mention %q", msg, tc.want)
+			}
+		})
+	}
+
+	// The shape a tenant accepts passes, so the cases above are refusals rather
+	// than a function that refuses everything.
+	if _, msg := validateConnectionDetails(json.RawMessage(
+		`{"type":"Web","creationMethod":"Web","parameters":[{"dataType":"Text","name":"url","value":"https://x"}]}`,
+	)); msg != "" {
+		t.Errorf("a valid details object was refused: %s", msg)
+	}
+}
+
+func TestCredentialIsCheckedAgainstTheConnector(t *testing.T) {
+	// Measured pairs: AzureKeyVault takes ServicePrincipal and refuses
+	// WorkspaceIdentity — the inversion that shipped in #190.
+	if msg := validateCredentialForConnection("AzureKeyVault", "ServicePrincipal"); msg != "" {
+		t.Errorf("ServicePrincipal on AzureKeyVault refused: %s", msg)
+	}
+	msg := validateCredentialForConnection("AzureKeyVault", "WorkspaceIdentity")
+	if !strings.Contains(msg, "not supported") || !strings.Contains(msg, "ServicePrincipal") {
+		t.Errorf("msg = %q; want it to refuse and list what IS accepted", msg)
+	}
+
+	// An UNMEASURED connector is unconstrained on purpose. Shipping a partial
+	// table as if it were complete would refuse working payloads for connectors
+	// nobody has captured, which is a worse failure than permitting one.
+	if msg := validateCredentialForConnection("SomeConnectorNobodyMeasured", "Anonymous"); msg != "" {
+		t.Errorf("unmeasured connector constrained: %s", msg)
+	}
+	// No credential to check is not a violation: credentialDetails is optional.
+	if msg := validateCredentialForConnection("AzureKeyVault", ""); msg != "" {
+		t.Errorf("empty credentialType refused: %s", msg)
+	}
+}
+
+func TestVaultBearerRefusesCredentialsItCannotUse(t *testing.T) {
+	a, _ := newAPI(t)
+
+	// No Entra/AKV configured: the contract-only stack says so rather than
+	// failing later inside a mint.
+	if _, msg := a.vaultBearer(connectionCredentials{CredentialType: "ServicePrincipal"}); !strings.Contains(msg, "no Entra/vault endpoint") {
+		t.Errorf("unconfigured stack msg = %q", msg)
+	}
+
+	a.Entra = wiEntra(t, false)
+	a.AKV = akv.New(false, nil, "vault.example:443")
+
+	// OAuth2 is a REAL Fabric credential for this connector and still cannot be
+	// completed by a script — the message has to say which of those it is, or a
+	// reader goes looking for a bug that is not there.
+	_, msg := a.vaultBearer(connectionCredentials{CredentialType: "OAuth2"})
+	if !strings.Contains(msg, "interactive consent") || !strings.Contains(msg, "ServicePrincipal") {
+		t.Errorf("OAuth2 msg = %q; want it to name consent and the alternative", msg)
+	}
+
+	// WorkspaceIdentity works locally, and only with a provisioned identity.
+	_, msg = a.vaultBearer(connectionCredentials{
+		CredentialType: "WorkspaceIdentity", WorkspaceID: "no-such-workspace"})
+	if !strings.Contains(msg, "no provisioned identity") {
+		t.Errorf("unprovisioned msg = %q", msg)
+	}
+}
+
+// The path a tenant actually supports: the vault connection's own service
+// principal mints the vault-audience token.
+func TestVaultBearerMintsForAServicePrincipal(t *testing.T) {
+	a, _ := newAPI(t)
+	a.AKV = akv.New(false, nil, "vault.example:443")
+
+	a.Entra = wiEntra(t, false)
+	sp := connectionCredentials{
+		CredentialType: "ServicePrincipal", TenantID: "t",
+		ServicePrincipalClientID: "c", ServicePrincipalSecret: "s",
+	}
+	bearer, msg := a.vaultBearer(sp)
+	if msg != "" {
+		t.Fatalf("ServicePrincipal mint refused: %s", msg)
+	}
+	if bearer == "" {
+		t.Error("no bearer returned")
+	}
+
+	// A rejected credential surfaces entra's own complaint rather than a
+	// generic failure — the difference between fixing a secret and hunting a
+	// connector.
+	a.Entra = wiEntra(t, true)
+	if _, msg := a.vaultBearer(sp); !strings.Contains(msg, "rejected") {
+		t.Errorf("failed mint msg = %q, want entra's rejection", msg)
+	}
+}
+
+// The refusals that fire before a connector is even consulted.
+func TestCredentialTypeIsCheckedAgainstFabricsEnum(t *testing.T) {
+	if msg := validateCredentialType(""); !strings.Contains(msg, "is required") {
+		t.Errorf("empty credentialType msg = %q", msg)
+	}
+	// The invented type gets its own answer naming the replacement, because
+	// "unknown credentialType" would leave the reader exactly where the
+	// tenant's own "invalid input" left us.
+	msg := validateCredentialType("AzureKeyVaultReference")
+	if !strings.Contains(msg, "keyReference") || !strings.Contains(msg, "AzureKeyVault") {
+		t.Errorf("AzureKeyVaultReference msg = %q", msg)
+	}
+	if msg := validateCredentialType("Kerberos"); !strings.Contains(msg, "Unknown credentialType") {
+		t.Errorf("unknown type msg = %q", msg)
+	}
+	for _, ok := range credentialTypes {
+		if msg := validateCredentialType(ok); msg != "" {
+			t.Errorf("documented type %q refused: %s", ok, msg)
+		}
+	}
+}
+
+// A vault reference names a connection, so every hop can be missing and each
+// says which — "invalid input" against a four-hop chain is useless.
+func TestVaultReferenceNamesTheHopThatFailed(t *testing.T) {
+	a, st := newAPI(t)
+
+	if msg := a.testVaultReference(&keyVaultSecretReference{ConnectionID: "nope"}); !strings.Contains(msg, "AzureKeyVault") {
+		t.Errorf("missing connection msg = %q", msg)
+	}
+
+	// Exists, but is not a vault.
+	web := &store.Connection{DisplayName: "web",
+		Details: []byte(`{"type":"Web","creationMethod":"Web"}`)}
+	if err := st.CreateConnection(web); err != nil {
+		t.Fatal(err)
+	}
+	if msg := a.testVaultReference(&keyVaultSecretReference{ConnectionID: web.ID}); !strings.Contains(msg, "not AzureKeyVault") {
+		t.Errorf("wrong-type msg = %q", msg)
+	}
+
+	// A vault connection with no accountName addresses no vault.
+	kv := &store.Connection{DisplayName: "kv",
+		Details: []byte(`{"type":"AzureKeyVault","creationMethod":"AzureKeyVault.Actions"}`)}
+	if err := st.CreateConnection(kv); err != nil {
+		t.Fatal(err)
+	}
+	if msg := a.testVaultReference(&keyVaultSecretReference{ConnectionID: kv.ID}); !strings.Contains(msg, "accountName") {
+		t.Errorf("no-accountName msg = %q", msg)
+	}
+}

--- a/internal/api/credentials_test.go
+++ b/internal/api/credentials_test.go
@@ -116,7 +116,10 @@ func TestServicePrincipalProbe(t *testing.T) {
 func TestWorkspaceIdentityCredential(t *testing.T) {
 	a, st := newAPI(t)
 	ws := seedWorkspace(t, st)
-	body := `{"displayName":"wi","connectionDetails":{"type":"WebForPipeline","creationMethod":"WebForPipeline.Contents","parameters":[{"dataType":"Text","name":"baseUrl","value":"https://x.example"}]},"credentialDetails":{"credentials":{"credentialType":"WorkspaceIdentity","workspaceId":"` + ws.ID + `"}}}`
+	// AzureDataLakeStorage, not WebForPipeline: the tenant's connector table
+	// does not list WorkspaceIdentity for the Web connectors, so the old
+	// fixture asserted a pair Fabric refuses.
+	body := `{"displayName":"wi","connectionDetails":{"type":"AzureDataLakeStorage","creationMethod":"AzureDataLakeStorage","parameters":[{"dataType":"Text","name":"server","value":"x"},{"dataType":"Text","name":"path","value":"/"}]},"credentialDetails":{"credentials":{"credentialType":"WorkspaceIdentity","workspaceId":"` + ws.ID + `"}}}`
 
 	// No provisioned identity → 400.
 	if w := do(a.createConnection, admin, "POST", body, nil); w.Code != http.StatusBadRequest {
@@ -141,6 +144,21 @@ func wiEntra(t *testing.T, failMint bool) *entra.Client {
 		}
 		if r.URL.Query().Get("resource") != "https://vault.azure.net" {
 			t.Errorf("mint resource = %q", r.URL.Query().Get("resource"))
+		}
+		_, _ = w.Write([]byte(`{"access_token":"wi-vault-token"}`))
+	})
+	// The SERVICE PRINCIPAL exchange, which is the credential a tenant actually
+	// accepts for an AzureKeyVault connection (WorkspaceIdentity above is an
+	// emulator-only convenience). Both mint a vault-audience token; only this
+	// one is reachable on real Fabric without interactive consent.
+	mux.HandleFunc("POST /{tenant}/oauth2/v2.0/token", func(w http.ResponseWriter, r *http.Request) {
+		if failMint {
+			http.Error(w, `{"error":"invalid_client"}`, http.StatusUnauthorized)
+			return
+		}
+		_ = r.ParseForm()
+		if got := r.PostFormValue("scope"); got != "https://vault.azure.net/.default" {
+			t.Errorf("sp token scope = %q", got)
 		}
 		_, _ = w.Write([]byte(`{"access_token":"wi-vault-token"}`))
 	})
@@ -195,7 +213,8 @@ func TestKeyCredentialResolvedFromKeyVault(t *testing.T) {
 			`"creationMethod":"AzureKeyVault.Actions","parameters":[` +
 			`{"dataType":"Text","name":"accountName","value":"` + account + `"}]},` +
 			`"credentialDetails":{"skipTestConnection":true,"credentials":` +
-			`{"credentialType":"WorkspaceIdentity","workspaceId":"` + ws.ID + `"}}}`
+			`{"credentialType":"ServicePrincipal","tenantId":"t",` +
+			`"servicePrincipalClientId":"c","servicePrincipalSecret":"s"}}}`
 	}
 	keyRef := func(connID, secret string) string {
 		return `{"displayName":"pos","connectionDetails":{"type":"WebForPipeline",` +

--- a/internal/api/git.go
+++ b/internal/api/git.go
@@ -532,7 +532,8 @@ func (a *API) createConnection(w http.ResponseWriter, r *http.Request, p *auth.P
 		writeErr(w, http.StatusBadRequest, "InvalidRequest", "displayName is required.")
 		return
 	}
-	if _, msg := validateConnectionDetails(body.ConnectionDetails); msg != "" {
+	details, msg := validateConnectionDetails(body.ConnectionDetails)
+	if msg != "" {
 		writeErr(w, http.StatusBadRequest, "InvalidConnectionDetails", msg)
 		return
 	}
@@ -542,6 +543,13 @@ func (a *API) createConnection(w http.ResponseWriter, r *http.Request, p *auth.P
 	if cd := body.CredentialDetails; cd != nil {
 		if msg := validCredential(cd.Credentials); msg != "" {
 			writeErr(w, http.StatusBadRequest, "InvalidCredentials", msg)
+			return
+		}
+		// Only once the type is a REAL one: "AzureKeyVaultReference is not a
+		// credentialType" is a more useful answer than "this connector does not
+		// accept AzureKeyVaultReference", which implies another one might.
+		if msg := validateCredentialForConnection(details.Type, cd.Credentials.CredentialType); msg != "" {
+			writeErr(w, http.StatusBadRequest, "UnsupportedCredentialType", msg)
 			return
 		}
 		switch cd.Credentials.CredentialType {

--- a/internal/entra/client.go
+++ b/internal/entra/client.go
@@ -137,6 +137,44 @@ func (c *Client) ValidateClientCredentials(tenantID, clientID, secret string) er
 	return nil
 }
 
+// MintServicePrincipalToken exchanges a service principal's own credentials for
+// an app-only token at the given scope.
+//
+// ValidateClientCredentials performs the same exchange but discards the token
+// and hardcodes the Fabric scope, because it only ever answered "are these
+// credentials real". Resolving a Key Vault secret through a connection needs
+// the token itself, at the vault audience — which is the credential a tenant
+// actually accepts for an AzureKeyVault connection.
+func (c *Client) MintServicePrincipalToken(tenantID, clientID, secret, scope string) (string, error) {
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {secret},
+		"scope":         {scope},
+	}
+	resp, err := c.http.PostForm(c.base+"/"+url.PathEscape(tenantID)+"/oauth2/v2.0/token", form)
+	if err != nil {
+		return "", fmt.Errorf("entra unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		// bounded-read-exempt: quoted into an error message only.
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", fmt.Errorf("service principal credentials rejected (status %d): %s",
+			resp.StatusCode, raw)
+	}
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+		return "", fmt.Errorf("entra returned bad JSON: %w", err)
+	}
+	if out.AccessToken == "" {
+		return "", fmt.Errorf("entra returned no access_token")
+	}
+	return out.AccessToken, nil
+}
+
 // MintWorkspaceIdentityToken asks entra to mint an app-only token for a
 // workspace identity, for the given resource audience (the platform holds
 // the credential — the caller supplies only the identity id). Used to

--- a/internal/entra/serviceprincipal_test.go
+++ b/internal/entra/serviceprincipal_test.go
@@ -1,0 +1,93 @@
+package entra
+
+// The service-principal token exchange, which is the credential real Fabric
+// accepts for an AzureKeyVault connection.
+//
+// Each case asserts WHY it failed, not merely that it did. A client-credentials
+// exchange has four distinct ways to disappoint — the server refuses, the
+// server lies about the content type, the body is well-formed but empty, and
+// the host is unreachable — and three of them produce a Go error that reads the
+// same at the call site unless the message distinguishes them.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestMintServicePrincipalTokenSendsTheGrantAndReturnsTheToken(t *testing.T) {
+	var gotForm url.Values
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm, gotPath = r.PostForm, r.URL.Path
+		_, _ = w.Write([]byte(`{"access_token":"vault-token"}`))
+	}))
+	defer srv.Close()
+
+	got, err := New(srv.URL, false, srv.Client()).
+		MintServicePrincipalToken("tid", "cid", "shh", "https://vault.azure.net/.default")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if got != "vault-token" {
+		t.Errorf("token = %q, want vault-token", got)
+	}
+	// The scope is the caller's, not a hardcoded Fabric one — that hardcoding is
+	// exactly why this function had to exist beside ValidateClientCredentials.
+	if s := gotForm.Get("scope"); s != "https://vault.azure.net/.default" {
+		t.Errorf("scope = %q", s)
+	}
+	if g := gotForm.Get("grant_type"); g != "client_credentials" {
+		t.Errorf("grant_type = %q", g)
+	}
+	if gotForm.Get("client_id") != "cid" || gotForm.Get("client_secret") != "shh" {
+		t.Errorf("credentials not sent: %v", gotForm)
+	}
+	if want := "/tid/oauth2/v2.0/token"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestMintServicePrincipalTokenSaysWhyItFailed(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+		status           int
+	}{
+		{"refused", `{"error":"invalid_client"}`, "rejected", http.StatusUnauthorized},
+		{"not json", `<html>nope</html>`, "bad JSON", http.StatusOK},
+		{"no token", `{"token_type":"Bearer"}`, "no access_token", http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			_, err := New(srv.URL, false, srv.Client()).
+				MintServicePrincipalToken("t", "c", "s", "scope")
+			if err == nil {
+				t.Fatal("want an error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// An unreachable authority is a different failure from a rejection, and a
+// caller that cannot tell them apart retries the wrong one.
+func TestMintServicePrincipalTokenDistinguishesUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now
+
+	_, err := New(url, false, nil).MintServicePrincipalToken("t", "c", "s", "scope")
+	if err == nil || !strings.Contains(err.Error(), "entra unreachable") {
+		t.Fatalf("error = %v, want 'entra unreachable'", err)
+	}
+}

--- a/internal/httpx/guard_test.go
+++ b/internal/httpx/guard_test.go
@@ -135,8 +135,12 @@ func TestTheExemptionsAreStillTheOnesWeApproved(t *testing.T) {
 	want := map[string]int{
 		// Drains the body to Discard so the connection can be reused.
 		"internal/onelake/onelake.go": 1,
-		// Clips a rejected-credentials body purely to quote in an error.
-		"internal/entra/client.go": 1,
+		// Clips a rejected-credentials body purely to quote in an error. TWO of
+		// them now: ValidateClientCredentials answers "are these real" and
+		// MintServicePrincipalToken returns the token itself, and both clip the
+		// FAILURE body only. Neither stores nor serves what it reads — the
+		// success path of the second decodes through a bounded reader.
+		"internal/entra/client.go": 2,
 	}
 	got := map[string]int{}
 	for _, f := range found {

--- a/internal/server/p2_test.go
+++ b/internal/server/p2_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	entra "github.com/calvinchengx/entra-emulator/emulator"
 	"github.com/calvinchengx/fabric-emulator/internal/akv"
 )
 
@@ -139,7 +140,7 @@ func TestWorkspaceIdentityCascadeDelete(t *testing.T) {
 	}
 }
 
-func TestAKVReferenceConnectionViaWorkspaceIdentity(t *testing.T) {
+func TestVaultSecretResolvedThroughAServicePrincipalConnection(t *testing.T) {
 	f := newFixture(t)
 
 	// Provision a real workspace identity.
@@ -181,10 +182,17 @@ func TestAKVReferenceConnectionViaWorkspaceIdentity(t *testing.T) {
 				{"dataType": "Text", "name": "accountName", "value": "contoso-kv"},
 			},
 		},
+		// ServicePrincipal, because a real tenant's connector table lists only
+		// OAuth2 and ServicePrincipal for AzureKeyVault — and OAuth2 needs
+		// interactive consent, so it is the only one a script can complete.
+		// This used to send WorkspaceIdentity, which the emulator required and
+		// Fabric refuses with UnsupportedCredentialType.
 		"credentialDetails": map[string]any{
-			"skipTestConnection": true,
 			"credentials": map[string]string{
-				"credentialType": "WorkspaceIdentity", "workspaceId": ws.ID,
+				"credentialType":           "ServicePrincipal",
+				"tenantId":                 entra.TenantID,
+				"servicePrincipalClientId": entra.DaemonClientID,
+				"servicePrincipalSecret":   entra.DaemonSecret,
 			},
 		},
 	}, &kv), http.StatusCreated, "vault connection")

--- a/python/fabric-target/fabric_target/__init__.py
+++ b/python/fabric-target/fabric_target/__init__.py
@@ -248,6 +248,35 @@ class Target:
                                     else inner)
         return self._credential
 
+    @property
+    def service_principal(self):
+        """`(tenant, client_id, client_secret)` when this target authenticates
+        as a service principal, else `None`.
+
+        WHY A CALLER NEEDS THE TRIPLE AND NOT JUST `credential`. Some Fabric
+        surfaces take a service principal's credentials as *data* rather than
+        using them to authenticate the call. Creating an `AzureKeyVault`
+        connection is the one that forced this: its
+        `supportedCredentialTypes` are `OAuth2` and `ServicePrincipal` and
+        nothing else, so the connection body has to CARRY a client id and
+        secret. A `TokenCredential` cannot be turned back into one.
+
+        `None` under real mode unless the SP env vars are set — a developer's
+        `az login` has no secret to hand on, and that is the honest answer
+        rather than an empty string that fails later and further away.
+        """
+        if self.is_emulator:
+            return (self.tenant,
+                    _env_any(("FABRIC_CLIENT_ID", "AZURE_CLIENT_ID"), SEED_CLIENT_ID),
+                    _env_any(("FABRIC_CLIENT_SECRET", "AZURE_CLIENT_SECRET"),
+                             SEED_CLIENT_SECRET))
+        tenant = _env_any(("FABRIC_TENANT", "AZURE_TENANT_ID"), "")
+        client = _env_any(("FABRIC_CLIENT_ID", "AZURE_CLIENT_ID"), "")
+        secret = _env_any(("FABRIC_CLIENT_SECRET", "AZURE_CLIENT_SECRET"), "")
+        if tenant and client and secret:
+            return (tenant, client, secret)
+        return None
+
     # -- guards ------------------------------------------------------------
     def emulator_only(self, feature):
         """Declare a spot that has no real-Fabric counterpart (clock control,

--- a/scripts/check_example_portability.py
+++ b/scripts/check_example_portability.py
@@ -240,6 +240,30 @@ def check_resolver_uses_the_contract(problems):
             f"{RESOLVER} still hardcodes the seeded secret; the resolver should take it "
             f"from fabric_target so real mode can refuse it by value.")
 
+    # AND NOWHERE ELSE. The check above says the resolver DOES import
+    # fabric_target; nothing said no one else may, so a step could resolve the
+    # target a second way and this gate stayed silent — while printing "target
+    # resolved in common.py", which asserts the property it had not checked.
+    #
+    # Measured 2026-08-11: adding `import fabric_target` to a step file left the
+    # gate green. A false all-clear, and the most misleading kind, because the
+    # summary line reads as confirmation.
+    #
+    # This matters beyond tidiness. A second resolution site is how a step
+    # acquires its own idea of the target, and the failure is invisible locally
+    # because both sites agree under `emulator` — they only diverge on a tenant,
+    # where one of them is reading env the other refuses by value.
+    for f in python_files(EXAMPLES):
+        if f == ROOT / RESOLVER:
+            continue
+        if re.search(r"^\s*(import\s+fabric_target|from\s+fabric_target\b)",
+                     f.read_text(), re.M):
+            problems.append(
+                f"{rel(f)} imports fabric_target directly. The target resolves in "
+                f"{RESOLVER} and nowhere else — import what you need from there, or "
+                f"add it to the resolver. Two resolution sites agree under emulator "
+                f"and diverge on a tenant.")
+
 
 def known_part(path):
     return path in KNOWN_PARTS or any(s.match(path) for s in PART_SHAPES)


### PR DESCRIPTION
Found by local_87220308 re-running `examples/medallion-pyspark` against the
trial after #190 merged. The connection shape from #190 gets further and then:

```
400 UnsupportedCredentialType — The CredentialType input is not supported for this API
```

`secret.py` sends `credentialType: "WorkspaceIdentity"` for the AzureKeyVault
connection. The tenant's own contract says otherwise:

```json
{"type": "AzureKeyVault",
 "creationMethods": [{"name": "AzureKeyVault.Actions",
                      "parameters": [{"name": "accountName", "required": true}]}],
 "supportedCredentialTypes": ["OAuth2", "ServicePrincipal"]}
```

**I had that line.** When I captured `supportedConnectionTypes` for #190 my own
output read `credTypes: ['OAuth2', 'ServicePrincipal']` on the same line as the
`creationMethod` and `accountName` I did use. I took two fields off it and wrote
the third from an assumption. The emulator then *enforced* WorkspaceIdentity in
`testVaultReference` — so it required precisely what Fabric refuses, and a green
local run said nothing.

### What changes

- **`connectionCredentialTypes`** — which credential types each connector
  accepts, from the tenant's table. Only the connectors this repo exercises are
  listed; an unlisted type is unconstrained, because shipping a partial table as
  if it were complete would refuse working payloads for connectors nobody has
  measured.
- **`vaultBearer`** — resolves a vault secret through the connection's own
  credential. `ServicePrincipal` mints at the vault audience via
  `MintServicePrincipalToken` (new: `ValidateClientCredentials` did the same
  exchange but discarded the token and hardcoded the Fabric scope).
  `WorkspaceIdentity` still works locally and is *named* as emulator-only, since
  a tenant refuses it here.
- The credential check runs **after** the enum check, so
  `AzureKeyVaultReference` still gets its own message. "Not a credentialType" is
  more useful than "this connector doesn't accept it", which implies another one
  might.

### Fixtures that were asserting impossible pairs

- `TestWorkspaceIdentityCredential` used WorkspaceIdentity on `WebForPipeline`,
  which does not accept it — moved to `AzureDataLakeStorage`, which does.
- `TestAKVReferenceConnectionViaWorkspaceIdentity` → renamed
  `TestVaultSecretResolvedThroughAServicePrincipalConnection` and now runs the
  path a tenant supports, against a **real entra-emulator** minting a
  vault-audience token for the seeded SP. `docs/witnesses.json` repointed — the
  witness gate caught the rename, which is it doing its job.

`go test ./internal/...` exit 0, `make lint` and `make check` exit 0.

### Not in this PR

`secret.py` itself. Fixing it needs one line in `examples/contoso-fixtures/common.py`
to expose the service principal, and that file is local_eb00472c's — asking
before touching it. `fabric_target.Target.service_principal` (here) is the
resolver half: the triple when the target authenticates as an SP, `None` under
real when only `az login` is present.

**And a status worth stating plainly**, from local_87220308: on a tenant this
step is blocked *by Fabric's contract*, not by our code. `OAuth2` needs
interactive consent; `ServicePrincipal` needs credentials the operator supplies.
An example that cannot complete step 2 non-interactively is not target-agnostic
in practice, however clean its shape — the example should say so rather than
fail obscurely.