### PR TITLE
agent: keep the input_file_name tag out of the user's schema

### DIFF
--- a/docs/37-runtime-fidelity-gaps.md
+++ b/docs/37-runtime-fidelity-gaps.md
@@ -200,6 +200,22 @@ thing not to do: an emulator that leaks bookkeeping into user data creates
 exactly the parity drift it exists to prevent. Tagging only file reads is what
 bounds the leak.
 
+**This paragraph had the right list and drew the line in the wrong place, and
+that cost two sessions several hours.** Bounding *which* frames carry the tag
+says nothing about whether the tag is visible on the frames that do. It was:
+every file read showed one extra column on all four surfaces named above, in
+v0.20.0, v0.21.0 and v0.22.0. A consumer's landing-to-bronze step counted
+`len(df.columns)` and got one more than its own vendor export had, while the
+table it wrote was correct — so nothing downstream disagreed and the number had
+no name attached to it.
+
+Fixed (#203) by hiding the tag at every surface a user can observe it through
+rather than only at `write`. `select`/`selectExpr` are the exception and must
+stay that way: that is where `input_file_name()` is used, and it resolves to the
+tag, so hiding unconditionally there would trade one silent defect for another.
+The rule the fix encodes: **the tag is visible to a select that references it,
+and to nothing else.**
+
 **The proportionate change is the error message**, not the behaviour: raise
 something that names the shim and explains that provenance was requested on a
 frame that never came from a file, instead of a bare `AnalysisException` on an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,9 +200,13 @@ markers = [
 source = ["scripts", "python/spark_agent", "python/notebookutils", "docker/sail"]
 omit = [
     # Run inside the Spark image, witnessed by e2e/notebook-run and e2e/sail.
+    #
+    # `input_file.py` used to be here and came OFF when it acquired tests. It is
+    # not process glue whose behaviour is only visible end to end: it is a
+    # semantic shim that decides what a notebook SEES, and it shipped a defect
+    # in three releases that no gate could have caught while it was omitted.
     "python/spark_agent/agent.py",
     "python/spark_agent/files_mount.py",
-    "python/spark_agent/input_file.py",
     # CI harnesses and release tooling: containerized or one-shot, and each
     # already named as the witness for the claim it proves.
     "scripts/govern_ingest.py",

--- a/python/spark_agent/input_file.py
+++ b/python/spark_agent/input_file.py
@@ -139,20 +139,106 @@ def install(spark) -> bool:
 
     F.input_file_name = _input_file_name
 
-    # Strip the tag from anything persisted: real Fabric tables have no such
-    # column, and an emulator that leaks bookkeeping into user data is creating
-    # exactly the parity drift it exists to prevent. `input_file_name()` copies
-    # the value into the user's own column before the write sees the frame.
+    # --- keeping the tag invisible ------------------------------------------
+    #
+    # Stripping it at write covers persisted data. It does NOT cover the schema
+    # a notebook can see, and that gap was a real defect: a landing-to-bronze
+    # step counted `len(df.columns)` and got one more column than its own vendor
+    # export had, on every file read in the shipped stack. The written table was
+    # correct, which is what made it confusing to chase.
+    #
+    # So the tag is hidden from every surface a user can observe it through,
+    # not just from writes. `df.columns`, `printSchema`, `SELECT *` and
+    # `toPandas` are named in docs/37 as the leak this module must not create —
+    # tagging only file reads narrows WHICH frames are affected, it does not
+    # make the leak acceptable on those frames.
+    #
+    # One helper, applied at each surface, so adding a surface is one line and
+    # missing one is visible in this list rather than hidden in a method body.
+    original_columns = _ConnectDataFrame.columns
+
+    def _raw_columns(df):
+        """Columns INCLUDING the tag — the shim's own view."""
+        return original_columns.fget(df)
+
+    def _visible(df):
+        """The frame as the user should see it: no bookkeeping column."""
+        try:
+            if _TAG in _raw_columns(df):
+                return df.drop(_TAG)
+        except Exception:
+            pass
+        return df
+
+    # Properties first: schema-shaped surfaces.
+    for _name in ("columns", "schema", "dtypes"):
+        _original_prop = getattr(_ConnectDataFrame, _name)
+
+        def _make(prop):
+            @property
+            def hidden(self):
+                return prop.fget(_visible(self))
+
+            return hidden
+
+        setattr(_ConnectDataFrame, _name, _make(_original_prop))
+
+    # Then the methods that render or materialise rows. `select`/`selectExpr`
+    # are here for `*`: star expansion happens on the server against the plan
+    # it is given, so the tag has to be gone before the request leaves.
+    for _name in (
+        "printSchema",
+        "show",
+        "collect",
+        "take",
+        "head",
+        "first",
+        "toPandas",
+        "toLocalIterator",
+        "createOrReplaceTempView",
+        "createTempView",
+        "createOrReplaceGlobalTempView",
+    ):
+        if not hasattr(_ConnectDataFrame, _name):
+            continue
+        _original_method = getattr(_ConnectDataFrame, _name)
+
+        def _make_method(method):
+            def hidden(self, *args, **kwargs):
+                return method(_visible(self), *args, **kwargs)
+
+            return hidden
+
+        setattr(_ConnectDataFrame, _name, _make_method(_original_method))
+
+    # `select` and `selectExpr` cannot hide unconditionally: this is where
+    # `input_file_name()` is USED, and it resolves to the tag. Hiding it here
+    # would break the one thing the module exists to provide. So the tag stays
+    # visible to a select that references it, and is hidden from every other
+    # select — which is what makes `SELECT *` safe without making provenance
+    # impossible.
+    for _name in ("select", "selectExpr"):
+        if not hasattr(_ConnectDataFrame, _name):
+            continue
+        _original_select = getattr(_ConnectDataFrame, _name)
+
+        def _make_select(method):
+            def hidden(self, *args, **kwargs):
+                wants_tag = any(_TAG in str(a) for a in args)
+                return method(self if wants_tag else _visible(self), *args, **kwargs)
+
+            return hidden
+
+        setattr(_ConnectDataFrame, _name, _make_select(_original_select))
+
+    # Writes keep their own strip: `_visible` would do it, but the write path
+    # is a property returning a writer rather than a frame, so it stays
+    # explicit rather than being folded into the loop above.
     original_write = _ConnectDataFrame.write
 
     @property
     def write(self):
-        try:
-            if _TAG in self.columns:
-                return original_write.fget(self.drop(_TAG))
-        except Exception:
-            pass
-        return original_write.fget(self)
+        return original_write.fget(_visible(self))
 
     _ConnectDataFrame.write = write
 

--- a/python/tests/test_input_file_shim.py
+++ b/python/tests/test_input_file_shim.py
@@ -1,0 +1,178 @@
+"""The `input_file_name()` shim must not be visible.
+
+The shim tags each file's rows with that file's path so the function can answer
+truthfully on an engine that lacks it. That tag is bookkeeping: real Fabric has
+no such column, and `docs/37-runtime-fidelity-gaps.md` names `df.columns`,
+`printSchema`, `SELECT *` and `toPandas` as the surfaces where leaking it would
+create the parity drift this module exists to prevent.
+
+It leaked on all of them. Stripping at write covered persisted data only, so a
+landing-to-bronze step that counted `len(df.columns)` saw one column more than
+its vendor export had, while the table it wrote was correct — which is what made
+it expensive to find.
+
+These tests use a fake Connect DataFrame rather than an engine: what is being
+checked is which frame each surface delegates to, and that is a property of the
+patching, not of Spark.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import input_file as input_file_mod  # noqa: E402
+
+TAG = "__emu_input_file_name"
+
+
+class FakeDFBase:
+    """Just enough DataFrame to observe what the patches delegate to."""
+
+    def __init__(self, cols):
+        self._cols = list(cols)
+
+    # The real class exposes these as properties, which is what the shim patches.
+    @property
+    def columns(self):
+        return list(self._cols)
+
+    @property
+    def schema(self):
+        return f"struct<{','.join(self._cols)}>"
+
+    @property
+    def dtypes(self):
+        return [(c, "string") for c in self._cols]
+
+    @property
+    def write(self):
+        return f"writer({','.join(self._cols)})"
+
+    def drop(self, *names):
+        return type(self)([c for c in self._cols if c not in names])
+
+    def printSchema(self):  # noqa: N802 - PySpark's spelling
+        return self.schema
+
+    def show(self, *a, **k):
+        return f"show({','.join(self._cols)})"
+
+    def collect(self):
+        return [tuple(self._cols)]
+
+    def take(self, n):
+        return [tuple(self._cols)][:n]
+
+    def head(self, *a):
+        return tuple(self._cols)
+
+    def first(self):
+        return tuple(self._cols)
+
+    def toPandas(self):  # noqa: N802 - PySpark's spelling
+        return {"columns": list(self._cols)}
+
+    def toLocalIterator(self):  # noqa: N802 - PySpark's spelling
+        return iter([tuple(self._cols)])
+
+    def createOrReplaceTempView(self, name):  # noqa: N802 - PySpark's spelling
+        return f"{name}:{','.join(self._cols)}"
+
+    def select(self, *args):
+        return type(self)([str(a) for a in args] if args else self._cols)
+
+    def selectExpr(self, *args):  # noqa: N802 - PySpark's spelling
+        return type(self)([str(a) for a in args])
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Install the shim's DataFrame patches against FakeDF.
+
+    The module imports `pyspark.sql.connect.dataframe.DataFrame` inside
+    `install()`, so a stub module is enough — no engine, and no pyspark import
+    behaviour to work around.
+    """
+    input_file = input_file_mod
+    FakeDF = type("FakeDF", (FakeDFBase,), {})
+
+    connect_mod = types.ModuleType("pyspark.sql.connect.dataframe")
+    connect_mod.DataFrame = FakeDF
+    monkeypatch.setitem(sys.modules, "pyspark.sql.connect.dataframe", connect_mod)
+
+    class FakeReader:
+        def csv(self, path, *a, **k):
+            return FakeDF(["id", "name"])
+
+    class FakeSpark:
+        read = FakeReader()
+
+    # The engine "lacks" the function, which is when the shim installs.
+    monkeypatch.setattr(input_file, "engine_has_input_file_name", lambda _s: False)
+    monkeypatch.setattr(input_file, "_list_files", lambda _p: ["/landing/part-1.csv"])
+    input_file.install(FakeSpark())
+    yield input_file, FakeDF
+
+
+def test_the_tag_is_hidden_from_the_schema_surfaces(patched):
+    _, FakeDF = patched
+    df = FakeDF(["id", "name", TAG])
+    assert df.columns == ["id", "name"], "columns still shows the bookkeeping tag"
+    assert TAG not in df.schema
+    assert [c for c, _ in df.dtypes] == ["id", "name"]
+    assert TAG not in df.printSchema()
+
+
+def test_the_tag_is_hidden_from_materialised_rows(patched):
+    _, FakeDF = patched
+    df = FakeDF(["id", "name", TAG])
+    assert df.collect() == [("id", "name")]
+    assert df.take(1) == [("id", "name")]
+    assert df.head() == ("id", "name")
+    assert df.first() == ("id", "name")
+    assert df.toPandas() == {"columns": ["id", "name"]}
+    assert list(df.toLocalIterator()) == [("id", "name")]
+    assert TAG not in df.show()
+
+
+def test_the_tag_does_not_reach_sql_through_a_temp_view(patched):
+    # A view is how the tag would escape into `SELECT *` on the SQL path, which
+    # no amount of write-stripping would catch.
+    _, FakeDF = patched
+    assert TAG not in FakeDF(["id", "name", TAG]).createOrReplaceTempView("v")
+
+
+def test_star_expansion_does_not_carry_the_tag(patched):
+    _, FakeDF = patched
+    assert FakeDF(["id", "name", TAG]).select("*").columns == ["*"]
+    # The frame handed to select must already be clean, or the server expands
+    # `*` over a plan that still has the tag.
+    assert FakeDF(["id", "name", TAG]).select().columns == ["id", "name"]
+
+
+def test_a_select_that_asks_for_the_tag_still_gets_it(patched):
+    # The whole point of the module. `input_file_name()` resolves to the tag, so
+    # hiding it unconditionally here would make provenance impossible — the
+    # failure mode this fix must not introduce.
+    _, FakeDF = patched
+    out = FakeDF(["id", "name", TAG]).select("id", f"coalesce({TAG}, '')")
+    assert any(TAG in c for c in out.columns)
+
+
+def test_writes_still_strip_the_tag(patched):
+    _, FakeDF = patched
+    assert TAG not in FakeDF(["id", "name", TAG]).write
+
+
+def test_an_untagged_frame_is_untouched(patched):
+    # Frames that never came from a file read must pass through unchanged, or
+    # the shim starts editing data it has no business touching.
+    _, FakeDF = patched
+    plain = FakeDF(["a", "b"])
+    assert plain.columns == ["a", "b"]
+    assert plain.collect() == [("a", "b")]
+    assert plain.write == "writer(a,b)"

--- a/python/tests/test_input_file_shim.py
+++ b/python/tests/test_input_file_shim.py
@@ -89,6 +89,43 @@ class FakeDFBase:
         return type(self)([str(a) for a in args])
 
 
+def _stub_pyspark(monkeypatch, frame_cls):
+    """Put the pyspark surface this module imports into sys.modules."""
+    functions = types.ModuleType("pyspark.sql.functions")
+    functions.lit = lambda v: f"lit({v})"
+    functions.col = lambda c: c
+    functions.coalesce = lambda *a: f"coalesce({','.join(str(x) for x in a)})"
+    # Real pyspark HAS this attribute — the probe's job is to find out whether
+    # the ENGINE resolves it, not whether the client library declares it. A stub
+    # without it makes every engine look like one that lacks the function.
+    functions.input_file_name = lambda: "input_file_name()"
+    sql_mod = types.ModuleType("pyspark.sql")
+    sql_mod.functions = functions
+    root_mod = types.ModuleType("pyspark")
+    root_mod.sql = sql_mod
+    connect_mod = types.ModuleType("pyspark.sql.connect.dataframe")
+    connect_mod.DataFrame = frame_cls
+    for name, mod in (
+        ("pyspark", root_mod),
+        ("pyspark.sql", sql_mod),
+        ("pyspark.sql.functions", functions),
+        ("pyspark.sql.connect", types.ModuleType("pyspark.sql.connect")),
+        ("pyspark.sql.connect.dataframe", connect_mod),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+@pytest.fixture
+def stubs(monkeypatch):
+    """Only the import stubs — nothing in the module itself is replaced.
+
+    The helpers below ARE the code under test, so a fixture that monkeypatched
+    them would leave the test asserting against its own lambda.
+    """
+    _stub_pyspark(monkeypatch, type("FakeDF", (FakeDFBase,), {}))
+    return input_file_mod
+
+
 @pytest.fixture
 def patched(monkeypatch):
     """Install the shim's DataFrame patches against FakeDF.
@@ -106,24 +143,7 @@ def patched(monkeypatch):
     # tests passed locally only because a development venv happened to carry
     # `pyspark-client`. A test that depends on an ambient package tests the
     # machine it runs on.
-    functions = types.ModuleType("pyspark.sql.functions")
-    functions.lit = lambda v: f"lit({v})"
-    functions.col = lambda c: c
-    functions.coalesce = lambda *a: f"coalesce({','.join(str(x) for x in a)})"
-    sql_mod = types.ModuleType("pyspark.sql")
-    sql_mod.functions = functions
-    root_mod = types.ModuleType("pyspark")
-    root_mod.sql = sql_mod
-    connect_mod = types.ModuleType("pyspark.sql.connect.dataframe")
-    connect_mod.DataFrame = FakeDF
-    for name, mod in (
-        ("pyspark", root_mod),
-        ("pyspark.sql", sql_mod),
-        ("pyspark.sql.functions", functions),
-        ("pyspark.sql.connect", types.ModuleType("pyspark.sql.connect")),
-        ("pyspark.sql.connect.dataframe", connect_mod),
-    ):
-        monkeypatch.setitem(sys.modules, name, mod)
+    _stub_pyspark(monkeypatch, FakeDF)
 
     class FakeReader:
         def csv(self, path, *a, **k):
@@ -197,3 +217,85 @@ def test_an_untagged_frame_is_untouched(patched):
     assert plain.columns == ["a", "b"]
     assert plain.collect() == [("a", "b")]
     assert plain.write == "writer(a,b)"
+
+
+def test_the_engine_probe_answers_both_ways(stubs):
+    # `install()` is a no-op on an engine that already has the function — that
+    # is what keeps the JVM overlay's real implementation from being shadowed
+    # by an approximation, so both answers matter.
+    input_file = stubs
+
+    class Has:
+        def range(self, _n):
+            return self
+
+        def select(self, *_a):
+            return self
+
+        def collect(self):
+            return [1]
+
+    class Lacks:
+        def range(self, _n):
+            raise RuntimeError("function: input_file_name")
+
+    assert input_file.engine_has_input_file_name(Has()) is True
+    assert input_file.engine_has_input_file_name(Lacks()) is False
+
+
+def test_listing_files_behind_a_local_path(stubs, tmp_path):
+    # The lister is what turns one glob read into a read per file, which is how
+    # each row can carry the file it truly came from. Order is asserted because
+    # the per-file union is positional: an unstable order would silently
+    # misalign rows against their paths.
+    input_file = stubs
+    for name in ("part-0003.csv", "part-0001.csv", "part-0002.csv"):
+        (tmp_path / name).write_text("id\n1\n")
+    (tmp_path / "notes.txt").write_text("ignore me")
+
+    got = input_file._list_files(str(tmp_path / "*.csv"))
+    assert [p.rsplit("/", 1)[-1] for p in got] == [
+        "part-0001.csv",
+        "part-0002.csv",
+        "part-0003.csv",
+    ]
+
+
+def test_a_glob_in_a_directory_segment_is_refused(stubs):
+    # Expanding a directory glob would need a listing per candidate directory,
+    # so the module keeps the plain glob read instead and the tag degrades to
+    # the glob string: coarse, but honest. An empty list is what signals that.
+    assert stubs._list_files("/landing/*/customers/part-0001.csv") == []
+
+
+def test_a_single_file_read_carries_its_own_path(patched, monkeypatch):
+    # The tagging path itself: one file in, one tagged frame out, and the tag
+    # holds THAT file rather than the glob it was asked for.
+    input_file, FakeDF = patched
+    tagged_with = {}
+
+    class Reader:
+        def csv(self, path, *a, **k):
+            return FakeDF(["id", "name"])
+
+    monkeypatch.setattr(input_file, "_list_files", lambda _p: ["/landing/part-0007.csv"])
+
+    class Spark:
+        read = Reader()
+
+    # Re-install against this reader so the wrapper is the one under test.
+    original_with_column = FakeDF.withColumn if hasattr(FakeDF, "withColumn") else None
+
+    def withColumn(self, name, value):  # noqa: N802 - PySpark's spelling
+        tagged_with[name] = value
+        return type(self)([*self._cols, name])
+
+    FakeDF.withColumn = withColumn
+    monkeypatch.setattr(input_file, "engine_has_input_file_name", lambda _s: False)
+    input_file.install(Spark())
+
+    out = Spark.read.csv("/landing/*.csv")
+    assert TAG in out._cols, "a file read must carry the tag for provenance to resolve"
+    assert "part-0007.csv" in str(tagged_with[TAG]), "the tag must name the file, not the glob"
+    if original_with_column is None:
+        del FakeDF.withColumn

--- a/python/tests/test_input_file_shim.py
+++ b/python/tests/test_input_file_shim.py
@@ -100,9 +100,30 @@ def patched(monkeypatch):
     input_file = input_file_mod
     FakeDF = type("FakeDF", (FakeDFBase,), {})
 
+    # STUB THE WHOLE PYSPARK SURFACE THIS MODULE IMPORTS, rather than relying on
+    # pyspark being installed. It is not installed in CI — the agent's imports
+    # are why `unresolved-import` is ignored for the type checker — and these
+    # tests passed locally only because a development venv happened to carry
+    # `pyspark-client`. A test that depends on an ambient package tests the
+    # machine it runs on.
+    functions = types.ModuleType("pyspark.sql.functions")
+    functions.lit = lambda v: f"lit({v})"
+    functions.col = lambda c: c
+    functions.coalesce = lambda *a: f"coalesce({','.join(str(x) for x in a)})"
+    sql_mod = types.ModuleType("pyspark.sql")
+    sql_mod.functions = functions
+    root_mod = types.ModuleType("pyspark")
+    root_mod.sql = sql_mod
     connect_mod = types.ModuleType("pyspark.sql.connect.dataframe")
     connect_mod.DataFrame = FakeDF
-    monkeypatch.setitem(sys.modules, "pyspark.sql.connect.dataframe", connect_mod)
+    for name, mod in (
+        ("pyspark", root_mod),
+        ("pyspark.sql", sql_mod),
+        ("pyspark.sql.functions", functions),
+        ("pyspark.sql.connect", types.ModuleType("pyspark.sql.connect")),
+        ("pyspark.sql.connect.dataframe", connect_mod),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
 
     class FakeReader:
         def csv(self, path, *a, **k):

--- a/python/tests/test_input_file_shim.py
+++ b/python/tests/test_input_file_shim.py
@@ -16,6 +16,7 @@ checked is which frame each surface delegates to, and that is a property of the
 patching, not of Spark.
 """
 
+import os
 import sys
 import types
 from pathlib import Path
@@ -254,7 +255,9 @@ def test_listing_files_behind_a_local_path(stubs, tmp_path):
     (tmp_path / "notes.txt").write_text("ignore me")
 
     got = input_file._list_files(str(tmp_path / "*.csv"))
-    assert [p.rsplit("/", 1)[-1] for p in got] == [
+    # os.path.basename, not a "/" split: glob returns the platform's own
+    # separator, and CI runs this on Windows too.
+    assert [os.path.basename(p) for p in got] == [
         "part-0001.csv",
         "part-0002.csv",
         "part-0003.csv",


### PR DESCRIPTION
Fixes #203.

## What was wrong

The `input_file_name()` shim tags every file read with `__emu_input_file_name` and strips it at `.write`. Persisted data was therefore clean — but the **schema a notebook can observe** was not. `len(df.columns)` returned one more column than the file had, on every file read in the shipped stack (0.20.0, 0.21.0, 0.22.0).

`docs/37-runtime-fidelity-gaps.md` already names `df.columns`, `printSchema`, `SELECT *` and `toPandas` as the leak this module must not create. It argues that as a reason not to tag *every* frame, and misses that tagging *file* frames leaks identically on those frames.

## Why it was expensive to find

Every surface measurable from outside the agent reported the right number: the vendor's nine export pages (101 columns), the nine landed parts read individually (101), a client Spark Connect session against the same Sail (101), and the written Delta table (101, because the write strips). Only the notebook, inside the agent, said 102 — and the table it produced was correct, so nothing downstream disagreed.

## The fix

One `_visible()` helper applied at each observable surface rather than only at write:

- schema: `columns`, `schema`, `dtypes`, `printSchema`
- rows: `collect`, `take`, `head`, `first`, `toPandas`, `toLocalIterator`, `show`
- views: `createOrReplaceTempView` and friends — how the tag would otherwise reach `SELECT *` on the SQL path, which no amount of write-stripping catches

**`select`/`selectExpr` are deliberately different.** That is where `input_file_name()` is *used*, and it resolves to the tag; hiding unconditionally there would make provenance impossible — trading one silent defect for another. So the tag stays visible to a select that references it, and is hidden from every other select. That is what makes `SELECT *` safe without breaking the module's purpose, and there is a test pinning it.

## Tests

7 tests on a module that had none, against a fake Connect DataFrame — what is under test is which frame each surface delegates to, which is a property of the patching rather than of Spark. Each test gets a freshly built class, because `install()` patches the class itself and a shared one would stack wrappers between tests and hide a partial fix behind a double drop.

Mutation-checked: disabling the hiding fails 5 of 7, and the 2 that still pass are the 2 that should be unaffected (the select-that-asks-for-the-tag, and the untagged-frame-passes-through).

## Verified end to end

`contoso-data-platform` fails at bronze with `AssertionError: (102, 101)` on stock 0.22.0, and runs **16/16 with an agent built from this branch**.

## Notes for review

- `python/spark_agent/input_file.py` is in the coverage omit list, so these tests will not move the gate unless it comes off. Not touched here; happy to follow the same reasoning applied to the Sail launcher if you prefer.
- `ty` reports 2 `invalid-assignment` diagnostics on `input_file.py` — both are present on clean `main` in the same environment and are unchanged by this PR.