### PR TITLE
fix: spark_agent must run on Python 3.8, and now says so

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,12 @@ ignore = [
 # Test files import a module by path before asserting on it, so the import is
 # not at the top and does not need to be.
 "python/tests/*" = ["E402"]
+# `python/spark_agent/` IS MOUNTED INTO THE JVM SPARK IMAGE, which ships
+# **Python 3.8** (`apache/spark:3.5.5-...-python3-ubuntu`). ruff targets py312
+# and UP017 rewrites `timezone.utc` to `datetime.UTC` — a 3.11+ alias that
+# raises ImportError there. That is not hypothetical: it broke the eventstream
+# JVM suite on main, and only a cron-only workflow could see it.
+"python/spark_agent/*" = ["UP017"]
 # The notebookutils shim mirrors Microsoft's API, which is camelCase and takes
 # arguments this code does not use. Renaming to satisfy a linter would break
 # the thing it exists to imitate.

--- a/python/spark_agent/eventstream_kafka.py
+++ b/python/spark_agent/eventstream_kafka.py
@@ -53,7 +53,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -838,14 +838,14 @@ def _as_timestamp(value):
         millis = float(value)
         if millis > 1e12:
             millis = millis / 1000.0
-        return datetime.fromtimestamp(millis, tz=UTC).replace(tzinfo=None)
+        return datetime.fromtimestamp(millis, tz=timezone.utc).replace(tzinfo=None)
     text = str(value).replace("Z", "+00:00")
     try:
         ts = datetime.fromisoformat(text)
     except ValueError:
-        return datetime.fromtimestamp(0, tz=UTC).replace(tzinfo=None)
+        return datetime.fromtimestamp(0, tz=timezone.utc).replace(tzinfo=None)
     if ts.tzinfo is not None:
-        ts = ts.astimezone(UTC).replace(tzinfo=None)
+        ts = ts.astimezone(timezone.utc).replace(tzinfo=None)
     return ts
 
 

--- a/python/spark_agent/storage.py
+++ b/python/spark_agent/storage.py
@@ -33,6 +33,15 @@ Config comes from the same env vars the rest of the stack already uses
 With none of these set, `options()` returns `{}` and delta-rs falls back to its
 own env handling — which is what makes local-path tables keep working.
 """
+
+# Lazy annotations, so PEP 604 unions below stay strings. This module is
+# Connect-only today (agent.py imports it only when SPARK_REMOTE is set),
+# but it lives in spark_agent/, which the JVM overlay mounts into an image
+# running Python 3.8 — where `str | None` is evaluated at import and
+# raises TypeError. One rule for the whole directory beats a precise one
+# that drifts the moment an import moves.
+from __future__ import annotations
+
 import json
 import os
 import ssl

--- a/python/tests/test_spark_agent_runs_on_python38.py
+++ b/python/tests/test_spark_agent_runs_on_python38.py
@@ -1,0 +1,122 @@
+"""`python/spark_agent/` must run on Python 3.8, because the JVM image ships it.
+
+WHY. The agent is mounted into `apache/spark:3.5.5-...-python3-ubuntu` by the
+JVM overlay, and that image's interpreter is **Python 3.8**. Everything else in
+this repo runs on 3.12, ruff targets py312, and nothing anywhere said the agent
+is different — so 3.11+ code lands in it and passes every gate.
+
+It already happened. `eventstream_kafka.py` imported `datetime.UTC`, a 3.11
+alias, and the JVM eventstream suite died on:
+
+    ImportError: cannot import name 'UTC' from 'datetime'
+    (/usr/lib/python3.8/datetime.py)
+
+ruff had actively pushed it there: UP017 rewrites `timezone.utc` to
+`datetime.UTC` under a py312 target. The lint was correct about the target it
+was told about and wrong about the one that matters, and only a **cron-only**
+workflow could see the result — so it sat on main.
+
+TWO CHECKS, because they catch different things. `ast.parse(feature_version=…)`
+rejects 3.9+ SYNTAX but accepts `datetime.UTC` happily: that is valid syntax and
+a missing attribute at runtime. The denylist covers those.
+"""
+import ast
+import pathlib
+
+import pytest
+
+AGENT = pathlib.Path(__file__).resolve().parents[1] / "spark_agent"
+
+# The interpreter in apache/spark's python3 image. Raise this only when the
+# image does, and change docker/spark-runtime with it.
+FLOOR = (3, 8)
+
+# Valid syntax on 3.8, missing at runtime. Each entry is (needle, since, use).
+DENY = [
+    ("from datetime import UTC", "3.11", "from datetime import timezone; timezone.utc"),
+    ("datetime.UTC", "3.11", "datetime.timezone.utc"),
+    ("from typing import Self", "3.11", "a string annotation"),
+    ("itertools.pairwise", "3.10", "zip(x, x[1:])"),
+    ("from typing import TypeAlias", "3.10", "a plain assignment"),
+]
+
+
+def _sources():
+    files = sorted(AGENT.rglob("*.py"))
+    assert files, f"no sources found under {AGENT} — this test would pass vacuously"
+    return files
+
+
+@pytest.mark.parametrize("path", _sources(), ids=lambda p: p.name)
+def test_the_agent_parses_on_the_image_interpreter(path):
+    """3.9+ SYNTAX would be a SyntaxError inside the container, where the only
+    symptom is a job that dies before it logs anything useful."""
+    src = path.read_text(encoding="utf-8")
+    try:
+        ast.parse(src, filename=str(path), feature_version=FLOOR)
+    except SyntaxError as e:
+        pytest.fail(
+            f"{path.name}:{e.lineno} is not valid Python {FLOOR[0]}.{FLOOR[1]}, "
+            f"which is what the JVM Spark image runs: {e.msg}")
+
+
+@pytest.mark.parametrize("path", _sources(), ids=lambda p: p.name)
+def test_the_agent_avoids_apis_that_are_newer_than_the_image(path):
+    """Valid syntax, absent at runtime — the case ast.parse cannot see."""
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").split("\n"), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        for needle, since, instead in DENY:
+            assert needle not in line, (
+                f"{path.name}:{lineno} uses {needle!r}, added in Python {since}; "
+                f"the JVM Spark image runs {FLOOR[0]}.{FLOOR[1]}. Use {instead}.")
+
+
+def test_ruff_is_told_not_to_reintroduce_the_alias():
+    """UP017 rewrites `timezone.utc` into the 3.11 alias under a py312 target.
+    Without the per-file ignore this is a fight the linter wins on every edit."""
+    cfg = (AGENT.parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"python/spark_agent/*" = ["UP017"]' in cfg, (
+        "the per-file ignore is gone; ruff will rewrite timezone.utc back to "
+        "datetime.UTC and break the JVM image again")
+
+
+@pytest.mark.parametrize("path", _sources(), ids=lambda p: p.name)
+def test_the_agent_avoids_pep604_unions_in_annotations(path):
+    """`int | None` is valid SYNTAX on 3.8 and a TypeError when the annotation
+    is EVALUATED, which is at import time for a def. So ast.parse accepts it and
+    the container dies on it — the gap a surviving mutant exposed here.
+
+    Allowed when the module opts into lazy annotations, because then they are
+    strings and never evaluated.
+    """
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src, filename=str(path))
+    lazy = any(
+        isinstance(n, ast.ImportFrom) and n.module == "__future__"
+        and any(a.name == "annotations" for a in n.names)
+        for n in tree.body)
+    if lazy:
+        return
+
+    annotations = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AnnAssign, ast.arg)) and node.annotation:
+            annotations.append(node.annotation)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.returns:
+            annotations.append(node.returns)
+
+    for ann in annotations:
+        for sub in ast.walk(ann):
+            if isinstance(sub, ast.BinOp) and isinstance(sub.op, ast.BitOr):
+                pytest.fail(
+                    f"{path.name}:{sub.lineno} uses PEP 604 `X | Y` in an "
+                    f"annotation. That is evaluated at import on Python "
+                    f"{FLOOR[0]}.{FLOOR[1]} and raises TypeError. Use "
+                    f"typing.Optional/Union, or add "
+                    f"`from __future__ import annotations`.")
+
+
+def test_the_denylist_is_not_empty():
+    """A parametrized scan over an empty list passes while checking nothing."""
+    assert len(DENY) >= 3


### PR DESCRIPTION
**main is red.** The freshness check flagged `spark-jvm` after #226 merged (it edits that workflow, which only runs on a Tuesday cron); dispatching it showed the Eventstream JVM job failing:

```
spark-jvm-1 | ImportError: cannot import name 'UTC' from 'datetime'
              (/usr/lib/python3.8/datetime.py)
```

## The constraint nothing recorded

`python/spark_agent/` is mounted into the JVM overlay's image — `apache/spark:3.5.5-...-python3-ubuntu` — whose interpreter is **Python 3.8**. Everything else in this repo runs 3.12, `ruff` targets `py312`, and nothing said the agent is different.

So `eventstream_kafka.py` used `datetime.UTC`, a 3.11 alias. **ruff had actively pushed it there**: `UP017` rewrites `timezone.utc` → `datetime.UTC` under a py312 target. The lint was right about the target it was told about and wrong about the one that matters — and only a cron-only workflow could see the result, so it sat on main.

## Three changes

- `eventstream_kafka.py` uses `timezone.utc`.
- **A per-file ruff ignore for `UP017` in `python/spark_agent/*`**, with the reason. Without it this is a fight the linter wins on the next edit.
- `test_spark_agent_runs_on_python38.py` enforces the floor: `ast.parse(feature_version=(3, 8))` for syntax, plus a denylist for APIs that are valid syntax and missing at runtime (`datetime.UTC`, `typing.Self`, `itertools.pairwise`, …), plus a check that the ruff ignore is still present.

## A second, pre-existing violation the new test found immediately

`storage.py:51` had `_cached_token: str | None = None` — PEP 604 at module level, which IS evaluated at import and raises `TypeError` on 3.8.

It is **latent, not live**: `agent.py` imports `storage` only when `SPARK_REMOTE` is set, and the JVM overlay unsets it. Fixed anyway with `from __future__ import annotations`, because one rule for the directory beats a precise rule that drifts the moment an import moves.

That check exists because a mutant survived: `ast.parse(feature_version=…)` accepts `int | None` happily — it is valid syntax and a runtime failure — so the AST walk for `BinOp`/`BitOr` in annotation position was added to cover what the parser cannot see. It allows `from __future__ import annotations`, since then annotations are strings and never evaluated.

## Verified by dispatch, not by diff

```
success — Fabric Runtime 1.3-aligned Spark 3.5.5 compatibility
success — Representative notebook on Spark 3.5
success — Eventstream notebook API on JVM Spark + Kafka
```

881 Python tests, ruff, ty green.
