### PR TITLE
A warehouse write announces itself, so gold stops looking unbuilt

### DIFF
--- a/internal/server/warehouselineage.go
+++ b/internal/server/warehouselineage.go
@@ -93,6 +93,20 @@ func (w *warehouseLineage) recordEdges(database string, f tsql.Flow) {
 	if !ok {
 		return
 	}
+	// ANNOUNCE THE WRITE, once per statement rather than once per source.
+	//
+	// The edges below give the graph its shape; this is what makes the node
+	// light. Without it a warehouse table sat grey through an entire run while
+	// every lakehouse table around it lit up — not because nothing was written,
+	// but because the only other emitter of a `table` event is a Delta commit
+	// in OneLake, and a warehouse is written over TDS instead. Grey therefore
+	// meant two different things, and a viewer had no way to tell "nothing
+	// happened here" from "this path is not instrumented".
+	//
+	// Before the loop: a table rebuilt from three sources is one write, and
+	// publishing per edge would report it three times. A statement with no
+	// resolvable sources (INSERT ... VALUES) is still a write, and still says so.
+	w.st.PublishWarehouseTable(target.workspaceID, target.itemID, target.path, activityNameFor(f.Kind))
 	for _, src := range w.sources(database, f.Sources) {
 		if src == target {
 			continue // a table rebuilt from itself is not a movement worth drawing
@@ -173,6 +187,17 @@ func (w *warehouseLineage) rename(database string, f tsql.Flow) {
 	if err := w.st.RenameLineagePath(from.itemID, from.path, to.path); err != nil {
 		log.Printf("lineage: renaming %s to %s: %v", from.path, to.path, err)
 	}
+	// THE RENAME IS WHEN THE VISIBLE TABLE APPEARS, so it announces itself too.
+	//
+	// dbt-fabric builds into `<model>__dbt_temp` and swaps: the CTAS above
+	// announced a write, but under a name the graph does not draw, because the
+	// edges were moved onto the real name by exactly this call. Publishing only
+	// on the CTAS lit nothing — measured against a real dbt build, where all
+	// nine gold tables emitted events named `..._dbt_temp` while every node a
+	// viewer can see stayed grey. The temp event stays: that write did happen,
+	// and inventing a rule about which names are scaffolding would be guessing
+	// at one tool's convention.
+	w.st.PublishWarehouseTable(to.workspaceID, to.itemID, to.path, activityNameFor(f.Kind))
 }
 
 // drop retires the edges into a dropped object: a table that no longer exists

--- a/internal/server/warehouselineage_events_test.go
+++ b/internal/server/warehouselineage_events_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/calvinchengx/fabric-emulator/internal/store"
+	"github.com/calvinchengx/fabric-emulator/internal/tsql"
+)
+
+// A warehouse write must ANNOUNCE ITSELF, not only be recorded.
+//
+// The flow view lights a node on a `table` event, and until this the only
+// emitter was a Delta commit in OneLake. A warehouse is written over TDS, so a
+// dbt-built gold layer appeared in the graph — correctly connected, by edges
+// this same observer records — and stayed grey for an entire run. Grey then
+// meant two different things: "nothing was written here" and "this path is not
+// instrumented", with nothing on screen to tell them apart.
+
+// tableEvents drains the subscription and keeps the table events.
+func tableEvents(t *testing.T, sub *store.Subscription) []store.Event {
+	t.Helper()
+	var out []store.Event
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == store.KindTable {
+				out = append(out, ev)
+			}
+		case <-time.After(200 * time.Millisecond):
+			return out
+		}
+	}
+}
+
+func TestWarehouseWriteAnnouncesTheTable(t *testing.T) {
+	f := newLineageFixture(t)
+	sub := f.st.Subscribe()
+	defer sub.Close()
+
+	f.observe(`CREATE TABLE dbo.fct_sales AS SELECT * FROM dbo.silver_orders`)
+
+	got := tableEvents(t, sub)
+	if len(got) != 1 {
+		t.Fatalf("got %d table events, want 1: %+v", len(got), got)
+	}
+	if got[0].Table != "Tables/fct_sales" {
+		t.Errorf("table = %q, want Tables/fct_sales", got[0].Table)
+	}
+	if got[0].ItemID != f.wh.ID {
+		t.Errorf("itemId = %q, want the warehouse", got[0].ItemID)
+	}
+	// The statement kind travels so the log can say what happened, matching
+	// what the lineage edge for the same write records.
+	if got[0].ActivityName == "" {
+		t.Error("no activity name: the log cannot say what kind of write this was")
+	}
+	// A warehouse has no Delta version. Inventing one would make a T-SQL write
+	// indistinguishable from a commit that really carried a version number.
+	if got[0].Version != nil {
+		t.Errorf("version = %v, want nil for a warehouse write", *got[0].Version)
+	}
+}
+
+func TestWarehouseWriteWithSeveralSourcesAnnouncesOnce(t *testing.T) {
+	// One statement is one write. Publishing per edge would report a table
+	// rebuilt from three sources three times, and the log is read by people.
+	f := newLineageFixture(t)
+	sub := f.st.Subscribe()
+	defer sub.Close()
+
+	f.observe(`CREATE TABLE dbo.fct_sales AS
+	           SELECT * FROM dbo.silver_orders
+	           JOIN dbo.silver_customers ON 1=1
+	           JOIN dbo.silver_party ON 1=1`)
+
+	if got := tableEvents(t, sub); len(got) != 1 {
+		t.Fatalf("got %d table events for one statement, want 1: %+v", len(got), got)
+	}
+}
+
+func TestStatementsThatWriteNoTableAnnounceNothing(t *testing.T) {
+	// A view holds no bytes and a drop removes them; neither is a write, and a
+	// node lighting up for either would be a lie in the direction that matters
+	// most — the graph claiming data moved when none did.
+	f := newLineageFixture(t)
+	sub := f.st.Subscribe()
+	defer sub.Close()
+
+	f.observe(`CREATE VIEW dbo.v AS SELECT * FROM dbo.silver_orders`)
+	f.observe(`DROP TABLE dbo.fct_sales`)
+
+	if got := tableEvents(t, sub); len(got) != 0 {
+		t.Fatalf("got %d table events, want none: %+v", len(got), got)
+	}
+}
+
+func TestAnUnresolvableTargetAnnouncesNothing(t *testing.T) {
+	// `resolve` refuses to guess which item a name belongs to. When it cannot,
+	// there is no node to light, and announcing anyway would put an event on the
+	// bus that names a table the graph does not have.
+	f := newLineageFixture(t)
+	sub := f.st.Subscribe()
+	defer sub.Close()
+
+	f.wl.observe("no-such-database", tsql.DataFlows(
+		`CREATE TABLE dbo.fct_sales AS SELECT * FROM dbo.silver_orders`))
+
+	if got := tableEvents(t, sub); len(got) != 0 {
+		t.Fatalf("got %d table events for an unresolvable target, want none: %+v", len(got), got)
+	}
+}
+
+// TestDbtBuildAndSwapAnnouncesTheRealTable replays dbt-fabric's actual shape —
+// build into `<model>__dbt_temp`, then sp_rename into place.
+//
+// THIS IS THE CASE THE FIRST VERSION MISSED. Announcing only the CTAS was green
+// in unit tests that wrote straight to the final name, and lit nothing at all
+// against a real dbt build: every gold table emitted an event named
+// `..._dbt_temp`, which is not a node the graph draws, so all nine stayed grey.
+func TestDbtBuildAndSwapAnnouncesTheRealTable(t *testing.T) {
+	f := newLineageFixture(t)
+	sub := f.st.Subscribe()
+	defer sub.Close()
+
+	f.observe(`CREATE TABLE dbo.fct_sales__dbt_temp AS SELECT * FROM dbo.silver_orders`)
+	f.observe(`EXEC sp_rename 'dbo.fct_sales__dbt_temp', 'fct_sales'`)
+
+	var names []string
+	for _, ev := range tableEvents(t, sub) {
+		names = append(names, ev.Table)
+	}
+	found := false
+	for _, n := range names {
+		if n == "Tables/fct_sales" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no event named the real table; got %v", names)
+	}
+}

--- a/internal/store/lineage.go
+++ b/internal/store/lineage.go
@@ -193,6 +193,31 @@ target_workspace_id, target_item_id, target_path, producer, source_kind, created
 	return e, err
 }
 
+// PublishWarehouseTable announces a T-SQL write the TDS front saw accepted.
+//
+// WHY THIS EXISTS. A `table` event is what lights a node in the flow view, and
+// the only other emitter is a Delta commit in OneLake. A warehouse is not
+// written that way — dbt issues T-SQL over TDS into the engine — so a gold
+// layer appeared in the graph, correctly connected by ProducerWarehouse edges,
+// and stayed grey for the whole run. To a viewer, grey means nothing happened
+// here; the most important step of a medallion looked like the one step that
+// never ran.
+//
+// NO VERSION, deliberately. `Version` is a Delta commit number and a warehouse
+// has none; the field stays nil rather than inventing a plausible integer.
+//
+// NO ATTRIBUTION either, for the reason that type documents: attribution is
+// never inferred. The TDS front knows a statement was accepted, not which job
+// or activity issued it, so the field stays empty rather than guessing. The
+// statement KIND travels in ActivityName — `CTAS`, `INSERT` — which is what the
+// lineage edge for the same write already records.
+func (s *Store) PublishWarehouseTable(workspaceID, itemID, table, activity string) {
+	s.publish(Event{
+		Kind: KindTable, WorkspaceID: workspaceID, ItemID: itemID,
+		Table: table, ActivityName: activity,
+	})
+}
+
 // PublishQuery reports a read of a semantic model — the Power BI end of a
 // flow. It is an event and not an edge on purpose: a query moves no data into
 // anything, and lineage_edges records movement.


### PR DESCRIPTION
## What was wrong

The flow view lights a node on a `table` event, and the only emitter was a Delta commit in OneLake (`internal/store/delta_commit.go`). A warehouse is not written that way — dbt issues T-SQL over TDS — so a gold layer appeared in the graph, correctly connected by the `ProducerWarehouse` edges this same observer already records, and **stayed grey for the whole run** while every lakehouse table around it lit up.

Grey therefore meant two different things: *nothing was written here* and *this path is not instrumented*, with nothing on screen to tell them apart. The gold build is the most important step in a medallion demo and it was the one step the view could not corroborate.

## The fix

`PublishWarehouseTable` fires where the TDS front already observes an accepted write — once per statement rather than once per source edge, since a table rebuilt from three inputs is one write.

No fabricated Delta version (a warehouse has none, so the field stays nil rather than inventing a plausible integer) and no invented attribution (the TDS front knows a statement was accepted, not which job issued it — and `Attribution`'s own docs say it is never inferred). The statement kind travels in `ActivityName`, matching what the lineage edge for the same write records.

**The rename announces too, and that half was found by running it.** dbt-fabric builds into `<model>__dbt_temp` and `sp_rename`s it into place. Publishing only on the CTAS was green in unit tests that wrote straight to the final name — and against a real dbt build it emitted nine events all named `..._dbt_temp`, which are not nodes the graph draws, so all nine gold nodes still stayed grey. The temp event stays: that write really happened, and suppressing names by pattern would be guessing at one tool's convention.

## Tests

Five, mutation-checked:

- a write announces its table, with the item, the statement kind, and no version
- one statement with several sources announces **once**
- views and drops announce nothing (a node lighting for either would claim data moved when none did)
- an unresolvable target announces nothing
- dbt's build-and-swap sequence announces the **real** table

Removing either publish fails exactly the tests that assert it, and leaves the negative tests passing.

## Verified end to end

Against `contoso-data-platform`'s pipeline, capturing `/_emulator/events` for a full run:

```
gold tables emitting under their REAL name: 9
  Tables/dim_country, dim_customer, dim_date, dim_party, dim_product,
  fct_daily_revenue, fct_orders, fct_revenue_summary, fct_sales
temp-name events (the scaffolding write, also real): 9
```

Before this change: zero table events from the warehouse, on any run.