### PR TITLE
fix: the sc-facade oracle never ran, and when it did it found a real defect

### DIFF
--- a/e2e/spark-jvm/docker-compose.yml
+++ b/e2e/spark-jvm/docker-compose.yml
@@ -46,6 +46,11 @@ services:
         condition: service_healthy
     volumes:
       - ./job.py:/opt/spark/work-dir/job.py:ro
+      # The sc-facade contract, beside job.py so `import rdd_contract` resolves
+      # from spark-submit's own script directory. Mounted rather than copied:
+      # ONE definition is the entire point — the facade's unit tests and this
+      # job must assert the same list, or each is only checking its author.
+      - ../../python/spark_agent/rdd_contract.py:/opt/spark/work-dir/rdd_contract.py:ro
     command:
       - /opt/spark/bin/spark-submit
       - --master

--- a/e2e/spark-jvm/job.py
+++ b/e2e/spark-jvm/job.py
@@ -95,6 +95,16 @@ for _label, _snippet, _expected in rdd_contract.CASES:
     assert _got == _expected, f"{_label}: real Spark gave {_got!r}, contract says {_expected!r}"
 for _label, _snippet in rdd_contract.VOID_CASES:
     assert eval(_snippet, {"sc": spark.sparkContext}) is None, _label  # noqa: S307
+# And what Spark REFUSES, because a contract that only lists what works cannot
+# catch the facade being MORE PERMISSIVE than the tenant — which is exactly the
+# defect this half found on its first real run.
+for _label, _snippet in rdd_contract.REFUSED_CASES:
+    try:
+        eval(_snippet, {"sc": spark.sparkContext})  # noqa: S307
+    except Exception:  # noqa: BLE001 — any refusal is the contract; the type is Spark's
+        pass
+    else:
+        raise AssertionError(f"{_label}: real Spark ACCEPTED what the contract says it refuses")
 print(f"sc-facade contract vs real Spark: {len(rdd_contract.CASES)} cases PASS", flush=True)
 assert spark._jvm.java.lang.Class.forName("com.calvinchengx.fabricemu.EntraTokenProvider") is not None
 print("SparkContext/RDD + JVM/JAR bridge: PASS", flush=True)

--- a/e2e/spark-jvm/job.py
+++ b/e2e/spark-jvm/job.py
@@ -1,7 +1,5 @@
 """Apache Spark 3.5 / Delta 3.2 compatibility witness for Fabric Runtime 1.3."""
 import json
-import pathlib
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -85,7 +83,11 @@ assert spark.sparkContext.parallelize([1, 2, 3]).sum() == 6
 # tests prove the facade matches the contract, and this proves the contract
 # matches Spark. Without this, the expected values would be a claim about
 # whoever wrote the facade.
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "python" / "spark_agent"))
+# Mounted beside this file by docker-compose.yml, so spark-submit's own script
+# directory resolves it. The previous version computed a HOST path
+# (`parents[2]/python/spark_agent`) that does not exist inside the container,
+# so this import raised ModuleNotFoundError and the whole oracle never ran —
+# discovered only by dispatching the weekly workflow by hand.
 import rdd_contract  # noqa: E402
 
 for _label, _snippet, _expected in rdd_contract.CASES:

--- a/python/spark_agent/rdd_contract.py
+++ b/python/spark_agent/rdd_contract.py
@@ -25,9 +25,22 @@ CASES = [
     ("parallelize.collect", "sc.parallelize([3, 1, 2]).collect()", [3, 1, 2]),
     ("parallelize.filter.collect", "sc.parallelize([1, 2, 3, 4]).filter(lambda x: x % 2 == 0).collect()", [2, 4]),
     ("parallelize.map.collect", "sc.parallelize([1, 2]).map(lambda x: x + 10).collect()", [11, 12]),
-    # The exact shape of Microsoft's diagnostic-emitter smoke idiom:
-    # `sc.parallelize(Seq(1,2,3,4)).toDF().count()`.
-    ("parallelize.toDF.count", "sc.parallelize([1, 2, 3, 4]).toDF().count()", 4),
+    # Microsoft's diagnostic-emitter idiom is `sc.parallelize(Seq(1,2,3,4)).toDF()`
+    # — SCALA, where implicits supply the encoder. PySpark has no equivalent and
+    # REFUSES an RDD of bare scalars (see REFUSED_CASES). So the reachable form
+    # is a row shape, which is what a Python notebook must write anyway.
+    ("parallelize.toDF.count", "sc.parallelize([(1,), (2,), (3,), (4,)]).toDF().count()", 4),
+]
+
+# Cases real PySpark REFUSES, which the facade must refuse too.
+#
+# This list exists because the JVM oracle caught the facade being MORE PERMISSIVE
+# than Spark: it wrapped bare scalars into one-tuples and returned a DataFrame,
+# where PySpark raises CANNOT_INFER_SCHEMA_FOR_TYPE. Accepting what a tenant
+# rejects is the emulator-green/tenant-broken direction, and it came from
+# transcribing a Scala snippet into a Python contract.
+REFUSED_CASES = [
+    ("parallelize.toDF.scalars", "sc.parallelize([1, 2, 3, 4]).toDF()"),
 ]
 
 # Returns None on both a real SparkContext and the facade; asserted separately

--- a/python/spark_agent/rddfacade.py
+++ b/python/spark_agent/rddfacade.py
@@ -79,10 +79,24 @@ class LocalRDD:
         """
         if self._session is None:
             raise _refuse("rdd.toDF()", " No Spark session is attached.")
-        rows = [x if isinstance(x, (tuple, list)) else (x,) for x in self._data]
+        # Scalars are REFUSED, exactly as PySpark refuses them. An earlier
+        # version wrapped them into one-tuples and succeeded, which the JVM
+        # oracle caught: real Spark raises CANNOT_INFER_SCHEMA_FOR_TYPE. The
+        # `sc.parallelize(Seq(1,2,3,4)).toDF()` idiom in Microsoft's docs is
+        # SCALA, where implicits supply the encoder; accepting it here made the
+        # emulator more permissive than the tenant, which is the direction that
+        # ships broken code.
+        bad = next((x for x in self._data if not isinstance(x, (tuple, list, dict))), None)
+        if bad is not None:
+            raise TypeError(
+                f"[CANNOT_INFER_SCHEMA_FOR_TYPE] Can not infer schema for type: "
+                f"`{type(bad).__name__}`. Real PySpark refuses this too — "
+                f"`toDF()` needs a row shape. Use "
+                f"`sc.parallelize([(1,), (2,)]).toDF()`, or pass a schema."
+            )
         if schema is not None:
-            return self._session.createDataFrame(rows, schema)
-        return self._session.createDataFrame(rows, ["_1"])
+            return self._session.createDataFrame(list(self._data), schema)
+        return self._session.createDataFrame(list(self._data))
 
     # -- everything else ------------------------------------------------------
     def __getattr__(self, name):

--- a/python/tests/test_rddfacade.py
+++ b/python/tests/test_rddfacade.py
@@ -69,6 +69,7 @@ def test_the_contract_is_not_empty():
     """A parametrized suite over an empty list passes while testing nothing."""
     assert len(rdd_contract.CASES) >= 5
     assert rdd_contract.VOID_CASES
+    assert rdd_contract.REFUSED_CASES, "no refusal is pinned, so over-permissiveness is unchecked"
 
 
 # --- setLogLevel really does something ---------------------------------------
@@ -148,14 +149,41 @@ def test_the_refusal_explains_it_is_a_protocol_limit_not_a_sail_gap(sc):
 
 # --- toDF, the shape Microsoft's smoke idiom needs ---------------------------
 
-def test_todf_wraps_scalars_because_createdataframe_needs_rows():
+def test_todf_refuses_scalars_exactly_as_pyspark_does():
+    """This test asserted the OPPOSITE and was wrong, which the JVM oracle
+    caught the first time it ran.
+
+    The facade wrapped bare scalars into one-tuples and returned a DataFrame.
+    Real PySpark raises CANNOT_INFER_SCHEMA_FOR_TYPE. The idiom that inspired
+    it — `sc.parallelize(Seq(1,2,3,4)).toDF()` in Microsoft's diagnostic-emitter
+    docs — is SCALA, where implicits supply the encoder, and transcribing it
+    into a Python contract made the emulator accept what a tenant rejects.
+    """
+    sc = rddfacade.SparkContextFacade(_FakeSession())
+    with pytest.raises(TypeError) as e:
+        sc.parallelize([1, 2, 3]).toDF()
+    msg = str(e.value)
+    assert "CANNOT_INFER_SCHEMA_FOR_TYPE" in msg, "does not name Spark's own error"
+    assert "(1,)" in msg, "the refusal shows no working form"
+
+
+@pytest.mark.parametrize("label,snippet",
+                         rdd_contract.REFUSED_CASES, ids=[c[0] for c in rdd_contract.REFUSED_CASES])
+def test_the_refused_contract_cases_are_refused(label, snippet):
+    """Same list the JVM oracle asserts real Spark refuses."""
+    sc = rddfacade.SparkContextFacade(_FakeSession())
+    with pytest.raises((TypeError, NotImplementedError)):
+        eval(snippet, {"sc": sc})  # noqa: S307
+
+
+def test_todf_accepts_the_row_shape_pyspark_accepts():
     session = _FakeSession()
     sc = rddfacade.SparkContextFacade(session)
-    sc.parallelize([1, 2, 3]).toDF()
+    sc.parallelize([(1,), (2,)]).toDF()
     assert session.created is not None
     rows, schema = session.created
-    assert rows == [(1,), (2,), (3,)], "scalars were not wrapped into row shape"
-    assert schema == ["_1"]
+    assert rows == [(1,), (2,)]
+    assert schema is None, "no schema should be invented when none was given"
 
 
 def test_todf_passes_an_explicit_schema_through():


### PR DESCRIPTION
Two bugs, both mine, both in code merged yesterday as #202. Found by auditing `main` and dispatching the weekly workflow by hand.

## 1. The oracle could not import its own contract

#202 claimed *"the JVM job proves the contract matches Spark."* The job mounts **only** `job.py` into the container, and my `sys.path.insert` computed a HOST path (`parents[2]/python/spark_agent`) that does not exist there. Result:

```
import rdd_contract
ModuleNotFoundError: No module named 'rdd_contract'
```

It failed at import and evaluated nothing. **The claim was false from the moment it merged**, and the next Tuesday cron would have failed identically. I wrote a module docstring saying "either alone would be a claim about my own head" and then never ran the half that was supposed to answer that.

Fixed by mounting `rdd_contract.py` beside `job.py`, so `import` resolves from spark-submit's own script directory.

## 2. With the import fixed, the oracle immediately caught a fidelity defect

```
PySparkTypeError: [CANNOT_INFER_SCHEMA_FOR_TYPE] Can not infer schema for type: `int`
```

My facade wrapped bare scalars into one-tuples and returned a DataFrame. **Real PySpark refuses.** The idiom I built it from — `sc.parallelize(Seq(1,2,3,4)).toDF()` in Microsoft's diagnostic-emitter docs — is **Scala**, where implicits supply the encoder. I transcribed Scala semantics into a Python facade, and the result was the emulator accepting what a tenant rejects: the emulator-green/tenant-broken direction.

- `toDF()` now refuses scalars, naming Spark's own error and showing the working form.
- The contract gained **`REFUSED_CASES`** — what Spark *rejects*. Without it a contract can only catch the facade being too STRICT, never too permissive, and too permissive is the direction that ships broken code.
- The oracle asserts the refusals too, and fails if real Spark *accepts* something the contract claims it refuses.
- The unit test that asserted scalar-wrapping was wrong; it now asserts the refusal, with the reason recorded.

## Verified, not assumed

Dispatched against this branch before opening the PR — the step whose absence caused all of this:

```
sc-facade contract vs real Spark: 7 cases PASS
SparkContext/RDD + JVM/JAR bridge: PASS
```

Both jobs green, and that line is printed by the contract loop itself, so the assertions demonstrably executed rather than being skipped.

720 Python tests, ruff, ty green locally.