### PR TITLE
feat: pin DEGREES and RADIANS against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -223,7 +223,8 @@ BLANK/`<=0` and `LOG` base `1`/`<=0` error), then `SIGN` (BLANK stays
 BLANK; `SIGN(0)` is 0), then `ASIN` / `ATAN` (BLANK stays BLANK;
 `ASIN` outside `[-1, 1]` errors), then `PI` / `SIN` / `COS` / `TAN`
 (`COS(BLANK())` is 1; `SIN`/`TAN` BLANK stays BLANK; `TAN` of a right
-angle errors). Captured on a UTM Windows 11 ARM guest + Desktop.
+angle errors), then `DEGREES` / `RADIANS` (BLANK stays BLANK). Captured
+on a UTM Windows 11 ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. PI/SIN/COS/TAN pinned live (COS(BLANK())=1; SIN/TAN BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. DEGREES/RADIANS pinned live (BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -248,6 +248,54 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SIN(-PI()/2))",
       "column": "[v]",
       "want": -1
+    },
+    {
+      "name": "DEGREES(PI())",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DEGREES(PI()))",
+      "column": "[v]",
+      "want": 180
+    },
+    {
+      "name": "DEGREES(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DEGREES(0))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "DEGREES(1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DEGREES(1))",
+      "column": "[v]",
+      "want": 57.29577951308232
+    },
+    {
+      "name": "DEGREES(-PI())",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DEGREES(-PI()))",
+      "column": "[v]",
+      "want": -180
+    },
+    {
+      "name": "RADIANS(180)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", RADIANS(180))",
+      "column": "[v]",
+      "want": 3.141592653589793
+    },
+    {
+      "name": "RADIANS(0)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", RADIANS(0))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "RADIANS(90)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", RADIANS(90))",
+      "column": "[v]",
+      "want": 1.5707963267948966
+    },
+    {
+      "name": "RADIANS(-180)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", RADIANS(-180))",
+      "column": "[v]",
+      "want": -3.141592653589793
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -10,7 +10,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, `DEGREES`, `RADIANS`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -1083,6 +1083,40 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, fmt.Errorf("TAN division by zero")
 		}
 		return out, nil
+	case "DEGREES":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("DEGREES expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop DEGREES(BLANK()) is BLANK. arithNum would make 0.
+		if a == nil {
+			return nil, nil
+		}
+		f, err := arithNum(a, "DEGREES")
+		if err != nil {
+			return nil, err
+		}
+		return f * 180 / math.Pi, nil
+	case "RADIANS":
+		if len(fc.args) != 1 {
+			return nil, fmt.Errorf("RADIANS expects 1 argument")
+		}
+		a, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop RADIANS(BLANK()) is BLANK. arithNum would make 0.
+		if a == nil {
+			return nil, nil
+		}
+		f, err := arithNum(a, "RADIANS")
+		if err != nil {
+			return nil, err
+		}
+		return f * math.Pi / 180, nil
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }


### PR DESCRIPTION
## Summary
- Pin `DEGREES` and `RADIANS` against Desktop-captured goldens (`DEGREES(PI())=180`, `DEGREES(0)=0`, `DEGREES(1)=57.29577951308232`, `DEGREES(-PI())=-180`, `RADIANS(180)=π`, `RADIANS(0)=0`, `RADIANS(90)=π/2`, `RADIANS(-180)=-π`).
- Desktop trap: `DEGREES(BLANK())` / `RADIANS(BLANK())` stay **BLANK**. Same family as `SIN`/`TAN`, not `COS`.
- Independent of #244–#252. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `DEGREES(PI())=180`, `RADIANS(180)=3.141592653589793`, `DEGREES(BLANK())` is BLANK