### PR TITLE
docs: v0.22.0 notes cover the whole range, not one PR

### DIFF
--- a/docs/release-notes/v0.22.0.md
+++ b/docs/release-notes/v0.22.0.md
@@ -42,6 +42,45 @@ The range starts at `571abfa` (#182), the first commit after the `v0.21.0` tag.
   injects the same names as the real prelude rather than a third set, and a test
   asserts no notebook this repo ships uses the bare spelling.
 
+- **Creating a connection now follows Fabric's contract, and rejects three
+  shapes it used to accept.** Measured against a tenant and against its own
+  `GET /v1/connections/supportedConnectionTypes` (321 types):
+
+  - `connectionDetails` on a **create** is `{type, creationMethod, parameters}`.
+    `path` is the *read* shape; sending it earns
+    `The CreationMethod field is required.` from a tenant, and is refused by
+    name here.
+  - **`AzureKeyVaultReference` is not a Fabric credentialType.** The enum is
+    Anonymous, Basic, Key, KeyPair, OAuth2, ServicePrincipal,
+    SharedAccessSignature, Windows, WindowsWithoutImpersonation and
+    WorkspaceIdentity. A vault-backed credential is the *owning* type carrying a
+    `KeyVaultSecretReference` — `credentialType: "Key"` with
+    `keyReference: {connectionId, secretName}` — where `connectionId` names a
+    **connection to the vault**, not a `vaultUri`. So a vault is now a
+    connection in its own right (`type: AzureKeyVault`, parameter
+    `accountName`), and binding one takes two creates.
+  - **A credential must be one the connector accepts.** `AzureKeyVault` takes
+    only OAuth2 or ServicePrincipal; the emulator previously *required*
+    WorkspaceIdentity for it, which is the one credential Fabric refuses. An
+    unmeasured connector stays unconstrained rather than guessed at.
+
+  Responses also render the documented read shape `{type, path}` — the emulator
+  had been echoing the request back, so a client could read `creationMethod` and
+  `parameters` off a response real Fabric never sends.
+
+  **If you create connections against this emulator, your payloads change.**
+  Every shape removed here is one a tenant rejects, which is the point: the old
+  ones worked locally and only locally.
+
+- **Variable Library types are validated.** A tenant refuses an unknown one
+  (`InvalidVariableType: The variable type 'X' is not supported.`) and refuses a
+  `ConnectionReference` naming a connection that does not exist
+  (`InvalidContent … ReferencedEntityNotFoundOrAccessDenied`). Both were
+  accepted here. The accepted set — String, Integer, Number, Boolean, DateTime,
+  Guid, ItemReference, ConnectionReference — was captured *with a deliberate
+  nonsense type alongside*, because a create that ignores `type` accepts the
+  plausible ones too and a round-trip would have echoed our own guesses back.
+
 ## Fixes found by running it
 
 - **The clients had no retry, and real Fabric refuses a connection now and
@@ -98,3 +137,87 @@ The range starts at `571abfa` (#182), the first commit after the `v0.21.0` tag.
   `common.py` now resolves both per target. The emulator serves both shapes on
   one surface, so nothing local distinguished them — this survived hundreds of
   green local runs before a tenant saw it.
+
+- **A Copy activity reported `Succeeded` and wrote to the wrong path.** Feeding
+  the emulator the dataset model a tenant requires — the source's `location` and
+  format properties on a `DelimitedText` dataset, the sink's `table` on its
+  `LakehouseTable` dataset — ran clean and landed the table at
+  **`Tables/[]/bronze_customers`**.
+
+  `resolveLoc` flattens a Copy side's nested scopes into one lookup, which puts
+  `datasetSettings.schema` within reach of the `schema` key. In Fabric's dataset
+  model that field is a **column list**, not a namespace; the empty array
+  rendered as `[]` and became a path segment. `annotations` and `structure` are
+  arrays on the same object, so the fix is general: a composite value now reads
+  as absent rather than as its Go rendering.
+
+  Nothing failed. The activity said Succeeded, the job said Completed, and the
+  table simply was not where anyone would look for it — which is why the test
+  asserts the **path** rather than the status. The first version of that test
+  passed while the bytes were in the wrong place.
+
+  A tenant refuses the abbreviated source outright
+  (`'formatProperties' is invalid: Value cannot be null`), so the examples carry
+  the full model now.
+
+- **An operation's state was missing three documented fields**, and one it did
+  send was invented. `GET /v1/operations/{id}` now returns `createdTimeUtc`,
+  `lastUpdatedTimeUtc` and `percentComplete` alongside `status` and `error`, with
+  `Location`, `Retry-After` and `x-ms-operation-id` on the poll as well as the
+  202. `percentComplete` is **100 only on Succeeded** — null while Running and
+  null on **Failed**, measured both ways. The emulator had been interpolating a
+  progress fraction from its own clock: honestly derived, and a number Fabric
+  does not publish.
+
+## New levers
+
+- **`FABRIC_NAME_RESERVATION`** holds a deleted item's display name for a chosen
+  duration before it can be reused, so a provision / teardown / re-provision loop
+  meets the answer a tenant gives: `409 ItemDisplayNameNotAvailableYet` with
+  **`isRetriable: true`**. That flag is the distinguishing field, not the status —
+  a name held after a delete and a name taken by a live item are both 409, and a
+  client treating them alike gives up on the one that would have succeeded
+  seconds later.
+
+  **A duration rather than a flag, because the tenant disagreed with itself:**
+  its message says "the upcoming minutes" and the name was free again on a retry
+  **20 seconds** later. Nothing observed licenses a constant, so the window is
+  yours to choose. Off by default, for the same reason as `FABRIC_FORCE_LRO`:
+  instant reuse is what a local loop wants, and the point is that the other
+  behaviour is reachable at all.
+
+## Packaging
+
+- **The release builds the full wheel set, and CI exercises the builder on every
+  PR.** v0.21.0's release job failed its own smoke install and published **no
+  wheels** — `contoso-fixtures` requires `fabric-emulator-notebookutils`, whose
+  uv path source does not survive into wheel metadata, and no wheel was built for
+  the shim. They were uploaded by hand afterwards, so the v0.21.0 assets are
+  complete, but nothing would have caught the next occurrence. The builder now
+  runs in `ci.yml` as well as at release, so a break shows up on the PR that
+  causes it rather than at the tag.
+
+## Honesty fixes in the project's own scaffolding
+
+- **The `real-fabric` differential leg reported `success` having run nothing.**
+  Both scheduled runs were green with every conformance step skipped for missing
+  secrets; the only steps that executed were checkout, toolchain setup and the
+  secret check. Two parity claims cite it as a witness, and `docs/witnesses.json`
+  claimed in text printed by every CI run that "a divergence shows up as a
+  conformance failure there". The gate is now its own job, so the conformance job
+  reports **skipped** — a skipped job is visibly not a passing one, while a
+  succeeded job full of skipped steps is indistinguishable from a real pass at
+  every level that reads a conclusion.
+
+- **The example-portability gate passed with two target-resolution sites in the
+  tree**, while printing that the target resolved in one place. It asserted that
+  the resolver *does* import `fabric-target`; nothing stopped any other example
+  file from doing so too. Two sites agree under `emulator` and diverge on a
+  tenant, so this could never have failed locally.
+
+- **One LRO resolver in the examples, not five.** `create_item` carried its own
+  copy of the poll loop — the older, worse one: it indexed `x-ms-operation-id`
+  with no fallback to the `Location` tail, and slept a flat second against a
+  service that had just stated its own pace. Measured on a tenant: `retry-after:
+  20` on a create that completed in 13 seconds, so the header is a floor the
+  service asks for rather than an estimate of the work.


### PR DESCRIPTION
Sixteen PRs have merged since the `v0.21.0` tag. The notes described **one**
(#182), because they were written when that was the whole range.

This matters more here than in most repos: a bare tag publishes GoReleaser's
commit list, and the release body is replaced from this file. Cutting v0.22.0 as
it stood would have published notes describing 1/16 of the release.

Written from the merged diffs rather than the PR titles — a title is not a diff.

### Added

**Behaviour changes** (the section a user must read before upgrading):
- The connection contract — `creationMethod`+`parameters` on create, the
  `AzureKeyVaultReference` credentialType that does not exist, per-connector
  credential validation, and the `{type, path}` read shape. Three shapes that
  used to work now fail, and every one of them is a shape a tenant rejects.
- Variable Library type validation, and the `ConnectionReference` whose target
  must resolve.

**Fixes:**
- The Copy activity that reported `Succeeded` and wrote to
  `Tables/[]/bronze_customers` — an empty column list rendered into a path
  segment.
- The operation state's three missing fields, and `percentComplete` being
  interpolated from our own clock when Fabric publishes 100-on-Succeeded only.

**New levers:** `FABRIC_NAME_RESERVATION`, with why it is a duration rather than
a flag (the tenant's message says "minutes" and the name freed in 20 seconds).

**Packaging:** v0.21.0 shipped no wheels; the builder now runs on every PR.

**Honesty fixes in our own scaffolding:** the differential leg that reported
success having run nothing, the portability gate that passed with two resolution
sites while printing that there was one, and the five LRO resolvers collapsed to
one.

### Deliberately not listed

#184, #188, #191 and #193 are internal documentation with no user-facing change.
#189 and #193 are covered by the Packaging note rather than as separate entries,
because what a reader needs is "the wheels ship now", not the two PRs it took.

`make check` and `make lint` exit 0.

**Not a release.** Tagging is a separate step at a named SHA, and the family
sweep (contoso-data-platform is pinned at 0.20.0; azure-emulators carries the
compose BOM) follows the tag.