### PR TITLE
fix(ci): run the three make-check gates CI never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,31 @@ jobs:
       # out still builds and still has a URL, but nothing links to it, so it is
       # published and unreachable. Same drift, same guard.
       - run: uv run --frozen --no-sync python scripts/check_docs_sidebar.py
+      # THE ONE `make check` RAN AND CI DID NOT. Every example must resolve its
+      # target through the `fabric-target` contract — no pinned seed principal,
+      # no localhost endpoint outside the resolver, no emulator-only lever, and
+      # every `definitions/` folder in Fabric's own source format. That is the
+      # whole segregation boundary between "code that runs on Fabric" and "code
+      # that runs here", and it was enforced only on the machine of whoever
+      # happened to type `make check`.
+      #
+      # It never failed, which is exactly why the gap survived: a check that
+      # passes is indistinguishable from a check that is running. Its unit test
+      # exercises the checker's LOGIC against synthetic trees
+      # (`cep.ROOT = tmp_path`) and never points it at this repo's own
+      # `examples/`, so nothing in CI touched the real files either.
+      - run: uv run --frozen --no-sync python scripts/check_example_portability.py
+      # Same gap, and this one is a PRIVACY claim: capture_definition_shape.py
+      # redacts a private tenant's values before a shape is printed to a public
+      # log, and its own docstring says a redactor that passes one value through
+      # "publishes a real customer's hostname forever". The capture runs from
+      # real-fabric.yml's workflow_dispatch, which has itself never run — so
+      # neither the redactor nor its test had ever executed in CI.
+      - run: uv run --frozen --no-sync python scripts/check_capture_redaction.py
+      # And the third: the retry in e2e/entra_install.py, asserted in both
+      # directions because "too narrow" and "too broad" look identical in a
+      # green log.
+      - run: uv run --frozen --no-sync python scripts/check_entra_install.py
       # The portal's event-kind list is GENERATED from internal/store/bus.go.
       # The stream names each SSE frame and EventSource has no wildcard
       # listener, so a kind missing from the client is invisible — no error,

--- a/python/tests/test_make_check_runs_in_ci.py
+++ b/python/tests/test_make_check_runs_in_ci.py
@@ -1,0 +1,82 @@
+"""Every invariant `make check` runs, CI runs too.
+
+WHY THIS EXISTS. `make check` is described in the Makefile as "the checks that
+used to exist only in CI". The drift went the other way and nobody noticed:
+three of its eleven scripts were never invoked by `ci.yml`, so they ran only on
+the machine of whoever happened to type `make check`.
+
+- `check_example_portability.py` — the whole segregation boundary between code
+  that runs on Fabric and code that runs here.
+- `check_capture_redaction.py` — a PRIVACY assertion, whose own docstring warns
+  that a redactor passing one value through "publishes a real customer's
+  hostname forever".
+- `check_entra_install.py` — a retry asserted in both directions.
+
+All three passed the entire time, which is why the gap survived: **a check that
+passes is indistinguishable from a check that is running.** The only way to tell
+them apart is to ask which one CI invokes, and nothing asked.
+
+Fixing the three instances would leave the shape intact — the next script added
+to `make check` repeats it silently. So the list is asserted instead.
+"""
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MAKEFILE = REPO / "Makefile"
+CI = REPO / ".github" / "workflows" / "ci.yml"
+
+# Scripts deliberately local-only belong here WITH A REASON, so an exemption is
+# a decision someone wrote down rather than an omission nobody saw. Empty today.
+LOCAL_ONLY: dict[str, str] = {}
+
+
+def _check_target_scripts() -> set[str]:
+    """The scripts the Makefile's `check` target runs."""
+    text = MAKEFILE.read_text(encoding="utf-8")
+    body, seen = [], False
+    for line in text.split("\n"):
+        if line.startswith("check:"):
+            seen = True
+            continue
+        if seen:
+            # A recipe line is TAB-indented; the first non-tab, non-blank line
+            # after it ends the target.
+            if line.startswith("\t"):
+                body.append(line)
+            elif line.strip():
+                break
+    return set(re.findall(r"scripts/([a-z_0-9]+)\.py", "\n".join(body)))
+
+
+def test_the_makefile_target_is_parsed_at_all():
+    """A parser that silently matches nothing turns this whole file into a
+    vacuous pass — the exact defect it exists to prevent, one level up."""
+    scripts = _check_target_scripts()
+    assert len(scripts) >= 8, f"parsed {len(scripts)} scripts from `make check`; the parser is broken"
+    assert "check_witnesses" in scripts
+
+
+def test_every_make_check_script_is_also_invoked_by_ci():
+    ci = CI.read_text(encoding="utf-8")
+    missing = sorted(
+        s for s in _check_target_scripts()
+        if s not in LOCAL_ONLY and f"scripts/{s}.py" not in ci
+    )
+    assert not missing, (
+        "`make check` runs these and ci.yml does not, so they are enforced only "
+        f"on a developer's laptop: {missing}\n"
+        "Add them to the repo-invariants job, or record an exemption with its "
+        "reason in LOCAL_ONLY."
+    )
+
+
+def test_exemptions_carry_a_reason():
+    """An exemption with an empty reason is an omission wearing a decision's
+    clothes."""
+    for name, why in LOCAL_ONLY.items():
+        assert why.strip(), f"{name} is exempt with no reason given"
+        assert f"scripts/{name}.py" in MAKEFILE.read_text(encoding="utf-8"), (
+            f"{name} is exempt but `make check` no longer runs it — a stale "
+            "exemption hides the next real omission"
+        )


### PR DESCRIPTION
Found auditing `main` at v0.24.0. `make check` is described in the Makefile as *"the checks that used to exist only in CI"* — the drift went the other way, and **three of its eleven scripts were never invoked by `ci.yml`**:

| Script | What it guards |
|---|---|
| `check_example_portability.py` | The whole segregation boundary: no pinned seed principal, no localhost endpoint outside the resolver, no emulator-only lever, every `definitions/` folder in Fabric's source format |
| `check_capture_redaction.py` | **A privacy claim.** Its own docstring: a redactor that passes one value through "publishes a real customer's hostname forever" |
| `check_entra_install.py` | A retry asserted in both directions, because "too narrow" and "too broad" look identical in a green log |

**All three pass, and passed the whole time — which is why the gap survived.** A check that passes is indistinguishable from a check that is running. The only way to tell them apart is to ask which one CI invokes, and nothing asked.

The redaction one is the sharpest: the capture it protects runs from `real-fabric.yml`'s `workflow_dispatch`, which has itself never run. So neither the redactor nor its test had ever executed in CI, on a path whose failure mode is publishing a private tenant's values to a public log.

## The structural half

Fixing three instances would leave the shape intact — the next script added to `make check` repeats it silently. So `test_make_check_runs_in_ci.py` asserts the two lists agree, with exemptions requiring a written reason (empty today) and stale exemptions failing too.

**Four mutants, four caught**: a gate removed from `ci.yml`, the Makefile parser matching nothing (which would make the whole file a vacuous pass — the same defect one level up), an exemption with an empty reason, and an exemption naming a script `make check` no longer runs.

Full gate green: ruff, ty, 721 Python tests, `check_workflow_concurrency`, and `ci.yml` still parses as YAML.