### PR TITLE
feat: input_file_name() in SQL, and a named error on a non-file frame

### DIFF
--- a/docs/37-runtime-fidelity-gaps.md
+++ b/docs/37-runtime-fidelity-gaps.md
@@ -1,8 +1,8 @@
 # 37 — Runtime fidelity: four documented divergences, and what closing each takes
 
-**Status: divergences 1 (Environments), 2a/2b/2c (Files mount), and 4 (async
-pipelines) are DONE — wire and witness each. The remaining `input_file_name`
-items stay stated in the code.** Each is a
+**Status: divergences 1 (Environments), 2a/2b/2c (Files mount), 3a/3b
+(`input_file_name` SQL rewrite and the non-file diagnostic), and 4 (async
+pipelines) are DONE — wire and witness each.** Each is a
 place where the emulator's *runtime* — the thing a notebook actually sees — is
 deliberately an analog of Fabric's rather than the thing itself. They were
 written down at the moment they were created, which is why this document can
@@ -156,7 +156,7 @@ every write. Its docstring is emphatic that a stub returning `""` would be worse
 than nothing, and that is the standard the two remaining gaps are measured
 against.
 
-### 3a. SQL-string usage bypasses the shim — **M, with real research risk**
+### 3a. SQL-string usage bypasses the shim — **DONE**
 
 `spark.sql("SELECT input_file_name() ...")` never touches the patched
 `F.input_file_name`, so it fails on the engine as if the shim were not there.
@@ -181,6 +181,14 @@ The risk is the same one T-SQL faced and answered with a lexer: a blind string
 replace would be *worse* than the honest gap, because it would corrupt queries
 that merely mention the name. Rewriting must know which relations are tagged and
 leave everything else alone.
+
+**Delivered.** `spark.sql` is wrapped beside the PySpark `F.input_file_name`
+patch. A lexer finds `input_file_name()` only in code (not in strings or
+comments). A view created from a tagged frame registers twice: a clean name
+for `SELECT *`, and a shadow that still carries the tag. SQL that asks for
+the function is rewritten onto that shadow and the tag column; SQL that
+merely mentions the name is left alone. A relation that was never a file
+read raises `InputFileNameError` rather than resolving to `""`.
 
 ### 3b. A non-file frame errors where Spark returns `""` — **do not fix**
 
@@ -215,6 +223,10 @@ and to nothing else.**
 something that names the shim and explains that provenance was requested on a
 frame that never came from a file, instead of a bare `AnalysisException` on an
 internal column name. **Size: XS.**
+
+**Delivered.** `df.select(F.input_file_name())` on a frame with no tag raises
+`InputFileNameError` naming the shim and pointing here. The empty-string
+stub is still refused.
 
 ---
 
@@ -320,12 +332,12 @@ lacks. That is the sequence this rule exists to force.
 | # | Capability | Size | Why this position |
 |---|---|---|---|
 | ~~2c~~ ✅ | ~~Refuse a conflicting lakehouse bind~~ | XS | Done: second bind of a different lakehouse is refused; first mount intact |
-| 3b | Diagnostic error for a non-file frame | XS | Behaviour stays; the message stops being cryptic |
+| ~~3b~~ ✅ | ~~Diagnostic error for a non-file frame~~ | XS | Done: `InputFileNameError` names the shim |
 | ~~—~~ ✅ | ~~Correct the Environments parity row and witness~~ | XS | Done: 🟡, reworded, witness removed. Regrade to 🟢 only with an e2e |
 | ~~1~~ ✅ | ~~Environment items reach the session~~ | S | Done in #67: wire + `e2e/environment` proof with negative control; row 🟢 |
 | ~~2a/2b~~ ✅ | ~~Mount write-back and per-statement refresh~~ | S | Done: flush + pull at every statement; deletes not propagated |
-| 4 | Pipelines async | M | Mechanical, but ~50 test sites |
-| 3a | `input_file_name()` in SQL | M | The only item with genuine research risk |
+| ~~4~~ ✅ | ~~Pipelines async~~ | M | Done: POST returns 202; the client polls |
+| ~~3a~~ ✅ | ~~`input_file_name()` in SQL~~ | M | Done: lexer rewrite onto the tagged shadow view |
 | 2c′ | Agent-per-session pool | L | Deferred; revisit only if concurrent multi-lakehouse sessions become real |
 
 ## What must NOT be done

--- a/python/spark_agent/input_file.py
+++ b/python/spark_agent/input_file.py
@@ -36,17 +36,59 @@ file would misalign silently, but it would do so in the plain glob read too.
 
 SCOPE, deliberately narrow. Only installed when the engine actually lacks the
 function, so the JVM overlay keeps Spark's native answer. Only the file readers
-are wrapped. A frame that never came from a file has no tag, and
-`input_file_name()` on it yields "", Spark's own answer for a non-file source.
+are wrapped. A frame that never came from a file has no tag; asking
+`input_file_name()` of it raises `InputFileNameError` naming the shim
+(docs/37 §3b). Spark itself returns "" here — we will not, because an empty
+lineage column is silently wrong.
+
+SQL-string usage (`spark.sql("SELECT input_file_name() …")`) never touches
+the patched `F.input_file_name`. The agent rewrites that call onto the tag
+column when the FROM/JOIN relation is a view registered from a tagged frame,
+and leaves every other mention (strings, comments) alone (docs/37 §3a).
 """
 from __future__ import annotations
 
 import fnmatch
 import glob as _glob
 import posixpath
+import re
 
 _TAG = "__emu_input_file_name"
 _GLOB_CHARS = "*?["
+_TAGGED_VIEWS: dict[str, list[str]] = {}
+_FROM_JOIN = re.compile(r"\b(?:from|join)\s+(`?[\w.]+`?)", re.IGNORECASE)
+_STAR = re.compile(r"(?<![\w.])\*(?!\s*\()")
+_SHADOW_PREFIX = "__emu_ifn_"
+
+
+class InputFileNameError(Exception):
+    """Provenance was asked of a frame or relation that never came from a file."""
+
+
+def forget_tagged_views():
+    """Drop every remembered view. Tests that share a process need a clean map."""
+    _TAGGED_VIEWS.clear()
+
+
+def remember_tagged_view(name: str, columns: list[str]):
+    """Record that `name` was created from a file-tagged frame."""
+    if name:
+        _TAGGED_VIEWS[name] = list(columns)
+
+
+def shadow_view_name(name: str) -> str:
+    """The view that still carries the tag, used only when SQL asks for it."""
+    return f"{_SHADOW_PREFIX}{name}"
+
+
+def _not_a_file_message() -> str:
+    return (
+        "input_file_name() was requested on a frame that never came from a "
+        "file. The emulator's shim reconstructs provenance by tagging file "
+        "reads; a range, table, or untagged view has no path to give. Do not "
+        "stub this to an empty string — that is silently wrong lineage "
+        "(docs/37 §3b)."
+    )
 
 
 def engine_has_input_file_name(spark) -> bool:
@@ -88,6 +130,158 @@ def _list_files(path: str) -> list[str]:
         return []
 
 
+def _code_chunks(sql: str):
+    """Yield (start, end, text) of SQL that is not a string or a comment."""
+    i = 0
+    n = len(sql)
+    code_start = 0
+    while i < n:
+        two = sql[i:i + 2]
+        if two == "--":
+            if i > code_start:
+                yield code_start, i, sql[code_start:i]
+            nl = sql.find("\n", i)
+            i = n if nl < 0 else nl + 1
+            code_start = i
+            continue
+        if two == "/*":
+            if i > code_start:
+                yield code_start, i, sql[code_start:i]
+            end = sql.find("*/", i + 2)
+            i = n if end < 0 else end + 2
+            code_start = i
+            continue
+        if sql[i] in ("'", '"'):
+            quote = sql[i]
+            if i > code_start:
+                yield code_start, i, sql[code_start:i]
+            i += 1
+            while i < n:
+                if sql[i] == quote:
+                    if i + 1 < n and sql[i + 1] == quote:
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            code_start = i
+            continue
+        i += 1
+    if code_start < n:
+        yield code_start, n, sql[code_start:]
+
+
+def _function_calls(sql: str, name: str) -> list[tuple[int, int]]:
+    """Absolute [start, end) spans of `name()` in code, not in strings/comments."""
+    spans = []
+    needle = name.lower()
+    for start, _end, chunk in _code_chunks(sql):
+        lower = chunk.lower()
+        i = 0
+        while True:
+            j = lower.find(needle, i)
+            if j < 0:
+                break
+            if j > 0 and (chunk[j - 1].isalnum() or chunk[j - 1] == "_"):
+                i = j + 1
+                continue
+            after = chunk[j + len(name):].lstrip()
+            if after.startswith("("):
+                close = chunk.find(")", j)
+                spans.append((start + j, start + (close + 1 if close >= 0 else j + len(name))))
+            i = j + 1
+    return spans
+
+
+def sql_uses_input_file_name(sql: str) -> bool:
+    return bool(_function_calls(sql, "input_file_name"))
+
+
+def _relation_names(sql: str) -> list[str]:
+    names = []
+    for _start, _end, chunk in _code_chunks(sql):
+        for match in _FROM_JOIN.finditer(chunk):
+            names.append(match.group(1).replace("`", "").rsplit(".", 1)[-1])
+    return names
+
+
+def _rewrite_relations(sql: str, tagged: list[str]) -> str:
+    tagged_l = {t.lower() for t in tagged}
+    out = []
+    last = 0
+    for start, end, chunk in _code_chunks(sql):
+        out.append(sql[last:start])
+        rewritten = chunk
+        for match in reversed(list(_FROM_JOIN.finditer(chunk))):
+            raw = match.group(1)
+            name = raw.replace("`", "").rsplit(".", 1)[-1]
+            if name.lower() not in tagged_l:
+                continue
+            shadow = shadow_view_name(name)
+            rewritten = rewritten[:match.start(1)] + shadow + rewritten[match.end(1):]
+        out.append(rewritten)
+        last = end
+    out.append(sql[last:])
+    return "".join(out)
+
+
+def _expand_stars(sql: str, columns: list[str]) -> str:
+    if not columns:
+        return sql
+    replacement = ", ".join(columns)
+    out = []
+    last = 0
+    for start, end, chunk in _code_chunks(sql):
+        out.append(sql[last:start])
+        out.append(_STAR.sub(replacement, chunk))
+        last = end
+    out.append(sql[last:])
+    return "".join(out)
+
+
+def rewrite_sql_input_file_name(sql: str) -> str:
+    """Rewrite `input_file_name()` onto the tag when the relation is tagged.
+
+    A UDF cannot do this: the function takes no arguments, so it cannot see
+    the row or the tag. Blind string replace would corrupt a query that merely
+    mentions the name. Leave those alone; fail loud when the relation was
+    never a file read.
+    """
+    if not isinstance(sql, str) or not sql_uses_input_file_name(sql):
+        return sql
+    rels = _relation_names(sql)
+    tagged = []
+    columns = []
+    known = {k.lower(): (k, v) for k, v in _TAGGED_VIEWS.items()}
+    for rel in rels:
+        hit = known.get(rel.lower())
+        if hit:
+            tagged.append(hit[0])
+            columns = hit[1]
+    if not tagged:
+        raise InputFileNameError(_not_a_file_message())
+    out = sql
+    for start, end in reversed(_function_calls(sql, "input_file_name")):
+        out = out[:start] + f"`{_TAG}`" + out[end:]
+    out = _rewrite_relations(out, tagged)
+    return _expand_stars(out, columns)
+
+
+def _install_sql(spark) -> None:
+    """Wrap `spark.sql` so SQL-string usage hits the same tag the PySpark wrap does."""
+    original = getattr(spark, "sql", None)
+    if original is None or getattr(original, "_emu_input_file_sql", False):
+        return
+
+    def sql(query, *args, **kwargs):
+        if isinstance(query, str) and sql_uses_input_file_name(query):
+            query = rewrite_sql_input_file_name(query)
+        return original(query, *args, **kwargs)
+
+    sql._emu_input_file_sql = True
+    spark.sql = sql
+
+
 def install(spark) -> bool:
     """Make `input_file_name()` work on this session. Returns True if installed.
 
@@ -103,6 +297,7 @@ def install(spark) -> bool:
 
     reader_cls = type(spark.read)
     if getattr(reader_cls, "_emu_input_file_patched", False):
+        _install_sql(spark)
         return True
 
     def _wrap(fmt_name):
@@ -195,9 +390,6 @@ def install(spark) -> bool:
         "first",
         "toPandas",
         "toLocalIterator",
-        "createOrReplaceTempView",
-        "createTempView",
-        "createOrReplaceGlobalTempView",
     ):
         if not hasattr(_ConnectDataFrame, _name):
             continue
@@ -225,7 +417,15 @@ def install(spark) -> bool:
         def _make_select(method):
             def hidden(self, *args, **kwargs):
                 wants_tag = any(_TAG in str(a) for a in args)
-                return method(self if wants_tag else _visible(self), *args, **kwargs)
+                if wants_tag:
+                    try:
+                        raw = _raw_columns(self)
+                    except Exception:
+                        raw = []
+                    if _TAG not in raw:
+                        raise InputFileNameError(_not_a_file_message())
+                    return method(self, *args, **kwargs)
+                return method(_visible(self), *args, **kwargs)
 
             return hidden
 
@@ -242,5 +442,33 @@ def install(spark) -> bool:
 
     _ConnectDataFrame.write = write
 
+    # Views: SELECT * stays on a clean registration so the tag cannot leak
+    # through SQL star expansion. A shadow view keeps the tag; spark.sql
+    # rewrites input_file_name() onto that shadow (docs/37 §3a).
+    for _name in (
+        "createOrReplaceTempView",
+        "createTempView",
+        "createOrReplaceGlobalTempView",
+    ):
+        if not hasattr(_ConnectDataFrame, _name):
+            continue
+        _original_view = getattr(_ConnectDataFrame, _name)
+
+        def _make_view(method):
+            def hidden(self, name, *args, **kwargs):
+                try:
+                    raw = _raw_columns(self)
+                except Exception:
+                    raw = []
+                if _TAG in raw:
+                    remember_tagged_view(name, [c for c in raw if c != _TAG])
+                    method(self, shadow_view_name(name), *args, **kwargs)
+                return method(_visible(self), name, *args, **kwargs)
+
+            return hidden
+
+        setattr(_ConnectDataFrame, _name, _make_view(_original_view))
+
+    _install_sql(spark)
     reader_cls._emu_input_file_patched = True
     return True

--- a/python/tests/test_input_file_shim.py
+++ b/python/tests/test_input_file_shim.py
@@ -80,7 +80,12 @@ class FakeDFBase:
     def toLocalIterator(self):  # noqa: N802 - PySpark's spelling
         return iter([tuple(self._cols)])
 
+    view_calls = None
+
     def createOrReplaceTempView(self, name):  # noqa: N802 - PySpark's spelling
+        calls = getattr(type(self), "view_calls", None)
+        if calls is not None:
+            calls.append((name, list(self._cols)))
         return f"{name}:{','.join(self._cols)}"
 
     def select(self, *args):
@@ -302,3 +307,103 @@ def test_a_single_file_read_carries_its_own_path(patched, monkeypatch):
     assert "part-0007.csv" in str(tagged_with[TAG]), "the tag must name the file, not the glob"
     if original_with_column is None:
         del FakeDF.withColumn
+
+
+def test_provenance_on_a_non_file_frame_names_the_shim(patched):
+    # docs/37 §3b: the behaviour stays a loud error. What changes is the
+    # message — a bare AnalysisException on an internal column name does not
+    # tell a notebook why provenance failed.
+    input_file, FakeDF = patched
+    from pyspark.sql import functions as F
+
+    with pytest.raises(input_file.InputFileNameError, match="never came from a file"):
+        FakeDF(["a", "b"]).select(F.input_file_name())
+
+
+def test_sql_rewrite_leaves_strings_and_comments_alone(patched):
+    # A blind replace would corrupt a query that merely mentions the name.
+    # That is worse than the honest gap (docs/37 §3a).
+    input_file, _ = patched
+    input_file.forget_tagged_views()
+    q = (
+        "SELECT 'input_file_name()' AS s, id FROM v "
+        "-- input_file_name()\n"
+        "/* input_file_name() */"
+    )
+    assert input_file.rewrite_sql_input_file_name(q) == q
+    assert input_file.sql_uses_input_file_name(q) is False
+
+
+def test_sql_rewrite_function_call_on_a_tagged_view(patched):
+    input_file, _ = patched
+    input_file.forget_tagged_views()
+    input_file.remember_tagged_view("landing", ["id", "name"])
+    out = input_file.rewrite_sql_input_file_name(
+        "SELECT input_file_name() AS src, id FROM landing"
+    )
+    assert input_file._TAG in out
+    assert "input_file_name()" not in out
+    assert input_file.shadow_view_name("landing") in out
+    assert "FROM landing" not in out
+
+
+def test_sql_rewrite_expands_star_so_the_tag_does_not_leak(patched):
+    # The shadow view still carries the tag. Expanding `*` to the columns the
+    # user can see keeps SELECT * from growing a bookkeeping column.
+    input_file, _ = patched
+    input_file.forget_tagged_views()
+    input_file.remember_tagged_view("landing", ["id", "name"])
+    out = input_file.rewrite_sql_input_file_name(
+        "SELECT *, input_file_name() FROM landing"
+    )
+    assert "id, name" in out
+    assert "count(*)" not in out
+    assert "*" not in out.replace(input_file._TAG, "")
+
+
+def test_sql_rewrite_refuses_an_untagged_relation(patched):
+    input_file, _ = patched
+    input_file.forget_tagged_views()
+    with pytest.raises(input_file.InputFileNameError, match="never came from a file"):
+        input_file.rewrite_sql_input_file_name(
+            "SELECT input_file_name() FROM not_a_file"
+        )
+
+
+def test_a_tagged_view_registers_a_shadow_that_keeps_the_tag(patched):
+    # SELECT * uses the clean view. SQL that asks for input_file_name() is
+    # rewritten onto the shadow, which is the only place the per-row path lives.
+    input_file, FakeDF = patched
+    input_file.forget_tagged_views()
+    FakeDF.view_calls = []
+    FakeDF(["id", "name", TAG]).createOrReplaceTempView("landing")
+    assert "landing" in input_file._TAGGED_VIEWS
+    names = [n for n, _ in FakeDF.view_calls]
+    assert "landing" in names
+    assert input_file.shadow_view_name("landing") in names
+    shadow_cols = dict(FakeDF.view_calls)[input_file.shadow_view_name("landing")]
+    assert TAG in shadow_cols
+    clean_cols = dict(FakeDF.view_calls)["landing"]
+    assert TAG not in clean_cols
+    FakeDF.view_calls = None
+
+
+def test_spark_sql_wrap_rewrites_before_the_engine_sees_the_text(patched, monkeypatch):
+    input_file, FakeDF = patched
+    input_file.forget_tagged_views()
+    input_file.remember_tagged_view("landing", ["id"])
+    seen = {}
+
+    class Spark:
+        read = type("R", (), {"csv": lambda self, path, *a, **k: FakeDF(["id"])})()
+
+        def sql(self, query, *a, **k):
+            seen["query"] = query
+            return FakeDF(["src"])
+
+    monkeypatch.setattr(input_file, "engine_has_input_file_name", lambda _s: False)
+    spark = Spark()
+    input_file.install(spark)
+    spark.sql("SELECT input_file_name() AS src FROM landing")
+    assert "input_file_name()" not in seen["query"]
+    assert input_file._TAG in seen["query"]


### PR DESCRIPTION
## Summary
- docs/37 §3b: `input_file_name()` on a frame that never came from a file raises `InputFileNameError` naming the shim, instead of a bare AnalysisException on an internal column.
- docs/37 §3a: `spark.sql("SELECT input_file_name() …")` is rewritten onto the tag column when the FROM/JOIN view was registered from a tagged file read. Strings and comments that merely mention the name are left alone. A UDF cannot do this (zero-arg). An empty-string stub is still refused.
- A tagged `createOrReplaceTempView` registers a clean view for `SELECT *` and a shadow that still carries the tag, so star expansion does not leak bookkeeping.

## Test plan
- [x] `uv run --group test pytest python/tests/test_input_file_shim.py` (18 passed)
- [ ] CI ruff + ty
- [ ] Do not stub `input_file_name()` to `""` on a non-file frame