### PR TITLE
fix(ci): let ty see pyspark, so the statement agent is actually type-checked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,22 @@ jobs:
       # `pytest.skip()` never returns, so a `str | None` guarded by it never
       # narrows and subprocess.run appears to be called with None. The checker
       # must see the packages the code actually runs with.
-      - run: uv run --frozen --group lint --group test ty check
+      #
+      # --group spark-client for the same reason, one subsystem later. Without
+      # it `import pyspark` resolved to nothing, so every type flowing through
+      # ~1800 statements of statement agent was `Unknown` and ty checked almost
+      # none of it. It was not that the agent was clean; it was unexamined. A
+      # deliberate `bad: int = col("x")` planted in python/spark_agent/ passed
+      # this job before this line was added.
+      #
+      # `spark-client` and not `sail-delta` (the agent's real group): sail-delta
+      # carries gssapi, which has no manylinux wheel and needs gcc + libkrb5-dev
+      # compiled on the runner — see docker/spark-agent/Dockerfile. A lint job
+      # should not build a Kerberos stack. ty does not error on imports it
+      # cannot resolve, so the few remaining agent imports (kafka, gssapi) stay
+      # Unknown and simply go unchecked, exactly as before. This buys the large
+      # win at no build risk; widening it later is a separate, deliberate change.
+      - run: uv run --frozen --group lint --group test --group spark-client ty check
 
   example-parity:
     name: Each medallion pair differs only in silver

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ logs: ## Tail logs (SVC=<service> to narrow)
 lint: ## ruff + ty over the Python sources — the CI lint job, locally
 	@if command -v uv >/dev/null 2>&1; then \
 	  uv run --frozen --group lint ruff check . && \
-	  uv run --frozen --group lint --group test ty check; \
+	  uv run --frozen --group lint --group test --group spark-client ty check; \
 	else \
 	  echo "lint SKIPPED: no uv on PATH — CI still runs ruff + ty" >&2; \
 	fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,9 +140,18 @@ runtime = []
 # Practical rule: the client may lag the server, but must never lead it. Pin
 # them together anyway — the `test` extra of each pysail release states the
 # client it was built against, and matching it is free.
+#
+# The client version therefore lives HERE, once. It used to be copied into five
+# groups, which meant "one number" was a claim maintained by hand across five
+# edit sites; the groups below include this one instead. It is also the leanest
+# thing that makes `ty` able to see pyspark — no compiled extras — which is why
+# the lint job installs exactly this and nothing more.
+spark-client = [
+    "pyspark-client==4.2.0",
+]
 sail = [
     "pysail==0.7.0",
-    "pyspark-client==4.2.0",
+    { include-group = "spark-client" },
 ]
 # The Sail statement agent also runs Delta maintenance (OPTIMIZE/VACUUM/CDF)
 # through delta-rs, since Sail's planner has no such commands — so the runtime
@@ -152,7 +161,7 @@ sail = [
 # lookalike. requests for the same reason spark-connect carries it: user
 # notebook code calls HTTP APIs, and the agent is where that code runs.
 sail-delta = [
-    "pyspark-client==4.2.0",
+    { include-group = "spark-client" },
     "deltalake>=0.23,<2",
     "pandas>=2,<3",
     "pyarrow>=18,<24",
@@ -177,13 +186,13 @@ sail-delta = [
 # because a restated version is one someone has to remember to update twice.
 jupyter = [
     "jupyterlab>=4.2,<5",
-    "pyspark-client==4.2.0",
+    { include-group = "spark-client" },
     "deltalake>=0.23,<2",
     "pyarrow>=18,<24",
     "requests>=2.32,<3",
 ]
 spark-connect = [
-    "pyspark-client==4.2.0",
+    { include-group = "spark-client" },
     "requests>=2.32,<3",
     "kafka-python>=2.0.2,<3",
     # JKS/P12 → PEM so kafka-python can honour Spark's Java truststore options.
@@ -209,7 +218,7 @@ data-science-loop = [
     "deltalake>=0.23,<2",
     "mlflow>=3.1,<4",
     "pyarrow>=18,<24",
-    "pyspark-client==4.2.0",
+    { include-group = "spark-client" },
 ]
 # NOTE: examples/ deliberately do NOT appear here. Each example owns its
 # pyproject.toml + uv.lock so it can be copied out and run standalone, and so
@@ -380,9 +389,17 @@ root = ["scripts", "python"]
 # Unresolved by CONSTRUCTION, not by mistake:
 #   * the checkers and their tests load one another by path via importlib, so
 #     no static checker can follow the module identity;
-#   * the agent imports pyspark, which is installed only inside the Spark image;
 #   * notebook content reads `spark`/`mssparkutils` from injected globals, which
-#     is the contract this emulator exists to provide (docs/38).
+#     is the contract this emulator exists to provide (docs/38);
+#   * the agent's remaining engine-side imports (kafka, gssapi) live only in the
+#     Spark image, because pulling them into a lint venv means compiling a
+#     Kerberos stack (docker/spark-agent/Dockerfile).
+#
+# `pyspark` USED to be the headline reason here, and is not any more: the lint
+# job installs `--group spark-client`, so pyspark resolves and the agent is
+# actually type-checked. That mattered — while pyspark was unresolved, every
+# type in ~1800 statements of agent was Unknown, so this ignore was not
+# narrowing the check, it was standing in for the absence of one.
 unresolved-import = "ignore"
 unresolved-attribute = "ignore"
 unresolved-reference = "ignore"

--- a/python/spark_agent/eventstream_kafka.py
+++ b/python/spark_agent/eventstream_kafka.py
@@ -1194,7 +1194,12 @@ def _install_connect(spark):
     DataFrameWriter.save = save
     DataStreamWriter.foreachBatch = foreachBatch
     DataStreamWriter.start = start
-    ConnectDF.writeStream = property(writeStream)
+    # Replacing a property with a property is the whole point of this function,
+    # and ty compares the wrapped types rather than the shape. Suppressed at the
+    # site rather than by ignoring invalid-assignment for the package: the other
+    # five patches above pass the check, so a blanket ignore would hide a real
+    # mismatch in any patch added later.
+    ConnectDF.writeStream = property(writeStream)  # ty: ignore[invalid-assignment]
     DataStreamReader._emu_eventstream_patched = True
     _connect_installed = True
     return True

--- a/python/spark_agent/input_file.py
+++ b/python/spark_agent/input_file.py
@@ -332,7 +332,10 @@ def install(spark) -> bool:
         # provenance on a non-file frame.
         return F.coalesce(F.col(_TAG), F.lit(""))
 
-    F.input_file_name = _input_file_name
+    # Swapping pyspark's own `input_file_name` for the tag-resolving one is this
+    # module's reason to exist; ty sees a signature that returns Unknown
+    # replacing one that returns Column.
+    F.input_file_name = _input_file_name  # ty: ignore[invalid-assignment]
 
     # --- keeping the tag invisible ------------------------------------------
     #
@@ -440,7 +443,9 @@ def install(spark) -> bool:
     def write(self):
         return original_write.fget(_visible(self))
 
-    _ConnectDataFrame.write = write
+    # Same shape as the writeStream patch in eventstream_kafka: a property
+    # replacing a property, so the tag is stripped before anything persists.
+    _ConnectDataFrame.write = write  # ty: ignore[invalid-assignment]
 
     # Views: SELECT * stays on a clean registration so the tag cannot leak
     # through SQL star expansion. A shadow view keeps the tag; spark.sql

--- a/python/tests/test_lint_matches_ci.py
+++ b/python/tests/test_lint_matches_ci.py
@@ -1,0 +1,75 @@
+"""`make lint` must run the same checks as the CI lint job.
+
+WHY. The Makefile target documents itself as "the CI lint job, locally", and
+that claim was maintained by hand in two files that nothing compared. It had
+already drifted once, in the direction that matters least visibly: CI gained a
+dependency group the Makefile did not, so a developer running `make lint` got a
+WEAKER check than the branch would get, and "it passed locally" stopped meaning
+what people assume it means.
+
+A weaker local check is worse than no local check. No local check sends you to
+CI knowing you have not been told anything; a local check that silently omits a
+group tells you that you have.
+
+This compares the dependency groups the two invocations request, not the whole
+command line, because they legitimately differ elsewhere: the Makefile wraps
+both tools in a `command -v uv` guard and splits ruff and ty across two lines,
+while CI runs each as its own step.
+"""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MAKEFILE = ROOT / "Makefile"
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _groups(command: str) -> set[str]:
+    """The `--group X` flags in one shell command."""
+    return set(re.findall(r"--group\s+([A-Za-z0-9._-]+)", command))
+
+
+def _ty_invocations(text: str) -> list[str]:
+    """Every line invoking `ty check`, whole-line so the flags come with it."""
+    return [ln for ln in text.split("\n") if "ty check" in ln and "uv run" in ln]
+
+
+def test_both_files_invoke_ty_exactly_once():
+    """Two invocations in one file would make 'the groups agree' ambiguous, and
+    zero would make every assertion below vacuously true."""
+    for path in (MAKEFILE, CI):
+        found = _ty_invocations(path.read_text(encoding="utf-8"))
+        assert len(found) == 1, (
+            f"{path.name} has {len(found)} `ty check` invocations, expected 1: {found}")
+
+
+def test_make_lint_requests_the_same_groups_as_ci():
+    make = _ty_invocations(MAKEFILE.read_text(encoding="utf-8"))[0]
+    ci = _ty_invocations(CI.read_text(encoding="utf-8"))[0]
+
+    make_groups, ci_groups = _groups(make), _groups(ci)
+    assert make_groups, f"no --group flags parsed from the Makefile line: {make!r}"
+
+    missing = ci_groups - make_groups
+    extra = make_groups - ci_groups
+    assert not missing, (
+        f"`make lint` is WEAKER than CI: it omits {sorted(missing)}. A developer "
+        f"running it would be told the types are fine when CI has not agreed.")
+    assert not extra, (
+        f"`make lint` requests {sorted(extra)} that CI does not, so it can fail "
+        f"on something the branch will never be judged on.")
+
+
+def test_the_agent_is_type_checked_at_all():
+    """The specific group this test was written for.
+
+    Without a group carrying pyspark, `import pyspark` resolves to nothing and
+    every type in the statement agent is Unknown — ty runs, reports success, and
+    has checked almost none of it. Asserting the group by name is crude, but the
+    alternative is a check that passes while the thing it names is absent, which
+    is the exact failure this file exists to stop.
+    """
+    ci = _ty_invocations(CI.read_text(encoding="utf-8"))[0]
+    assert "spark-client" in _groups(ci), (
+        "the CI ty job no longer installs a group carrying pyspark, so the "
+        "statement agent is unchecked again")

--- a/uv.lock
+++ b/uv.lock
@@ -1390,6 +1390,9 @@ sail-delta = [
     { name = "pyspark-client" },
     { name = "requests" },
 ]
+spark-client = [
+    { name = "pyspark-client" },
+]
 spark-connect = [
     { name = "cryptography" },
     { name = "gssapi" },
@@ -1503,6 +1506,7 @@ sail-delta = [
     { name = "pyspark-client", specifier = "==4.2.0" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
+spark-client = [{ name = "pyspark-client", specifier = "==4.2.0" }]
 spark-connect = [
     { name = "cryptography", specifier = ">=42,<50" },
     { name = "gssapi", specifier = ">=1.8,<2" },


### PR DESCRIPTION
The `ruff + ty` job installed `--group lint --group test`. Neither carries
pyspark, so `import pyspark` resolved to nothing, every type flowing through
~1800 statements of statement agent was `Unknown`, and ty checked almost none of
it. The job was green because it was looking at nothing.

**Demonstrated before fixing.** A file containing exactly this was added to
`python/spark_agent/` and the job's own command was run:

```python
from pyspark.sql.functions import col
bad: int = col("x")
```

`All checks passed!` — with the current invocation. With `--group spark-client`
added: `Object of type Column is not assignable to int`.

## The pin now lives in one place

`pyspark-client` was written out in **five** groups. Moving the version meant
five hand-edits, and the comment above them claimed it was "one number" — a
claim maintained by discipline rather than by structure. It is now one
`spark-client` group that the other five `include-group`, which is also the
leanest thing that makes pyspark visible. `uv.lock` resolves to the same 268
packages with no version drift; the diff is structure only.

**Not `sail-delta`** (the agent's real group), because it carries `gssapi`,
which has no manylinux wheel and needs `gcc` + `libkrb5-dev` compiled on the
runner — `docker/spark-agent/Dockerfile` installs exactly that. A lint job
should not build a Kerberos stack. ty does not error on imports it cannot
resolve, so the agent's remaining engine-side imports (`kafka`, `gssapi`) stay
Unknown and go unchecked exactly as before. This takes the large win at no
build risk; widening it further is a separate, deliberate change.

## Three real findings, suppressed at the site

Turning the checker on surfaced three `invalid-assignment` diagnostics, all
deliberate monkey-patches of pyspark Connect classes
(`eventstream_kafka.py:1197`, `input_file.py:335`, `input_file.py:443`). They
are **pre-existing** — they appear identically on main with the old pins, so
this change did not introduce them.

Suppressed inline with a reason each, **not** by adding
`invalid-assignment = "ignore"` for the package the way `e2e/**` and
`examples/**` do. Five sibling patches in that same `eventstream_kafka` block
pass the check; a blanket ignore would hide a real mismatch in the next patch
someone writes, which would re-blind the checker immediately after this change
un-blinds it.

The suppressions cannot rot into decoration: `unused-type-ignore-comment` is
active here, and I verified it fires — a deliberately unnecessary
`# ty: ignore` was flagged with "Remove the unused suppression comment". So all
three are load-bearing, and any that stops being needed will say so.

## A stale premise, corrected

`[tool.ty.rules]` justified its global `unresolved-*` ignores with three
reasons, one of which was "the agent imports pyspark, which is installed only
inside the Spark image". That premise is what this PR removes. The comment now
says so, and names what genuinely remains unresolvable (importlib-by-path
checkers, injected notebook globals, and the engine-side imports above).

Worth stating plainly: while pyspark was unresolved, that ignore was not
narrowing the check. It was standing in for the absence of one.

## The drift this already caused, now guarded

The Makefile's `lint` target documents itself as "the CI lint job, locally" —
and had already drifted, in the least visible direction: I had to update it
separately, because nothing compared the two. A developer running `make lint`
was getting a **weaker** check than the branch would get, which is worse than no
local check: no local check tells you nothing, a silently narrower one tells you
that you have been told something.

`python/tests/test_lint_matches_ci.py` now compares the `--group` flags of both
invocations. Mutation-tested, and the two assertions catch different failures:

- Makefile drops the group → `make lint is WEAKER than CI: it omits ['spark-client']`
- both files drop it → `the CI ty job no longer installs a group carrying pyspark, so the statement agent is unchecked again`

It also asserts each file invokes `ty check` exactly once, so "the groups agree"
cannot be satisfied vacuously by there being nothing to compare.

## Verification

- `ruff check`, `ty check`, and `make lint` green
- 912 passed, 1 skipped
- `uv.lock`: no version drift, structure only
