### PR TITLE
feat: upgrade Sail to 0.7.0, moving the paired Connect client to 4.2.0

### DIFF
--- a/docs/20-lakesail-engine.md
+++ b/docs/20-lakesail-engine.md
@@ -9,6 +9,22 @@ a complete emulation of the Microsoft Fabric runtime.
 Grounded against Sail **v0.6.6** (local checkout audit; citations are that
 repo's paths).
 
+> **The shipped pin is now v0.7.0; this audit has not been redone against it.**
+> The version numbers below are left at v0.6.6 deliberately rather than
+> search-replaced forward, because every one of them cites a line in a source
+> tree somebody actually read. Rewriting them to 0.7.0 would turn a measurement
+> into a guess that reads exactly like a measurement.
+>
+> What the upgrade DID establish is narrower and worth separating: the
+> engine-matrix and conformance suites pass on 0.7.0, so the behaviours those
+> probes assert still hold. What is unverified is the prose here that no probe
+> covers, and the 0.7.0 changelog touches several of these areas directly
+> (`fix: correct ceil/floor edge-case bugs and ANSI overflow behavior`,
+> `fix: match Spark ordering semantics for agg and window functions`,
+> `feat: add basic checkpoint support`, `feat: share driver server among
+> sessions`). The checkpoint work in particular may move the streaming gap this
+> doc records. Re-audit before citing any un-probed claim below as current.
+
 ## Why
 
 - **The JVM is our heaviest dependency.** The `apache/spark:3.5.5` stack costs
@@ -82,7 +98,7 @@ Compute claims are split into three evidence tiers:
 
 | Tier | Engine | What a pass establishes |
 |---|---|---|
-| Default | Sail 0.6.6 + PySpark Connect 4.2 | Spark Connect DataFrame/SQL behavior, native Delta behavior, OneLake paths, auth, Livy and notebook integration |
+| Default | Sail 0.7.0 + PySpark Connect 4.2 | Spark Connect DataFrame/SQL behavior, native Delta behavior, OneLake paths, auth, Livy and notebook integration |
 | JVM oracle | Apache Spark 3.5.5 + Delta 3.2 + Java 11 | Fabric Runtime 1.3-aligned Spark Core/JVM behavior and Hadoop ABFS compatibility; scheduled/manual, not part of the default stack |
 | Release oracle | real Microsoft Fabric | representative notebook and API conformance in the managed production runtime; secret-gated and run before releases |
 

--- a/docs/44-interaction-surfaces.md
+++ b/docs/44-interaction-surfaces.md
@@ -130,9 +130,12 @@ gives for the catalog UI and Airflow gives for orchestration. What makes it a
   entra-emulator's seeded identity, so only the endpoints are named.
 - `SPARK_REMOTE` points at **Sail** — the same engine a `RunNotebook` job and a
   Livy session use, so a cell here and a cell in a job execute identically.
-- `pyspark-client` is pinned to the **same 4.1.1 the agent uses**. A kernel on a
-  different client than the engine is precisely the drift this profile exists to
-  avoid, and the pin comment in `pyproject.toml` explains what breaks otherwise.
+- `pyspark-client` is pinned to the **same version the agent uses**. A kernel on
+  a different client than the engine is precisely the drift this profile exists
+  to avoid, and the pin comment in `pyproject.toml` explains what breaks
+  otherwise. The version is deliberately not restated here: it is one number
+  shared by the Sail server and every Connect client, and a copy of it in prose
+  is a copy that goes stale silently.
 - `./notebooks` is a host mount, so what you author survives the container and
   is the same file `fabric-cicd` publishes and git syncs.
 

--- a/docs/engine-matrix.md
+++ b/docs/engine-matrix.md
@@ -117,7 +117,7 @@ buy capabilities most tests never touch.
 | Time travel — `option("versionAsOf")` | ✅ | ✅ | ✅ |
 | Time travel — SQL `VERSION AS OF` | ✅ | ✅ | ✅ |
 | `MERGE INTO` a registered table at a **local path** ᵃ | ❌ `attribute ObjectName([Identifier("#0")]) is missing from the schema: cannot resolve attrib` | ✅ | ✅ |
-| `MERGE INTO delta.`path`` (path target) | ❌ `Table not found: [TABLE_OR_VIEW_NOT_FOUND] Table or view not found: /tmp/probe/t_merge_pat` | ✅ | ✅ |
+| `MERGE INTO delta.`path`` (path target) | ❌ `attribute ObjectName([Identifier("#0")]) is missing from the schema: cannot resolve attrib` | ✅ | ✅ |
 | `OPTIMIZE` | ❌ `invalid argument: found OPTIMIZE at 0:8 expected something else, ';', statement, or end of` | ✅ | ✅ |
 | `VACUUM` | ❌ `invalid argument: found VACUUM at 0:6 expected something else, ';', statement, or end of i` | ✅ | ✅ |
 | Change Data Feed (must not be inert) ᵇ | ❌ `Table features must be specified, please specify: ChangeDataFeed` | ✅ | ✅ |

--- a/e2e/engine-matrix/probes.py
+++ b/e2e/engine-matrix/probes.py
@@ -297,9 +297,16 @@ def python_udf(spark):
 
     This failed for a while with `read_udfs() missing 2 required positional
     arguments`, which looked like an engine gap but was a client pin: pyspark
-    4.2.0 added two parameters to `pyspark.worker.read_udfs` and pysail 0.6.6
-    calls the 3-argument form. Fixed by pinning the client to 4.1.1, the version
-    pysail is built against. If this regresses, check that pin before the engine.
+    4.2.0 added two parameters to `pyspark.worker.read_udfs`, and pysail 0.6.x
+    called the 3-argument form. The fix was not a particular version — it was
+    pinning the client to whatever the pysail release is built against, which
+    `pyproject.toml` now does for both halves at once (Sail 0.7.0 + client
+    4.2.0).
+
+    The direction of the constraint was measured rather than assumed, and it is
+    asymmetric: an OLD server cannot take a NEW client, but 0.7.0 takes 4.1.1
+    fine. So a regression here means the client LEADS the server, not merely
+    that the two differ. Check that pin before suspecting the engine.
     """
     from pyspark.sql.functions import udf
     from pyspark.sql.types import IntegerType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,17 +111,38 @@ great-expectations = [
     "pandas>=2.2,<4",
 ]
 runtime = []
-# pyspark-client is pinned to what pysail 0.6.6 is built and tested against
-# (its own `test` extra pins 4.1.1). This is not cosmetic: 4.2.0 added
-# `runner_conf`/`eval_conf` to `pyspark.worker.read_udfs`, which Sail calls with
-# the 3-argument form, so every Python UDF died with
+# pyspark-client is pinned to what pysail is built and tested against — read
+# BOTH versions below as one number, and move them together or not at all.
+#
+# The reason is a real outage, not tidiness. pyspark-client 4.2.0 added
+# `runner_conf`/`eval_conf` to `pyspark.worker.read_udfs`; Sail 0.6.x called the
+# 3-argument form, so pairing 0.6.6 with 4.2.0 killed every Python UDF with
 #   TypeError: read_udfs() missing 2 required positional arguments
 # The UDF runs inside the Sail server's embedded CPython, so the *server* image
-# is what must match — but client and server are pinned together so the two
-# never drift apart. Revisit when pysail supports a newer client.
+# is what must match. Client and server are pinned together so they cannot drift.
+#
+# Sail 0.7.0 moved to Spark 4.2 (lakehq/sail#2289) and its own `test` extra now
+# pins pyspark-client==4.2.0, which is why both numbers change together.
+#
+# MEASURED, because the obvious symmetry argument is wrong. Three combinations
+# were run locally against a real Sail server before this landed:
+#   0.7.0 + 4.2.0  UDF round-trips            <- what we ship
+#   0.7.0 + 4.1.1  UDF ALSO round-trips       <- 0.7.0 tolerates the old client
+#   0.6.6 + 4.2.0  dies in `createDataFrame`  <- ValueError: invalid literal
+#                                                for int() with base 10: '3GB'
+# So the constraint is NOT symmetric, and it is worth knowing which way it runs:
+# the OLD server cannot take the NEW client, while the new server takes either.
+# Note also that the 0.6.6 + 4.2.0 break reproduces as a config-parse failure
+# well before any UDF runs — the `read_udfs` TypeError above is a second,
+# later incompatibility on the same pairing, reachable only once you avoid
+# `createDataFrame` (which is why e2e/sail/driver.py builds rows with VALUES).
+#
+# Practical rule: the client may lag the server, but must never lead it. Pin
+# them together anyway — the `test` extra of each pysail release states the
+# client it was built against, and matching it is free.
 sail = [
-    "pysail==0.6.6",
-    "pyspark-client==4.1.1",
+    "pysail==0.7.0",
+    "pyspark-client==4.2.0",
 ]
 # The Sail statement agent also runs Delta maintenance (OPTIMIZE/VACUUM/CDF)
 # through delta-rs, since Sail's planner has no such commands — so the runtime
@@ -131,7 +152,7 @@ sail = [
 # lookalike. requests for the same reason spark-connect carries it: user
 # notebook code calls HTTP APIs, and the agent is where that code runs.
 sail-delta = [
-    "pyspark-client==4.1.1",
+    "pyspark-client==4.2.0",
     "deltalake>=0.23,<2",
     "pandas>=2,<3",
     "pyarrow>=18,<24",
@@ -149,17 +170,20 @@ sail-delta = [
 # APIs, and the statement agent is where that code executes.
 # JupyterLab for the `jupyter` compose profile: a REAL notebook editor shipped
 # rather than one built into the portal (docs/44). pyspark-client is pinned to
-# the SAME 4.1.1 the agent uses — a kernel on a different client than the engine
-# is exactly the drift this profile exists to avoid.
+# the SAME version the agent uses (see the `sail` group above, which explains
+# why that number is really one number shared with the server) — a kernel on a
+# different client than the engine is exactly the drift this profile exists to
+# avoid. Stated as "the same as the agent" rather than repeating the digits,
+# because a restated version is one someone has to remember to update twice.
 jupyter = [
     "jupyterlab>=4.2,<5",
-    "pyspark-client==4.1.1",
+    "pyspark-client==4.2.0",
     "deltalake>=0.23,<2",
     "pyarrow>=18,<24",
     "requests>=2.32,<3",
 ]
 spark-connect = [
-    "pyspark-client==4.1.1",
+    "pyspark-client==4.2.0",
     "requests>=2.32,<3",
     "kafka-python>=2.0.2,<3",
     # JKS/P12 → PEM so kafka-python can honour Spark's Java truststore options.
@@ -185,7 +209,7 @@ data-science-loop = [
     "deltalake>=0.23,<2",
     "mlflow>=3.1,<4",
     "pyarrow>=18,<24",
-    "pyspark-client==4.1.1",
+    "pyspark-client==4.2.0",
 ]
 # NOTE: examples/ deliberately do NOT appear here. Each example owns its
 # pyproject.toml + uv.lock so it can be copied out and run standalone, and so

--- a/python/spark_agent/rddfacade.py
+++ b/python/spark_agent/rddfacade.py
@@ -234,10 +234,12 @@ def attach(session):
     Instance assignment is what makes this possible without patching pyspark:
     its Connect `SparkSession` guards these names in `__getattr__`, which Python
     only consults when normal attribute lookup FAILS. Setting them on the
-    instance means the guard is never reached. Verified against
-    pyspark-client 4.1.1, and it rests on Python's attribute protocol rather
-    than on pyspark internals, so a version bump cannot quietly re-arm the guard
-    without the tests noticing.
+    instance means the guard is never reached. This rests on Python's attribute
+    protocol rather than on pyspark internals, so a client bump cannot quietly
+    re-arm the guard — `test_attach_binds_past_pysparks_getattr_guard` asserts
+    the guard fires BEFORE attach and not after, and it runs against whatever
+    client is pinned. The test is the claim; naming a version here would only
+    record which bump was current when someone last edited the comment.
 
     A JVM session already has real ones; this must never overwrite them, which
     is why the caller checks first and this function is only reached for Connect.

--- a/uv.lock
+++ b/uv.lock
@@ -1425,7 +1425,7 @@ data-science-loop = [
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "mlflow", specifier = ">=3.1,<4" },
     { name = "pyarrow", specifier = ">=18,<24" },
-    { name = "pyspark-client", specifier = "==4.1.1" },
+    { name = "pyspark-client", specifier = "==4.2.0" },
 ]
 dbt-duckdb = [
     { name = "dbt-duckdb", specifier = ">=1.9,<2" },
@@ -1469,7 +1469,7 @@ jupyter = [
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "jupyterlab", specifier = ">=4.2,<5" },
     { name = "pyarrow", specifier = ">=18,<24" },
-    { name = "pyspark-client", specifier = "==4.1.1" },
+    { name = "pyspark-client", specifier = "==4.2.0" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 lint = [
@@ -1489,8 +1489,8 @@ s3 = [
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 sail = [
-    { name = "pysail", specifier = "==0.6.6" },
-    { name = "pyspark-client", specifier = "==4.1.1" },
+    { name = "pysail", specifier = "==0.7.0" },
+    { name = "pyspark-client", specifier = "==4.2.0" },
 ]
 sail-delta = [
     { name = "cryptography", specifier = ">=42,<50" },
@@ -1500,7 +1500,7 @@ sail-delta = [
     { name = "pandas", specifier = ">=2,<3" },
     { name = "pyarrow", specifier = ">=18,<24" },
     { name = "pyjks", specifier = ">=20,<22" },
-    { name = "pyspark-client", specifier = "==4.1.1" },
+    { name = "pyspark-client", specifier = "==4.2.0" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 spark-connect = [
@@ -1508,7 +1508,7 @@ spark-connect = [
     { name = "gssapi", specifier = ">=1.8,<2" },
     { name = "kafka-python", specifier = ">=2.0.2,<3" },
     { name = "pyjks", specifier = ">=20,<22" },
-    { name = "pyspark-client", specifier = "==4.1.1" },
+    { name = "pyspark-client", specifier = "==4.2.0" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 test = [
@@ -4133,20 +4133,20 @@ wheels = [
 
 [[package]]
 name = "pysail"
-version = "0.6.6"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/f2/1cb9f63aba6ed73679f6fecb15ee8cd8d71e613e79768fa05631a69ee1fe/pysail-0.6.6.tar.gz", hash = "sha256:96295eb07c5004353ff09f9b22b6cfd78ee553842564aeb80a9cc5f3c63c4fa8", size = 2936417, upload-time = "2026-07-07T12:18:27.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f3/3b7ebad447b43f888ff678d0cd6c0d2b69c8f1412b91c417c8794052e357/pysail-0.7.0.tar.gz", hash = "sha256:93551f92f832c0f90b7a913f90103fd4333c06075c0e6550d52744d78d00d7ff", size = 3302189, upload-time = "2026-08-03T13:15:30.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/14/025104ef476e756e738672c2d654c19f897704ad09b815a597f54f451f0b/pysail-0.6.6-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2f0d9dfe48a10fe1dcc2d12b10e4fab1d09e08e383f8cdec7388cdd50a014f51", size = 54863573, upload-time = "2026-07-07T12:18:01.213Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d9/d847d93c6e8a7daaacd22d5f4ab8b64861a36b5fa1a0b4beb0400633731a/pysail-0.6.6-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c57b9c1182c15b9e12acf960208d930f9de91f2eeae7869513c112a6aa8b2851", size = 50913327, upload-time = "2026-07-07T12:18:06.654Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/54/9162e389fa051b9c1a3f52c54364d66d6f9c7c9c71f70f78542520ac1bb0/pysail-0.6.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6725d7ed514a841af545f4fe1bb76b39d3420ce26b2860e6833c9b5bb7f54366", size = 56182291, upload-time = "2026-07-07T12:18:12.482Z" },
-    { url = "https://files.pythonhosted.org/packages/50/07/aa892d71c1a7786b55a619a1f730c44926938eee13cea651e7ebd52983cb/pysail-0.6.6-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:c9c74bcaaa8b0f27ecd75350d7b2439548abcb9453994d594985d4afff544530", size = 52860872, upload-time = "2026-07-07T12:18:18.057Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d9/0bdf216671f98f1dc73839e18c6064d028d8572de93cb826a2db9954c0a6/pysail-0.6.6-cp38-abi3-win_amd64.whl", hash = "sha256:6d5d2805370388ed8a348645fe6539fc6f2a96653bd20b9df7ff5d1f7ae0ea9b", size = 61648294, upload-time = "2026-07-07T12:18:23.994Z" },
+    { url = "https://files.pythonhosted.org/packages/56/97/adb98367a47703c69c2512132bd7b8845747109bdf632fca086a888f2ee4/pysail-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6e9e7b4b693cee9e04a21e86b714834738656517f088945f41623abe98b18420", size = 54416624, upload-time = "2026-08-03T13:15:12.824Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/7e/11744ae642c3f75540f553628b90614b17820463d7ce0825dd16bf145575/pysail-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:b9a6912147f181cec21e272056a0a0669ada7311195441982a7bf89d006a4a22", size = 50598771, upload-time = "2026-08-03T13:15:15.817Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/8cbe71173fa226120f802145b4e762062c0d3970b916ceaffe89bee0723b/pysail-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b952cf718d2fbc670cdcb7a1662dd79f35f217be8badf7e4d7138a32bb475bec", size = 55583286, upload-time = "2026-08-03T13:15:18.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4a/c271eba2310091149cd117465b15a09a8c136e94099400b1997399137db1/pysail-0.7.0-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:7bf65e4741bee6f4b4c75e902f8662a7d867b4a5e493b28b8e22988b28e2efad", size = 52535074, upload-time = "2026-08-03T13:15:21.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5f/693b8b34a14bc9169c6b5290d185620fa286d6909ae471770a6cbe01a9d8/pysail-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:e76ff2c945d1d14ee6eadad9f3429dbdcd137a2bf267b98fc49c666216562a8f", size = 61358452, upload-time = "2026-08-03T13:15:28.255Z" },
 ]
 
 [[package]]
 name = "pyspark-client"
-version = "4.1.1"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -4158,7 +4158,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/b0/fde39357666529049f2f71235d7126c7b2d5b4c5e20c072dccf845e9a09d/pyspark_client-4.1.1.tar.gz", hash = "sha256:23bd428d1f96c7196ae8ba29facca7eb56f66b3c380294385101ec8f1872a44a", size = 1600762, upload-time = "2026-01-09T09:38:50.679Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/1b/b7fc2cb3cb34a9d71790bd556ac5802c2d93e861c6af850f6e97e3e92b7c/pyspark_client-4.2.0.tar.gz", hash = "sha256:4008fe5e537bf0e57e7243d03abfaac089b7c87316bd07024784d8ea726f5d41", size = 1675557, upload-time = "2026-07-14T22:41:58.134Z" }
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
Sail v0.7.0 shipped 2026-08-03. This moves the engine and, with it, the Connect
client it is built against.

## It is one number, in five places

`pysail` and `pyspark-client` are pinned together on purpose: the UDF runs
inside the Sail server's embedded CPython, so server and client must agree.
pysail 0.7.0's own `test` extra pins `pyspark-client==4.2.0` (0.6.6 pinned
4.1.1), so both halves move.

The client is pinned in **five** groups, not one, and the resolver caught that
before I did: `sail`, `sail-delta` (the spark-agent image), `jupyter`,
`spark-connect` (six e2e stacks), and `data-science-loop`. Every one is a
Connect client pointed at `sc://sail:50051`, so all five move together. The JVM
overlay is unaffected because it never uses `pyspark-client` at all: it goes
through spark-submit/Livy with the image's own pyspark.

## The direction of the constraint, measured

I was about to write that bumping pysail alone would break the mirror image of
the historical failure. **I tested it, and that is wrong.** Three combinations
against a real Sail server:

| server | client | result |
|---|---|---|
| 0.7.0 | 4.2.0 | Python UDF round-trips — what ships here |
| 0.7.0 | 4.1.1 | UDF **also** round-trips — 0.7.0 tolerates the old client |
| 0.6.6 | 4.2.0 | dies in `createDataFrame`: `invalid literal for int() with base 10: '3GB'` |

So the constraint is **asymmetric**: an old server cannot take a new client, but
the new server takes either. The client may lag, never lead. That is now in the
pin comment, because "keep them equal" and "never let the client lead" fail
differently and only the second explains what to check when it breaks.

A second correction worth recording: the 0.6.6 + 4.2.0 break reproduces as a
**config-parse** failure well before any UDF runs. The `read_udfs` TypeError the
old comment described is a *later* incompatibility on the same pairing, reachable
only once you avoid `createDataFrame` — which is exactly what
`e2e/sail/driver.py` does by building rows with `VALUES`. Both failures are real;
they are not the same failure.

## Docs: what I did and did not renumber

`docs/20` is grounded on a **local checkout audit of v0.6.6**, and its claims
cite line numbers in that source tree. I did not search-replace those to 0.7.0 —
that would convert a measurement into a guess that reads like a measurement.
Instead there is a note saying the shipped pin has moved, the audit has not been
redone, and which 0.7.0 changelog entries land near its claims (`ceil/floor
edge-case bugs`, `agg and window ordering semantics`, `basic checkpoint support`,
`share driver server among sessions`). The checkpoint work may move the streaming
gap that doc records.

What *did* move is the tier table row, which describes what ships rather than
what was audited.

Elsewhere I replaced restated version digits with a pointer to the pin
(`docs/44`, `rddfacade.py`), since a version copied into prose is one that goes
stale silently — `docs/44` still said "the same 4.1.1 the agent uses" while the
agent had moved on.

## Verification

- Python UDF round-trip against a live Sail 0.7.0 server, locally: `[2, 4, 6]`
- `ruff check` and `ty check` green **as CI runs them**
- 909 passed, 1 skipped

**Noted, not fixed:** with the `sail` group installed, `ty` reports 3
pre-existing diagnostics on the agent's deliberate monkey-patches
(`eventstream_kafka.py:1197`, `input_file.py:335,443`). They appear identically
on main with the old pins, so this change does not introduce them — but CI never
sees them, because its `ty` job installs only `lint` and `test`, and neither
carries pyspark. The type checker is blind to the agent's pyspark interactions.
Worth its own change.

## The engine matrix moved, and it says something

CI's `engine-matrix` gate regenerates `docs/engine-matrix.md` and asserts no
diff. It went red on the first push, correctly: exactly one row changed.

`MERGE INTO delta.\`path\`` (path target), on the **bare engine** column:

- 0.6.6: `Table not found: [TABLE_OR_VIEW_NOT_FOUND] ... /tmp/probe/t_merge_pat`
- 0.7.0: `attribute ObjectName([Identifier("#0")]) is missing from the schema`

That is Sail 0.7.0's `fix: support MERGE INTO with path-based target`
(lakehq/sail#1654) genuinely landing. The path now **resolves** instead of being
"not found", and then hits the same downstream attribute-resolution limit the
registered-table MERGE variant already hit under 0.6.6 — the row above it
carried that exact error before this change. So the two MERGE rows now fail
identically rather than at different depths.

Both stay ❌ on the bare engine and ✅ on `Sail + delta-rs`, which is the path
the emulator actually ships, so no user-visible behaviour changes.

The regenerated row was taken from the generator's own CI output rather than
hand-written, and the same gate re-verifies it: if I copied it wrong, the check
fails again.
