### PR TITLE
Stop crediting the VALUES choice to an engine we no longer pin

### DIFF
--- a/e2e/sail/driver.py
+++ b/e2e/sail/driver.py
@@ -132,10 +132,14 @@ print("connected to sail")
 
 url = "az://sailws/lake.Lakehouse/Tables/events"
 
-# Rows via SQL VALUES, not createDataFrame: pyspark 4.2's local-relation path
-# asks the server for spark.sql.session.localRelationSizeLimit and chokes on
-# Sail 0.6.6's "3GB" string. VALUES keeps everything server-side (and is the
-# better engine witness anyway).
+# Rows via SQL VALUES, not createDataFrame: VALUES keeps everything
+# server-side, so the engine builds the rows. A local relation would ship
+# them from the client and prove less about the engine under test.
+#
+# This was also a workaround once, for an engine that served
+# spark.sql.session.localRelationSizeLimit in a form the client could not
+# parse. That no longer applies on the pinned engine — createDataFrame here
+# was measured working — so the witness argument is the whole reason now.
 step("delta write (overwrite, 3 rows)")
 df = spark.sql(
     "SELECT * FROM VALUES (1,'signup','eu'), (2,'purchase','us'), (3,'signup','us')"


### PR DESCRIPTION
The comment on the `SELECT ... FROM VALUES` write justified it by an
engine-specific parse failure:

> pyspark 4.2's local-relation path asks the server for
> `spark.sql.session.localRelationSizeLimit` and chokes on Sail 0.6.6's "3GB"
> string.

That has not been the pinned engine for a while. On the current pin
`createDataFrame` in this driver runs clean — I swapped it in, ran the full
`e2e/sail` witness (delta write, sql, append, time travel, MERGE, abfss, the
concurrent-writer race), watched it pass, and put `VALUES` back.

## Why this is worth a commit

A stale workaround comment fails in both directions. A reader either tries to
reproduce a break that no longer exists, or concludes the line is obsolete and
deletes it — losing the reason that *does* still hold.

That reason was already there, in parentheses: `VALUES` keeps row construction
server-side, so the engine builds the rows. A local relation ships them from
the client and proves less about the engine under test. For an engine witness
that is the whole point, so it is now the stated reason rather than an aside.

## Scope

Comment only — no statement, assertion or pin changes, and `VALUES` stays.

The historical record is deliberately left alone: `pyproject.toml` keeps the
measured 0.6.6/4.2.0 matrix that explains why client and server move together,
and `docs/20-lakesail-engine.md` keeps its v0.6.6 citations, which it states
outright are pinned to the audited version on purpose. Neither is stale; both
are dated evidence.