### PR TITLE
feat: pin LN against a Desktop golden

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -218,7 +218,8 @@ Pins so far, in
 [`e2e/semantic-model/fixtures/desktop_goldens.json`](../e2e/semantic-model/fixtures/desktop_goldens.json),
 replayed by `TestDesktopFunctionGoldens`: `ACOS`, then `ABS` (BLANK stays
 BLANK), then `ROUND` (half away from zero; BLANK number stays BLANK,
-BLANK digits count as 0). Captured on a UTM Windows 11 ARM guest + Desktop.
+BLANK digits count as 0), then `LN` (argument must be > 0; BLANK
+coerces to 0 and errors). Captured on a UTM Windows 11 ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. ABS(-2.5)/ABS(0)/ABS(3) and ROUND half-away-from-zero (ROUND(-1.5,0)=-2, unlike Go math.Round) pinned live the same day. Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. LN pinned live (LN(0)/LN(-1)/LN(BLANK()) error). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -74,6 +74,30 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ROUND(1234, -2))",
       "column": "[v]",
       "want": 1200
+    },
+    {
+      "name": "LN(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LN(1))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "LN(10)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LN(10))",
+      "column": "[v]",
+      "want": 2.302585092994046
+    },
+    {
+      "name": "LN(0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LN(0.5))",
+      "column": "[v]",
+      "want": -0.6931471805599453
+    },
+    {
+      "name": "LN(e)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LN(2.718281828459045))",
+      "column": "[v]",
+      "want": 1
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LN`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -911,6 +911,23 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, err
 		}
 		return daxRound(n, digits), nil
+	case "LN":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("LN expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop LN(BLANK()) errors (BLANK coerces to 0). Do not return BLANK.
+		f, err := arithNum(a, "LN")
+		if err != nil {
+			return nil, err
+		}
+		if f <= 0 {
+			return nil, fmt.Errorf("LN argument must be > 0")
+		}
+		return math.Log(f), nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }

--- a/internal/semanticmodel/dax_test.go
+++ b/internal/semanticmodel/dax_test.go
@@ -168,6 +168,8 @@ func TestDAXErrorsAndEdges(t *testing.T) {
 		`EVALUATE SUMMARIZECOLUMNS('Time'[FiscalYear], "x", [NoMeasure])`, // unknown measure
 		"EVALUATE (",             // parse error
 		"EVALUATE 'Store' extra", // trailing tokens
+		`EVALUATE SUMMARIZECOLUMNS("v", LN(0))`,  // Desktop refuses
+		`EVALUATE SUMMARIZECOLUMNS("v", LN(-1))`, // Desktop refuses
 	}
 	for _, q := range bad {
 		if _, err := Evaluate(m, d, q); err == nil {


### PR DESCRIPTION
## Summary
- Phase 3: `LN` in the Go evaluator, replayed by `TestDesktopFunctionGoldens` with empty `FABRIC_DAX_URL`.
- Desktop: `LN(1) = 0`, `LN(10) = 2.302585092994046`, `LN(0.5) = -0.6931471805599453`.
- `LN(0)`, `LN(-1)`, and `LN(BLANK())` error. BLANK coerces to 0 — not ABS/SQRT’s BLANK-stays-BLANK.

Independent of #244–#249. Branched from `main` at #243.

## Test plan
- [x] `go test ./internal/semanticmodel/`
- [ ] CI `test` job (includes DAX goldens)
- [x] Live pump at `192.168.64.3:8080` agreed on the pinned probes