### PR TITLE
feat: pin ASIN and ATAN against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -220,7 +220,9 @@ replayed by `TestDesktopFunctionGoldens`: `ACOS`, then `ABS` (BLANK stays
 BLANK), then `ROUND` (half away from zero; BLANK number stays BLANK,
 BLANK digits count as 0), then `LOG` / `LOG10` (default `LOG` base is 10;
 BLANK/`<=0` and `LOG` base `1`/`<=0` error), then `SIGN` (BLANK stays
-BLANK; `SIGN(0)` is 0). Captured on a UTM Windows 11 ARM guest + Desktop.
+BLANK; `SIGN(0)` is 0), then `ASIN` / `ATAN` (BLANK stays BLANK;
+`ASIN` outside `[-1, 1]` errors). Captured on a UTM Windows 11 ARM guest
++ Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. SIGN pinned live (BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. ASIN/ATAN pinned live (BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -146,6 +146,48 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIGN(0.1))",
       "column": "[v]",
       "want": 1
+    },
+    {
+      "name": "ASIN(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ASIN(0))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "ASIN(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ASIN(1))",
+      "column": "[v]",
+      "want": 1.5707963267948966
+    },
+    {
+      "name": "ASIN(-1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ASIN(-1))",
+      "column": "[v]",
+      "want": -1.5707963267948966
+    },
+    {
+      "name": "ASIN(0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ASIN(0.5))",
+      "column": "[v]",
+      "want": 0.5235987755982989
+    },
+    {
+      "name": "ATAN(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ATAN(0))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "ATAN(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ATAN(1))",
+      "column": "[v]",
+      "want": 0.7853981633974483
+    },
+    {
+      "name": "ATAN(-1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ATAN(-1))",
+      "column": "[v]",
+      "want": -0.7853981633974483
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -988,6 +988,43 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 		default:
 			return 0.0, nil
 		}
+	case "ASIN":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("ASIN expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop ASIN(BLANK()) is BLANK. arithNum would make ASIN(0)=0.
+		if a == nil {
+			return nil, nil
+		}
+		f, err := arithNum(a, "ASIN")
+		if err != nil {
+			return nil, err
+		}
+		if f < -1 || f > 1 {
+			return nil, fmt.Errorf("ASIN argument must be between -1 and 1")
+		}
+		return math.Asin(f), nil
+	case "ATAN":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("ATAN expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop ATAN(BLANK()) is BLANK. arithNum would make ATAN(0)=0.
+		if a == nil {
+			return nil, nil
+		}
+		f, err := arithNum(a, "ATAN")
+		if err != nil {
+			return nil, err
+		}
+		return math.Atan(f), nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }


### PR DESCRIPTION
## Summary
- Pin `ASIN` and `ATAN` against Desktop-captured goldens (`ASIN(0)=0`, `ASIN(1)=π/2`, `ASIN(-1)=-π/2`, `ASIN(0.5)=π/6`, `ATAN(0)=0`, `ATAN(1)=π/4`, `ATAN(-1)=-π/4`).
- Desktop traps: `ASIN(BLANK())` / `ATAN(BLANK())` stay **BLANK** (unlike Go `ACOS`, which uses `arithNum`). `ASIN` outside `[-1, 1]` errors.
- Independent of #244–#252. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `ASIN(1)=1.5707963267948966`, `ATAN(1)=0.7853981633974483`, `ASIN(BLANK())` is BLANK