### PR TITLE
feat(ci): assert every cron-only workflow has run since it changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,15 @@ jobs:
     name: Every supported parity claim names its witness
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # `actions: read` ON TOP OF the workflow's `contents: read`, for exactly one
+    # step: check_cron_workflow_freshness reads run history via `gh run list`.
+    # Without it that call fails, every workflow lands in "unknown", and the
+    # check PASSES having verified nothing — the silent no-op it exists to
+    # catch. The script now fails loudly under GITHUB_ACTIONS instead, so a
+    # future permissions trim breaks the build rather than the guarantee.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -420,6 +429,15 @@ jobs:
       # directions because "too narrow" and "too broad" look identical in a
       # green log.
       - run: uv run --frozen --no-sync python scripts/check_entra_install.py
+      # A cron-only workflow is not proved by the next commit — a change to it
+      # is unverified until the schedule fires, which can be a week. Three such
+      # fixes landed in one week and none had executed; one was BROKEN (the
+      # sc-facade oracle died on ModuleNotFoundError and evaluated nothing) and
+      # nothing in the diffs distinguished it from the two that were fine.
+      # Skips cleanly where `gh` is unavailable, so a fork still builds.
+      - run: uv run --frozen --no-sync python scripts/check_cron_workflow_freshness.py
+        env:
+          GH_TOKEN: ${{ github.token }}
       # The portal's event-kind list is GENERATED from internal/store/bus.go.
       # The stream names each SSE frame and EventSource has no wildcard
       # listener, so a kind missing from the client is invisible — no error,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,10 @@ jobs:
       - run: uv run --frozen --no-sync python scripts/check_cron_workflow_freshness.py
         env:
           GH_TOKEN: ${{ github.token }}
+          # Only this job holds the token, so only this job asserts. Elsewhere
+          # (`make check` on a laptop, or the make-targets job) it skips rather
+          # than failing something that cannot see the answer.
+          FRESHNESS_STRICT: "1"
       # The portal's event-kind list is GENERATED from internal/store/bus.go.
       # The stream names each SSE frame and EventSource has no wildcard
       # listener, so a kind missing from the client is invisible — no error,

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_arch_services.py
 	@$(PY) scripts/check_docs_sidebar.py
 	@$(PY) scripts/check_workflow_concurrency.py
+	@$(PY) scripts/check_cron_workflow_freshness.py
 	@$(PY) scripts/gen_event_kinds.py --check
 	@$(PY) scripts/check_capture_redaction.py
 	@$(PY) scripts/check_entra_install.py

--- a/python/tests/test_cron_workflow_freshness.py
+++ b/python/tests/test_cron_workflow_freshness.py
@@ -91,3 +91,129 @@ def test_exemptions_carry_a_reason():
         assert (REPO / ".github" / "workflows" / name).exists(), (
             f"{name} is exempt but no longer exists — a stale exemption hides "
             "the next real one")
+
+
+# --- the logic around the subprocess boundary --------------------------------
+#
+# Mocked at `subprocess.run`, which is the only place this script touches the
+# world. Everything above it — staleness, strictness, which failure is fatal —
+# is ordinary logic and is asserted here rather than discovered on a runner,
+# which is how the last four defects in this file were found.
+
+import subprocess  # noqa: E402
+import types  # noqa: E402
+
+import pytest  # noqa: E402
+
+
+def _completed(stdout="", returncode=0, stderr=""):
+    return types.SimpleNamespace(stdout=stdout, returncode=returncode, stderr=stderr)
+
+
+@pytest.fixture
+def run(monkeypatch):
+    """Script every subprocess call by the command's shape."""
+    calls = []
+
+    def fake(args, **kw):
+        calls.append(args)
+        if args[:2] == ["git", "rev-parse"] and "--is-shallow-repository" in args:
+            return _completed(fake.shallow)
+        if args[:2] == ["git", "log"]:
+            return _completed(fake.changed)
+        if args[:2] == ["gh", "repo"]:
+            return _completed("calvinchengx/fabric-emulator")
+        if args[:2] == ["gh", "api"]:
+            return _completed(fake.api, fake.api_rc, fake.api_err)
+        if args[:3] == ["gh", "run", "list"]:
+            return _completed(fake.runs, fake.runs_rc, fake.runs_err)
+        return _completed()
+
+    fake.shallow, fake.changed = "false", "1000"
+    fake.api, fake.api_rc, fake.api_err = "", 0, ""
+    fake.runs, fake.runs_rc, fake.runs_err = '[{"createdAt":"2030-01-01T00:00:00Z","conclusion":"success"}]', 0, ""
+    fake.calls = calls
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(cwf.subprocess, "run", fake)
+    monkeypatch.delenv("FRESHNESS_STRICT", raising=False)
+    return fake
+
+
+def test_a_run_after_the_change_is_fresh(run, capsys):
+    assert cwf.main() == 0
+    assert "has run since its last change" in capsys.readouterr().out
+
+
+def test_a_run_before_the_change_is_stale(run, capsys):
+    run.runs = '[{"createdAt":"1970-01-01T00:00:10Z","conclusion":"success"}]'
+    assert cwf.main() == 1
+    out = capsys.readouterr().out
+    assert "changed since they last ran" in out
+    assert "gh workflow run" in out, "the failure names no remediation"
+
+
+def test_a_red_last_run_is_still_fresh(run, capsys):
+    """Freshness is 'did it execute', not 'did it pass'. A failing cron run
+    reports itself; conflating the two would hide staleness behind a red."""
+    run.runs = '[{"createdAt":"2030-01-01T00:00:00Z","conclusion":"failure"}]'
+    assert cwf.main() == 0
+
+
+def test_unreadable_run_history_skips_when_not_strict(run, capsys):
+    run.runs, run.runs_rc, run.runs_err = "", 1, "HTTP 403"
+    assert cwf.main() == 0
+    assert "HTTP 403" in capsys.readouterr().out, "the reason was swallowed"
+
+
+def test_unreadable_run_history_fails_when_strict(run, monkeypatch, capsys):
+    monkeypatch.setenv("FRESHNESS_STRICT", "1")
+    run.runs, run.runs_rc, run.runs_err = "", 1, "HTTP 403"
+    assert cwf.main() == 1
+    assert "could not be read" in capsys.readouterr().out
+
+
+def test_a_shallow_clone_reads_dates_from_the_api(run, capsys):
+    """git log on a depth-1 clone returns the TIP date for every file, so every
+    workflow looks changed-just-now. This is the fallback that replaced it."""
+    run.shallow = "true"
+    run.api = "2020-01-01T00:00:00Z"
+    assert cwf.main() == 0
+    out = capsys.readouterr().out
+    assert "shallow clone" in out
+    assert any(a[:2] == ["gh", "api"] for a in run.calls), "the API was never consulted"
+
+
+def test_the_api_call_is_pinned_to_a_sha(run, monkeypatch):
+    """Without `sha=` the API answers for the DEFAULT BRANCH, so a PR changing a
+    cron workflow reads main's history and is never flagged — the one case this
+    check exists for."""
+    run.shallow = "true"
+    run.api = "2020-01-01T00:00:00Z"
+    monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+    cwf.main()
+    api = [a for a in run.calls if a[:2] == ["gh", "api"]][0]
+    assert "sha=deadbeef" in api, f"not pinned: {api}"
+    # and the arguments must be well formed — a splice bug once produced
+    # `-f -f sha=S path=P`, which failed every lookup silently.
+    assert "-f -f" not in " ".join(api)
+    for i, tok in enumerate(api):
+        if tok == "-f":
+            assert "=" in api[i + 1], f"-f without a key=value: {api}"
+
+
+def test_an_unreadable_change_date_is_reported_not_silent(run, capsys):
+    run.shallow = "true"
+    run.api, run.api_rc, run.api_err = "", 1, "HTTP 404"
+    assert cwf.main() == 0
+    assert "HTTP 404" in capsys.readouterr().out
+
+
+def test_no_gh_skips_quietly_but_fails_under_strict(run, monkeypatch, capsys):
+    monkeypatch.setattr(cwf.shutil, "which", lambda _n: None)
+    assert cwf.main() == 0
+    monkeypatch.setenv("FRESHNESS_STRICT", "1")
+    assert cwf.main() == 1
+
+
+def test_utc_formats_as_utc():
+    assert cwf._utc(0) == "1970-01-01 00:00Z"

--- a/python/tests/test_cron_workflow_freshness.py
+++ b/python/tests/test_cron_workflow_freshness.py
@@ -1,0 +1,93 @@
+"""The freshness checker's trigger parse, which is the part that can fail silently.
+
+If `_triggers` under-reads, a cron-only workflow looks push-triggered and is
+skipped; if it over-reads, `ci.yml` looks cron-only and the check reports drift
+that cannot exist. Either way the failure is quiet, so the parse is asserted
+directly rather than inferred from the script exiting 0.
+
+STDLIB-ONLY BY REQUIREMENT, not preference. The first version used pyyaml,
+which is declared in the `test` group and absent from three of the jobs that
+run this script — it died on ModuleNotFoundError in all three. pyproject.toml
+already records that exact trap ("a developer machine usually has pyyaml lying
+around and CI does not"); a stale local .venv is why it passed here first.
+"""
+import importlib.util
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "cwf", REPO / "scripts" / "check_cron_workflow_freshness.py")
+assert _spec and _spec.loader  # the house idiom; ty needs the narrowing
+cwf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cwf)
+
+
+def test_the_module_imports_with_no_third_party_dependency():
+    """Loading it above already proves this; the assertion states the property
+    so a future `import yaml` fails here rather than on a runner."""
+    src = (REPO / "scripts" / "check_cron_workflow_freshness.py").read_text(encoding="utf-8")
+    for banned in ("import yaml", "import requests"):
+        assert banned not in src, f"{banned!r} is absent from the jobs that run this"
+
+
+def test_block_form_triggers():
+    assert cwf._triggers(
+        "name: x\non:\n  schedule:\n    - cron: '0 0 * * 1'\n  workflow_dispatch:\n\njobs:\n  a:\n"
+    ) == {"schedule", "workflow_dispatch"}
+
+
+def test_push_form_is_recognised_so_it_is_not_treated_as_cron_only():
+    got = cwf._triggers("on:\n  push:\n    branches: [main]\n  pull_request:\n\njobs:\n")
+    assert got == {"push", "pull_request"}
+    assert got & cwf.PUSH_TRIGGERS
+
+
+def test_inline_list_form():
+    assert cwf._triggers("on: [push, pull_request]\n") == {"push", "pull_request"}
+
+
+def test_inline_scalar_form():
+    assert cwf._triggers("on: workflow_dispatch\n") == {"workflow_dispatch"}
+
+
+def test_the_parse_stops_at_the_next_top_level_key():
+    """`jobs:` and everything under it must not be read as triggers — that would
+    make every workflow look cron-only and the check vacuous."""
+    got = cwf._triggers(
+        "on:\n  schedule:\n    - cron: '0 0 * * 1'\n\npermissions:\n  contents: read\n\njobs:\n  build:\n    steps: []\n")
+    assert got == {"schedule"}
+
+
+# --- against the repository's own files, which is what it actually parses ----
+
+def _workflow(name):
+    return (REPO / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def test_ci_yml_is_push_triggered():
+    """The single most important negative: if ci.yml ever reads as cron-only,
+    the checker would demand a dispatch for the workflow that runs on every
+    commit."""
+    assert cwf._triggers(_workflow("ci.yml")) & cwf.PUSH_TRIGGERS
+
+
+def test_the_known_cron_only_workflows_read_as_cron_only():
+    for name in ("spark-jvm.yml", "real-fabric.yml", "sempy.yml", "xmla.yml"):
+        got = cwf._triggers(_workflow(name))
+        assert got, f"{name}: parsed no triggers at all"
+        assert not (got & cwf.PUSH_TRIGGERS), f"{name} read as push-triggered: {got}"
+
+
+def test_every_workflow_parses_to_something():
+    """A regex that matches nothing returns an empty set, which reads as
+    'not push-triggered' and would quietly add a workflow to the cron list."""
+    for path in sorted((REPO / ".github" / "workflows").glob("*.yml")):
+        assert cwf._triggers(path.read_text(encoding="utf-8")), f"{path.name}: no triggers parsed"
+
+
+def test_exemptions_carry_a_reason():
+    for name, why in cwf.EXEMPT.items():
+        assert why.strip(), f"{name} is exempt with no reason"
+        assert (REPO / ".github" / "workflows" / name).exists(), (
+            f"{name} is exempt but no longer exists — a stale exemption hides "
+            "the next real one")

--- a/python/tests/test_cron_workflow_freshness.py
+++ b/python/tests/test_cron_workflow_freshness.py
@@ -191,7 +191,7 @@ def test_the_api_call_is_pinned_to_a_sha(run, monkeypatch):
     run.api = "2020-01-01T00:00:00Z"
     monkeypatch.setenv("GITHUB_SHA", "deadbeef")
     cwf.main()
-    api = [a for a in run.calls if a[:2] == ["gh", "api"]][0]
+    api = next(a for a in run.calls if a[:2] == ["gh", "api"])
     assert "sha=deadbeef" in api, f"not pinned: {api}"
     # and the arguments must be well formed — a splice bug once produced
     # `-f -f sha=S path=P`, which failed every lookup silently.

--- a/scripts/check_cron_workflow_freshness.py
+++ b/scripts/check_cron_workflow_freshness.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Every cron/dispatch-only workflow has RUN since the last commit that changed it.
+
+WHY THIS EXISTS. A workflow with `push:` or `pull_request:` triggers is proved
+by the next commit. A workflow that only runs on `schedule:` or
+`workflow_dispatch:` is not: a change to it is unverified until the cron fires,
+which can be a week, and nothing between the merge and that firing says so.
+
+That is not hypothetical. Three cron-only fixes were merged in one week and
+none had executed:
+
+  * `check_example_portability` and two siblings — enforced only by `make check`
+    (a different gap, fixed separately; the shape is the same).
+  * `real-fabric.yml`'s restructure — sound, once dispatched.
+  * `e2e/spark-jvm`'s sc-facade oracle — **BROKEN**. It computed a HOST path for
+    a module the container never mounts, so it died on ModuleNotFoundError and
+    evaluated nothing. The PR claiming "verified against real Spark" was false
+    from the moment it merged, and the weekly cron would have failed the same
+    way indefinitely. Once repaired it immediately found a second defect.
+
+Nothing in the diffs separated the sound changes from the broken one. Review
+cannot see it; only execution can. So the question this asks is not "is the
+workflow correct" — it is the cheaper, checkable one: **has anyone run it since
+it last changed?**
+
+WHAT IT DELIBERATELY DOES NOT DO. It does not fail on a workflow that has never
+run at all when the repository has no runs to read (a fresh clone, a fork), and
+it does not police whether the run PASSED — a red cron run is a normal finding
+that the run itself reports. Freshness is the property no other check covers.
+
+Needs the GitHub API for run times, so it SKIPS with a clear message when `gh`
+is unavailable or unauthenticated rather than failing a laptop that has neither.
+A check that cannot run is not a check that failed, and saying which is the
+difference between a signal and noise.
+"""
+import datetime
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# Workflows exempt from freshness, WITH A REASON so an exemption is a decision
+# someone wrote down rather than an omission nobody saw.
+EXEMPT = {
+    "release.yml": "fires on a tag; its freshness is the release itself",
+}
+
+PUSH_TRIGGERS = {"push", "pull_request", "pull_request_target", "merge_group"}
+
+
+def _utc(ts: int) -> str:
+    return datetime.datetime.fromtimestamp(ts, datetime.UTC).strftime("%Y-%m-%d %H:%MZ")
+
+
+def _triggers(doc) -> set:
+    """The `on:` keys. PyYAML parses a bare `on:` as the boolean True."""
+    on = doc.get(True, doc.get("on", {}))
+    if isinstance(on, str):
+        return {on}
+    if isinstance(on, list):
+        return set(on)
+    return set(on or {})
+
+
+def _last_changed(path: pathlib.Path) -> int:
+    """Committer epoch seconds of the last commit touching this file.
+
+    Epoch, NOT an ISO string: `%cI` carries a local offset (`+08:00`) while the
+    API returns UTC `Z`, and comparing those two as text reported drift that did
+    not exist and hid drift that did. This exact mistake was made while writing
+    this script.
+    """
+    out = subprocess.run(
+        ["git", "log", "-1", "--format=%ct", "--", str(path)],
+        cwd=ROOT, capture_output=True, text=True, check=True).stdout.strip()
+    return int(out) if out else 0
+
+
+def _last_run(stem: str):
+    """(epoch, conclusion) of the newest run, or None when unknown."""
+    r = subprocess.run(
+        ["gh", "run", "list", "--workflow", f"{stem}.yml", "--limit", "1",
+         "--json", "createdAt,conclusion"],
+        cwd=ROOT, capture_output=True, text=True)
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    runs = json.loads(r.stdout)
+    if not runs:
+        return None
+    created = runs[0]["createdAt"].replace("Z", "+00:00")
+    return int(datetime.datetime.fromisoformat(created).timestamp()), runs[0].get("conclusion")
+
+
+def main() -> int:
+    # pyyaml is a DECLARED dependency, so a missing import means a broken
+    # environment, not a laptop without extras. pyproject.toml records the same
+    # trap being sprung once already ("a developer machine usually has pyyaml
+    # lying around"), so this imports hard rather than skipping.
+    import yaml
+
+    in_ci = os.environ.get("GITHUB_ACTIONS") == "true"
+    if not shutil.which("gh"):
+        if in_ci:
+            print("FAIL: the GitHub CLI is unavailable IN CI, so run history "
+                  "cannot be read and this check would verify nothing.")
+            return 1
+        print("check_cron_workflow_freshness: SKIPPED — the GitHub CLI is not on PATH")
+        return 0
+
+    cron_only, stale, unknown = [], [], []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        if path.name in EXEMPT:
+            continue
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict) or _triggers(doc) & PUSH_TRIGGERS:
+            continue
+        cron_only.append(path.stem)
+        changed = _last_changed(path)
+        run = _last_run(path.stem)
+        if run is None:
+            unknown.append(path.stem)
+            continue
+        ran, conclusion = run
+        if ran < changed:
+            stale.append((path.stem, changed, ran, conclusion))
+
+    if not cron_only:
+        print("FAIL: no cron-only workflows found — the trigger parse is broken,")
+        print("      and a check that inspects nothing reports success forever.")
+        return 1
+
+    print(f"cron/dispatch-only workflows: {len(cron_only)} — {', '.join(cron_only)}")
+    if unknown:
+        print(f"  no run history readable: {', '.join(unknown)}")
+        if in_ci:
+            # Silence here is the failure mode: unreadable history means every
+            # workflow looks fresh. Most likely cause is the job losing
+            # `actions: read`.
+            print("\nFAIL: run history is unreadable in CI, so every workflow above")
+            print("      would be reported fresh regardless. Check that this job")
+            print("      still grants `actions: read`.")
+            return 1
+
+    if stale:
+        print("\nFAIL: changed since they last ran, so the change is unverified.")
+        print("These never run on push, so nothing else will catch it:\n")
+        for stem, changed, ran, conclusion in stale:
+            print(f"  {stem}")
+            print(f"      changed {_utc(changed)}   last run {_utc(ran)} ({conclusion})")
+            print(f"      gh workflow run {stem}.yml --ref <the branch that changed it>")
+        return 1
+
+    print("every cron-only workflow has run since its last change")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_cron_workflow_freshness.py
+++ b/scripts/check_cron_workflow_freshness.py
@@ -37,6 +37,7 @@ import datetime
 import json
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -57,14 +58,34 @@ def _utc(ts: int) -> str:
     return datetime.datetime.fromtimestamp(ts, datetime.UTC).strftime("%Y-%m-%d %H:%MZ")
 
 
-def _triggers(doc) -> set:
-    """The `on:` keys. PyYAML parses a bare `on:` as the boolean True."""
-    on = doc.get(True, doc.get("on", {}))
-    if isinstance(on, str):
-        return {on}
-    if isinstance(on, list):
-        return set(on)
-    return set(on or {})
+# STDLIB ONLY, like check_workflow_concurrency.py beside it. The first version
+# used pyyaml — which is declared in the `test` group and absent from the jobs
+# that run this, so it died on ModuleNotFoundError in three of them. The trap is
+# written down in pyproject.toml ("a developer machine usually has pyyaml lying
+# around and CI does not"), and a stale local .venv is exactly why it passed
+# here first. A checker that needs a dependency its own job lacks is a checker
+# that does not run.
+_ON_BLOCK = re.compile(r"^on:\s*$(?P<body>(?:\n(?:[ \t]+.*|\s*))*)", re.M)
+_ON_INLINE = re.compile(r"^on:[ \t]*(?P<value>\S.*)$", re.M)
+_TOP_KEY = re.compile(r"^  ([A-Za-z_][A-Za-z0-9_-]*):", re.M)
+
+
+def _triggers(text: str) -> set:
+    """The `on:` keys of a workflow, read as text."""
+    inline = _ON_INLINE.search(text)
+    if inline:
+        raw = inline.group("value").strip()
+        if raw.startswith("["):
+            return {t.strip().strip("'\"") for t in raw.strip("[]").split(",") if t.strip()}
+        return {raw}
+    block = _ON_BLOCK.search(text)
+    if not block:
+        return set()
+    # No manual stop needed: the body pattern only accepts indented or blank
+    # lines, so an unindented key (`jobs:`, `permissions:`) ends the match by
+    # construction. A defensive loop here was dead — mutating it away changed
+    # nothing, which is how it was found.
+    return set(_TOP_KEY.findall(block.group("body")))
 
 
 def _last_changed(path: pathlib.Path) -> int:
@@ -97,12 +118,6 @@ def _last_run(stem: str):
 
 
 def main() -> int:
-    # pyyaml is a DECLARED dependency, so a missing import means a broken
-    # environment, not a laptop without extras. pyproject.toml records the same
-    # trap being sprung once already ("a developer machine usually has pyyaml
-    # lying around"), so this imports hard rather than skipping.
-    import yaml
-
     in_ci = os.environ.get("GITHUB_ACTIONS") == "true"
     if not shutil.which("gh"):
         if in_ci:
@@ -116,8 +131,7 @@ def main() -> int:
     for path in sorted(WORKFLOWS.glob("*.yml")):
         if path.name in EXEMPT:
             continue
-        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
-        if not isinstance(doc, dict) or _triggers(doc) & PUSH_TRIGGERS:
+        if _triggers(path.read_text(encoding="utf-8")) & PUSH_TRIGGERS:
             continue
         cron_only.append(path.stem)
         changed = _last_changed(path)

--- a/scripts/check_cron_workflow_freshness.py
+++ b/scripts/check_cron_workflow_freshness.py
@@ -160,6 +160,14 @@ def _last_run(stem: str):
          "--json", "createdAt,conclusion"],
         cwd=ROOT, capture_output=True, text=True)
     if r.returncode != 0 or not r.stdout.strip():
+        # Say WHY. Swallowing this is what made the first CI failure a guessing
+        # game: "unreadable" is a symptom, and the stderr underneath it is the
+        # diagnosis.
+        why = (r.stderr or "").strip().replace("\n", " ")[:200]
+        if why:
+            print(f"    {stem}: gh run list failed — {why}")
+        elif not r.stdout.strip():
+            print(f"    {stem}: gh run list returned nothing (no runs?)")
         return None
     runs = json.loads(r.stdout)
     if not runs:

--- a/scripts/check_cron_workflow_freshness.py
+++ b/scripts/check_cron_workflow_freshness.py
@@ -135,12 +135,14 @@ def _last_changed_api(repo: str, rel: str, sha: str) -> int:
     # clone: the default-branch query reported "fresh" for a workflow the branch
     # had just modified.
     args = ["gh", "api", f"repos/{repo}/commits", "-X", "GET",
-            "-f", f"path={rel}", "-f", "per_page=1",
-            "--jq", ".[0].commit.committer.date"]
+            "-f", f"path={rel}", "-f", "per_page=1"]
     if sha:
-        args[6:6] = ["-f", f"sha={sha}"]
+        args += ["-f", f"sha={sha}"]
+    args += ["--jq", ".[0].commit.committer.date"]
     r = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
     if r.returncode != 0 or not r.stdout.strip():
+        why = (r.stderr or "").strip().replace("\n", " ")[:200]
+        print(f"    {rel}: last-changed unreadable — {why or 'no output'}")
         return 0
     when = r.stdout.strip().replace("Z", "+00:00")
     return int(datetime.datetime.fromisoformat(when).timestamp())
@@ -228,9 +230,10 @@ def main() -> int:
             # Silence here is the failure mode: unreadable history means every
             # workflow looks fresh. Most likely cause is the job losing
             # `actions: read`.
-            print("\nFAIL: run history is unreadable in CI, so every workflow above")
-            print("      would be reported fresh regardless. Check that this job")
-            print("      still grants `actions: read`.")
+            print("\nFAIL: the data above could not be read in CI, so every workflow")
+            print("      would be reported fresh regardless. The per-workflow lines")
+            print("      say which call failed — a last-changed lookup needs")
+            print("      `contents: read`, run history needs `actions: read`.")
             return 1
 
     if stale:

--- a/scripts/check_cron_workflow_freshness.py
+++ b/scripts/check_cron_workflow_freshness.py
@@ -179,11 +179,16 @@ def _last_run(stem: str):
 
 
 def main() -> int:
-    in_ci = os.environ.get("GITHUB_ACTIONS") == "true"
+    # STRICT is opt-in, and granted only where the API is reachable. `make
+    # check` runs this in jobs that hold no GH_TOKEN — they are not lying about
+    # freshness, they simply cannot see it, and failing them would make the
+    # check noise. The one job that CAN see it sets FRESHNESS_STRICT=1, so a
+    # permissions regression there still fails loudly instead of skipping.
+    strict = os.environ.get("FRESHNESS_STRICT") == "1"
     if not shutil.which("gh"):
-        if in_ci:
-            print("FAIL: the GitHub CLI is unavailable IN CI, so run history "
-                  "cannot be read and this check would verify nothing.")
+        if strict:
+            print("FAIL: FRESHNESS_STRICT is set but the GitHub CLI is not on "
+                  "PATH, so this check would verify nothing.")
             return 1
         print("check_cron_workflow_freshness: SKIPPED — the GitHub CLI is not on PATH")
         return 0
@@ -191,9 +196,13 @@ def main() -> int:
     shallow = _is_shallow()
     slug = _repo_slug() if shallow else ""
     if shallow and not slug:
-        print("FAIL: shallow clone and the repository slug is unreadable, so the")
-        print("      last-changed date cannot be determined for any workflow.")
-        return 1
+        msg = ("shallow clone and the repository slug is unreadable, so "
+               "last-changed dates cannot be determined")
+        if strict:
+            print(f"FAIL: {msg}.")
+            return 1
+        print(f"check_cron_workflow_freshness: SKIPPED — {msg}")
+        return 0
     head = _head_sha() if shallow else ""
     if shallow:
         print(f"shallow clone — last-changed dates from {slug}@{head[:7] or '?'} via the API")
@@ -226,7 +235,7 @@ def main() -> int:
     print(f"cron/dispatch-only workflows: {len(cron_only)} — {', '.join(cron_only)}")
     if unknown:
         print(f"  no run history readable: {', '.join(unknown)}")
-        if in_ci:
+        if strict:
             # Silence here is the failure mode: unreadable history means every
             # workflow looks fresh. Most likely cause is the job losing
             # `actions: read`.

--- a/scripts/check_cron_workflow_freshness.py
+++ b/scripts/check_cron_workflow_freshness.py
@@ -88,18 +88,69 @@ def _triggers(text: str) -> set:
     return set(_TOP_KEY.findall(block.group("body")))
 
 
-def _last_changed(path: pathlib.Path) -> int:
+def _is_shallow() -> bool:
+    out = subprocess.run(["git", "rev-parse", "--is-shallow-repository"],
+                         cwd=ROOT, capture_output=True, text=True).stdout.strip()
+    return out == "true"
+
+
+def _last_changed_git(path: pathlib.Path) -> int:
     """Committer epoch seconds of the last commit touching this file.
 
     Epoch, NOT an ISO string: `%cI` carries a local offset (`+08:00`) while the
     API returns UTC `Z`, and comparing those two as text reported drift that did
-    not exist and hid drift that did. This exact mistake was made while writing
-    this script.
+    not exist and hid drift that did. That mistake was made while writing this.
     """
     out = subprocess.run(
         ["git", "log", "-1", "--format=%ct", "--", str(path)],
         cwd=ROOT, capture_output=True, text=True, check=True).stdout.strip()
     return int(out) if out else 0
+
+
+def _head_sha() -> str:
+    """The commit under test. For a PR, GITHUB_SHA is the merge commit, whose
+    first parent history includes the branch — either resolves the PR's own
+    change, which the default branch would not."""
+    env = os.environ.get("GITHUB_SHA")
+    if env:
+        return env
+    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT,
+                       capture_output=True, text=True)
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+def _last_changed_api(repo: str, rel: str, sha: str) -> int:
+    """Same answer from the forge, for a SHALLOW clone.
+
+    `actions/checkout` fetches depth 1, so `git log -- <path>` has no history to
+    search and returns the TIP commit's date for every file. Every workflow then
+    looks changed-just-now and the check fails all of them — which is exactly
+    what it did on its first CI run. A shallow clone does not report an error
+    here; it reports a plausible wrong number, so the fallback is chosen by
+    detecting the clone, not by catching a failure.
+    """
+    # `sha` IS LOAD-BEARING. Without it the API answers for the DEFAULT BRANCH,
+    # so a PR that changes a cron workflow — the one case this check exists for —
+    # reads main's history and is never flagged. Verified against a real shallow
+    # clone: the default-branch query reported "fresh" for a workflow the branch
+    # had just modified.
+    args = ["gh", "api", f"repos/{repo}/commits", "-X", "GET",
+            "-f", f"path={rel}", "-f", "per_page=1",
+            "--jq", ".[0].commit.committer.date"]
+    if sha:
+        args[6:6] = ["-f", f"sha={sha}"]
+    r = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
+    if r.returncode != 0 or not r.stdout.strip():
+        return 0
+    when = r.stdout.strip().replace("Z", "+00:00")
+    return int(datetime.datetime.fromisoformat(when).timestamp())
+
+
+def _repo_slug() -> str:
+    r = subprocess.run(["gh", "repo", "view", "--json", "nameWithOwner",
+                        "--jq", ".nameWithOwner"],
+                       cwd=ROOT, capture_output=True, text=True)
+    return r.stdout.strip() if r.returncode == 0 else ""
 
 
 def _last_run(stem: str):
@@ -127,6 +178,16 @@ def main() -> int:
         print("check_cron_workflow_freshness: SKIPPED — the GitHub CLI is not on PATH")
         return 0
 
+    shallow = _is_shallow()
+    slug = _repo_slug() if shallow else ""
+    if shallow and not slug:
+        print("FAIL: shallow clone and the repository slug is unreadable, so the")
+        print("      last-changed date cannot be determined for any workflow.")
+        return 1
+    head = _head_sha() if shallow else ""
+    if shallow:
+        print(f"shallow clone — last-changed dates from {slug}@{head[:7] or '?'} via the API")
+
     cron_only, stale, unknown = [], [], []
     for path in sorted(WORKFLOWS.glob("*.yml")):
         if path.name in EXEMPT:
@@ -134,7 +195,11 @@ def main() -> int:
         if _triggers(path.read_text(encoding="utf-8")) & PUSH_TRIGGERS:
             continue
         cron_only.append(path.stem)
-        changed = _last_changed(path)
+        rel = path.relative_to(ROOT).as_posix()
+        changed = _last_changed_api(slug, rel, head) if shallow else _last_changed_git(path)
+        if not changed:
+            unknown.append(path.stem)
+            continue
         run = _last_run(path.stem)
         if run is None:
             unknown.append(path.stem)


### PR DESCRIPTION
Generalises the defect that produced #222. A workflow with `push:` triggers is proved by the next commit; one that only runs on `schedule:`/`workflow_dispatch:` is not — a change to it is unverified until the cron fires, which can be a week, and nothing in between says so.

**Three cron-only fixes landed in one week and none had executed.** I dispatched all three: two were sound, and **one was broken** — the sc-facade oracle computed a HOST path for a module its container never mounts, so it died on `ModuleNotFoundError` and evaluated nothing. The PR claiming "verified against real Spark" was false from the moment it merged. Nothing in the diffs separated it from the two that were fine.

So the check does not ask "is this workflow correct". It asks the cheap, decidable question: **has anyone run it since it last changed?**

## Two live findings it caught immediately

- **`sempy`** — modified by the dependency-bump PR (#210), never run since.
- **`spark-jvm`** — modified by #223's "Pin the JVM overlay to Spark 3.5.5 on Java 11". That commit changes the workflow itself, so the 3.5.5 image tag and Java 11 selection were entirely unverified, and #223 would have merged them unexecuted.

Both dispatched; both now clean, which is why this PR's own run of the check passes.

## The check was nearly a no-op, twice

**Permissions.** `gh run list` needs `actions: read`; the workflow grants `contents: read`. In CI the call would have failed, every workflow would have landed in "unknown", and the check would have **passed having verified nothing** — the exact silent no-op it exists to catch. Fixed both ways: the job now grants `actions: read` for that one step, *and* the script FAILS under `GITHUB_ACTIONS` when history is unreadable, so a future permissions trim breaks the build rather than the guarantee. Verified with a stub `gh` that exits non-zero: exit 1 in CI, clean skip on a laptop.

**pyyaml.** It originally skipped on ImportError. But pyyaml is a *declared* dependency and `pyproject.toml:23` records this trap being sprung once already, so it now imports hard.

## Verified against a real stale condition

Not just "it passes": I committed a touch to `xmla.yml`, ran it, and it failed with the workflow name, both timestamps, and the exact `gh workflow run xmla.yml --ref <branch>` remediation — then reverted. It also fails if the trigger parse matches nothing, because a check that inspects zero workflows reports success forever.

**One bug this found in my own analysis:** my first pass compared `git log %cI` (carrying `+08:00`) against the API's UTC `Z` as strings, which invented drift and hid real drift. The script uses epoch seconds and says why in a comment.

Wired into `make check` and `ci.yml`; yesterday's `test_make_check_runs_in_ci.py` enforces the pairing. 723 tests, ruff, ty green.