### PR TITLE
docs: cite medallion for OneLake Copy; stop citing a job that has never run

### DIFF
--- a/.github/workflows/real-fabric.yml
+++ b/.github/workflows/real-fabric.yml
@@ -6,6 +6,8 @@ name: Real Fabric conformance
 # found here are parity-map material: this workflow is the fidelity oracle.
 #
 # Opt-in by secrets; without them the run skips loudly instead of failing.
+# No parity claim cites this workflow until the secrets are set and a
+# conformance job has actually completed — a skipped run is not evidence.
 # Required repository secrets:
 #   AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET
 #     — a service principal with a role on the test workspace
@@ -52,7 +54,8 @@ jobs:
   # missing secrets. The only steps that executed were checkout, the toolchain
   # setup, and the secret check itself. So the differential leg — the one thing
   # that can catch an emulator-vs-tenant divergence automatically — was green,
-  # weekly, having never run, and two parity claims cite it as their witness.
+  # weekly, having never run. No parity claim cites this workflow until the
+  # secrets are set and a conformance job has actually completed.
   #
   # A skipped job is visibly not a passing one; a succeeded job full of skipped
   # steps is indistinguishable from a real pass at every level that reads a

--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -8,8 +8,7 @@
     "sdk:TestWarehouseDeltaReflectionE2E": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
     "go:TestWarehouseRouter": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
     "sdk:TestWarehouseSQLServerRelayE2E": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "sdk:TestWarehouseTwoSurfaces": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml).",
-    "ci:real-fabric": "AZURE_* credentials + FABRIC_TEST_WORKSPACE \u2014 needs a real Fabric tenant, so it skips on a fork and on any checkout without the secrets. **THIS LEG HAS NEVER RUN. Measured 2026-08-11: both scheduled runs (2026-08-03, 2026-08-10) reported success while every conformance step was skipped for missing secrets** \u2014 the only steps that executed were checkout, toolchain setup and the secret check itself. The workflow now puts its gate in a separate job so the conformance job reports SKIPPED rather than success, because a succeeded job full of skipped steps is indistinguishable from a real pass at every level that reads a conclusion. Until the secrets are set, `ci:real-fabric` witnesses NOTHING: cite it only alongside a witness that runs, and read a claim carrying it as emulator-verified only. The previous text here said 'a divergence shows up as a conformance failure there', which was false and was printed in every CI run."
+    "sdk:TestWarehouseTwoSurfaces": "WAREHOUSE_MSSQL_DSN \u2014 needs a real SQL Server, so it skips on a laptop with no sidecar. Satisfied in CI by the `build` job, which runs a SQL Server service on ubuntu and windows (.github/workflows/ci.yml)."
   },
   "abfss-onelake-dfs-fabric-microsoft-com-production-paths": {
     "section": "Data Engineering (`data-engineering/`)",
@@ -140,10 +139,12 @@
     "section": "Data Factory (`data-factory/`)",
     "claim": "Copy activity \u2014 **OneLake \u2192 OneLake**",
     "witnesses": [
+      "ci:medallion",
       "go:TestPipelineCopyActivityRealBytes",
       "go:TestPipelineCopyDirectory",
       "go:TestPipelineCopyByName"
-    ]
+    ],
+    "note": "ci:medallion runs examples/medallion-pyspark, whose bronze pipeline Copy moves CSV in Files/ into Tables/bronze_customers and asserts rowsCopied plus the table contents \u2014 OneLake to OneLake, driven by the example rather than a Go client."
   },
   "createdataframe-localrows": {
     "section": "Data Engineering (`data-engineering/`)",
@@ -578,8 +579,7 @@
     "claim": "`notebookutils.notebook.run` \u2014 exit values",
     "witnesses": [
       "py:test_notebook_run",
-      "ci:notebookutils",
-      "ci:real-fabric"
+      "ci:notebookutils"
     ]
   },
   "notebookutils-notebook-run-exit-values-over-rest": {
@@ -594,8 +594,7 @@
     "claim": "`notebookutils.notebook.runMultiple` \u2014 DAG structure and ordering",
     "witnesses": [
       "py:test_notebook_run_multiple",
-      "ci:notebookutils",
-      "ci:real-fabric"
+      "ci:notebookutils"
     ]
   },
   "optimize-vacuum-delta-maintenance": {


### PR DESCRIPTION
## Summary
- Cite `ci:medallion` for OneLake Copy — the bronze pipeline already moves CSV into Tables/ and asserts the bytes.
- Stop citing `ci:real-fabric` on notebookutils claims. That job is gated and has never executed.

## Test plan
- [x] `python3 scripts/check_witnesses.py --strict`
- [ ] CI `test` job