### PR TITLE
chore: name the renamed consumer repo in the release.yml comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
   # The wheels the standalone acceptance repo installs: the fixture generators
   # and `fabric-target`.
   #
-  # `contoso-data-platform` runs this medallion against the RELEASED image, and
+  # `contoso-fabric-platform` runs this medallion against the RELEASED image, and
   # its assertions must be the same numbers the in-tree examples assert. One
   # generator, published, is what makes that guarantee structural rather than
   # hopeful — two copies differing by a single RNG draw would each pass their


### PR DESCRIPTION
#269 moved the dispatch target from `contoso-data-platform` to
`contoso-fabric-platform`, but the comment eight lines above that job still
named the old repo, so the file contradicted itself: the prose said one repo,
the `gh api .../dispatches` call said another.

All four references in `release.yml` now agree.

## Scope, deliberately narrow

28 files still mention `contoso-data-platform`, and **most of them should**.
The ones in `AUDIT.md` and `docs/16-warehouse-tds.md` are dated attributions
("Reported 2026-08-04 from `contoso-data-platform`") — that was the repo's name
when the measurement was taken, and renaming those would misdate the evidence.

This changes only the one reference that describes **current** behaviour and
sits next to the job it contradicts. `release.yml` was the file #269 edited, so
it is the one place the stale name reads as a live claim rather than history.

Note the old name still resolves: GitHub keeps a redirect after a rename, so
nothing was broken either way. This is about the file agreeing with itself.