### PR TITLE
feat: pin FLOOR and CEILING against Desktop goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -218,7 +218,9 @@ Pins so far, in
 [`e2e/semantic-model/fixtures/desktop_goldens.json`](../e2e/semantic-model/fixtures/desktop_goldens.json),
 replayed by `TestDesktopFunctionGoldens`: `ACOS`, then `ABS` (BLANK stays
 BLANK), then `ROUND` (half away from zero; BLANK number stays BLANK,
-BLANK digits count as 0). Captured on a UTM Windows 11 ARM guest + Desktop.
+BLANK digits count as 0), then `FLOOR` (`s * INT(n/s)`; BLANK n is
+BLANK; s = 0 errors), then `CEILING` (`s *` ceil toward +∞; s = 0
+returns 0). Captured on a UTM Windows 11 ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. ABS(-2.5)/ABS(0)/ABS(3) and ROUND half-away-from-zero (ROUND(-1.5,0)=-2, unlike Go math.Round) pinned live the same day. Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. FLOOR and CEILING pinned live (FLOOR s=0 errors; CEILING s=0 returns 0). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -74,6 +74,78 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ROUND(1234, -2))",
       "column": "[v]",
       "want": 1200
+    },
+    {
+      "name": "FLOOR(10.5, 1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(10.5, 1))",
+      "column": "[v]",
+      "want": 10
+    },
+    {
+      "name": "FLOOR(10.5, 0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(10.5, 0.5))",
+      "column": "[v]",
+      "want": 10.5
+    },
+    {
+      "name": "FLOOR(-2.5, 1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(-2.5, 1))",
+      "column": "[v]",
+      "want": -3
+    },
+    {
+      "name": "FLOOR(-2.5, -1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(-2.5, -1))",
+      "column": "[v]",
+      "want": -2
+    },
+    {
+      "name": "FLOOR(10, 3)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(10, 3))",
+      "column": "[v]",
+      "want": 9
+    },
+    {
+      "name": "CEILING(10.5, 1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(10.5, 1))",
+      "column": "[v]",
+      "want": 11
+    },
+    {
+      "name": "CEILING(10.5, 0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(10.5, 0.5))",
+      "column": "[v]",
+      "want": 10.5
+    },
+    {
+      "name": "CEILING(-2.5, 1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(-2.5, 1))",
+      "column": "[v]",
+      "want": -2
+    },
+    {
+      "name": "CEILING(-2.5, -1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(-2.5, -1))",
+      "column": "[v]",
+      "want": -3
+    },
+    {
+      "name": "CEILING(10, 3)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(10, 3))",
+      "column": "[v]",
+      "want": 12
+    },
+    {
+      "name": "CEILING(-10, 3)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(-10, 3))",
+      "column": "[v]",
+      "want": -9
+    },
+    {
+      "name": "CEILING(10.5, 0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(10.5, 0))",
+      "column": "[v]",
+      "want": 0
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `FLOOR`, `CEILING`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -911,6 +911,66 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, err
 		}
 		return daxRound(n, digits), nil
+	case "FLOOR":
+		if len(fc.args) != 2 {
+			return nil, fmt.Errorf("FLOOR expects 2 arguments")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		if a == nil {
+			return nil, nil // FLOOR(BLANK, s) is BLANK
+		}
+		n, err := arithNum(a, "FLOOR")
+		if err != nil {
+			return nil, err
+		}
+		b, err := e.scalar(fc.args[1])
+		if err != nil {
+			return nil, err
+		}
+		s, err := arithNum(b, "FLOOR")
+		if err != nil {
+			return nil, err
+		}
+		if s == 0 {
+			return nil, fmt.Errorf("FLOOR division by zero")
+		}
+		// Desktop: s * INT(n/s), INT = floor toward −∞.
+		// FLOOR(-2.5, 1) = -3; FLOOR(-2.5, -1) = -2.
+		return s * math.Floor(n/s), nil
+	case "CEILING":
+		if len(fc.args) != 2 {
+			return nil, fmt.Errorf("CEILING expects 2 arguments")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		if a == nil {
+			return nil, nil // CEILING(BLANK, s) is BLANK
+		}
+		n, err := arithNum(a, "CEILING")
+		if err != nil {
+			return nil, err
+		}
+		b, err := e.scalar(fc.args[1])
+		if err != nil {
+			return nil, err
+		}
+		s, err := arithNum(b, "CEILING")
+		if err != nil {
+			return nil, err
+		}
+		// Desktop: CEILING(10.5, 0) = 0 and CEILING(10.5, BLANK()) = 0.
+		// FLOOR(10.5, 0) errors. Do not share FLOOR's zero-significance path.
+		if s == 0 {
+			return 0.0, nil
+		}
+		// s * CEILING(n/s) toward +∞. CEILING(-2.5, 1) = -2;
+		// CEILING(-2.5, -1) = -3.
+		return s * math.Ceil(n/s), nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }

--- a/internal/semanticmodel/dax_test.go
+++ b/internal/semanticmodel/dax_test.go
@@ -168,6 +168,7 @@ func TestDAXErrorsAndEdges(t *testing.T) {
 		`EVALUATE SUMMARIZECOLUMNS('Time'[FiscalYear], "x", [NoMeasure])`, // unknown measure
 		"EVALUATE (",             // parse error
 		"EVALUATE 'Store' extra", // trailing tokens
+		`EVALUATE SUMMARIZECOLUMNS("v", FLOOR(10.5, 0))`, // Desktop: division by zero
 	}
 	for _, q := range bad {
 		if _, err := Evaluate(m, d, q); err == nil {


### PR DESCRIPTION
## Summary
- Phase 3: `FLOOR` and `CEILING` in the Go evaluator, replayed by `TestDesktopFunctionGoldens` with empty `FABRIC_DAX_URL`.
- Desktop `FLOOR` is `s * INT(n/s)`: `FLOOR(-2.5, 1) = -3`, `FLOOR(-2.5, -1) = -2`. Significance 0 errors.
- Desktop `CEILING` is `s *` ceil toward +∞: `CEILING(-2.5, 1) = -2`, `CEILING(10, 3) = 12`. **`CEILING(10.5, 0) = 0`** — do not share FLOOR's zero-significance error.
- BLANK n is BLANK for both.

Independent of #244–#248. Rebased onto `main` after #243.

## Test plan
- [x] `go test ./internal/semanticmodel/`
- [ ] CI `test` job (includes DAX goldens)
- [x] Live pump at `192.168.64.3:8080` agreed on the pinned probes