### PR TITLE
Publish the compute images under emulator-* names, tagged by dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,7 @@ jobs:
       # right, the cast of services had drifted. Nothing about adding a service
       # reminds anyone to redraw, so the roster is asserted instead.
       - run: uv run --frozen --no-sync python scripts/check_arch_services.py
+      - run: uv run --frozen --no-sync python scripts/check_image_digests.py
       # Starlight's sidebar is an explicit list — no autogenerate. A doc left
       # out still builds and still has a URL, but nothing links to it, so it is
       # published and unreachable. Same drift, same guard.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,11 +125,24 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # The dependency version this image is tagged with, read from the pins
+      # so a pysail bump cannot publish a tag naming the version it no longer
+      # contains. See scripts/image_tags.py.
+      - name: Dependency version for the tag
+        id: dep
+        run: echo "version=$(python3 scripts/image_tags.py ${{ matrix.name }})" >> "$GITHUB_OUTPUT"
+      # Two names during the rename. The new name says what a consumer pins the
+      # image FOR; the old one keeps every existing reference resolving until
+      # they have moved. The old name keeps its release-version tag, because
+      # that is what those references already pin.
       - uses: docker/metadata-action@v6
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}-${{ matrix.name }}
+          images: |
+            ghcr.io/${{ github.repository_owner }}/emulator-${{ matrix.name }}
+            ghcr.io/${{ github.repository }}-${{ matrix.name }}
           tags: |
+            type=raw,value=${{ steps.dep.outputs.version }},enable=true
             type=semver,pattern={{version}}
             type=raw,value=latest
       - uses: docker/build-push-action@v7

--- a/scripts/check_image_digests.py
+++ b/scripts/check_image_digests.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Every reference to a compute sidecar image must pin @sha256.
+
+WHY THIS EXISTS. These images are tagged with the version of the dependency a
+consumer pins them FOR -- emulator-sail:0.7.0 is the Sail engine,
+emulator-spark-agent:4.2.0 is the Spark Connect client. That makes the tag
+readable, and it makes it NOT an identity: both images also carry first-party
+code (launcher.py, the whole spark_agent package) that changes independently of
+those pins, so successive releases republish the same tag over different
+content.
+
+Under the old scheme the tag was the emulator's release version, so a bare tag
+was effectively immutable and a missing digest cost nothing. That is no longer
+true. A reference like `emulator-sail:0.7.0` with no digest now silently
+follows whatever was published last -- the compose still parses, the stack
+still starts, and the thing under test changed. That is the failure this
+guards: not a broken pin, an invisibly floating one.
+
+The rule is deliberately narrow. It applies ONLY to the images this repo
+publishes and versions this way; third-party images keep their own conventions,
+and a `build:` service has no tag to pin.
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+# The names are derived, not typed twice: image_tags.py owns the suffix list.
+sys.path.insert(0, str(ROOT / "scripts"))
+from image_tags import TAGGED_BY  # noqa: E402
+
+IMAGES = tuple(f"emulator-{suffix}" for suffix in TAGGED_BY)
+SKIP_DIRS = {".git", "node_modules", ".venv", "out", "dist", "__pycache__"}
+# <registry>/<org>/emulator-<suffix>:<tag> with an optional @sha256:<hex>.
+#
+# The lookbehind is load-bearing: without it `fabric-emulator-spark-agent`
+# matches as a suffix of `emulator-spark-agent`, and the checker reports the
+# OLD image name -- which is exactly the reference this rule does not govern.
+REF = re.compile(
+    r"(?<![A-Za-z0-9._-])(?P<name>" + "|".join(re.escape(i) for i in IMAGES) + r")"
+    r":(?P<tag>[A-Za-z0-9._-]+)(?P<digest>@sha256:[0-9a-f]{64})?"
+)
+
+
+def offenders(root=ROOT):
+    """Yield (file, line number, the unpinned reference)."""
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or any(p in SKIP_DIRS for p in path.parts):
+            continue
+        if path.suffix not in {".yml", ".yaml", ".py", ".md", ".sh", ".env"}:
+            continue
+        if path.name in {"check_image_digests.py", "image_tags.py"}:
+            continue  # this checker and its source name the images on purpose
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for n, line in enumerate(text.splitlines(), 1):
+            for m in REF.finditer(line):
+                if m.group("digest") is None:
+                    yield path.relative_to(root), n, m.group(0)
+
+
+def main():
+    bad = list(offenders())
+    if not bad:
+        print(f"every {', '.join(IMAGES)} reference pins @sha256")
+        return 0
+    print("references to a compute sidecar image without @sha256:\n")
+    for path, n, ref in bad:
+        print(f"  {path}:{n}  {ref}")
+    print(
+        "\nThe tag is the dependency version, not an identity: the same tag is"
+        "\nrepublished over new first-party code. Add @sha256:<digest> so the"
+        "\nreference names one build. `docker buildx imagetools inspect <ref>`"
+        "\nprints it."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_image_digests.py
+++ b/scripts/check_image_digests.py
@@ -16,9 +16,20 @@ follows whatever was published last -- the compose still parses, the stack
 still starts, and the thing under test changed. That is the failure this
 guards: not a broken pin, an invisibly floating one.
 
-The rule is deliberately narrow. It applies ONLY to the images this repo
-publishes and versions this way; third-party images keep their own conventions,
-and a `build:` service has no tag to pin.
+The rule is deliberately narrow, in two directions.
+
+BY FILE: only files that can pull -- compose and env. Documentation naming the
+image in a sentence pulls nothing, and demanding a digest there produces prose
+no one can read and that goes stale every release. The first cut of this
+checker scanned .md and flagged a README, which is how that was learned.
+
+BY LINE: a tag that floats on purpose (`:dev`, `:latest`, an image built
+locally) has no digest to pin, and pinning one would defeat it. Such a line
+carries `digest-exempt: <reason>` and is skipped. The reason is required, and
+it sits on the line it excuses rather than in a list that drifts away from it.
+
+Third-party images keep their own conventions, and a `build:` service has no
+tag to pin.
 """
 import pathlib
 import re
@@ -31,6 +42,16 @@ from image_tags import TAGGED_BY  # noqa: E402
 
 IMAGES = tuple(f"emulator-{suffix}" for suffix in TAGGED_BY)
 SKIP_DIRS = {".git", "node_modules", ".venv", "out", "dist", "__pycache__"}
+# Only files that can actually PULL. Prose naming the image in a sentence
+# cannot float a stack, and requiring a 64-hex digest inside documentation
+# makes it unreadable and stale on every release -- the first version of this
+# checker did exactly that, and flagged a README.
+PULLING_SUFFIXES = {".yml", ".yaml", ".env"}
+# A tag that is floating ON PURPOSE -- `:dev`, `:latest`, a locally built
+# image -- has no digest to pin and pinning one would defeat it. Those lines
+# opt out in place, with a reason, so the exemption is reviewable where it
+# applies rather than in a list somewhere else.
+EXEMPT = re.compile(r"digest-exempt:\s*(?P<reason>\S.*?)\s*$")
 # <registry>/<org>/emulator-<suffix>:<tag> with an optional @sha256:<hex>.
 #
 # The lookbehind is load-bearing: without it `fabric-emulator-spark-agent`
@@ -47,18 +68,18 @@ def offenders(root=ROOT):
     for path in sorted(root.rglob("*")):
         if not path.is_file() or any(p in SKIP_DIRS for p in path.parts):
             continue
-        if path.suffix not in {".yml", ".yaml", ".py", ".md", ".sh", ".env"}:
+        if path.suffix not in PULLING_SUFFIXES:
             continue
-        if path.name in {"check_image_digests.py", "image_tags.py"}:
-            continue  # this checker and its source name the images on purpose
         try:
             text = path.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
             continue
         for n, line in enumerate(text.splitlines(), 1):
+            exemption = EXEMPT.search(line)
             for m in REF.finditer(line):
-                if m.group("digest") is None:
-                    yield path.relative_to(root), n, m.group(0)
+                if m.group("digest") is not None or exemption:
+                    continue
+                yield path.relative_to(root), n, m.group(0)
 
 
 def main():

--- a/scripts/image_tags.py
+++ b/scripts/image_tags.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""The dependency version each compute image is tagged with.
+
+WHY THIS EXISTS. The sidecar images are named for what a consumer pins them
+FOR, not for the repo that happens to publish them: emulator-sail carries the
+Sail engine, emulator-spark-agent carries the Spark Connect client. So the tag
+has to be the version of that dependency — and that version already has exactly
+one home, the pins in pyproject.toml.
+
+Reading it here rather than writing it into the workflow is the point. A tag
+typed into release.yml is a second copy of a number, and the release that bumps
+pysail without also editing the workflow publishes an image whose tag names the
+version it no longer contains. Nothing fails; the tag simply lies.
+
+WHAT THE TAG DOES NOT SAY. Both images also carry first-party code — sail has
+launcher.py, spark-agent has the whole spark_agent package — which changes
+independently of these pins. So a tag is NOT an identity: two releases can
+publish emulator-sail:0.7.0 with different launcher code. That is deliberate,
+and it is why every reference to these images must pin @sha256 as well
+(scripts/check_image_digests.py enforces it) and why the release version is
+carried in the OCI labels the metadata action already emits.
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+
+# image name suffix -> the pin whose version it is tagged with
+TAGGED_BY = {
+    "sail": "pysail",
+    "spark-agent": "pyspark-client",
+}
+
+
+def version_of(package, text=None):
+    """The pinned version of `package`, read from pyproject.toml."""
+    text = PYPROJECT.read_text(encoding="utf-8") if text is None else text
+    found = re.findall(rf'"{re.escape(package)}==([0-9][^"]*)"', text)
+    if not found:
+        raise SystemExit(f"{package} is not pinned with == in pyproject.toml")
+    if len(set(found)) > 1:
+        raise SystemExit(f"{package} is pinned to several versions: {sorted(set(found))}")
+    return found[0]
+
+
+def main(argv):
+    if len(argv) == 2 and argv[1] in TAGGED_BY:
+        print(version_of(TAGGED_BY[argv[1]]))
+        return 0
+    for image, package in TAGGED_BY.items():
+        print(f"{image}={version_of(package)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
Step 1 of the rename: **publish** the new names. No consumer moves in this PR.

## The problem

The sidecar images are named for the repo that publishes them, which is not what
a consumer pins them *for*. `fabric-emulator-sail` carries upstream Sail, and
`databricks-emulator` consumes it with no Fabric in the picture at all.

The tag compounds it. `0.25.0` is fabric-emulator's release number; the Sail
inside is **0.6.6**. Both `0.22.0` and `0.25.0` contain the same engine and
nothing in either tag says so — a confusion that cost me an entire false finding
earlier today, when I read a tag as an engine version and "discovered" a Sail
regression that did not exist.

## What changes

Both images now also publish as `emulator-sail` and `emulator-spark-agent`,
tagged with the version of the dependency each is pinned for:

```
emulator-sail:0.7.0           # the pysail pin
emulator-spark-agent:4.2.0    # the pyspark-client pin
```

Both read from `pyproject.toml` via `scripts/image_tags.py` rather than typed
into the workflow — a tag written in `release.yml` is a second copy of a number,
and the release that bumps `pysail` without editing the workflow publishes a tag
naming the version it no longer contains. Nothing fails; the tag just lies.

**Both names publish this release.** The old name keeps its release-version tag,
so the 21 references across five repos keep resolving while they move.

## The trade this makes, and the gate that pays for it

A dependency tag is deliberately **not an identity**. Both images also carry
first-party code — `launcher.py`, the whole `spark_agent` package — that changes
independently of those pins, so successive releases republish one tag over new
content.

Under the old scheme the tag was the release version, so a bare tag was
effectively immutable and a missing digest cost nothing. That is no longer true:
an unpinned reference now *floats silently* — the compose still parses, the
stack still starts, and the thing under test changed.

`scripts/check_image_digests.py` makes that a build error. The release version
stays recoverable from the OCI labels the metadata action already emits, so the
tag loses that information but the image does not.

## One bug worth flagging

The checker's regex needed a lookbehind. Without it `fabric-emulator-spark-agent`
matches as a suffix of `emulator-spark-agent`, so the gate reported the **old**
name — the one reference this rule explicitly does not govern. Caught by running
it, not by reading it; the comment in the source says so, so the next person to
touch that pattern knows why the lookbehind is there.

## Verification

- `image_tags.py` reads `0.7.0` / `4.2.0` from the pins
- the gate passes on the current tree, and fails on a planted unpinned
  `emulator-sail:0.7.0` reference — checked in both directions
- 912 unit tests pass; both workflow files parse

## Next

Once this releases and the images exist: move the 21 consumer references to the
new names **with digests**, repo by repo, then retire the old name.