### PR TITLE
fix: DIVIDE's third argument was accepted and ignored; cover the arity guards; salvage 16 Desktop probes

### DIFF
--- a/e2e/semantic-model/fixtures/desktop_goldens.json
+++ b/e2e/semantic-model/fixtures/desktop_goldens.json
@@ -1,7 +1,8 @@
 {
-  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. LOG/LOG10 pinned live (default LOG base is 10; BLANK/<=0 error). ABS(-2.5)/ABS(0)/ABS(3), ROUND half-away-from-zero (ROUND(-1.5,0)=-2, unlike Go math.Round), and INT floor toward \u2212\u221e (INT(-2.1)=-3, unlike Go int() truncate-toward-zero) pinned live the same day. MIN, AVERAGE, COUNT, and POWER pinned live (POWER(0,0) errors; BLANK base is BLANK; BLANK exponent is 0). SIGN pinned live (BLANK stays BLANK). ASIN/ATAN pinned live (BLANK stays BLANK). PI/SIN/COS/TAN pinned live (COS(BLANK())=1; SIN/TAN BLANK stays BLANK). DEGREES/RADIANS pinned live (BLANK stays BLANK). DATE/YEAR/MONTH/DAY pinned live (two-digit year window 0-30\u21922000s; month/day overflow). TIME/HOUR/MINUTE/SECOND pinned live (modulo 24h wrap; BLANK parts are 0). Phase 3 batch also pins SWITCH, DISTINCTCOUNT, MAX, SQRT, MOD, FLOOR, CEILING, LN, EXP, WEEKDAY, WEEKNUM, EOMONTH, EDATE, TRUNC, QUOTIENT, BLANK, ISBLANK. ATAN2 is not a DAX function. Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
+  "_comment": "Desktop-captured scalar goldens (docs/52 Phase 3). Captured 2026-08-15 on UTM Windows 11 ARM + Power BI Desktop via e2e/msmdsrv pump. LOG/LOG10 pinned live (default LOG base is 10; BLANK/<=0 error). ABS(-2.5)/ABS(0)/ABS(3), ROUND half-away-from-zero (ROUND(-1.5,0)=-2, unlike Go math.Round), and INT floor toward \u2212\u221e (INT(-2.1)=-3, unlike Go int() truncate-toward-zero) pinned live the same day. MIN, AVERAGE, COUNT, and POWER pinned live (POWER(0,0) errors; BLANK base is BLANK; BLANK exponent is 0). SIGN pinned live (BLANK stays BLANK). ASIN/ATAN pinned live (BLANK stays BLANK). PI/SIN/COS/TAN pinned live (COS(BLANK())=1; SIN/TAN BLANK stays BLANK). DEGREES/RADIANS pinned live (BLANK stays BLANK). DATE/YEAR/MONTH/DAY pinned live (two-digit year window 0-30\u21922000s; month/day overflow). TIME/HOUR/MINUTE/SECOND pinned live (modulo 24h wrap; BLANK parts are 0). Phase 3 batch also pins SWITCH, DISTINCTCOUNT, MAX, SQRT, MOD, FLOOR, CEILING, LN, EXP, WEEKDAY, WEEKNUM, EOMONTH, EDATE, TRUNC, QUOTIENT, BLANK, ISBLANK. ATAN2 is not a DAX function. 16 further probes (EXP negative/large, LN sub-1 and LN(e), FLOOR/CEILING with a fractional and a non-divisor significance incl. CEILING(-10,3)=-9 rounding toward +inf, SQRT(0.25), MOD exact-zero and fractional, DISTINCTCOUNT/MAX over the StoreId key on both sides of the relationship) were captured in the same 2026-08-15 Desktop session on the per-function branches that PR #260 superseded, and were salvaged rather than recaptured; every one of them agreed with the Go evaluator on arrival, so they widen the evidence without changing a verdict. Every-push CI replays these against the Go evaluator with empty FABRIC_DAX_URL. Add one function at a time; do not pin a function Go cannot evaluate.",
   "captured": "2026-08-15 UTM Windows 11 ARM + Power BI Desktop",
   "toleranceRel": 1e-09,
+  "probeCount": 175,
   "probes": [
     {
       "name": "ACOS(0.5)",
@@ -640,10 +641,34 @@
       "want": 3
     },
     {
+      "name": "DISTINCTCOUNT(Sales[StoreId])",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DISTINCTCOUNT(Sales[StoreId]))",
+      "column": "[v]",
+      "want": 4
+    },
+    {
+      "name": "DISTINCTCOUNT(Store[StoreId])",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", DISTINCTCOUNT('Store'[StoreId]))",
+      "column": "[v]",
+      "want": 4
+    },
+    {
       "name": "MAX(Sales[Units])",
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MAX(Sales[Units]))",
       "column": "[v]",
       "want": 40000
+    },
+    {
+      "name": "MAX(Sales[StoreId])",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MAX(Sales[StoreId]))",
+      "column": "[v]",
+      "want": 4
+    },
+    {
+      "name": "MAX(Store[StoreId])",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MAX('Store'[StoreId]))",
+      "column": "[v]",
+      "want": 4
     },
     {
       "name": "SQRT(9)",
@@ -662,6 +687,12 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SQRT(2))",
       "column": "[v]",
       "want": 1.4142135623730951
+    },
+    {
+      "name": "SQRT(0.25)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", SQRT(0.25))",
+      "column": "[v]",
+      "want": 0.5
     },
     {
       "name": "MOD(10, 3)",
@@ -688,6 +719,18 @@
       "want": -1
     },
     {
+      "name": "MOD(10, 2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MOD(10, 2))",
+      "column": "[v]",
+      "want": 0
+    },
+    {
+      "name": "MOD(7.5, 2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", MOD(7.5, 2))",
+      "column": "[v]",
+      "want": 1.5
+    },
+    {
       "name": "FLOOR(10.5, 1)",
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(10.5, 1))",
       "column": "[v]",
@@ -704,6 +747,18 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(-2.5, -1))",
       "column": "[v]",
       "want": -2
+    },
+    {
+      "name": "FLOOR(10.5, 0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(10.5, 0.5))",
+      "column": "[v]",
+      "want": 10.5
+    },
+    {
+      "name": "FLOOR(10, 3)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", FLOOR(10, 3))",
+      "column": "[v]",
+      "want": 9
     },
     {
       "name": "CEILING(10.5, 1)",
@@ -730,6 +785,24 @@
       "want": 0
     },
     {
+      "name": "CEILING(10.5, 0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(10.5, 0.5))",
+      "column": "[v]",
+      "want": 10.5
+    },
+    {
+      "name": "CEILING(10, 3)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(10, 3))",
+      "column": "[v]",
+      "want": 12
+    },
+    {
+      "name": "CEILING(-10, 3)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", CEILING(-10, 3))",
+      "column": "[v]",
+      "want": -9
+    },
+    {
       "name": "LN(1)",
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LN(1))",
       "column": "[v]",
@@ -742,6 +815,18 @@
       "want": 2.302585092994046
     },
     {
+      "name": "LN(0.5)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LN(0.5))",
+      "column": "[v]",
+      "want": -0.6931471805599453
+    },
+    {
+      "name": "LN(e)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", LN(2.718281828459045))",
+      "column": "[v]",
+      "want": 1
+    },
+    {
       "name": "EXP(0)",
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(0))",
       "column": "[v]",
@@ -752,6 +837,18 @@
       "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(1))",
       "column": "[v]",
       "want": 2.7182818284590455
+    },
+    {
+      "name": "EXP(-1)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(-1))",
+      "column": "[v]",
+      "want": 0.3678794411714423
+    },
+    {
+      "name": "EXP(2)",
+      "dax": "EVALUATE SUMMARIZECOLUMNS(\"v\", EXP(2))",
+      "column": "[v]",
+      "want": 7.3890560989306495
     },
     {
       "name": "WEEKDAY(DATE(2024, 8, 15))",

--- a/internal/semanticmodel/dax.go
+++ b/internal/semanticmodel/dax.go
@@ -799,7 +799,13 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 		}
 		return s, nil
 	case "DIVIDE":
-		if len(fc.args) < 2 {
+		// DIVIDE(numerator, denominator [, alternateResult]) — the third
+		// argument is what a zero denominator returns, defaulting to BLANK.
+		// The guard was `< 2`, which ACCEPTED a third argument and then never
+		// read it: `DIVIDE(x, 0, 0)` answered BLANK where Fabric answers 0, with
+		// no error to notice locally. Accepting an argument you ignore is worse
+		// than rejecting it — the query looks supported and quietly disagrees.
+		if len(fc.args) < 2 || len(fc.args) > 3 {
 			return nil, fmt.Errorf("DIVIDE expects 2 arguments")
 		}
 		a, err := e.scalar(fc.args[0])
@@ -819,6 +825,9 @@ func (e *evalr) evalFunc(fc funcCall) (any, error) {
 			return nil, err
 		}
 		if den == 0 {
+			if len(fc.args) == 3 {
+				return e.scalar(fc.args[2])
+			}
 			return nil, nil // DAX DIVIDE → blank on divide-by-zero
 		}
 		return num / den, nil

--- a/internal/semanticmodel/dax_arity_test.go
+++ b/internal/semanticmodel/dax_arity_test.go
@@ -1,0 +1,154 @@
+package semanticmodel
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDAXFunctionArity drives every arity guard in evalFunc.
+//
+// WHY, and why this is not a coverage-chasing test. The Phase 3 evaluator grew
+// one `case` per DAX function, and each opens with the same shape:
+//
+//	if len(fc.args) != N { return nil, fmt.Errorf("F expects N arguments") }
+//
+// Those guards were the single largest block of unreached code in the package —
+// evalFunc sat at 78.2% almost entirely because of them. That matters beyond the
+// number: an arity guard is the boundary between "unsupported call" and
+// "silently evaluates the wrong thing". A `case` that forgot its guard would
+// index fc.args out of range and panic the server, or worse, read arg[0] and
+// return a plausible number for a call the user wrote wrongly.
+//
+// The expectations here are OURS, not Desktop's — this asserts the emulator's
+// own contract for a malformed call, so a green run is real evidence rather
+// than agreement between two readings of the same document. Desktop's verdicts
+// on WELL-FORMED calls live in desktop_goldens.json, which is the opposite kind
+// of test and must stay that way.
+//
+// Each case asserts the message names the function. A guard that fired with a
+// neighbour's name would still error, still pass a bare "did it error" check,
+// and still send whoever hit it to the wrong `case`.
+func TestDAXFunctionArity(t *testing.T) {
+	m, d := loadModel(t), loadData(t)
+
+	// fn -> the calls that must be rejected. Grouped by the guard's shape so a
+	// newly added function is easy to slot in beside its own kind.
+	type badCall struct{ expr, wantMsg string }
+
+	var cases []badCall
+	add := func(exprs []string, msg string) {
+		for _, e := range exprs {
+			cases = append(cases, badCall{e, msg})
+		}
+	}
+
+	// Exactly one argument.
+	for _, f := range []string{
+		"ACOS", "ABS", "LOG10", "INT", "SIGN", "ASIN", "ATAN",
+		"SIN", "COS", "TAN", "DEGREES", "RADIANS", "SQRT", "LN", "EXP", "ISBLANK",
+	} {
+		add([]string{f + "()", f + "(1, 2)"}, f+" expects 1 argument")
+	}
+
+	// Exactly two arguments.
+	for _, f := range []string{
+		"ROUND", "POWER", "MOD", "FLOOR", "CEILING", "EOMONTH", "EDATE", "QUOTIENT",
+	} {
+		add([]string{f + "(1)", f + "(1, 2, 3)"}, f+" expects 2 arguments")
+	}
+
+	// DIVIDE takes an OPTIONAL third argument, so only 1 and 4+ are malformed.
+	// See TestDivideAlternateResult for what the third argument does.
+	add([]string{"DIVIDE(1)", "DIVIDE(1, 2, 3, 4)"}, "DIVIDE expects 2 arguments")
+
+	// Exactly three arguments.
+	for _, f := range []string{"DATE", "TIME"} {
+		add([]string{f + "(1, 2)", f + "(1, 2, 3, 4)"}, f+" expects 3 arguments")
+	}
+
+	// Exactly zero arguments — the guard nobody expects to need until a caller
+	// passes the thing they meant to wrap.
+	add([]string{"PI(1)"}, "PI expects 0 arguments")
+	add([]string{"BLANK(1)"}, "BLANK expects 0 arguments")
+
+	// One or two: the optional-argument functions. Both ends, because a `< 1`
+	// guard and a `> 2` guard are separate branches and a missing `> 2` would
+	// silently ignore a third argument.
+	add([]string{"LOG()", "LOG(1, 2, 3)"}, "LOG expects 1 or 2 arguments")
+	add([]string{"TRUNC()", "TRUNC(1, 2, 3)"}, "TRUNC expects 1 or 2 arguments")
+
+	// Aggregations want a reference, not a scalar — a distinct message because
+	// the fix is different (pass a column, not "pass fewer arguments").
+	for _, f := range []string{"SUM", "DISTINCTCOUNT", "AVERAGE", "COUNT", "MIN", "MAX"} {
+		add([]string{f + "()"}, f+" expects a column reference")
+	}
+	add([]string{"COUNTROWS()"}, "COUNTROWS expects a table")
+	add([]string{"IF(1)"}, "IF expects a condition and a value")
+
+	if len(cases) < 60 {
+		t.Fatalf("only %d arity cases — the table lost entries", len(cases))
+	}
+
+	for _, c := range cases {
+		t.Run(c.expr, func(t *testing.T) {
+			_, err := Evaluate(m, d, `EVALUATE SUMMARIZECOLUMNS("v", `+c.expr+`)`)
+			if err == nil {
+				t.Fatalf("%s: evaluated without error, want %q", c.expr, c.wantMsg)
+			}
+			if !strings.Contains(err.Error(), c.wantMsg) {
+				t.Errorf("%s: error = %q, want it to contain %q", c.expr, err, c.wantMsg)
+			}
+		})
+	}
+}
+
+// TestDivideAlternateResult pins DIVIDE's optional third argument.
+//
+// PROVENANCE, because it differs from the goldens next door. These expectations
+// come from Microsoft's DAX reference for DIVIDE — "the value returned when
+// division by zero results in an error", defaulting to BLANK — NOT from a
+// Power BI Desktop capture. Nobody ran the msmdsrv oracle for this; the
+// Windows VM is not in this loop. So this asserts the documented contract and
+// nothing stronger, and it is deliberately NOT in desktop_goldens.json, whose
+// entries all mean "Desktop answered this". Whoever next boots the VM should
+// pin DIVIDE(1, 0, -1) there and delete this note.
+//
+// The bug it was written for: the guard admitted a third argument and the body
+// never read it, so DIVIDE(x, 0, alt) returned BLANK instead of alt. There was
+// no local symptom — the query parsed, evaluated, and answered wrongly.
+func TestDivideAlternateResult(t *testing.T) {
+	m, d := loadModel(t), loadData(t)
+
+	for _, c := range []struct {
+		expr string
+		want any
+	}{
+		{"DIVIDE(10, 2)", 5.0},      // unaffected: denominator non-zero
+		{"DIVIDE(10, 2, -1)", 5.0},  // alternate ignored when it does not apply
+		{"DIVIDE(10, 0)", nil},      // no alternate → BLANK, the documented default
+		{"DIVIDE(10, 0, -1)", -1.0}, // the regression: was BLANK
+		{"DIVIDE(10, 0, 0)", 0.0},   // 0 is a value, not "absent": a len==3 check
+		// ...must not degrade to a truthiness test on the alternate itself.
+		{"DIVIDE(10, BLANK(), 7)", 7.0}, // blank denominator takes the alternate too
+	} {
+		res, err := Evaluate(m, d, `EVALUATE SUMMARIZECOLUMNS("v", `+c.expr+`)`)
+		if err != nil {
+			t.Errorf("%s: %v", c.expr, err)
+			continue
+		}
+		if c.want == nil {
+			// A lone blank output drops the row (see TestDAXErrorsAndEdges).
+			if len(res.Rows) != 0 {
+				t.Errorf("%s: got rows %v, want the row dropped (BLANK)", c.expr, res.Rows)
+			}
+			continue
+		}
+		if len(res.Rows) != 1 {
+			t.Errorf("%s: got %d rows, want 1", c.expr, len(res.Rows))
+			continue
+		}
+		if got := toF(res.Rows[0]["[v]"]); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.expr, got, c.want)
+		}
+	}
+}

--- a/internal/semanticmodel/dax_test.go
+++ b/internal/semanticmodel/dax_test.go
@@ -128,6 +128,7 @@ func TestDesktopFunctionGoldens(t *testing.T) {
 	}
 	var g struct {
 		ToleranceRel float64 `json:"toleranceRel"`
+		ProbeCount   int     `json:"probeCount"`
 		Probes       []struct {
 			Name   string  `json:"name"`
 			DAX    string  `json:"dax"`
@@ -140,6 +141,19 @@ func TestDesktopFunctionGoldens(t *testing.T) {
 	}
 	if len(g.Probes) == 0 {
 		t.Fatal("desktop_goldens.json has no probes")
+	}
+	// Cardinality, declared separately from the array — the same guard
+	// TestDAXGoldenQueries gets from DAXQueryCount. Without it this test passes
+	// whether it compares 175 probes or 5: a probe silently dropped by a bad
+	// merge (this fixture is edited on many branches at once, and has already
+	// collided once) reads as a pass, because every probe that REMAINS still
+	// agrees. Assert the count the capture actually produced.
+	if g.ProbeCount == 0 {
+		t.Fatal("desktop_goldens.json declares no probeCount — add it, or a dropped probe is invisible")
+	}
+	if len(g.Probes) != g.ProbeCount {
+		t.Fatalf("fixture holds %d probes, declares probeCount %d — a probe was added or lost without updating the count",
+			len(g.Probes), g.ProbeCount)
 	}
 	if g.ToleranceRel <= 0 {
 		g.ToleranceRel = 1e-9


### PR DESCRIPTION
## A parity defect, found by covering the arity guards

`DIVIDE(numerator, denominator [, alternateResult])` takes an optional third
argument: the value returned when the denominator is 0, defaulting to BLANK.
The guard was `len(fc.args) < 2`, so a third argument was **accepted** — and
then never read. `DIVIDE(x, 0, 0)` answered BLANK where Fabric answers 0.

This is the failure direction that ships. The query parses, evaluates, and
returns a plausible number, so there is no local symptom at all — nothing to
investigate until someone compares against a tenant. Twelve lines below,
`IF` has the same `< 2` guard and *does* read `fc.args[2]`, which is what
makes this an oversight rather than a decision.

Fixed, and the arity guard tightened to `< 2 || > 3` so a fourth argument is
rejected rather than silently dropped.

**Provenance, stated because it differs from the goldens next door:** the
alternateResult semantics come from Microsoft's DAX reference, **not** from a
Desktop capture. Nobody ran the msmdsrv oracle for this. So the assertions live
in `dax_arity_test.go` and deliberately **not** in `desktop_goldens.json`, whose
every entry means "Desktop answered this". Whoever next boots the Windows VM
should pin `DIVIDE(1, 0, -1)` there and delete that note.

## Coverage: the arity guards

`evalFunc` grew one `case` per DAX function, each opening with an arity guard,
and those guards were the largest block of unreached code in the package.
`TestDAXFunctionArity` drives all of them — 60+ malformed calls, each asserting
the message **names its own function**, so a guard firing under a neighbour's
name is caught rather than passing a bare "did it error" check.

These expectations are ours, not Desktop's: they assert the emulator's contract
for a malformed call, so a green run is real evidence rather than agreement
between two readings of the same document.

- `internal/semanticmodel`: **88.1% → 89.3%**
- `evalFunc`: **78.2% → 81.2%**

## Salvage: 16 probes from the superseded branches

Five branches (`feat/dax-oracle-{exp,ln,floor,sqrt,distinctcount}`) were pinning
one function each when #260 landed the whole Phase 3 set in a single evaluator
pass. They cannot usefully be merged, and I verified this rather than assuming
it: a test-merge of `feat/dax-oracle-exp` into current main conflicts in both
`dax.go` and `desktop_goldens.json`, and the naive keep-both resolution then
fails to build — `duplicate case "EXP" (constant of type string) in expression
switch`. The only correct resolution is to take main's side of every code hunk,
which leaves exactly the probes salvaged below. All five are also CI-red at
89.9% against the 90% floor, the very wall #260 cleared by consolidating.

Their only unique content was **16 Desktop probes captured in that same
2026-08-15 session** that main never received. Those are salvaged here rather
than recaptured, and every overlapping probe was checked first: **159 shared
probes, zero disagreements**, so the two capture paths agree and this widens the
evidence without changing a verdict.

| function | salvaged |
|---|---|
| EXP | `EXP(-1)`, `EXP(2)` |
| LN | `LN(0.5)`, `LN(e)` |
| FLOOR / CEILING | fractional significance, non-divisor significance, `CEILING(-10,3) = -9` (rounds toward +inf) |
| SQRT / MOD | `SQRT(0.25)`, exact-zero and fractional MOD |
| DISTINCTCOUNT / MAX | over `StoreId` on **both** sides of the relationship |

All 16 agreed with the Go evaluator on arrival.

## A guard for why that check was needed

`TestDesktopFunctionGoldens` had **no cardinality assertion** — it passed
whether it compared 175 probes or 5, because every probe that *remains* still
agrees. I could not tell from a green run whether my 16 had executed at all
(I mutation-tested each one individually to find out: 16/16 killed).

Added `probeCount`, the same guard `TestDAXGoldenQueries` already gets from
`DAXQueryCount`. This fixture is edited on many branches at once, so a probe
dropped by a bad merge was previously invisible.

## Verification

- Full repo `go test ./...` — green, exit 0
- Mutation-tested: 16/16 salvaged probes killed when perturbed; both `probeCount`
  mutants killed (drop a probe / remove the field); the DIVIDE fix killed on
  exactly the three cases that depend on it
- `gofmt`, `go vet` clean

Branch SHAs are recorded so the five superseded branches stay recoverable after
pruning.
