### PR TITLE
feat: pin SIGN against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -219,8 +219,8 @@ Pins so far, in
 replayed by `TestDesktopFunctionGoldens`: `ACOS`, then `ABS` (BLANK stays
 BLANK), then `ROUND` (half away from zero; BLANK number stays BLANK,
 BLANK digits count as 0), then `LOG` / `LOG10` (default `LOG` base is 10;
-BLANK/`<=0` and `LOG` base `1`/`<=0` error). Captured on a UTM Windows 11
-ARM guest + Desktop.
+BLANK/`<=0` and `LOG` base `1`/`<=0` error), then `SIGN` (BLANK stays
+BLANK; `SIGN(0)` is 0). Captured on a UTM Windows 11 ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. LOG/LOG10 pinned live (default LOG base is 10; BLANK/<=0 error). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. SIGN pinned live (BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -116,6 +116,36 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LOG10(1))",
       "column": "[v]",
       "want": 0
+    },
+    {
+      "name": "SIGN(5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIGN(5))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "SIGN(-5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIGN(-5))",
+      "column": "[v]",
+      "want": -1
+    },
+    {
+      "name": "SIGN(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIGN(0))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "SIGN(-0.1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIGN(-0.1))",
+      "column": "[v]",
+      "want": -1
+    },
+    {
+      "name": "SIGN(0.1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIGN(0.1))",
+      "column": "[v]",
+      "want": 1
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -964,6 +964,30 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, fmt.Errorf("LOG10 argument must be > 0")
 		}
 		return math.Log10(n), nil
+	case "SIGN":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("SIGN expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop SIGN(BLANK()) is BLANK. arithNum would make 0.
+		if a == nil {
+			return nil, nil
+		}
+		f, err := arithNum(a, "SIGN")
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case f > 0:
+			return 1.0, nil
+		case f < 0:
+			return -1.0, nil
+		default:
+			return 0.0, nil
+		}
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }


### PR DESCRIPTION
## Summary
- Pin `SIGN` against Desktop-captured goldens (`SIGN(5)=1`, `SIGN(-5)=-1`, `SIGN(0)=0`, `SIGN(-0.1)=-1`, `SIGN(0.1)=1`).
- Desktop trap: `SIGN(BLANK())` is **BLANK** (SUMMARIZECOLUMNS drops the row). Same family as `ABS`, not `EXP`/`LOG`. `arithNum` would make 0.
- Independent of #244–#252. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `SIGN(5)=1`, `SIGN(0)=0`, `SIGN(BLANK())` is BLANK