### PR TITLE
Dispatch acceptance at contoso-fabric-platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
   # expired is silence, which is why the acceptance workflow also runs on a
   # daily schedule — see its own comment.
   dispatch:
-    name: Tell contoso-data-platform to verify this release
+    name: Tell contoso-fabric-platform to verify this release
     needs: fixtures
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -207,7 +207,7 @@ jobs:
           if [ -z "$GH_TOKEN" ]; then
             echo "::error::ACCEPTANCE_DISPATCH_TOKEN is not set — the release " \
                  "shipped but nothing downstream was told. Add a PAT with " \
-                 "'contents: write' on calvinchengx/contoso-data-platform."
+                 "'contents: write' on calvinchengx/contoso-fabric-platform."
             exit 1
           fi
           # The version travels WITH the event. Without it the downstream repo
@@ -215,7 +215,7 @@ jobs:
           # the previous release — and report success for a release nobody
           # tested.
           version="${GITHUB_REF_NAME#v}"
-          gh api repos/calvinchengx/contoso-data-platform/dispatches \
+          gh api repos/calvinchengx/contoso-fabric-platform/dispatches \
             -f event_type=fabric-emulator-release \
             -F "client_payload[version]=$version" \
             -F "client_payload[tag]=${GITHUB_REF_NAME}"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Concretely, that also unlocks:
   (`202` → poll `/v1/operations/{id}`). The emulator's clock control makes an LRO
   complete instantly or pins it in `Running` — impossible against real Fabric.
 
-See [`contoso-data-platform`](https://github.com/calvinchengx/contoso-data-platform)
+See [`contoso-fabric-platform`](https://github.com/calvinchengx/contoso-fabric-platform)
 for what this looks like end to end: four real vendor sources, a full medallion,
 a semantic model serving Power BI, all catalogued in OpenMetadata, running
 against a published release of this emulator.

--- a/examples/README.md
+++ b/examples/README.md
@@ -182,7 +182,7 @@ The controllable clock, fault injection, schedules, event triggers, and
 put-if-absent (`If-None-Match` — the Delta concurrency primitive).
 
 The fullest demonstration of those is not in this repository at all. The
-[contoso-data-platform](https://github.com/calvinchengx/contoso-data-platform)
+[contoso-fabric-platform](https://github.com/calvinchengx/contoso-fabric-platform)
 consumer drives the clock, creates schedules and Reflex triggers, and implements
 the `FABRIC_TARGET` toggle. The emulator's own examples show a data platform; a
 downstream consumer shows the emulator's fidelity. That is the wrong way round.


### PR DESCRIPTION
## Summary
- The consumer repo was renamed to `contoso-fabric-platform`. Release dispatch, README, and examples now use that name.

## Test plan
- [ ] Confirm `gh api repos/calvinchengx/contoso-fabric-platform/dispatches` is the path the next tag will fire