### PR TITLE
docs: sync README and the site to what the emulator actually runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@
 
 A clean-room, local emulator of **Microsoft Fabric**, built to compose with
 [entra-emulator](https://github.com/calvinchengx/entra-emulator) — the control
-plane (workspaces, items, RBAC, git, LROs) plus a real **OneLake** ADLS/Blob
-data plane, a **T-SQL warehouse** over TDS, native **Livy** sessions on a real
-Spark engine, **Data Factory** pipelines, **Apache Airflow** jobs on a real
-Airflow scheduler, and **KQL** eventhouses.
+plane (workspaces, items, RBAC, git, LROs, Fabric Core MCP) plus a real
+**OneLake** ADLS/Blob data plane, a **T-SQL warehouse** over TDS, native
+**Livy** sessions on a real Spark engine, **Data Factory** pipelines (Web,
+REST, Salesforce, and Azure Batch Custom on by default), **Apache Airflow**
+jobs on a real Airflow scheduler, **KQL** eventhouses, and **Eventstream**
+on a real Apache Kafka broker (Lakehouse and Reflex destinations included).
 
 ![the Data flow view drawing the advanced medallion as it is built: three source systems landing, conformed to bronze, resolved to silver, joined into a Warehouse star, and served to a semantic model](docs/demo/flow.gif)
 
@@ -135,14 +137,31 @@ are shipped and CI-verified on Linux, macOS, and Windows.
   lakehouse rule is enforced, and `concurrency` is honoured when asked for —
   sequential by default, a divergence recorded in [parity.md](docs/parity.md).
   *Schedules* — `.../jobs/{jobType}/schedules` on any item. And *Apache Airflow
-  jobs*, below.
+  jobs*, below. Pipeline **Web** activities make the real HTTP call (stub only
+  if you set `FABRIC_WEB_ACTIVITY=stub`). **Custom** (Azure Batch) runs the
+  command on the Spark agent by default (`FABRIC_CUSTOM_ACTIVITY=off` refuses
+  it). `RestSource`/`RestSink` and Salesforce Bulk API 2.0 are real too.
+- **Real-Time Intelligence (opt-in sidecars):** Eventhouse / KQL Database
+  execute on Microsoft's `kustainer` (`--profile rti`). Eventstream items
+  provision a Kafka topic; Custom HTTP produce writes real key/value bytes;
+  notebooks read with `format("kafka")` + `eventstream.*`. Bind a **Lakehouse**
+  destination to append those events as Delta, or a **Reflex** destination to
+  start a real `EventTriggered` item job
+  (`Microsoft.Fabric.Eventstream.EventReceived`). Eventhouse streaming dest
+  and operators stay refused. See [51](docs/51-eventstream-kafka.md).
+- **Fabric Core MCP** (`POST /v1/mcp/core`) — Streamable HTTP over the same
+  Core REST handlers, witnessed by the unmodified Python `mcp` SDK.
+- **Optional full DAX oracle** — empty `FABRIC_DAX_URL` keeps the in-process
+  bounded evaluator. Point it at a pump in front of Power BI Desktop's
+  `msmdsrv` on a machine you own ([52](docs/52-msmdsrv-hosts.md)). Not a
+  compose default and not GitHub `macos-latest` / `ubuntu-latest`.
 - **Real orchestration (Airflow):** `ApacheAirflowJob` items run on
   **genuine Apache Airflow** — Fabric's own code-first orchestrator *is* upstream
   Airflow, so the sidecar pins the versions Microsoft documents (2.10.5 on
   Python 3.12). DAG sources are stored as item definitions in OneLake, synced
   into the scheduler's DAG folder, and driven through Airflow's REST API for
   discovery, unpause, trigger and terminal-state polling. Real scheduler, real
-  executor, real DAG semantics — no orchestration emulation at all. Attach it
+  executor, real DAG semantics — no orchestration emulation at all.
   On by default in `make up`; `make up PROFILE="--profile governance"` leaves it
   out, and without the wiring the routes answer `AirflowNotConfigured` rather
   than pretending. See
@@ -151,8 +170,9 @@ are shipped and CI-verified on Linux, macOS, and Windows.
 The bare binary runs none of the engines (clock-derived, milliseconds) — but
 `docker compose up` auto-loads the override that attaches them, so the
 documented path is engine-backed by default. Heavier services (KQL,
-OpenMetadata, the terminal) sit behind profiles; `make up` enables `governance`
-for you and the others are opt-in. Coverage floor is 90% (currently ~90%).
+Eventstream, OpenMetadata, the terminal, an optional `msmdsrv` DAX oracle)
+sit behind profiles or a host you own; `make up` enables `governance` for
+you and the others are opt-in. Coverage floor is 90% (currently ~90%).
 
 Docs: <https://calvinchengx.github.io/fabric-emulator/>
 
@@ -166,20 +186,21 @@ and both gold engines. Reference:
 [real compute](docs/14-real-compute.md), the
 [warehouse over TDS](docs/16-warehouse-tds.md),
 [flow observability](docs/31-flow-observability.md),
-[running modes](docs/27-running-modes.md), the [roadmap](docs/13-roadmap.md), and
+[running modes](docs/27-running-modes.md),
+[Eventstream](docs/51-eventstream-kafka.md),
+[the DAX oracle](docs/52-msmdsrv-hosts.md), the [roadmap](docs/13-roadmap.md), and
 the [parity map](docs/parity.md).
 
 ## Parity at a glance
 
-| | Rows | Meaning |
+| | Claims | Meaning |
 |---|---|---|
-| 🟢 **Real** | 89 | Genuine work — real signed JWTs, real bytes on disk, a real engine or client computes |
-| 🟡 **Emulated** | 17 | Faithful API contract and persisted state, but no engine behind it |
-| 🟠 **Non-default engine** | 14 | Real on the JVM Spark overlay or an opt-in profile — *not* "bring your own": `docker compose up` already starts Sail and the SQL Server sidecar |
-| 🔴 **Not implemented** | 19 | Deliberately out of scope — the parity map argues where the boundary sits and why |
+| 🟢 **Real** | **111** | Witnessed — `check_witnesses.py --strict` fails CI if a supported claim loses its witness. Genuine work: real signed JWTs, real bytes, a real engine or client computes |
+| 🟡 **Emulated** | management / clock | Faithful API contract and persisted state, but no engine — LROs and generic item jobs on purpose |
+| 🟠 **Non-default engine** | JVM overlay or a profile | Real on the JVM Spark overlay, `--profile rti`, or `--profile eventstream` — *not* "bring your own": `docker compose up` already starts Sail and the SQL Server sidecar |
+| 🔴 **Not implemented** | honest 501 | Deliberately out of scope — Eventhouse streaming dest, operators, Dataflow exec, Purview system classifiers. The parity map argues where the boundary sits and why |
 
-Every 🟢 row names the witness that proves it, and a CI job fails the build if a
-claim loses its witness. Full detail: [parity map](docs/parity.md).
+Every 🟢 claim names the witness that proves it. Full detail: [parity map](docs/parity.md).
 
 ## What `docker compose up` gives you
 
@@ -192,7 +213,8 @@ identities), so it could equally point at a real Entra tenant.
 | `docker compose up` | both emulators **plus real engines** — a Spark agent and a SQL Server sidecar, via the auto-loaded [override](docker-compose.override.yml). Livy sessions, notebook cells and the T-SQL/TDS warehouse run for real |
 | `docker compose -f docker-compose.yml up` | the lite, contract-only pair — honest `501`s on the engine surfaces |
 | `--profile rti` | Microsoft's own KQL engine behind Eventhouse / KQL Database ([docs/25](docs/25-rti-kusto.md)) |
-| `--profile eventstream` | Apache Kafka KRaft behind Eventstream items — needs `-f docker-compose.eventstream.yml` ([docs/51](docs/51-eventstream-kafka.md)). Works on Sail (default) and the JVM overlay |
+| `--profile eventstream` | Apache Kafka KRaft behind Eventstream items — needs `-f docker-compose.eventstream.yml` ([docs/51](docs/51-eventstream-kafka.md)). Custom HTTP produce, Lakehouse Delta dest, Reflex job dest. Works on Sail (default) and the JVM overlay |
+| `FABRIC_DAX_URL` | Optional pump in front of `msmdsrv` on a machine you own — not a compose profile ([docs/52](docs/52-msmdsrv-hosts.md)) |
 | `--profile governance` | OpenMetadata over the same state your pipelines write ([docs/22](docs/22-openmetadata.md)) |
 | `--profile terminal` | a shell in the Flow view beside the graph — needs `-f docker-compose.terminal.yml` too ([docs/31](docs/31-flow-observability.md#the-terminal-pane)) |
 | `-f docker-compose.spark-jvm.yml` | **swaps** Sail for JVM Spark, buying the RDD API, structured streaming, `OPTIMIZE`/`VACUUM` and Java/Scala UDFs at the cost of image size ([docs/20](docs/20-lakesail-engine.md)) |

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -265,3 +265,8 @@ get the same switch via `eval "$(python -m fabric_target env real)"`.
 - Freeze time and inject faults: [testing](10-testing.md).
 - Every endpoint: [control-plane API](07-control-plane-api.md) and
   [OneLake](08-onelake.md).
+- Eventstream (Kafka, Lakehouse dest, Reflex dest):
+  [51-eventstream-kafka.md](51-eventstream-kafka.md).
+- Optional full DAX against `msmdsrv`:
+  [52-msmdsrv-hosts.md](52-msmdsrv-hosts.md).
+- What is real vs emulated: [parity map](parity.md).

--- a/docs/02-installation.md
+++ b/docs/02-installation.md
@@ -65,6 +65,11 @@ SQL Server sidecar (the T-SQL/TDS warehouse surface — Warehouse, Lakehouse SQL
 endpoint, Fabric SQL Database). `docker-compose.override.yml` — auto-loaded
 alongside [`docker-compose.yml`](../docker-compose.yml), no flag needed — adds
 those sidecars and their env vars; see [14-real-compute.md](14-real-compute.md).
+`--profile rti` attaches Microsoft's KQL engine; `--profile eventstream`
+plus `-f docker-compose.eventstream.yml` attaches Apache Kafka (Lakehouse
+and Reflex destinations included). An optional `msmdsrv` DAX oracle is
+`FABRIC_DAX_URL` on a machine you own, not a compose profile
+([52](52-msmdsrv-hosts.md)).
 
 To run the same stack explicitly on **LakeSail's Sail** (the default Rust
 Spark-Connect engine, with no JVM; see

--- a/docs/03-architecture.md
+++ b/docs/03-architecture.md
@@ -1,9 +1,11 @@
 # 03 — Architecture
 
-fabric-emulator is a **control-plane contract emulator** for Microsoft Fabric,
-plus a thin OneLake data-plane surface. It is the sibling of
+fabric-emulator is a **local Microsoft Fabric runtime**: the control-plane
+contract (workspaces, items, RBAC, git, jobs, LROs, Fabric Core MCP), a real
+OneLake ADLS/Blob data plane, and attached engines for Spark, T-SQL, pipelines,
+Airflow, KQL, and Eventstream. It is the sibling of
 [entra-emulator](https://github.com/calvinchengx/entra-emulator): where that
-project is an Entra ID STS, this one is the Fabric REST surface that *consumes*
+project is an Entra ID STS, this one is the Fabric surface that *consumes*
 Entra tokens.
 
 ## Version grounding
@@ -82,10 +84,12 @@ flowchart LR
         direction TB
         Secrets["/secrets/{name} — data plane 7.4"]
     end
-    subgraph engines["opt-in engine sidecars"]
+    subgraph engines["engine sidecars"]
         direction TB
-        Spark["Spark agent (Livy)"]
-        SQL["SQL Server (warehouse)"]
+        Spark["Spark agent (Livy) — default"]
+        SQL["SQL Server (warehouse) — default"]
+        KQL["kustainer (Eventhouse) — profile rti"]
+        Kafka["Apache Kafka (Eventstream) — profile eventstream"]
     end
     Client -->|"Bearer (aud = fabric / storage)"| API
     Client -->|"Bearer (aud = storage)"| OL
@@ -96,6 +100,8 @@ flowchart LR
     Secrets -->|"verify (iss + aud + sig)"| JWKS
     API -.->|"native execution"| Spark
     WH -.->|"session splice"| SQL
+    API -.->|"KQL relay"| KQL
+    API -.->|"produce / consume"| Kafka
 ```
 
 Every core service in [`docker-compose.yml`](../docker-compose.yml) appears in

--- a/docs/07-control-plane-api.md
+++ b/docs/07-control-plane-api.md
@@ -5,7 +5,9 @@ handful of routes below are what SDKs, `fabric-cicd`, git integration, and
 deployment-pipeline automation actually call. Typed item collections
 (`/notebooks`, `/lakehouses`, `/warehouses`, `/dataPipelines`, …) are thin
 aliases over the **generic item** shape, so one implementation covers dozens of
-item types. The OneLake data plane has its own page: [08-onelake.md](08-onelake.md).
+item types. Eventstream destination bind, Reflex triggers, and Fabric Core
+MCP (`POST /v1/mcp/core`) are on this plane too. The OneLake data plane has
+its own page: [08-onelake.md](08-onelake.md).
 
 All routes are under `https://api.fabric.microsoft.com/v1` unless noted.
 `application/json`. Bearer required. Mutations are async (see **LRO** below)

--- a/docs/13-roadmap.md
+++ b/docs/13-roadmap.md
@@ -327,9 +327,11 @@ proxy would be a separate sibling.
       real path (`exists`/`itemType`/`size`/`lastModified`/`childItems`);
       **Script**/**SqlServerStoredProcedure** run real T-SQL against a
       Warehouse/SQLDatabase item's own SQL Server database (Track C's backend),
-      targeted the same `{workspaceId?, itemId}` way as Copy/Lookup. Web /
-      external-connector leaves stay stubbed (a real network call breaks the
-      offline/deterministic guarantee).
+      targeted the same `{workspaceId?, itemId}` way as Copy/Lookup.
+      Web, WebHook, REST, Salesforce and Custom (Azure Batch) run for real
+      (Web and Custom can be refused with `FABRIC_WEB_ACTIVITY=stub` /
+      `FABRIC_CUSTOM_ACTIVITY=off`). External stores on Copy stay
+      refused by name.
     - [x] **R5 (Apache Airflow + Dataflow Gen2 boundary)** —
       `ApacheAirflowJob` item/file APIs sync Python DAGs into an attached
       Airflow 2.10.5/Python 3.12 sidecar, unpause and trigger them through the
@@ -402,9 +404,30 @@ Connect) becomes the engine behind every compute surface — PySpark with no JVM
       `createDataFrame` included); JVM image build dropped.
 - [x] **S3** — `e2e/spark` (A2) reborn on Sail with the same
       production-shaped `abfs://` URLs; `EntraTokenProvider.java` + the JVM
-      Dockerfile deleted. **No JVM remains anywhere in the repo.** Tradeoff
-      accepted: the Hadoop-ABFS-driver witness is gone — resurrect as an
-      opt-in nightly if demand appears.
+      Dockerfile deleted. The **default** path has no JVM; the opt-in
+      overlay (`docker-compose.spark-jvm.yml` / `make up-jvm`) later
+      brought JVM Spark back for RDD, checkpointed streaming, and
+      Java/Scala UDFs. Tradeoff accepted on the default: the Hadoop-ABFS
+      driver witness lives on that overlay, not on Sail.
+
+## After S — shipped on the same contract
+
+These landed after the Sail swap and are CI-verified. They are not a new
+phase letter; they extend surfaces the earlier phases already named.
+
+- [x] **Eventstream** — Apache Kafka KRaft sidecar (`--profile eventstream`),
+      Fabric notebook API (`format("kafka")` + `eventstream.*`), Custom HTTP
+      produce. **Lakehouse destination** appends produce payloads as Delta;
+      **Reflex destination** fires `Microsoft.Fabric.Eventstream.EventReceived`
+      as a real `EventTriggered` job. Eventhouse streaming dest and operators
+      stay refused. [51-eventstream-kafka.md](51-eventstream-kafka.md).
+- [x] **Custom activity on by default** — Azure Batch `command` runs on the
+      Spark agent; `FABRIC_CUSTOM_ACTIVITY=off` restores the refusal.
+- [x] **Fabric Core MCP** — `POST /v1/mcp/core`, unmodified Python `mcp` SDK
+      in CI.
+- [x] **Optional `msmdsrv` DAX oracle** — `FABRIC_DAX_URL` relays
+      `executeQueries` to a pump in front of Desktop's engine on a machine
+      you own. Not a compose default. [52-msmdsrv-hosts.md](52-msmdsrv-hosts.md).
 
 ## Sequencing note
 

--- a/docs/14-real-compute.md
+++ b/docs/14-real-compute.md
@@ -36,7 +36,7 @@ service — it is:
 
 1. this repo's OneLake plane becoming complete enough for real engines,
 2. e2e harnesses in `e2e/` (like `e2e/fabric-cicd/`),
-3. compose-level sidecar attachments (Spark, DuckDB, SQL Server).
+3. compose-level sidecar attachments (Spark, SQL Server, Airflow, kustainer, Kafka).
 
 This held even for the piece once expected to become a separate service: the
 **TDS-FedAuth termination** (Track C) shipped **in this repo** as `internal/tds`
@@ -269,7 +269,11 @@ policies — with leaf activities delegating to real work where an engine exists
 | Copy | real byte movement, **OneLake→OneLake** (a file or a directory subtree) | ✅ real (in-family) |
 | Notebook | Livy → the real Spark agent (Track B) | ✅ real (with `--spark-agent-url`) |
 | Script / SqlServerStoredProcedure | real T-SQL against a Warehouse/SQLDatabase item's own SQL Server database (Track C's backend) — the emulator's own scoped `{workspaceId?, itemId}` target reference, not Fabric's linkedService wire shape | ✅ real (with `--warehouse-sql-url`) |
-| Web / Webhook | real HTTP calls to arbitrary URLs would break the offline/deterministic guarantee | 📐 not yet wired |
+| Web / WebHook | real HTTP call; `FABRIC_WEB_ACTIVITY=stub` records success without calling | ✅ real (default) |
+| Custom (Azure Batch) | `command` runs in the Spark agent container; `FABRIC_CUSTOM_ACTIVITY=off` refuses | ✅ real (default) |
+| RestSource / RestSink | real HTTP + pagination into a Lakehouse Delta sink | ✅ real |
+| Salesforce | Bulk API 2.0 ingest and sink | ✅ real |
+| SparkJobDefinition / InvokeCopyJob | run the referenced item; CopyJob moves real OneLake bytes | ✅ real |
 
 Control-flow fidelity is deterministic on the controllable clock: **ForEach**
 honors `isSequential` + `batchCount` and reports the right wall-clock (sequential
@@ -282,9 +286,10 @@ does is real: it exercises real Spark, real OneLake bytes, and real data movemen
 
 **E3 — honestly unobtainable → 501.** Dataflow Gen2 (the Power Query M
 compute is proprietary), self-hosted integration runtime / gateway scenarios,
-and the long tail of cloud connectors outside the scoped set. Activities we
-cannot execute for real fail with a clear 501 — a pipeline "succeeding"
-without doing its work is exactly what this design forbids.
+and cloud connectors outside the scoped set (REST, Salesforce, ServiceNow via
+RestSource, and Custom are in-scope and run). Activities we cannot execute
+for real fail with a clear 501 — a pipeline "succeeding" without doing its
+work is exactly what this design forbids.
 
 CI/CD for pipelines needs none of this and works **today**: `DataPipeline`
 definitions round-trip through git and fabric-cicd like any other item.
@@ -314,7 +319,7 @@ compose files under `e2e/`, independent of this one.
 | `docker compose -f docker-compose.yml up` (opt-out) | entra + fabric-emulator only, same as the bare binary | milliseconds |
 | `docker compose up` (default) | + a Spark agent + a SQL Server sidecar | ~1.5 GB+, seconds to start |
 | A1 delta-rs | Rust library in a Python wheel — no JVM | tens of MB |
-| A2/B PySpark | **full JVM Spark** (local mode or container, via Livy) | GBs, seconds to start |
+| A2/B PySpark | **Sail** (default, Spark Connect, no JVM); JVM overlay is `make up-jvm` | hundreds of MB / GBs |
 | C1 DuckDB | in-process library — no server, no JVM | a few MB |
 | C2 SQL Server | **full SQL Server engine** in a container | ~1.5 GB, x86 (emulated on ARM) |
 
@@ -333,7 +338,7 @@ C2 SQL-auth compromise.
 | **R1+R2** (merged) | **containerized Spark** — A2 (real PySpark writes Delta via ABFS, cross-engine read with delta-rs) **and** B1+B2 (native Livy sessions/HC on a real Spark agent; real RunNotebook mode). JVM Spark image + Docker network so ABFS resolves to the emulator. | ✅ shipped (`e2e/spark`, `e2e/livy`, `e2e/notebook-run`) |
 | **R3** | C1 (DuckDB SQL over the lakehouse) **and** C2/C3 (SQL Server sidecar + in-repo FedAuth-over-TDS splice; two driver witnesses) | ✅ shipped (`e2e/duckdb`, `e2e/dbt-fabric`, gated TDS tests) |
 | **R4** | D1 notebookutils, D2 default-lakehouse sessions, and the pinned D3 VS Code extension authoring contract | ✅ shipped |
-| **R5** | E2 DataPipeline interpreter and real-engine leaves; E1 real Airflow sidecar; explicit Dataflow Gen2 engine boundary | ✅ shipped |
+| **R5** | E2 DataPipeline interpreter and real-engine leaves (Web, Custom, REST, Salesforce, SJD, InvokeCopyJob included); E1 real Airflow sidecar; explicit Dataflow Gen2 engine boundary | ✅ shipped |
 
 ## Correctness: how we prove it
 

--- a/docs/24-parity-completion.md
+++ b/docs/24-parity-completion.md
@@ -15,9 +15,11 @@ preceded its code).
 ## Baseline
 
 Graded from `docs/parity.md` at the time of writing: **60 🟢, 7 🟡, 7 🟠, 14 🔴**
-across 8 areas (a row may carry two marks). CI/CD, Data Warehouse, Platform, and
-OneLake are effectively complete; Data Engineering holds the largest cluster of
-non-green marks, and "item types, engine absent" holds the rest.
+across 8 areas (a row may carry two marks). **Those counts are historical.**
+`check_witnesses.py --strict` now reports **111** supported (🟢) claims.
+CI/CD, Data Warehouse, Platform, and OneLake are effectively complete; Data
+Engineering holds the largest cluster of non-green marks, and "item types,
+engine absent" holds the rest.
 
 ## Won't do — and why that's the right call
 

--- a/docs/27-running-modes.md
+++ b/docs/27-running-modes.md
@@ -1,8 +1,9 @@
 # 27 — Running modes: default, swapped engine, real Fabric
 
-The emulator runs in five shapes. This page is the map: what each one starts,
-how to confirm it actually works, and when you would want it. Every mode has a
-`make` target, so the commands are identical on Linux, macOS and Windows.
+The emulator runs in a handful of shapes. This page is the map: what each one
+starts, how to confirm it actually works, and when you would want it. Every
+mode has a `make` target, so the commands are identical on Linux, macOS and
+Windows.
 
 If you only want to get going, [the quickstart](01-quickstart.md) walks mode 1
 end to end. Come back here when you need to change something.
@@ -15,6 +16,7 @@ end to end. Come back here when you need to change something.
 | …plus Spark and the T-SQL warehouse | `docker compose up` | 6 | ~1 GB | **8 GB** |
 | …plus catalog, lineage, glossary, Airflow | `make up` | 12 | ~3 GB | **13 GB** |
 | …plus KQL (Eventhouse) | add `--profile rti` | 13 | +4 GB | +4 GB |
+| …plus Eventstream (Kafka, Lakehouse/Reflex dest) | add `--profile eventstream` and `-f docker-compose.eventstream.yml` | +1 | +400 MB | +400 MB |
 | …plus a shell in the Flow view | add `--profile terminal` | 14 | +5 MB | +5 MB |
 | Spark features Sail lacks (RDD, JVM UDFs) | `make up-jvm` | 6 | ~1 GB | 10 GB |
 | full DAX against `msmdsrv` (optional oracle) | a machine you own — [52](52-msmdsrv-hosts.md) | +Windows guest | — | **8–16 GB**; not `make up`; not `macos-latest` / `ubuntu-latest` |
@@ -55,8 +57,8 @@ SQL Server sidecar behind the T-SQL/TDS warehouse. Livy sessions, notebook
 cells, and warehouse queries all do real work — nothing to attach.
 
 `make up` also brings up the **governance profile** (OpenMetadata and its
-Postgres/Elasticsearch), because the quickstart advertises it. That is eleven
-containers. To skip it:
+Postgres/OpenSearch) and **Airflow**, because the quickstart advertises them.
+That is twelve containers. To skip them:
 
 ```bash
 make up PROFILE=          # same stack, no OpenMetadata
@@ -67,8 +69,8 @@ make up PROFILE=          # same stack, no OpenMetadata
 Worth knowing that this is **not** the same as `make up`:
 
 ```bash
-docker compose up         # 6 services  — no governance profile
-make up                   # 11 services — adds OpenMetadata
+docker compose up         # 6 services  — no governance / airflow profiles
+make up                   # 12 services — adds OpenMetadata + Airflow
 ```
 
 Compose auto-loads [`docker-compose.override.yml`](../docker-compose.override.yml),
@@ -139,7 +141,7 @@ them again if you still want them.
 | `governance` | OpenMetadata + Postgres + OpenSearch | catalog, glossary, lineage over the state your pipelines wrote ([22](22-openmetadata.md)) | ~2.8 GB |
 | `airflow` | `apache/airflow` scheduler + webserver | `ApacheAirflowJob` items run on genuine Airflow ([14](14-real-compute.md#e1)) | ~1.1 GB |
 | `rti` | `kustainer` | Microsoft's own KQL engine behind Eventhouse ([25](25-rti-kusto.md)) | 4 GB (its own `mem_limit`) |
-| `eventstream` | `kafka` (`apache/kafka` KRaft) | Fabric Eventstream notebook API on Sail (default) and the JVM overlay ([51](51-eventstream-kafka.md)) | ~400 MB |
+| `eventstream` | `kafka` (`apache/kafka` KRaft) | Fabric Eventstream notebook API, Custom HTTP produce, Lakehouse Delta dest, Reflex job dest ([51](51-eventstream-kafka.md)) | ~400 MB |
 | `terminal` | `ttyd` | a shell in the Flow view, beside the graph ([31](31-flow-observability.md#the-terminal-pane)) | negligible |
 
 ```bash

--- a/docs/43-activity-completion-plan.md
+++ b/docs/43-activity-completion-plan.md
@@ -18,11 +18,12 @@ defects were.
 
 What is verifiable, stated so anyone can re-derive it rather than trust it:
 
-- **17 leaf activity types execute for real** in `internal/api/pipelines.go`'s
+- **19 leaf activity types execute for real** in `internal/api/pipelines.go`'s
   dispatch: notebook, invoke-pipeline, Copy, Lookup, GetMetadata, Delete,
   Script, stored procedure, Web, WebHook, Functions, HDInsight Spark,
   Databricks notebook, Databricks python, Azure Batch, Validation,
-  Data Explorer command. (Several accept more than one wire spelling —
+  Data Explorer command, Spark Job Definition, Invoke Copy Job. (Several
+  accept more than one wire spelling —
   `RunNotebook`/`TridentNotebook`/`SynapseNotebook` are one behaviour, as are
   `SqlServerStoredProcedure`/`SqlPoolStoredProcedure` and `Web`/`WebActivity` —
   so the *case-label* count is higher than the behaviour count.)
@@ -31,9 +32,9 @@ What is verifiable, stated so anyone can re-derive it rather than trust it:
   Wait, Fail), plus the `Inactive` activity *state*.
 - **13 types refuse by name with a cause**: Dataflow Gen2 (3 spellings), the
   three Azure ML types, the Databricks JAR task, and the six in Phase 7.
-- **7 remain blocked on a wire-name capture** from a real tenant (Phase 0):
-  Refresh SQL Endpoint, Lakehouse maintenance, KQL, Spark Job Definition,
-  Teams, Copy job, Approval.
+- **5 remain blocked on a wire-name capture** from a real tenant (Phase 0):
+  Refresh SQL Endpoint, Lakehouse maintenance, KQL script activity, Teams,
+  Approval. Spark Job Definition and Invoke Copy Job have landed.
 
 **To re-derive:** list the `case` labels in the dispatch switch and in
 `activities.go`, and diff them against the `x-ms-discriminator-value` set in
@@ -59,7 +60,7 @@ dispatch default — see Phase 7 for why that matters.
 | Item | Needs | Unblocks |
 |---|---|---|
 | Wire-name capture | One throwaway pipeline in a real tenant containing Refresh SQL Endpoint, Lakehouse maintenance, KQL, Spark Job Definition, Teams, Copy job, Approval and Refresh Materialized Lake View activities. **Now a button rather than a chore:** run the `Real Fabric conformance` workflow with `capture_item_type: dataPipelines` and the pipeline's display name, and it prints the SHAPE — every `type` discriminator and every property name, with all values redacted, because this repository's logs are public. See `scripts/capture_definition_shape.py` | Phase 2, and the five other blocked activities |
-| Copy job activity case | #78 to settle; owned by the CopyJob session, or claimed by notice after | The 24th real activity — wiring the existing `copyjob` executor into the `pipelines.go` dispatch |
+| ~~Copy job activity case~~ | **Landed** as `InvokeCopyJob` — same executor a direct Copy job run uses | — |
 
 ## Phase 1 — async pipelines (the prerequisite, doc 37 §4)
 
@@ -78,7 +79,7 @@ behaviour inline execution cannot produce.
 | Refresh SQL Endpoint | warehouse reflection | the documented `Success` / **`NotRun`** (nothing unsynced) / `Failure` output statuses; lock-contention failure stays representable | Go: stale reflection → activity → tables current; `NotRun` on a second run with no new data |
 | Lakehouse maintenance | delta_ops OPTIMIZE/VACUUM via the Livy agent | table-scoped maintenance; v-order accepted where documented, refused-by-name where Sail cannot | Go + assertion in `e2e/livy` (compaction observed, not just exit 0) |
 | KQL | kustainer under `--profile rti` | script against a KQL DB; honest 501 without the profile | e2e under the rti job; grade ceiling 🟠 (AVX2/amd64) |
-| SJD wrapper | SJD item execution | activity → item job, both `jobs.go` switches if a job type appears, bus-subscribe-then-drain test per the CopyJob lesson | Go: SJD activity runs the item's job to terminal |
+| ~~SJD wrapper~~ | **Landed** — `SparkJobDefinition` activity runs the referenced item job | — | — |
 
 ## Phase 3 — HTTP-real externals (no park needed)
 
@@ -113,7 +114,7 @@ what exists, refuse what cannot be honoured by name:
 |---|---|---|---|
 | HDInsight | the activity's Spark-job submission | Sail (JVM overlay for JAR types) | M |
 | Azure Databricks | Jobs API stand-in (runs/submit → poll) | notebook/python via the agent; JAR → JVM overlay or refusal-by-name | L |
-| Azure Batch | task submission | the script in a sandboxed container sidecar | L |
+| Azure Batch | **Landed** — `command` on the Spark agent (`FABRIC_CUSTOM_ACTIVITY=off` refuses) | the agent's container, not a Batch node | — |
 | Azure ML | ~~job submission~~ **nothing — refused by name** | ~~python entry via the agent~~ **there is no entry point to run** | S |
 
 **The Azure ML row did not survive its oracle, and the correction is recorded

--- a/docs/44-interaction-surfaces.md
+++ b/docs/44-interaction-surfaces.md
@@ -22,7 +22,9 @@ the Fabric portal":
    graph, identities) plus read views of emulator state.
 3. **Sidecars ship real UIs rather than reimplementing them.** OpenMetadata is
    the catalog UI, Airflow is the orchestration UI, kustainer is the KQL
-   engine. A UI that already exists is attached, not rebuilt.
+   engine, Kafka is the Eventstream broker. A UI that already exists is
+   attached, not rebuilt. Fabric Core MCP (`POST /v1/mcp/core`) is the
+   same Core REST behind Streamable HTTP — not a second implementation.
 
 ### The thin/thick line for portal surfaces
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -13,7 +13,7 @@ The heavyweight or proprietary **compute engines** run by default: `docker
 compose up` auto-loads an override that starts Sail (Spark Connect) and a SQL
 Server sidecar, so Livy sessions, notebook cells and the T-SQL warehouse do real
 work out of the box. What stays 🟠 is the narrower set that needs a *different*
-engine — the JVM overlay, or an opt-in profile — and what cannot be done
+engine — the JVM overlay, or an opt-in profile (`rti`, `eventstream`) — and what cannot be done
 honestly at all is stubbed.
 
 **"Real via our own wire-protocol implementation."** A row is 🟢 **Real** not

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
         Search: './src/components/Search.astro',
       },
       description:
-        'A local emulator of the Microsoft Fabric control plane — workspaces, items, RBAC, git integration, and long-running operations — that validates Entra bearer tokens.',
+        'A local emulator of Microsoft Fabric — control plane, OneLake, Spark, T-SQL, pipelines, Eventstream, and KQL — that validates Entra bearer tokens.',
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/calvinchengx/fabric-emulator' },
       ],

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -115,23 +115,30 @@ function convert(name) {
 
 function writeIndex() {
   const body = rewriteLinks(
-    `Local emulator of the **Microsoft Fabric control plane** in a single Go binary — ` +
-      `workspaces, items and their CI/CD definitions, workspace RBAC, git integration, jobs, and ` +
-      `the 202/poll long-running-operation contract, all validating Microsoft Entra bearer tokens. ` +
-      `Pairs with its sibling [entra-emulator](https://calvinchengx.github.io/entra-emulator/) — ` +
-      `fabric-emulator validates tokens against its JWKS exactly as real Fabric validates against ` +
-      `Entra — so you can test service-principal automation and \`fabric-cicd\` pipelines offline ` +
-      `with no capacity and no cloud tenant.\n\n` +
-      `:::caution\nLocal development tool only — intentionally insecure (no real authorization ` +
-      `boundary, self-signed TLS). It emulates the control-plane **contract**, not the runtime: ` +
-      `nothing actually computes. Run it on \`localhost\` only.\n:::\n\n` +
+    `Local emulator of **Microsoft Fabric** in a single Go binary — the control ` +
+      `plane (workspaces, items, RBAC, git, jobs, LROs, Fabric Core MCP), a real ` +
+      `OneLake ADLS/Blob data plane, T-SQL over TDS, Livy on a real Spark engine, ` +
+      `Data Factory pipelines, Airflow jobs, KQL eventhouses, and Eventstream on ` +
+      `Apache Kafka. It validates Microsoft Entra bearer tokens against ` +
+      `[entra-emulator](https://calvinchengx.github.io/entra-emulator/) exactly as ` +
+      `real Fabric validates against Entra, so the same pipeline runs unmodified ` +
+      `here and against a real tenant (\`FABRIC_TARGET\`).\n\n` +
+      `\`docker compose up\` attaches Sail and a SQL Server sidecar, so Livy, ` +
+      `notebooks and the warehouse **do real work**. KQL, Eventstream, OpenMetadata ` +
+      `and the Flow terminal sit behind profiles. 111 supported capability claims ` +
+      `each name a witness; CI fails if one is lost.\n\n` +
+      `:::caution\nLocal development tool only — intentionally insecure (no real ` +
+      `authorization boundary, self-signed TLS). Run it on \`localhost\` only.\n:::\n\n` +
       `## Start here\n\n` +
-      `- [Quickstart](01-quickstart.md) — compose up the pair, mint a token, create a workspace, write to OneLake\n` +
+      `- [Quickstart](01-quickstart.md) — compose up the family, mint a token, create a workspace, write to OneLake\n` +
       `- [Installation](02-installation.md) — brew, winget, go install, Docker, compose\n` +
+      `- [Running modes](27-running-modes.md) — default stack, lite, JVM overlay, profiles, optional DAX oracle\n` +
       `- [Architecture](03-architecture.md) — the three-emulator model, token acceptance, the LRO engine\n` +
       `- [Control-plane API](07-control-plane-api.md) and [OneLake](08-onelake.md) — every emulated endpoint\n` +
+      `- [Eventstream](51-eventstream-kafka.md) — Kafka broker, Lakehouse dest, Reflex dest\n` +
       `- [Testing](10-testing.md) — freeze the clock, inject faults; [run the real fabric-cicd](11-testing-with-fabric-cicd.md)\n` +
-      `- [Roadmap](13-roadmap.md) — phases P0–P3 and what's next\n`,
+      `- [Parity](parity.md) — every claim, graded, with its witness\n` +
+      `- [Roadmap](13-roadmap.md) — phases P0–P3, R0–R5, S, and what landed after\n`,
   );
   // The landing page is synthesized here (no /docs source), so it has no
   // "Edit this page" target.


### PR DESCRIPTION
## Summary
- README and the docs-site homepage no longer claim a contract-only emulator or 89 greens. Both now match the 111 witnessed claims, Eventstream Lakehouse/Reflex destinations, Custom-on-by-default, Fabric Core MCP, and the optional `msmdsrv` DAX oracle.
- Architecture, running modes, roadmap, real-compute, and the activity plan stop contradicting the code (Web/Custom/SJD/InvokeCopyJob are real; `make up` is 12 services; JVM overlay is opt-in).

## Test plan
- [x] `python3 scripts/check_arch_services.py`
- [x] `python3 scripts/check_witnesses.py --strict` (111)
- [ ] Docs site job builds the updated index