### PR TITLE
fix(e2e): bind entra to all interfaces so the sempy container can reach it

### DIFF
--- a/e2e/sempy/run.py
+++ b/e2e/sempy/run.py
@@ -210,8 +210,24 @@ entra_bin = os.path.join(WORK, "entra-emulator" + EXE)
 
 try:
     log(f"starting entra on :{ENTRA_PORT}, fabric on :{FABRIC_PORT} (TLS ON)")
+    # HOST=0.0.0.0 is LOAD-BEARING and was the whole reason this suite had never
+    # passed. entra-emulator defaults to `localhost`, and the sempy container
+    # reaches it as `host.docker.internal:<port>` — the host-gateway address,
+    # not loopback — so every token mint was refused with Errno 111 before XMLA
+    # was ever reached.
+    #
+    # It affects semantic-link-labs ONLY, which is why the failure looked
+    # selective: `sempy` is handed a pre-minted SEMPY_TOKEN and never calls
+    # entra, while labs routes every REST call through this repo's notebookutils
+    # shim, which mints its own. Nine sempy checks passed and all three labs
+    # checks failed, on a suite whose parity row claims "two independent
+    # Microsoft clients".
+    #
+    # The issuer stays `localhost` on purpose: it is the string fabric validates
+    # tokens against, not an address anything dials.
     start("entra", [entra_bin], {**os.environ, "ORIGIN_MODE": "compat",
-          "PORT": ENTRA_PORT, "DB_PATH": os.path.join(WORK, "entra.sqlite"),
+          "PORT": ENTRA_PORT, "HOST": "0.0.0.0",
+          "DB_PATH": os.path.join(WORK, "entra.sqlite"),
           "TLS_CERT_DIR": os.path.join(WORK, "entra-tls")})
     # TLS stays ON: the client will not speak plain HTTP to an XMLA endpoint,
     # and the emulator's own cert already carries api.fabric.microsoft.com.


### PR DESCRIPTION
`ci:sempy` had **never passed**. Three runs in its entire history — 2026-08-12 and twice on 08-14 — all failures. It was written, merged and cited as a parity witness without ever having been observed green, because it is weekly-only and so never ran on the PRs that created it.

## Root cause, from the services' own logs

```
fabric-emulator listening on https://[::]:19543     ← all interfaces
entra-emulator  listening on localhost:18543        ← loopback ONLY
```

`entra-emulator` defaults to `HOST=localhost` ([config.go:134](https://github.com/calvinchengx/entra-emulator)). The sempy container reaches it as `host.docker.internal:<port>` — the host-gateway address, not loopback — so **every token mint was refused with Errno 111** before XMLA was reached. The fabric emulator is started with an explicit `-addr 0.0.0.0`; entra was given only `PORT`.

## Why it failed *selectively*, which is what made it confusing

Nine sempy checks passed and exactly the three `semantic-link-labs` ones failed. `sempy` is handed a pre-minted `SEMPY_TOKEN` and never calls entra. **labs routes every REST call through this repo's own `notebookutils` shim**, which mints its own token — so it died on its first call. The parity row already documents that dependency ("Labs also needs this repo's own notebookutils shim... that was measured, not assumed"); this is the same fact biting from the other side.

The traceback was four stdlib `urllib` frames with no URL, which is why the endpoint had to be inferred from *which* client failed rather than read off the error.

## The claim this affects

`docs/parity.md` grades this **🟢 Real** and says "**Two independent Microsoft clients** drive this surface in CI, which is the point: they read it differently." Until now one of the two had never worked. The row also asserts "**Writes work too**... adds a measure and it survives a reconnect" — one of the three failing checks. The claim is now true; before this it was not, and nothing could have told you, because `check_witnesses.py` verifies a claim NAMES a witness, not that the witness passes.

## Verified before opening this

Dispatched against this branch, not merged-and-hoped:

```
PASS  semantic-link-labs materialises the model through TOM
PASS  labs reads the SEEDED model's table names, not an empty Database
PASS  semantic-link-labs writes a measure that SURVIVES a reconnect
PASSED: SemPy and semantic-link-labs drive the emulator's XMLA surface.
```

12/12, the suite's first green run ever. The issuer stays `localhost` deliberately — that string is what fabric validates tokens against, not an address anything dials.