### PR TITLE
feat: pin EXP against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -218,7 +218,8 @@ Pins so far, in
 [`e2e/semantic-model/fixtures/desktop_goldens.json`](../e2e/semantic-model/fixtures/desktop_goldens.json),
 replayed by `TestDesktopFunctionGoldens`: `ACOS`, then `ABS` (BLANK stays
 BLANK), then `ROUND` (half away from zero; BLANK number stays BLANK,
-BLANK digits count as 0). Captured on a UTM Windows 11 ARM guest + Desktop.
+BLANK digits count as 0), then `EXP` (BLANK coerces to 0, so
+`EXP(BLANK())` is 1). Captured on a UTM Windows 11 ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. ABS(-2.5)/ABS(0)/ABS(3) and ROUND half-away-from-zero (ROUND(-1.5,0)=-2, unlike Go math.Round) pinned live the same day. Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. EXP pinned live (EXP(BLANK())=1). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -74,6 +74,30 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ROUND(1234, -2))",
       "column": "[v]",
       "want": 1200
+    },
+    {
+      "name": "EXP(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(0))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "EXP(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(1))",
+      "column": "[v]",
+      "want": 2.7182818284590455
+    },
+    {
+      "name": "EXP(-1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(-1))",
+      "column": "[v]",
+      "want": 0.3678794411714423
+    },
+    {
+      "name": "EXP(2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(2))",
+      "column": "[v]",
+      "want": 7.3890560989306495
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `EXP`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -911,6 +911,24 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, err
 		}
 		return daxRound(n, digits), nil
+	case "EXP":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("EXP expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop EXP(BLANK()) = 1 — BLANK coerces to 0. Do not return BLANK.
+		f, err := arithNum(a, "EXP")
+		if err != nil {
+			return nil, err
+		}
+		out := math.Exp(f)
+		if math.IsNaN(out) || math.IsInf(out, 0) {
+			return nil, fmt.Errorf("EXP result is not a number")
+		}
+		return out, nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }


### PR DESCRIPTION
## Summary
- Pin `EXP` against Desktop-captured goldens (`EXP(0)`, `EXP(1)`, `EXP(-1)`, `EXP(2)`).
- Desktop trap: `EXP(BLANK())` is **1** (BLANK coerces to 0). Pair to `LN`, which errors on BLANK. Implemented with `arithNum`, not ABS/SQRT’s BLANK-stays-BLANK.
- Independent of #244–#251. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `EXP(0)=1`, `EXP(1)=2.7182818284590455`, `EXP(BLANK())=1`