### PR TITLE
feat: pin TIME, HOUR, MINUTE, and SECOND against Desktop-captured goldens

### DIFF
--- a/docs/52-msmdsrv-hosts.md
+++ b/docs/52-msmdsrv-hosts.md
@@ -225,8 +225,10 @@ BLANK; `SIGN(0)` is 0), then `ASIN` / `ATAN` (BLANK stays BLANK;
 (`COS(BLANK())` is 1; `SIN`/`TAN` BLANK stays BLANK; `TAN` of a right
 angle errors), then `DEGREES` / `RADIANS` (BLANK stays BLANK), then
 `DATE` / `YEAR` / `MONTH` / `DAY` (two-digit years 0–30 → 2000s, 31–99 →
-1900s; month/day overflow; day `<=0` errors; `YEAR(BLANK())` is BLANK).
-Captured on a UTM Windows 11 ARM guest + Desktop.
+1900s; month/day overflow; day `<=0` errors; `YEAR(BLANK())` is BLANK),
+then `TIME` / `HOUR` / `MINUTE` / `SECOND` (wraps modulo 24h; BLANK parts
+are 0; negative total errors). Captured on a UTM Windows 11 ARM guest +
+Desktop.
 Clone that guest only while it is **stopped** (`utmctl clone` refuses a
 running VM). Do not treat the live oracle as disposable.
 

--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. DATE/YEAR/MONTH/DAY pinned live (two-digit year window 0-30→2000s; month/day overflow). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. TIME/HOUR/MINUTE/SECOND pinned live (modulo 24h wrap; BLANK parts are 0). Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-9,
   "probes": [
@@ -398,6 +398,78 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", YEAR(DATE(2024.9, 8, 15)))",
       "column": "[v]",
       "want": 2025
+    },
+    {
+      "name": "HOUR(TIME(12, 30, 45))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", HOUR(TIME(12, 30, 45)))",
+      "column": "[v]",
+      "want": 12
+    },
+    {
+      "name": "MINUTE(TIME(12, 30, 45))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MINUTE(TIME(12, 30, 45)))",
+      "column": "[v]",
+      "want": 30
+    },
+    {
+      "name": "SECOND(TIME(12, 30, 45))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SECOND(TIME(12, 30, 45)))",
+      "column": "[v]",
+      "want": 45
+    },
+    {
+      "name": "HOUR(TIME(0, 0, 0))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", HOUR(TIME(0, 0, 0)))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "HOUR(TIME(25, 0, 0))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", HOUR(TIME(25, 0, 0)))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
+      "name": "HOUR(TIME(24, 0, 0))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", HOUR(TIME(24, 0, 0)))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "MINUTE(TIME(0, 90, 0))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MINUTE(TIME(0, 90, 0)))",
+      "column": "[v]",
+      "want": 30
+    },
+    {
+      "name": "SECOND(TIME(0, 0, 90))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SECOND(TIME(0, 0, 90)))",
+      "column": "[v]",
+      "want": 30
+    },
+    {
+      "name": "HOUR(DATE(2024, 8, 15))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", HOUR(DATE(2024, 8, 15)))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "HOUR(TIME(12.9, 0, 0))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", HOUR(TIME(12.9, 0, 0)))",
+      "column": "[v]",
+      "want": 13
+    },
+    {
+      "name": "MINUTE(TIME(0, 30.9, 0))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MINUTE(TIME(0, 30.9, 0)))",
+      "column": "[v]",
+      "want": 31
+    },
+    {
+      "name": "SECOND(TIME(0, 0, 45.9))",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SECOND(TIME(0, 0, 45.9)))",
+      "column": "[v]",
+      "want": 46
     }
   ]
 }

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -11,7 +11,7 @@ import (
 
 // A bounded DAX evaluator — the subset the golden fixture (and the SemPy/GX
 // tutorial's four assets) needs: `EVALUATE <table>`, `SUMMARIZECOLUMNS`, measure
-// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, `DEGREES`, `RADIANS`, `DATE`, `YEAR`, `MONTH`, `DAY`, the infix operators
+// references, `SUM`, `DIVIDE`, `COUNTROWS`, `IF`, `ACOS`, `ABS`, `ROUND`, `LOG`, `LOG10`, `SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, `DEGREES`, `RADIANS`, `DATE`, `YEAR`, `MONTH`, `DAY`, `TIME`, `HOUR`, `MINUTE`, `SECOND`, the infix operators
 // (`+ - * / &` and the comparisons) and single-hop relationship filter
 // propagation. Not full DAX (no CALCULATE filter modifiers, no time-intelligence,
 // no row context beyond aggregation) — unsupported constructs error out rather
@@ -1155,6 +1155,42 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 		return e.datePart(fc, "MONTH", func(t time.Time) float64 { return float64(t.Month()) })
 	case "DAY":
 		return e.datePart(fc, "DAY", func(t time.Time) float64 { return float64(t.Day()) })
+	case "TIME":
+		if len(fc.args) != 3 {
+			return nil, fmt.Errorf("TIME expects 3 arguments")
+		}
+		hv, err := e.scalar(fc.args[0])
+		if err != nil {
+			return nil, err
+		}
+		mv, err := e.scalar(fc.args[1])
+		if err != nil {
+			return nil, err
+		}
+		sv, err := e.scalar(fc.args[2])
+		if err != nil {
+			return nil, err
+		}
+		// Desktop TIME(BLANK(), …) coerces BLANK to 0. TIME(-1, 0, 0) errors.
+		h, err := arithNum(hv, "TIME")
+		if err != nil {
+			return nil, err
+		}
+		m, err := arithNum(mv, "TIME")
+		if err != nil {
+			return nil, err
+		}
+		s, err := arithNum(sv, "TIME")
+		if err != nil {
+			return nil, err
+		}
+		return daxTime(h, m, s)
+	case "HOUR":
+		return e.datePart(fc, "HOUR", func(t time.Time) float64 { return float64(t.Hour()) })
+	case "MINUTE":
+		return e.datePart(fc, "MINUTE", func(t time.Time) float64 { return float64(t.Minute()) })
+	case "SECOND":
+		return e.datePart(fc, "SECOND", func(t time.Time) float64 { return float64(t.Second()) })
 	}
 	return nil, fmt.Errorf("unsupported DAX function %q", fc.name)
 }
@@ -1167,7 +1203,7 @@ func (e *evalr) datePart(fc funcCall, fn string, part func(time.Time) float64) (
 	if err != nil {
 		return nil, err
 	}
-	// Desktop YEAR/MONTH/DAY(BLANK()) is BLANK.
+	// Desktop YEAR/MONTH/DAY/HOUR/MINUTE/SECOND(BLANK()) is BLANK.
 	if a == nil {
 		return nil, nil
 	}
@@ -1201,6 +1237,19 @@ func daxDateYear(y int) int {
 	default:
 		return y
 	}
+}
+
+// daxTime is DAX TIME: parts round half-away-from-zero; hour/minute/second
+// overflow wraps modulo 24h onto the DAX epoch date 1899-12-30 (TIME(25,0,0)
+// is 01:00, TIME(24,0,0) is 00:00 that same day). A negative total errors
+// (TIME(-1,0,0)). BLANK parts coerce to 0.
+func daxTime(h, m, s float64) (time.Time, error) {
+	sec := roundHalfAwayInt(h)*3600 + roundHalfAwayInt(m)*60 + roundHalfAwayInt(s)
+	if sec < 0 {
+		return time.Time{}, fmt.Errorf("TIME result is negative")
+	}
+	sec %= 86400
+	return time.Date(1899, 12, 30, 0, 0, sec, 0, time.UTC), nil
 }
 
 // daxRound is Excel/DAX ROUND: half away from zero (ROUND(-1.5, 0) = -2),


### PR DESCRIPTION
## Summary
- Pin `TIME` / `HOUR` / `MINUTE` / `SECOND` against Desktop-captured goldens (clock parts, 24h wrap, fractional rounding, `HOUR(DATE(…))=0`).
- Desktop traps: overflow wraps modulo 24h onto the DAX epoch `1899-12-30` (`TIME(25,0,0)` hour 1, `TIME(24,0,0)` hour 0). BLANK parts coerce to 0 (unlike `DATE` day). `TIME(-1,0,0)` errors. Parts round half-away-from-zero (`TIME(12.9,0,0)` hour 13). `HOUR(BLANK())` is BLANK.
- Independent of #244–#252. Merging any two Phase 3 PRs without rebase will conflict on `desktop_goldens.json` and `docs/52-msmdsrv-hosts.md`.

## Test plan
- [ ] `go test ./internal/semanticmodel/ -count=1 -timeout 60s`
- [ ] CI green with empty `FABRIC_DAX_URL`
- [ ] Live pump (optional): `HOUR(TIME(12, 30, 45))=12`, `HOUR(TIME(25, 0, 0))=1`, `TIME(-1, 0, 0)` errors