### PR TITLE
feat: pin LOG and LOG10 against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -218,7 +218,9 @@ Pins so far, in
 [`e2e/semantic-model/fixtures/desktop_goldens.json`](../e2e/semantic-model/fixtures/desktop_goldens.json),
 replayed by `TestDesktopFunctionGoldens`: `ACOS`, then `ABS` (BLANK stays
 BLANK), then `ROUND` (half away from zero; BLANK number stays BLANK,
-BLANK digits count as 0). Captured on a UTM Windows 11 ARM guest + Desktop.
+BLANK digits count as 0), then `LOG` / `LOG10` (default `LOG` base is 10;
+BLANK/`<=0` and `LOG` base `1`/`<=0` error). Captured on a UTM Windows 11
+ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. ABS(-2.5)/ABS(0)/ABS(3) and ROUND half-away-from-zero (ROUND(-1.5,0)=-2, unlike Go math.Round) pinned live the same day. Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. LOG/LOG10 pinned live (default LOG base is 10; BLANK/<=0 error). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -74,6 +74,48 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ROUND(1234, -2))",
       "column": "[v]",
       "want": 1200
+    },
+    {
+      "name": "LOG(10)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG(10))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "LOG(100)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG(100))",
+      "column": "[v]",
+      "want": 2
+    },
+    {
+      "name": "LOG(8, 2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG(8, 2))",
+      "column": "[v]",
+      "want": 3
+    },
+    {
+      "name": "LOG(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG(1))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "LOG10(100)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG10(100))",
+      "column": "[v]",
+      "want": 2
+    },
+    {
+      "name": "LOG10(10)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG10(10))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "LOG10(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG10(1))",
+      "column": "[v]",
+      "want": 0
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -911,6 +911,59 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, err
 		}
 		return daxRound(n, digits), nil
+	case "LOG":
+		if len(fc.args) < 1 || len(fc.args) > 2 {
+			return nil, fmt.Errorf("LOG expects 1 or 2 arguments")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop LOG(BLANK()) errors (BLANK coerces to 0). Do not return BLANK.
+		n, err := arithNum(a, "LOG")
+		if err != nil {
+			return nil, err
+		}
+		if n <= 0 {
+			return nil, fmt.Errorf("LOG argument must be > 0")
+		}
+		base := 10.0
+		if len(fc.args) == 2 {
+			b, err := e.scalar(fc.args[1])
+			if err != nil {
+				return nil, err
+			}
+			base, err = arithNum(b, "LOG")
+			if err != nil {
+				return nil, err
+			}
+		}
+		// Desktop: base 1 is "Division by zero"; base <= 0 is a domain error.
+		if base <= 0 || base == 1 {
+			return nil, fmt.Errorf("LOG base must be > 0 and not 1")
+		}
+		out := math.Log(n) / math.Log(base)
+		if math.IsNaN(out) || math.IsInf(out, 0) {
+			return nil, fmt.Errorf("LOG result is not a number")
+		}
+		return out, nil
+	case "LOG10":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("LOG10 expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop LOG10(BLANK()) errors (BLANK coerces to 0). Do not return BLANK.
+		n, err := arithNum(a, "LOG10")
+		if err != nil {
+			return nil, err
+		}
+		if n <= 0 {
+			return nil, fmt.Errorf("LOG10 argument must be > 0")
+		}
+		return math.Log10(n), nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }


### PR DESCRIPTION
## Summary
- Pin `LOG` and `LOG10` against Desktop-captured goldens (`LOG(10)=1`, `LOG(100)=2`, `LOG(8, 2)=3`, `LOG(1)=0`, `LOG10(100)=2`, `LOG10(10)=1`, `LOG10(1)=0`).
- Desktop traps: default `LOG` base is **10** (not *e*). `LOG(BLANK())` / `LOG10(BLANK())` **error** (BLANK → 0, like `LN`). `LOG(8, 1)` is “Division by zero”; base `<=0` is a domain error. Pair to `EXP`, where `EXP(BLANK())` is 1.
- Independent of #244–#252. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `LOG(10)=1`, `LOG(8, 2)=3`, `LOG(BLANK())` errors