### PR TITLE
feat: pin PI, SIN, COS, and TAN against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -221,8 +221,9 @@ BLANK), then `ROUND` (half away from zero; BLANK number stays BLANK,
 BLANK digits count as 0), then `LOG` / `LOG10` (default `LOG` base is 10;
 BLANK/`<=0` and `LOG` base `1`/`<=0` error), then `SIGN` (BLANK stays
 BLANK; `SIGN(0)` is 0), then `ASIN` / `ATAN` (BLANK stays BLANK;
-`ASIN` outside `[-1, 1]` errors). Captured on a UTM Windows 11 ARM guest
-+ Desktop.
+`ASIN` outside `[-1, 1]` errors), then `PI` / `SIN` / `COS` / `TAN`
+(`COS(BLANK())` is 1; `SIN`/`TAN` BLANK stays BLANK; `TAN` of a right
+angle errors). Captured on a UTM Windows 11 ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. ASIN/ATAN pinned live (BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. PI/SIN/COS/TAN pinned live (COS(BLANK())=1; SIN/TAN BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -188,6 +188,66 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", ATAN(-1))",
       "column": "[v]",
       "want": -0.7853981633974483
+    },
+    {
+      "name": "PI()",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", PI())",
+      "column": "[v]",
+      "want": 3.141592653589793
+    },
+    {
+      "name": "SIN(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIN(0))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "COS(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", COS(0))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "TAN(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", TAN(0))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "SIN(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIN(1))",
+      "column": "[v]",
+      "want": 0.8414709848078965
+    },
+    {
+      "name": "COS(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", COS(1))",
+      "column": "[v]",
+      "want": 0.5403023058681397
+    },
+    {
+      "name": "TAN(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", TAN(1))",
+      "column": "[v]",
+      "want": 1.5574077246549023
+    },
+    {
+      "name": "SIN(2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIN(2))",
+      "column": "[v]",
+      "want": 0.9092974268256817
+    },
+    {
+      "name": "SIN(PI()/2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIN(PI()/2))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "SIN(-PI()/2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIN(-PI()/2))",
+      "column": "[v]",
+      "want": -1
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -1025,6 +1025,64 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, err
 		}
 		return math.Atan(f), nil
+	case "PI":
+		if len(fc.args) != 0 {
+			return nil, fmt.Errorf("PI expects 0 arguments")
+		}
+		return math.Pi, nil
+	case "SIN":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("SIN expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop SIN(BLANK()) is BLANK. arithNum would make SIN(0)=0.
+		if a == nil {
+			return nil, nil
+		}
+		f, err := arithNum(a, "SIN")
+		if err != nil {
+			return nil, err
+		}
+		return math.Sin(f), nil
+	case "COS":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("COS expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop COS(BLANK()) = 1 — BLANK coerces to 0. Do not return BLANK.
+		f, err := arithNum(a, "COS")
+		if err != nil {
+			return nil, err
+		}
+		return math.Cos(f), nil
+	case "TAN":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("TAN expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop TAN(BLANK()) is BLANK. arithNum would make TAN(0)=0.
+		if a == nil {
+			return nil, nil
+		}
+		f, err := arithNum(a, "TAN")
+		if err != nil {
+			return nil, err
+		}
+		out := math.Tan(f)
+		// Desktop TAN(PI()/2) is "Division by zero", not a huge IEEE finite.
+		if math.IsNaN(out) || math.IsInf(out, 0) {
+			return nil, fmt.Errorf("TAN division by zero")
+		}
+		return out, nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }


### PR DESCRIPTION
## Summary
- Pin `PI`, `SIN`, `COS`, and `TAN` against Desktop-captured goldens (`PI()`, `SIN(0)`, `COS(0)`, `TAN(0)`, `SIN(1)`, `COS(1)`, `TAN(1)`, `SIN(2)`, `SIN(PI()/2)`, `SIN(-PI()/2)`).
- Desktop traps: `COS(BLANK())` is **1** (BLANK → 0); `SIN`/`TAN` keep BLANK. `TAN(PI()/2)` is “Division by zero”, not a huge IEEE finite.
- Not pinned: `SIN(PI())` / `COS(PI())` / `TAN(PI()/4)` — Desktop disagreed with IEEE; `SIN(1)` matches, so those stay off the golden.
- Independent of #244–#252. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `SIN(1)=0.8414709848078965`, `COS(BLANK())=1`, `TAN(PI()/2)` errors