### PR TITLE
feat: pin DATE, YEAR, MONTH, and DAY against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -223,8 +223,10 @@ BLANK/`<=0` and `LOG` base `1`/`<=0` error), then `SIGN` (BLANK stays
 BLANK; `SIGN(0)` is 0), then `ASIN` / `ATAN` (BLANK stays BLANK;
 `ASIN` outside `[-1, 1]` errors), then `PI` / `SIN` / `COS` / `TAN`
 (`COS(BLANK())` is 1; `SIN`/`TAN` BLANK stays BLANK; `TAN` of a right
-angle errors), then `DEGREES` / `RADIANS` (BLANK stays BLANK). Captured
-on a UTM Windows 11 ARM guest + Desktop.
+angle errors), then `DEGREES` / `RADIANS` (BLANK stays BLANK), then
+`DATE` / `YEAR` / `MONTH` / `DAY` (two-digit years 0–30 → 2000s, 31–99 →
+1900s; month/day overflow; day `<=0` errors; `YEAR(BLANK())` is BLANK).
+Captured on a UTM Windows 11 ARM guest + Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. DEGREES/RADIANS pinned live (BLANK stays BLANK). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. DATE/YEAR/MONTH/DAY pinned live (two-digit year window 0-30→2000s; month/day overflow). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -296,6 +296,108 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", RADIANS(-180))",
       "column": "[v]",
       "want": -3.141592653589793
+    },
+    {
+      "name": "YEAR(DATE(2024, 8, 15))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(2024, 8, 15)))",
+      "column": "[v]",
+      "want": 2024
+    },
+    {
+      "name": "MONTH(DATE(2024, 8, 15))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MONTH(DATE(2024, 8, 15)))",
+      "column": "[v]",
+      "want": 8
+    },
+    {
+      "name": "DAY(DATE(2024, 8, 15))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DAY(DATE(2024, 8, 15)))",
+      "column": "[v]",
+      "want": 15
+    },
+    {
+      "name": "YEAR(DATE(2024, 13, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(2024, 13, 1)))",
+      "column": "[v]",
+      "want": 2025
+    },
+    {
+      "name": "MONTH(DATE(2024, 13, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MONTH(DATE(2024, 13, 1)))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "YEAR(DATE(2024, 0, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(2024, 0, 1)))",
+      "column": "[v]",
+      "want": 2023
+    },
+    {
+      "name": "MONTH(DATE(2024, 0, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MONTH(DATE(2024, 0, 1)))",
+      "column": "[v]",
+      "want": 12
+    },
+    {
+      "name": "MONTH(DATE(2024, 1, 32))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MONTH(DATE(2024, 1, 32)))",
+      "column": "[v]",
+      "want": 2
+    },
+    {
+      "name": "DAY(DATE(2024, 1, 32))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DAY(DATE(2024, 1, 32)))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "MONTH(DATE(2023, 2, 29))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MONTH(DATE(2023, 2, 29)))",
+      "column": "[v]",
+      "want": 3
+    },
+    {
+      "name": "DAY(DATE(2023, 2, 29))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DAY(DATE(2023, 2, 29)))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "YEAR(DATE(0, 1, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(0, 1, 1)))",
+      "column": "[v]",
+      "want": 2000
+    },
+    {
+      "name": "YEAR(DATE(30, 1, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(30, 1, 1)))",
+      "column": "[v]",
+      "want": 2030
+    },
+    {
+      "name": "YEAR(DATE(99, 1, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(99, 1, 1)))",
+      "column": "[v]",
+      "want": 1999
+    },
+    {
+      "name": "YEAR(DATE(100, 1, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(100, 1, 1)))",
+      "column": "[v]",
+      "want": 100
+    },
+    {
+      "name": "YEAR(DATE(-1, 1, 1))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(-1, 1, 1)))",
+      "column": "[v]",
+      "want": 1899
+    },
+    {
+      "name": "YEAR(DATE(2024.9, 8, 15))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(2024.9, 8, 15)))",
+      "column": "[v]",
+      "want": 2025
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -6,11 +6,12 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, `DEGREES`, `RADIANS`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, `DEGREES`, `RADIANS`, `DATE`, `YEAR`, `MONTH`, `DAY`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -1117,8 +1118,89 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, err
 		}
 		return f * math.Pi / 180, nil
+	case "DATE":
+		if len(fc.args) != 3 {
+			return nil, fmt.Errorf("DATE expects 3 arguments")
+		}
+		yv, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		mv, err := e.scalar(fc.args[1])
+		if err != nil {
+			return nil, err
+		}
+		dv, err := e.scalar(fc.args[2])
+		if err != nil {
+			return nil, err
+		}
+		// BLANK year/month coerce to 0 (year 0 → 2000; month 0 overflows).
+		// BLANK day becomes 0 and errors — Desktop DATE(2024, 1, BLANK()) errors.
+		y, err := arithNum(yv, "DATE")
+		if err != nil {
+			return nil, err
+		}
+		m, err := arithNum(mv, "DATE")
+		if err != nil {
+			return nil, err
+		}
+		d, err := arithNum(dv, "DATE")
+		if err != nil {
+			return nil, err
+		}
+		return daxDate(y, m, d)
+	case "YEAR":
+		return e.datePart(fc, "YEAR", func(t time.Time) float64 { return float64(t.Year()) })
+	case "MONTH":
+		return e.datePart(fc, "MONTH", func(t time.Time) float64 { return float64(t.Month()) })
+	case "DAY":
+		return e.datePart(fc, "DAY", func(t time.Time) float64 { return float64(t.Day()) })
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
+}
+
+func (e *evalr) datePart(fc funcCall, fn string, part func(time.Time) float64) (any, error) {
+	if len(fc.args) != 1 {
+		return nil, fmt.Errorf("%s expects 1 argument", fn)
+	}
+	a, err := e.scalar(fc.args[0])
+	if err != nil {
+		return nil, err
+	}
+	// Desktop YEAR/MONTH/DAY(BLANK()) is BLANK.
+	if a == nil {
+		return nil, nil
+	}
+	t, ok := a.(time.Time)
+	if !ok {
+		return nil, fmt.Errorf("%s expects a date", fn)
+	}
+	return part(t), nil
+}
+
+// daxDate is Excel/DAX DATE: parts round half-away-from-zero; month/day overflow
+// (DATE(2024,13,1)=2025-01-01, DATE(2024,1,32)=2024-02-01); day <= 0 errors.
+// Two-digit years: 0–30 → 2000–2030, 31–99 → 1931–1999. Negative years add 1900
+// (DATE(-1,1,1) is 1899). DATE(100,1,1) stays year 100.
+func daxDate(y, m, d float64) (time.Time, error) {
+	di := roundHalfAwayInt(d)
+	if di <= 0 {
+		return time.Time{}, fmt.Errorf("DATE day must be > 0")
+	}
+	return time.Date(daxDateYear(roundHalfAwayInt(y)), time.Month(roundHalfAwayInt(m)), di, 0, 0, 0, 0, time.UTC), nil
+}
+
+func daxDateYear(y int) int {
+	switch {
+	case y >= 0 && y <= 30:
+		return y + 2000
+	case y >= 31 && y <= 99:
+		return y + 1900
+	case y < 0:
+		return y + 1900
+	default:
+		return y
+	}
 }
 
 // daxRound is Excel/DAX ROUND: half away from zero (ROUND(-1.5, 0) = -2),


### PR DESCRIPTION
## Summary
- Pin `DATE` / `YEAR` / `MONTH` / `DAY` against Desktop-captured goldens (calendar parts, month/day overflow, two-digit years, fractional rounding).
- Desktop traps: years 0–30 → 2000–2030, 31–99 → 1931–1999 (`DATE(0)=2000`, `DATE(99)=1999`, `DATE(100)` stays 100). Month/day overflow (`DATE(2024,13,1)=2025-01-01`, `DATE(2023,2,29)=2023-03-01`). Day `<=0` and BLANK day error. `YEAR(BLANK())` is BLANK. Parts round half-away-from-zero (`DATE(2024.9,…)` is 2025).
- Independent of #244–#252. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `YEAR(DATE(2024, 8, 15))=2024`, `YEAR(DATE(0, 1, 1))=2000`, `DATE(2024, 1, 0)` errors