### PR TITLE
feat: derive Atlas lineage from Process inputs/outputs

### DIFF
--- a/internal/purview/datamap.go
+++ b/internal/purview/datamap.go
@@ -87,6 +87,8 @@ func (s *Service) register(mux *http.ServeMux, wrap func(handler) http.HandlerFu
 		mux.HandleFunc(method+" "+BasePath+rest, wrap(fn))
 	}
 	// --- type system -------------------------------------------------------
+	// --- lineage: DERIVED from Process inputs/outputs, never stored ---------
+	h("GET /atlas/v2/lineage/{guid}", s.getLineage)
 	h("GET /atlas/v2/types/typedefs", s.listTypeDefs)
 	h("POST /atlas/v2/types/typedefs", s.createTypeDefs)
 	h("PUT /atlas/v2/types/typedefs", s.updateTypeDefs)

--- a/internal/purview/datamap_test.go
+++ b/internal/purview/datamap_test.go
@@ -353,6 +353,7 @@ func TestEveryRouteRequiresAToken(t *testing.T) {
 	s.Register(mux)
 
 	for _, c := range []struct{ method, target string }{
+		{"GET", "/atlas/v2/lineage/x"},
 		{"GET", "/atlas/v2/types/typedefs"},
 		{"POST", "/atlas/v2/types/typedefs"},
 		{"PUT", "/atlas/v2/types/typedefs"},

--- a/internal/purview/entities.go
+++ b/internal/purview/entities.go
@@ -450,6 +450,11 @@ func (s *Service) deleteEntityByUniqueAttr(w http.ResponseWriter, r *http.Reques
 // EntityStatus doc says so — "Deleted entities are not removed" — and a hard
 // delete would break the lineage and audit reads that later increments add.
 func (s *Service) softDelete(row *store.AtlasEntityRow) (*EntityMutationResponse, error) {
+	// Status must be set on the in-memory row BEFORE PutEntity rewrites the
+	// body: PutEntity persists e.Status, and leaving it ACTIVE here would
+	// undo SetEntityStatus. Lineage filters on the column, so that undo
+	// would keep a deleted Process in the graph.
+	row.Status = statusDeleted
 	if err := s.Store.SetEntityStatus(row.GUID, statusDeleted); err != nil {
 		return nil, err
 	}
@@ -463,7 +468,6 @@ func (s *Service) softDelete(row *store.AtlasEntityRow) (*EntityMutationResponse
 			}
 		}
 	}
-	row.Status = statusDeleted
 	return &EntityMutationResponse{MutatedEntities: map[string][]entityHeader{
 		opDelete: {headerOf(row, generic)},
 	}}, nil

--- a/internal/purview/lineage.go
+++ b/internal/purview/lineage.go
@@ -1,0 +1,216 @@
+package purview
+
+// Atlas lineage, DERIVED rather than stored.
+//
+// There is no lineage table and there must not be one. Atlas computes lineage
+// by walking `Process` entities' `inputs` and `outputs`: a process that reads A
+// and writes B *is* the edge A -> B. Storing edges separately would drift from
+// the entities that justify them and would pass its own tests forever, which is
+// the failure this package's other tests exist to prevent.
+//
+// Confirmed before implementing, three ways: our own seed describes Process as
+// "something that reads inputs and writes outputs, lineage hangs off this";
+// `pyapacheatlas.core.entity.AtlasProcess` "forces you to include the inputs
+// and outputs of the process"; and the read route is a graph walk with depth,
+// width and direction rather than a fetch.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/calvinchengx/fabric-emulator/internal/auth"
+)
+
+// AtlasLineageInfo is the documented reply shape. `guidEntityMap` carries the
+// entities the relations refer to, so a client can render a graph from one call
+// rather than fetching every node.
+type AtlasLineageInfo struct {
+	BaseEntityGUID   string                     `json:"baseEntityGuid"`
+	LineageDirection string                     `json:"lineageDirection"`
+	LineageDepth     int                        `json:"lineageDepth"`
+	GUIDEntityMap    map[string]json.RawMessage `json:"guidEntityMap"`
+	Relations        []AtlasLineageRelation     `json:"relations"`
+}
+
+// AtlasLineageRelation is one edge. `relationshipId` is the PROCESS's guid: the
+// edge exists because that process declared the two assets, so naming it is how
+// a client asks "why is this connected?".
+type AtlasLineageRelation struct {
+	FromEntityID   string `json:"fromEntityId"`
+	ToEntityID     string `json:"toEntityId"`
+	RelationshipID string `json:"relationshipId"`
+}
+
+// edge is one derived connection plus the process that justifies it.
+type edge struct{ from, to, via string }
+
+// processEdges reads every process reachable through the Process supertype and
+// expands it into the cross-product of its inputs and outputs. A process with
+// two inputs and one output contributes two edges, which is what Atlas shows.
+func (s *Service) processEdges() ([]edge, error) {
+	procs, err := s.Store.ListEntitiesBySuperType("Process")
+	if err != nil {
+		return nil, err
+	}
+	out := []edge{}
+	for _, p := range procs {
+		ins, outs := referencedGUIDs(p.Body, "inputs"), referencedGUIDs(p.Body, "outputs")
+		for _, i := range ins {
+			for _, o := range outs {
+				out = append(out, edge{from: i, to: o, via: p.GUID})
+			}
+		}
+	}
+	return out, nil
+}
+
+// referencedGUIDs pulls guids out of one attribute, tolerating BOTH shapes a
+// real client sends: a bare guid string, and an object reference carrying
+// `guid` (what `AtlasProcess` emits). Accepting only one shape would reject
+// half of the clients for a reason the error would not name.
+func referencedGUIDs(body json.RawMessage, attr string) []string {
+	var e struct {
+		Attributes map[string]json.RawMessage `json:"attributes"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil {
+		return nil
+	}
+	raw, ok := e.Attributes[attr]
+	if !ok {
+		return nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil
+	}
+	out := []string{}
+	for _, it := range items {
+		var str string
+		if err := json.Unmarshal(it, &str); err == nil {
+			if str != "" {
+				out = append(out, str)
+			}
+			continue
+		}
+		var ref struct {
+			GUID string `json:"guid"`
+		}
+		if err := json.Unmarshal(it, &ref); err == nil && ref.GUID != "" {
+			out = append(out, ref.GUID)
+		}
+	}
+	return out
+}
+
+// getLineage serves GET /atlas/v2/lineage/{guid}.
+func (s *Service) getLineage(w http.ResponseWriter, r *http.Request, _ *auth.Principal) {
+	guid := r.PathValue("guid")
+	if _, err := s.Store.GetEntity(guid); err != nil {
+		writeAtlasErr(w, http.StatusNotFound, "ATLAS-404-00-005",
+			"Given instance guid "+guid+" is invalid/not found.")
+		return
+	}
+
+	direction := strings.ToUpper(r.URL.Query().Get("direction"))
+	if direction == "" {
+		direction = "BOTH"
+	}
+	// The client asserts this set before sending, so an unknown value is a
+	// caller error rather than something to silently coerce to BOTH.
+	if direction != "BOTH" && direction != "INPUT" && direction != "OUTPUT" {
+		writeAtlasErr(w, http.StatusBadRequest, "ATLAS-400-00-06A",
+			"Invalid lineage direction "+direction+". Valid values: BOTH, INPUT, OUTPUT.")
+		return
+	}
+	depth := intParam(r, "depth", 3)
+	width := intParam(r, "width", 10)
+
+	edges, err := s.processEdges()
+	if err != nil {
+		writeAtlasErr(w, http.StatusInternalServerError, "ATLAS-500-00-001", err.Error())
+		return
+	}
+
+	info := AtlasLineageInfo{
+		BaseEntityGUID:   guid,
+		LineageDirection: direction,
+		LineageDepth:     depth,
+		GUIDEntityMap:    map[string]json.RawMessage{},
+		Relations:        []AtlasLineageRelation{},
+	}
+	seen := map[string]bool{guid: true}
+	collected := map[edge]bool{}
+
+	// Breadth-first, one hop per level, so `depth` means hops as documented
+	// rather than "nodes visited". INPUT walks backwards, OUTPUT forwards, and
+	// BOTH does each — a node reached by both directions is still one node.
+	frontier := []string{guid}
+	for hop := 0; hop < depth && len(frontier) > 0; hop++ {
+		next := []string{}
+		for _, cur := range frontier {
+			fanout := 0
+			for _, e := range edges {
+				var other string
+				switch {
+				case (direction == "OUTPUT" || direction == "BOTH") && e.from == cur:
+					other = e.to
+				case (direction == "INPUT" || direction == "BOTH") && e.to == cur:
+					other = e.from
+				default:
+					continue
+				}
+				// `width` bounds fan-out PER NODE, which is what stops one
+				// heavily-shared asset returning the whole graph.
+				if fanout >= width {
+					break
+				}
+				fanout++
+				if !collected[e] {
+					collected[e] = true
+					info.Relations = append(info.Relations, AtlasLineageRelation{
+						FromEntityID: e.from, ToEntityID: e.to, RelationshipID: e.via,
+					})
+				}
+				if !seen[other] {
+					seen[other] = true
+					next = append(next, other)
+				}
+			}
+		}
+		frontier = next
+	}
+
+	for g := range seen {
+		row, err := s.Store.GetEntity(g)
+		if err != nil {
+			// A dangling reference is a fact about the data, not an error: a
+			// process may name an asset that was hard-deleted elsewhere. Skip
+			// it rather than failing the whole walk.
+			continue
+		}
+		var generic map[string]any
+		_ = json.Unmarshal(row.Body, &generic)
+		b, err := json.Marshal(headerOf(row, generic))
+		if err != nil {
+			continue
+		}
+		info.GUIDEntityMap[g] = b
+	}
+	writeJSON(w, http.StatusOK, info)
+}
+
+func intParam(r *http.Request, name string, def int) int {
+	v := r.URL.Query().Get(name)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	// A negative or unparseable bound would make the walk return nothing, which
+	// reads as "no lineage" rather than "bad request", so fall back instead.
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}

--- a/internal/purview/lineage_test.go
+++ b/internal/purview/lineage_test.go
@@ -1,0 +1,365 @@
+package purview
+
+// Lineage is DERIVED from Process inputs/outputs. A stored-edge table would
+// pass its own tests forever while drifting from the entities that justify the
+// graph — so every assertion here is something a stored-edge stub would get
+// wrong: a Process subclass must appear, a deleted Process must vanish, a
+// dangling output must not 500, and direction/depth/width must bound the walk
+// rather than decorate the reply.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func createProcess(t *testing.T, mux *http.ServeMux, qname, typeName, inputsJSON, outputsJSON string) string {
+	t.Helper()
+	if typeName == "" {
+		typeName = "Process"
+	}
+	body := `{"entity":{"typeName":"` + typeName + `","attributes":{` +
+		`"qualifiedName":"` + qname + `","name":"` + qname + `",` +
+		`"inputs":` + inputsJSON + `,"outputs":` + outputsJSON + `}}}`
+	w := do(t, mux, "POST", BasePath+"/atlas/v2/entity", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create process %s = %d %s", qname, w.Code, w.Body)
+	}
+	var resp EntityMutationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.MutatedEntities[opCreate]) != 1 {
+		t.Fatalf("create process %s did not report a CREATE: %s", qname, w.Body)
+	}
+	return resp.MutatedEntities[opCreate][0].GUID
+}
+
+func getLineage(t *testing.T, mux *http.ServeMux, guid, query string) (*AtlasLineageInfo, *httptest.ResponseRecorder) {
+	t.Helper()
+	target := BasePath + "/atlas/v2/lineage/" + guid
+	if query != "" {
+		target += "?" + query
+	}
+	w := do(t, mux, "GET", target, "")
+	if w.Code != http.StatusOK {
+		return nil, w
+	}
+	var info AtlasLineageInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+		t.Fatalf("lineage reply is not AtlasLineageInfo: %s", w.Body)
+	}
+	return &info, w
+}
+
+func refs(guids ...string) string {
+	b, _ := json.Marshal(func() []map[string]string {
+		out := make([]map[string]string, 0, len(guids))
+		for _, g := range guids {
+			out = append(out, map[string]string{"guid": g})
+		}
+		return out
+	}())
+	return string(b)
+}
+
+func stringsJSON(ss ...string) string {
+	b, _ := json.Marshal(ss)
+	return string(b)
+}
+
+// An unknown guid is a 404, not an empty graph. Returning 200 with no
+// relations would make "this asset does not exist" indistinguishable from
+// "this asset is isolated".
+func TestLineageOfAnUnknownGUIDIsNotFound(t *testing.T) {
+	_, mux := newService(t)
+	_, w := getLineage(t, mux, "no-such-guid", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unknown guid = %d, want 404 (%s)", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != "ATLAS-404-00-005" {
+		t.Fatalf("errorCode = %s, want ATLAS-404-00-005", code)
+	}
+}
+
+// The client asserts direction before sending. Silently coercing SIDEWAYS to
+// BOTH would hide a caller bug behind a graph that looks complete.
+func TestLineageRejectsAnUnknownDirection(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://src")
+	_, w := getLineage(t, mux, src, "direction=SIDEWAYS")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("bad direction = %d, want 400 (%s)", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != "ATLAS-400-00-06A" {
+		t.Fatalf("errorCode = %s, want ATLAS-400-00-06A", code)
+	}
+}
+
+// An asset with no Process pointing at it is isolated: 200, itself in the
+// map, no relations. A stub that always invented an edge would fail this.
+func TestAnIsolatedAssetReportsNoRelations(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://lonely")
+	info, w := getLineage(t, mux, src, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("isolated = %d %s", w.Code, w.Body)
+	}
+	if info.BaseEntityGUID != src {
+		t.Fatalf("baseEntityGuid = %s, want %s", info.BaseEntityGUID, src)
+	}
+	if info.LineageDirection != "BOTH" {
+		t.Fatalf("default direction = %s, want BOTH", info.LineageDirection)
+	}
+	if info.LineageDepth != 3 {
+		t.Fatalf("default depth = %d, want 3", info.LineageDepth)
+	}
+	if len(info.Relations) != 0 {
+		t.Fatalf("isolated asset has relations: %+v", info.Relations)
+	}
+	if _, ok := info.GUIDEntityMap[src]; !ok {
+		t.Fatalf("guidEntityMap is missing the base entity")
+	}
+}
+
+// THE BEHAVIOUR THE ROUTE EXISTS FOR. A Process that reads A and writes B
+// *is* the edge A -> B. The relationshipId is the process guid, because that
+// is how a client asks "why is this connected?".
+func TestLineageIsDerivedFromProcessInputsAndOutputs(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://bronze")
+	dst := createEntity(t, mux, "DataSet", "lake://silver")
+	proc := createProcess(t, mux, "job://copy", "Process", refs(src), refs(dst))
+
+	info, w := getLineage(t, mux, src, "direction=OUTPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("lineage = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 1 {
+		t.Fatalf("relations = %+v, want one A->B edge", info.Relations)
+	}
+	rel := info.Relations[0]
+	if rel.FromEntityID != src || rel.ToEntityID != dst || rel.RelationshipID != proc {
+		t.Fatalf("edge = %+v, want from=%s to=%s via=%s", rel, src, dst, proc)
+	}
+	for _, g := range []string{src, dst} {
+		if _, ok := info.GUIDEntityMap[g]; !ok {
+			t.Fatalf("guidEntityMap missing %s: %v", g, keysOf(info.GUIDEntityMap))
+		}
+	}
+}
+
+// pyapacheatlas emits object references; other clients send bare guid
+// strings. Accepting only one shape would reject half the clients for a
+// reason the error would not name.
+func TestLineageAcceptsBareGUIDStringsAsWellAsObjectRefs(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://in")
+	dst := createEntity(t, mux, "DataSet", "lake://out")
+	createProcess(t, mux, "job://bare", "Process", stringsJSON(src), stringsJSON(dst))
+
+	info, w := getLineage(t, mux, src, "direction=OUTPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("lineage = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 1 || info.Relations[0].FromEntityID != src || info.Relations[0].ToEntityID != dst {
+		t.Fatalf("bare-guid process did not produce A->B: %+v", info.Relations)
+	}
+}
+
+// INPUT walks backwards. Asking OUTPUT of the destination must not invent
+// the same edge the other way — that would be a stored undirected graph.
+func TestLineageDirectionBoundsTheWalk(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://a")
+	dst := createEntity(t, mux, "DataSet", "lake://b")
+	createProcess(t, mux, "job://oneway", "Process", refs(src), refs(dst))
+
+	out, w := getLineage(t, mux, dst, "direction=OUTPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("OUTPUT of dest = %d %s", w.Code, w.Body)
+	}
+	if len(out.Relations) != 0 {
+		t.Fatalf("OUTPUT of the destination invented an edge: %+v", out.Relations)
+	}
+
+	in, w := getLineage(t, mux, dst, "direction=INPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("INPUT of dest = %d %s", w.Code, w.Body)
+	}
+	if len(in.Relations) != 1 || in.Relations[0].FromEntityID != src {
+		t.Fatalf("INPUT of dest = %+v, want the A->B edge", in.Relations)
+	}
+}
+
+// depth is hops, not "nodes visited". A chain A->B->C with depth=1 from A
+// must stop at B. Returning C would mean depth decorated the reply.
+func TestLineageDepthIsHops(t *testing.T) {
+	_, mux := newService(t)
+	a := createEntity(t, mux, "DataSet", "lake://a")
+	b := createEntity(t, mux, "DataSet", "lake://b")
+	c := createEntity(t, mux, "DataSet", "lake://c")
+	createProcess(t, mux, "job://ab", "Process", refs(a), refs(b))
+	createProcess(t, mux, "job://bc", "Process", refs(b), refs(c))
+
+	info, w := getLineage(t, mux, a, "direction=OUTPUT&depth=1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("depth=1 = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 1 || info.Relations[0].ToEntityID != b {
+		t.Fatalf("depth=1 relations = %+v, want only A->B", info.Relations)
+	}
+	if _, ok := info.GUIDEntityMap[c]; ok {
+		t.Fatalf("depth=1 reached C: %v", keysOf(info.GUIDEntityMap))
+	}
+
+	both, w := getLineage(t, mux, a, "direction=OUTPUT&depth=2")
+	if w.Code != http.StatusOK {
+		t.Fatalf("depth=2 = %d %s", w.Code, w.Body)
+	}
+	if len(both.Relations) != 2 {
+		t.Fatalf("depth=2 relations = %+v, want A->B and B->C", both.Relations)
+	}
+}
+
+// width bounds fan-out PER NODE. One shared source feeding many sinks must
+// not dump the whole graph because the client asked for that source.
+func TestLineageWidthBoundsFanout(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://hub")
+	for _, name := range []string{"x", "y", "z"} {
+		dst := createEntity(t, mux, "DataSet", "lake://"+name)
+		createProcess(t, mux, "job://"+name, "Process", refs(src), refs(dst))
+	}
+	info, w := getLineage(t, mux, src, "direction=OUTPUT&width=1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("width=1 = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 1 {
+		t.Fatalf("width=1 relations = %+v, want one edge", info.Relations)
+	}
+}
+
+// A real model subclasses Process. Querying type_name = 'Process' would miss
+// every CopyJob and return empty lineage that looks like "nothing yet".
+func TestLineageFindsAProcessSubclass(t *testing.T) {
+	_, mux := newService(t)
+	body := `{"entityDefs":[{"name":"CopyJob","superTypes":["Process"],"attributeDefs":[]}]}`
+	if w := do(t, mux, "POST", BasePath+"/atlas/v2/types/typedefs", body); w.Code != http.StatusOK {
+		t.Fatalf("register CopyJob = %d %s", w.Code, w.Body)
+	}
+	src := createEntity(t, mux, "DataSet", "lake://in")
+	dst := createEntity(t, mux, "DataSet", "lake://out")
+	createProcess(t, mux, "job://copyjob", "CopyJob", refs(src), refs(dst))
+
+	info, w := getLineage(t, mux, src, "direction=OUTPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("subclass lineage = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 1 {
+		t.Fatalf("CopyJob produced no edge — ListEntitiesBySuperType missed the subclass: %+v", info.Relations)
+	}
+}
+
+// Atlas soft-deletes. A deleted Process no longer connects the assets it
+// used to join — otherwise lineage would outlive the job that justified it.
+func TestADeletedProcessNoLongerConnects(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://in")
+	dst := createEntity(t, mux, "DataSet", "lake://out")
+	proc := createProcess(t, mux, "job://gone", "Process", refs(src), refs(dst))
+
+	if d := do(t, mux, "DELETE", BasePath+"/atlas/v2/entity/guid/"+proc, ""); d.Code != http.StatusOK {
+		t.Fatalf("delete process = %d %s", d.Code, d.Body)
+	}
+	info, w := getLineage(t, mux, src, "direction=OUTPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("after delete = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 0 {
+		t.Fatalf("deleted process still connects: %+v", info.Relations)
+	}
+}
+
+// A process may name an asset that was hard-deleted elsewhere. That is a
+// fact about the data, not a 500.
+func TestADanglingOutputDoesNotFailTheWalk(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://in")
+	createProcess(t, mux, "job://dangling", "Process", refs(src), refs("never-created"))
+
+	info, w := getLineage(t, mux, src, "direction=OUTPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("dangling = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 1 || info.Relations[0].ToEntityID != "never-created" {
+		t.Fatalf("dangling relations = %+v", info.Relations)
+	}
+	if _, ok := info.GUIDEntityMap["never-created"]; ok {
+		t.Fatalf("dangling guid was materialised in the map")
+	}
+}
+
+// Two inputs and one output is two edges. A stub that stored "the process
+// connected these sets" as one undirected blob would report one relation.
+func TestAProcessWithTwoInputsContributesTwoEdges(t *testing.T) {
+	_, mux := newService(t)
+	a := createEntity(t, mux, "DataSet", "lake://a")
+	b := createEntity(t, mux, "DataSet", "lake://b")
+	out := createEntity(t, mux, "DataSet", "lake://out")
+	createProcess(t, mux, "job://join", "Process", refs(a, b), refs(out))
+
+	info, w := getLineage(t, mux, out, "direction=INPUT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("join = %d %s", w.Code, w.Body)
+	}
+	if len(info.Relations) != 2 {
+		t.Fatalf("join relations = %+v, want two edges", info.Relations)
+	}
+}
+
+// Unparseable or non-positive bounds fall back rather than returning an
+// empty graph that reads as "no lineage".
+func TestLineageBoundsFallBackWhenUnparseable(t *testing.T) {
+	_, mux := newService(t)
+	src := createEntity(t, mux, "DataSet", "lake://src")
+	dst := createEntity(t, mux, "DataSet", "lake://dst")
+	createProcess(t, mux, "job://ok", "Process", refs(src), refs(dst))
+
+	info, w := getLineage(t, mux, src, "direction=OUTPUT&depth=-1&width=nope")
+	if w.Code != http.StatusOK {
+		t.Fatalf("bad bounds = %d %s", w.Code, w.Body)
+	}
+	if info.LineageDepth != 3 {
+		t.Fatalf("depth fallback = %d, want 3", info.LineageDepth)
+	}
+	if len(info.Relations) != 1 {
+		t.Fatalf("fallback walk missed the edge: %+v", info.Relations)
+	}
+}
+
+func TestReferencedGUIDsToleratesBothShapesAndJunk(t *testing.T) {
+	if got := referencedGUIDs(json.RawMessage(`not-json`), "inputs"); got != nil {
+		t.Fatalf("malformed body = %v, want nil", got)
+	}
+	if got := referencedGUIDs(json.RawMessage(`{"attributes":{}}`), "inputs"); got != nil {
+		t.Fatalf("missing attr = %v, want nil", got)
+	}
+	if got := referencedGUIDs(json.RawMessage(`{"attributes":{"inputs":"x"}}`), "inputs"); got != nil {
+		t.Fatalf("non-array attr = %v, want nil", got)
+	}
+	body := json.RawMessage(`{"attributes":{"inputs":["",{"guid":""},{"guid":"ok"},"bare",{"no":"guid"}]}}`)
+	got := referencedGUIDs(body, "inputs")
+	if len(got) != 2 || got[0] != "ok" || got[1] != "bare" {
+		t.Fatalf("mixed = %v, want [ok bare]", got)
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/purview/seed.go
+++ b/internal/purview/seed.go
@@ -76,6 +76,22 @@ var baseTypes = []struct {
 		"typeVersion": "1.0",
 		"serviceType": "atlas_core",
 		"superTypes":  []string{"Asset"},
+		// inputs/outputs are not decoration: Atlas lineage is DERIVED by walking
+		// them, so without these two attributes there is nothing for
+		// /lineage/{guid} to compute from and every asset would report itself
+		// as isolated. Real Atlas declares both as array<DataSet>.
+		"attributeDefs": []map[string]any{
+			{
+				"name": "inputs", "typeName": "array<DataSet>",
+				"isOptional": true, "cardinality": "SET",
+				"isUnique": false, "isIndexable": false,
+			},
+			{
+				"name": "outputs", "typeName": "array<DataSet>",
+				"isOptional": true, "cardinality": "SET",
+				"isUnique": false, "isIndexable": false,
+			},
+		},
 	}},
 }
 

--- a/internal/store/purview.go
+++ b/internal/store/purview.go
@@ -233,6 +233,93 @@ func (s *Store) SetEntityStatus(guid, status string) error {
 
 // ListEntitiesByGUIDs returns the entities for the given GUIDs, skipping any
 // that do not exist — the bulk read is a lookup, not an assertion.
+// ListEntitiesBySuperType returns every ACTIVE entity whose type is `name` or
+// descends from it, resolved through the supertype chain.
+//
+// Lineage needs this because it is DERIVED rather than stored: Atlas computes
+// it by walking `Process` entities' inputs/outputs, and a real model subclasses
+// Process (`CopyJob`, `Notebook`, …) rather than instantiating it directly. A
+// query for type_name = 'Process' would therefore find the base type only, and
+// return empty lineage for every model anyone actually builds — a wrong answer
+// that looks like "no lineage yet" rather than like a bug.
+//
+// DELETED entities are excluded: Atlas soft-deletes, and a deleted process no
+// longer connects the assets it used to join.
+func (s *Store) ListEntitiesBySuperType(name string) ([]*AtlasEntityRow, error) {
+	names, err := s.typeAndDescendants(name)
+	if err != nil {
+		return nil, err
+	}
+	out := []*AtlasEntityRow{}
+	for _, tn := range names {
+		rows, err := s.db.Query(`
+SELECT guid, type_name, qualified_name, status, body, created_at, updated_at
+FROM purview_entities WHERE type_name = ? AND status != 'DELETED'`, tn)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			e := &AtlasEntityRow{}
+			var body string
+			if err := rows.Scan(&e.GUID, &e.TypeName, &e.QualifiedName, &e.Status,
+				&body, &e.CreateAt, &e.UpdateAt); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			e.Body = json.RawMessage(body)
+			out = append(out, e)
+		}
+		err = rows.Err()
+		rows.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// typeAndDescendants is `name` plus every entity type reaching it through
+// superTypes. Bounded by the number of registered types, and visited-guarded,
+// so a cyclic registration cannot spin here even though the registration path
+// should refuse one.
+func (s *Store) typeAndDescendants(name string) ([]string, error) {
+	defs, err := s.ListTypeDefs("ENTITY")
+	if err != nil {
+		return nil, err
+	}
+	parents := map[string][]string{}
+	for _, d := range defs {
+		var body struct {
+			SuperTypes []string `json:"superTypes"`
+		}
+		_ = json.Unmarshal(d.Body, &body)
+		parents[d.Name] = body.SuperTypes
+	}
+	var descends func(string, map[string]bool) bool
+	descends = func(t string, seen map[string]bool) bool {
+		if t == name {
+			return true
+		}
+		if seen[t] {
+			return false
+		}
+		seen[t] = true
+		for _, p := range parents[t] {
+			if descends(p, seen) {
+				return true
+			}
+		}
+		return false
+	}
+	out := []string{}
+	for _, d := range defs {
+		if descends(d.Name, map[string]bool{}) {
+			out = append(out, d.Name)
+		}
+	}
+	return out, nil
+}
+
 func (s *Store) ListEntitiesByGUIDs(guids []string) ([]*AtlasEntityRow, error) {
 	out := make([]*AtlasEntityRow, 0, len(guids))
 	for _, g := range guids {

--- a/internal/store/purview_supertype_test.go
+++ b/internal/store/purview_supertype_test.go
@@ -1,0 +1,84 @@
+package store
+
+// ListEntitiesBySuperType is what makes derived lineage real rather than a
+// query for type_name = 'Process'. A real model subclasses Process; a query
+// that only matches the base type returns empty lineage that looks like
+// "nothing yet" rather than like a bug.
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func putType(t *testing.T, s *Store, name string, supers []string) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"name": name, "superTypes": supers})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateTypeDef(&AtlasTypeDef{Name: name, Category: "ENTITY", Body: body}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func putEntity(t *testing.T, s *Store, typeName, qname, status string) *AtlasEntityRow {
+	t.Helper()
+	row := &AtlasEntityRow{
+		TypeName:      typeName,
+		QualifiedName: qname,
+		Status:        status,
+		Body:          json.RawMessage(`{"typeName":"` + typeName + `"}`),
+	}
+	if _, err := s.PutEntity(row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func TestListEntitiesBySuperTypeIncludesDescendantsAndSkipsDeleted(t *testing.T) {
+	s := newTestStore(t)
+	putType(t, s, "Process", nil)
+	putType(t, s, "CopyJob", []string{"Process"})
+	putType(t, s, "DataSet", nil)
+
+	live := putEntity(t, s, "CopyJob", "job://live", "ACTIVE")
+	putEntity(t, s, "CopyJob", "job://gone", "DELETED")
+	base := putEntity(t, s, "Process", "job://base", "ACTIVE")
+	putEntity(t, s, "DataSet", "lake://table", "ACTIVE")
+
+	got, err := s.ListEntitiesBySuperType("Process")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]string{}
+	for _, e := range got {
+		seen[e.QualifiedName] = e.TypeName
+	}
+	if seen[live.QualifiedName] != "CopyJob" {
+		t.Fatalf("CopyJob subclass missing: %v", seen)
+	}
+	if seen[base.QualifiedName] != "Process" {
+		t.Fatalf("base Process missing: %v", seen)
+	}
+	if _, ok := seen["job://gone"]; ok {
+		t.Fatalf("DELETED process was returned: %v", seen)
+	}
+	if _, ok := seen["lake://table"]; ok {
+		t.Fatalf("DataSet is not a Process descendant: %v", seen)
+	}
+}
+
+// A cyclic superTypes registration must not spin. The registration path
+// should refuse one, but a store written by an older build cannot hang here.
+func TestTypeAndDescendantsTerminatesOnACycle(t *testing.T) {
+	s := newTestStore(t)
+	putType(t, s, "A", []string{"B"})
+	putType(t, s, "B", []string{"A"})
+	names, err := s.typeAndDescendants("A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) == 0 {
+		t.Fatal("cycle produced no names — A should still match itself")
+	}
+}


### PR DESCRIPTION
## Summary
- No lineage table — a process that reads A and writes B IS the edge.
- Seeds Process inputs/outputs and walks them with depth/width/direction bounds.

## Test plan
- [x] `go test ./internal/purview/... ./internal/store/ -count=1 -timeout 120s`
- [ ] CI `test` job