### PR TITLE
build(deps): entra 0.8.1 in the three composes the gate cannot see

### DIFF
--- a/e2e/az-rest/docker-compose.yml
+++ b/e2e/az-rest/docker-compose.yml
@@ -10,7 +10,7 @@
 # tenant returns, which is the claim this job binds.
 services:
   entra:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.6.0}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.8.1}
     user: "0:0"
     environment:
       PUBLIC_ORIGIN: "https://login.microsoftonline.com"

--- a/e2e/conformance/docker-compose.jvm.yml
+++ b/e2e/conformance/docker-compose.jvm.yml
@@ -4,7 +4,7 @@
 # spark-submit agent.py 8099). No Sail. fabric still drives the agent.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.7.0}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.8.1}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"

--- a/e2e/conformance/docker-compose.sail.yml
+++ b/e2e/conformance/docker-compose.sail.yml
@@ -6,7 +6,7 @@
 # over DFS HTTP; it never asks spark.table whether the write landed.
 services:
   entra-emulator:
-    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.7.0}
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.8.1}
     environment:
       ORIGIN_MODE: compat
       TLS_ENABLED: "false"


### PR DESCRIPTION
Three compose files sat on entra **0.6.0** and **0.7.0** while the BOM is on **0.8.1**:

| file | was |
|---|---|
| `e2e/az-rest/docker-compose.yml` | 0.6.0 |
| `e2e/conformance/docker-compose.jvm.yml` | 0.7.0 |
| `e2e/conformance/docker-compose.sail.yml` | 0.7.0 |

They drifted because `check_family_pins.py` enumerates `FABRIC_COMPOSES` **by hand**: `docker-compose.yml`, `e2e/notebook-run/docker-compose.jvm.yml`, and `e2e/{suite}/docker-compose.yml` for 22 named suites. This repo has **30** compose files carrying an entra pin, so six match nothing — these three plus `e2e/eventstream`, `e2e/terraform-fabric` and `examples/fab-driven`, which happen to be current today but are not kept that way by anything.

A hand-maintained allowlist fails in exactly one direction: silently, whenever a suite is added. Every miss here is a suite that landed after the list was written.

After this, every entra default across all 30 compose files reads `0.8.1` — verified by `git grep`, not by inspection. All three files still pass `docker compose config`.

azure-emulators has a companion PR switching `FABRIC_COMPOSES` to a glob so the hole closes.