### PR TITLE
docs: record Phase 0c — headless msmdsrv listens; ROW needs a table

### DIFF
--- a/docs/33-pbix-tooling.md
+++ b/docs/33-pbix-tooling.md
@@ -1,11 +1,13 @@
 # 33 — PBIX tooling: what can read one, what can write one
 
-**Status: Phase 0 and Phase 0b BOTH RUN and passed.** A `.pbix` built from this
-platform's own TMSL is opened by **Microsoft's Power BI Desktop**, which
+**Status: Phase 0, Phase 0b, and Phase 0c have all RUN.** A `.pbix` built from
+this platform's own TMSL is opened by **Microsoft's Power BI Desktop**, which
 evaluates the fixture DAX to bit-identical numbers — measured on a GitHub
-Windows runner, 5 runs out of 5. Nothing is adopted yet; what changed is that
-the ceiling on what can be claimed has moved, and one of the two documented
-blockers turned out not to exist.
+Windows runner, 5 runs out of 5. Phase 0c showed `msmdsrv` listens and accepts
+ADOMD with a shoestring parent PID; `EVALUATE ROW` needs a table. Desktop
+remains the oracle. Nothing is adopted as a headless gold source; what
+changed is that the ceiling on what can be claimed has moved, and one of the
+two documented blockers turned out not to exist.
 
 This exists because a belief in this project was wrong, in the direction that
 matters: a `.pbix` carrying a data model was recorded as not programmatically
@@ -205,6 +207,53 @@ for a human, and it is the one thing here no amount of running will settle.
 Also unmeasured: durability. Five runs on one afternoon against one Desktop
 build is a pass rate, not a trend. Desktop ships monthly, which is why the
 suite is scheduled weekly rather than run once and believed.
+
+## Phase 0c — RUN: msmdsrv listens; ROW needs a table
+
+Phase 0b proved the engine answers when Desktop hosts it. Phase 0c asked
+whether that hosting is required. It is not. `msmdsrv.exe` from the same
+install starts as a sidecar — an `ini`, a live parent PID, a port, no
+`PBIDesktop.exe` — and accepts ADOMD. Desktop remains the oracle; this is
+the engine host, not a new gold source.
+
+### Attempt 1 — refused at listen
+
+`PrivateProcess=0`, `InstanceVisible=1`, a four-line `ini`. The binary
+started, then exited 0 before anything bound the port. The log:
+"Microsoft Analysis Services evaluation period has expired"
+(`0xC1210000`). Run
+[31865593127](https://github.com/calvinchengx/fabric-emulator/actions/runs/31865593127).
+
+`PrivateProcess=0` is the opposite of the published recipe
+([SSAS-on-a-shoestring](https://github.com/akavalar/SSAS-on-a-shoestring)).
+Attempt 1 tested the wrong configuration.
+
+### Attempt 2 — sidecar is real; ROW needs a table
+
+Shoestring `ini`: `PrivateProcess` = a keeper process's PID,
+`InstanceVisible=0`. The probe ran before that process exited. Run
+[31866148921](https://github.com/calvinchengx/fabric-emulator/actions/runs/31866148921):
+
+```
+STAGE listen   :: OK localhost:55123
+STAGE connect  :: OK
+STAGE create   :: OK
+STAGE query    :: AdomdErrorResponseException ::
+                   DAX Evaluate queries work only on databases
+                   which have at least one table.
+```
+
+The engine listened. ADOMD attached. TMSL `createOrReplace` of an empty
+database succeeded. `EVALUATE ROW("x", 1)` was refused because the catalog
+had zero tables — a `DeploymentMode=2` rule, not a sidecar failure.
+
+What this does **not** establish: deploying `retail.bim`, answering
+real-model DAX, or surviving after the parent PID exits. The sidecar
+shape already shipped as #232: a keeper process, and `FABRIC_DAX_URL`
+pointed at the pump. Desktop remains the gold source.
+
+Same EULA caveat as Phase 0b. No `witnesses.json` row. Phases 1–2 are
+not reordered on this.
 
 ## Phases 1–2 — and Phase 0b reorders them
 

--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -43,7 +43,7 @@ not "the Linux row." See [Not GitHub-hosted runners](#not-github-hosted-runners)
 |---|---|---|---|
 | **macOS** | [UTM](https://github.com/utmapp/UTM) (or Parallels) on the **host**, not inside OrbStack | Install Windows in the guest, then Power BI Desktop or SSAS Developer. Desktop hosts `msmdsrv` as a child; the port is in `%LOCALAPPDATA%\Microsoft\Power BI Desktop*\*\Data\msmdsrv.port.txt` — the same file `e2e/pbix-desktop/desktop.ps1` already polls. Then `pwsh e2e/msmdsrv/start.ps1` | `FABRIC_DAX_URL=http://<guest-ip>:8080` from the Mac |
 | **Linux** | Docker **Engine on the metal** (or a VM that already has KVM) + [`dockur/windows`](https://github.com/dockur/windows) with `/dev/kvm` | Same guest install as Windows. Compose file: [`e2e/msmdsrv/docker-compose.yml`](../e2e/msmdsrv/docker-compose.yml). `make dax-linux` refuses unless `uname` is Linux **and** `/dev/kvm` exists. Pump still starts inside the guest | `FABRIC_DAX_URL=http://127.0.0.1:8080` (published port) |
-| **Windows** | Nothing. The kernel is already there | Desktop (the path `e2e/pbix-desktop` already runs in CI) or a later headless `msmdsrv` once [33](33-pbix-tooling.md) Phase 0c lands. Then `pwsh e2e/msmdsrv/start.ps1` | `FABRIC_DAX_URL=http://127.0.0.1:8080` |
+| **Windows** | Nothing. The kernel is already there | Desktop (the path `e2e/pbix-desktop` already runs in CI) plus `FABRIC_DAX_URL` (#232). Headless `msmdsrv` listens with a shoestring parent PID ([33](33-pbix-tooling.md) Phase 0c); `ROW` needs a table, so it is not a ready oracle. Then `pwsh e2e/msmdsrv/start.ps1` | `FABRIC_DAX_URL=http://127.0.0.1:8080` |
 
 `dockur/windows` is QEMU in a Linux container. It needs `/dev/kvm` passed
 in. Their own requirements are Linux+KVM or Docker Desktop on **Windows 11**


### PR DESCRIPTION
## Summary
- Phase 0c ran: `msmdsrv` listens and accepts ADOMD with a shoestring parent PID; `EVALUATE ROW` needs a table (`DeploymentMode=2`).
- Desktop remains the oracle. The sidecar shape already shipped as #232 (keeper + `FABRIC_DAX_URL`).
- Notes only — the spike tree (`e2e/msmdsrv-headless/`) is not copied onto main.

## Test plan
- [ ] Read the Phase 0c section in `docs/33-pbix-tooling.md` and the Windows row in `docs/52-msmdsrv-hosts.md`
- [ ] Confirm no link to `e2e/msmdsrv-headless/`