### PR TITLE
feat: Desktop DAX goldens — first pin is ACOS

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -199,6 +199,12 @@ the open catalog. Opening a `.pbix` by hand remains valid; it is no longer
 required on a host that accepts TMSL (SSAS Developer, later headless
 `msmdsrv`).
 
+DATATABLE columns must set `sourceColumn` (the BIM `sourceColumn`, or the
+column name). Desktop rejects the omit. The pump also maps that refusal —
+and empty-partition errors — to 409 so a still-open `.pbix` stays queryable.
+If the named catalog is missing on Desktop's workspace instance, `/v1/dax`
+retries without `Initial Catalog=` and hits the open file.
+
 ### Phase 3 — grow the Go subset against the oracle
 
 Unchanged from [33](33-pbix-tooling.md): every new function is one Desktop
@@ -207,6 +213,13 @@ Linux laptop reaches that oracle without waiting for Monday's
 `windows-latest` job. Every-push CI on ubuntu/mac does **not** boot that
 VM; it replays the goldens against Go. That is what keeps those jobs
 honest: they test the engine those runners actually have.
+
+First pin: `ACOS` in
+[`e2e/semantic-model/fixtures/desktop_goldens.json`](../e2e/semantic-model/fixtures/desktop_goldens.json),
+captured on a UTM Windows 11 ARM guest + Desktop, replayed by
+`TestDesktopFunctionGoldens`. Clone that guest only while it is **stopped**
+(`utmctl clone` refuses a running VM). Do not treat the live oracle as
+disposable.
 
 ### Phase 4 — XMLA write-through (only if demanded)
 

--- a/e2e/msmdsrv/pump/Program.cs
+++ b/e2e/msmdsrv/pump/Program.cs
@@ -81,8 +81,30 @@ app.MapPost("/v1/dax", async (HttpRequest req) =>
     catch (Exception e)
     {
         conn?.Dispose();
-        return Results.Json(new { error = new { code = "DAXEngineUnreachable", message = Pump.FirstLine(e) } },
-            statusCode: 503);
+        conn = null;
+        // Desktop's workspace instance often has no database named like the
+        // item (or SYSTEM/the pump user cannot see that name). The open
+        // .pbix is the default catalog on the port — retry without Initial Catalog=.
+        if (!string.IsNullOrWhiteSpace(body.Catalog) && Pump.IsMissingCatalog(e))
+        {
+            try
+            {
+                src = Pump.ResolveSource(null);
+                conn = new AdomdConnection(src.ConnectionString);
+                conn.Open();
+            }
+            catch (Exception e2)
+            {
+                conn?.Dispose();
+                return Results.Json(new { error = new { code = "DAXEngineUnreachable", message = Pump.FirstLine(e2) } },
+                    statusCode: 503);
+            }
+        }
+        else
+        {
+            return Results.Json(new { error = new { code = "DAXEngineUnreachable", message = Pump.FirstLine(e) } },
+                statusCode: 503);
+        }
     }
 
     try
@@ -329,6 +351,14 @@ static class Pump
         return null;
     }
 
+    internal static bool IsMissingCatalog(Exception e)
+    {
+        var msg = FirstLine(e);
+        return msg.Contains("does not exist", StringComparison.OrdinalIgnoreCase) ||
+               msg.Contains("does not have access", StringComparison.OrdinalIgnoreCase) ||
+               msg.Contains("cannot find the", StringComparison.OrdinalIgnoreCase);
+    }
+
     internal static bool IsRejected(string msg)
     {
         if (string.IsNullOrEmpty(msg))
@@ -340,7 +370,12 @@ static class Pump
                msg.Contains("read-only", StringComparison.OrdinalIgnoreCase) ||
                msg.Contains("readonly", StringComparison.OrdinalIgnoreCase) ||
                msg.Contains("cannot create", StringComparison.OrdinalIgnoreCase) ||
-               msg.Contains("operation is not allowed", StringComparison.OrdinalIgnoreCase);
+               msg.Contains("operation is not allowed", StringComparison.OrdinalIgnoreCase) ||
+               // Desktop workspace instance: calculated-table TMSL without
+               // SourceColumn (or empty partitions) cannot CreateOrReplace.
+               // 409 → emulator queries the open .pbix catalog (docs/52).
+               msg.Contains("SourceColumn", StringComparison.OrdinalIgnoreCase) ||
+               msg.Contains("at least one partition", StringComparison.OrdinalIgnoreCase);
     }
 
     static int ReadDesktopPort()

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
+  "toleranceRel": 1e-9,
+  "probes": [
+    {
+      "name": "ACOS(0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ACOS(0.5))",
+      "column": "[v]",
+      "want": 1.0471975511965976
+    },
+    {
+      "name": "ACOS(-1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ACOS(-1))",
+      "column": "[v]",
+      "want": 3.141592653589793
+    }
+  ]
+}

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -2,6 +2,7 @@ package semanticmodel
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -9,12 +10,13 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
-// than mis-evaluate. Correctness is gated by the captured golden fixtures, since
-// no live DAX engine can run in CI.
+// than mis-evaluate. Correctness is gated by captured goldens: tutorial
+// fixtures plus Desktop-agreed scalars in desktop_goldens.json (docs/52
+// Phase 3). Every-push CI replays those against Go; it does not boot msmdsrv.
 
 // Result is a query result: ordered column keys + rows keyed by them, matching
 // the executeQueries JSON shape ("Table[Col]" / "[Measure]").
@@ -849,6 +851,22 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 		return float64(len(e.activeRows(tbl))), nil
 	case "SELECTEDVALUE":
 		return e.selectedValue(fc)
+	case "ACOS":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("ACOS expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		f, err := arithNum(a, "ACOS")
+		if err != nil {
+			return nil, err
+		}
+		if f < -1 || f > 1 {
+			return nil, fmt.Errorf("ACOS argument must be between -1 and 1")
+		}
+		return math.Acos(f), nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }

--- a/internal/semanticmodel/dax_test.go
+++ b/internal/semanticmodel/dax_test.go
@@ -2,6 +2,7 @@ package semanticmodel
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,6 +114,48 @@ func TestDAXGoldenQueries(t *testing.T) {
 	}
 	if ran != g.DAXQueryCount {
 		t.Fatalf("ran %d DAX golden queries, fixture declares %d", ran, g.DAXQueryCount)
+	}
+}
+
+// TestDesktopFunctionGoldens replays Desktop-captured scalar probes against
+// the Go evaluator (docs/52 Phase 3). CI never boots msmdsrv; the numbers
+// were agreed on a UTM Windows 11 ARM guest + Power BI Desktop.
+func TestDesktopFunctionGoldens(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(fixturesDir(), "desktop_goldens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var g struct {
+		ToleranceRel float64 `json:"toleranceRel"`
+		Probes       []struct {
+			Name   string  `json:"name"`
+			DAX    string  `json:"dax"`
+			Column string  `json:"column"`
+			Want   float64 `json:"want"`
+		} `json:"probes"`
+	}
+	if err := json.Unmarshal(b, &g); err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Probes) == 0 {
+		t.Fatal("desktop_goldens.json has no probes")
+	}
+	if g.ToleranceRel <= 0 {
+		g.ToleranceRel = 1e-9
+	}
+	m, d := loadModel(t), loadData(t)
+	for _, p := range g.Probes {
+		res, err := Evaluate(m, d, p.DAX)
+		if err != nil {
+			t.Fatalf("%s: %v", p.Name, err)
+		}
+		if len(res.Rows) != 1 {
+			t.Fatalf("%s: got %d rows, want 1", p.Name, len(res.Rows))
+		}
+		got := toF(res.Rows[0][p.Column])
+		if math.Abs(got-p.Want) > g.ToleranceRel*math.Abs(p.Want) {
+			t.Errorf("%s: got %v, want %v (rel %g)", p.Name, got, p.Want, g.ToleranceRel)
+		}
 	}
 }
 

--- a/internal/semanticmodel/deploy.go
+++ b/internal/semanticmodel/deploy.go
@@ -44,6 +44,15 @@ func CreateOrReplaceTMSL(m *Model, data Data) ([]byte, error) {
 			if c.DataType == "" {
 				col["dataType"] = "string"
 			}
+			// Desktop rejects calculated-table columns that omit SourceColumn
+			// ("Column 'X' in calculated table 'Y' is missing the SourceColumn
+			// property"). DATATABLE aliases match the column name unless the
+			// BIM already named a different source.
+			src := c.SourceColumn
+			if src == "" {
+				src = c.Name
+			}
+			col["sourceColumn"] = src
 			cols = append(cols, col)
 		}
 		table := map[string]any{

--- a/internal/semanticmodel/deploy_test.go
+++ b/internal/semanticmodel/deploy_test.go
@@ -48,6 +48,9 @@ func TestCreateOrReplaceTMSLRetail(t *testing.T) {
 	if !strings.Contains(s, `"type":"calculated"`) && !strings.Contains(s, `"type": "calculated"`) {
 		t.Fatal("expected calculated partitions")
 	}
+	if !strings.Contains(s, `"sourceColumn":"StoreId"`) && !strings.Contains(s, `"sourceColumn": "StoreId"`) {
+		t.Fatal("expected sourceColumn on DATATABLE columns (Desktop rejects the omit)")
+	}
 }
 
 func TestCreateOrReplaceTMSLRefusesDirectLake(t *testing.T) {


### PR DESCRIPTION
## Summary
- First Desktop-captured golden (`ACOS`) in `e2e/semantic-model/fixtures/desktop_goldens.json`, replayed by `TestDesktopFunctionGoldens` with empty `FABRIC_DAX_URL`.
- DATATABLE columns now set `sourceColumn` (BIM or the column name) so Desktop accepts the model.
- Pump maps SourceColumn / empty-partition refusals to 409, and retries without `Initial Catalog=` when Desktop's workspace instance has no named catalog.

## Test plan
- [x] `go test ./internal/semanticmodel/...`
- [ ] CI `test` job (includes DAX goldens)
- [ ] Do not treat the live UTM oracle as disposable