### PR TITLE
feat: pin SWITCH no-else and 1.0==1 goldens

### DIFF
--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -616,6 +616,18 @@
       "want": 99
     },
     {
+      "name": "SWITCH(1, 1, 10, 2, 20)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SWITCH(1, 1, 10, 2, 20))",
+      "column": "[v]",
+      "want": 10
+    },
+    {
+      "name": "SWITCH(1.0, 1, 10, 99)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SWITCH(1.0, 1, 10, 99))",
+      "column": "[v]",
+      "want": 10
+    },
+    {
       "name": "DISTINCTCOUNT(Sales[Units])",
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DISTINCTCOUNT(Sales[Units]))",
       "column": "[v]",


### PR DESCRIPTION
## Summary
- Adds the two SWITCH Desktop golden probes that lived on `feat/dax-oracle-switch` but were omitted from #260: no-else first-match (`SWITCH(1, 1, 10, 2, 20)` → 10) and numeric equality (`SWITCH(1.0, 1, 10, 99)` → 10).
- Fixture-only change in `e2e/semantic-model/fixtures/desktop_goldens.json`. Does not change `dax.go`.

## Test plan
- [x] `go test ./internal/semanticmodel/ -count=1 -run TestDesktopFunctionGoldens` passes
- [ ] CI green