### PR TITLE
feat(e2e): run the family chain, so FABRIC_DATABRICKS_URL is finally exercised

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1269,6 +1269,29 @@ jobs:
           version: "0.11.32"
       - run: uv run --frozen --no-sync python e2e/pipeline-activities/run.py
 
+  databricks-chain:
+    name: fabric submits to databricks-emulator, the Databricks SDK confirms it (containerized)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      # THE FAMILY CHAIN, and the reason it is worth a job of its own:
+      # `FABRIC_DATABRICKS_URL` was documented in the README, in docs/04
+      # (which names databricks-emulator as the target), in the v0.25.0 notes
+      # and in databricksremote.go — and appeared in NO workflow. The parity row
+      # grades the Databricks activities "🟢 Real (notebook + python, local or
+      # FABRIC_DATABRICKS_URL)"; the local half ran on every push and the remote
+      # half had never executed anywhere. This is an unexercised code path
+      # getting exercised, and the witness is the side effect.
+      #
+      # Six services: entra → fabric → databricks → spark-agent → sail, plus the
+      # client. Sail and the agent build from THIS checkout so the chain breaks
+      # when this tree breaks it; a pinned image would hide that.
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+      - run: uv run --frozen --no-sync python e2e/databricks-chain/run.py
+
   terraform-fabric:
     name: microsoft/fabric Terraform provider drives Fabric REST (containerized)
     runs-on: ubuntu-latest

--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -1101,7 +1101,8 @@
       "go:TestDatabricksRemoteAcceptsDBFS",
       "go:TestDatabricksRemoteImportsLakehouseFile",
       "go:TestDatabricksRemoteFailureFailsTheActivity",
-      "go:TestDatabricksRemoteStillRefusesJAR"
+      "go:TestDatabricksRemoteStillRefusesJAR",
+      "ci:databricks-chain"
     ]
   },
   "azure-batch-activity-adf-custom": {

--- a/e2e/databricks-chain/README.md
+++ b/e2e/databricks-chain/README.md
@@ -1,0 +1,69 @@
+# The family chain: fabric → databricks-emulator → Spark agent → Sail
+
+fabric-emulator submits a Databricks activity to **databricks-emulator**, which
+runs it on the family's Spark agent, which runs it on Sail. Databricks' own
+**`databricks-sdk`** then reads the workspace side and confirms the run.
+
+```sh
+python3 e2e/databricks-chain/run.py
+```
+
+## Why this exists, and it is not mainly the witness
+
+`FABRIC_DATABRICKS_URL` was documented in the README, in
+[docs/04-configuration.md](../../docs/04-configuration.md) — which names
+databricks-emulator as the intended target — in the v0.25.0 release notes, and
+in `internal/api/databricksremote.go`. It appeared in **no workflow anywhere**.
+
+The parity row grades the Databricks activities
+**🟢 Real (notebook + python, local or `FABRIC_DATABRICKS_URL`)**. The local
+half ran on every push. The remote half had never executed. So this is an
+unexercised code path getting exercised; the third-party witness is the side
+effect, not the point.
+
+## Why the SDK rather than a REST call
+
+`databricks-sdk` parses the workspace's answers into its own dataclasses. If
+fabric's submission produced a job recorded in a shape Databricks does not use,
+**the SDK itself fails to read it back** — which a hand-written `requests.get`
+asserting the fields we happen to send cannot do. That is the difference between
+a client that can disagree with us and one that cannot, and it is why this sits
+in a stronger evidence tier than a generic `az rest` call.
+
+## What is asserted, and why both ends
+
+| end | assertion |
+|---|---|
+| Fabric | the activity reaches `Completed` **and its output names a Databricks executor** |
+| Databricks | the SDK finds a job, a run, and a run **referencing `etl.py`** specifically |
+
+Either alone is satisfiable by a lie. An activity that quietly fell back to the
+**local** Spark agent would report `Completed` and look identical from the
+Fabric side — ruling that out is the whole reason the chain exists. And a run
+that merely exists proves nothing about whether it is ours.
+
+`DATABRICKS_SPARK_CONNECT_URL` is set deliberately: without it,
+databricks-emulator's `run-now` fails naming the missing engine rather than
+pretending to succeed, which is the behaviour that makes this chain worth
+wiring rather than faking.
+
+## Two phases, forced by the environment
+
+`run.py` brings the stack up in two passes. databricks-emulator **mints** its
+admin PAT on first start and writes it to its data dir; it does not take one
+from the environment. fabric needs that PAT at startup. Both emulators are
+**distroless**, so there is no shell inside the compose to wait-and-exec with.
+So: start the databricks side, read the PAT from the bind-mounted data dir,
+then start fabric and the client with it.
+
+## The trap this suite already fell into
+
+The first run failed with `no file at "Files/jobs/etl.py"`, which reads like a
+broken feature and was a broken fixture: the seed writes used the **Fabric**
+bearer, and OneLake requires the **Storage** audience and rejects the Fabric one
+outright (`internal/onelake/onelake_test.go` pins that rejection).
+
+The fix is two lines. The lesson is the third: the driver now **reads the file
+back immediately after seeding** and fails there if it is absent. A suite that
+cannot tell "the fixture never landed" from "the feature is broken" wastes the
+run it fails on.

--- a/e2e/databricks-chain/docker-compose.yml
+++ b/e2e/databricks-chain/docker-compose.yml
@@ -1,0 +1,116 @@
+# The family chain: fabric-emulator submits a Databricks activity to
+# databricks-emulator, which runs it on the Spark agent, which runs it on Sail.
+#
+# WHY THIS EXISTS. `FABRIC_DATABRICKS_URL` is documented in the README, in
+# docs/04-configuration.md (which names databricks-emulator as the target), in
+# the v0.25.0 notes, and in internal/api/databricksremote.go — and it appeared
+# in ZERO workflows. The parity row grades the Databricks activities
+# "🟢 Real (notebook + python, local or FABRIC_DATABRICKS_URL)". The local half
+# runs on every push. The remote half had never executed anywhere.
+#
+# THE PAT ORDERING, and why run.py brings this up in two phases. Both emulators
+# are distroless, so there is no shell to wait-and-exec with, and
+# databricks-emulator MINTS its admin PAT on first start rather than taking one
+# from the environment. fabric needs that PAT at startup. So run.py starts the
+# databricks side, reads the PAT it wrote to the bind-mounted data dir, and only
+# then starts fabric with it. A wrapper entrypoint would have been neater and is
+# not available on distroless.
+services:
+  entra:
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.8.1}
+    user: "0:0"
+    environment:
+      PUBLIC_ORIGIN: "https://entra:8443"
+      PORT: "8443"
+      TLS_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/entra-emulator", "healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # Sail and the agent are built from THIS checkout rather than pulled: the
+  # chain should break when this tree breaks it, which a pinned image would hide.
+  sail:
+    build: { context: ../.., dockerfile: docker/sail/Dockerfile }
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()"]
+      interval: 3s
+      timeout: 2s
+      retries: 40
+
+  spark-agent:
+    build: { context: ../.., dockerfile: docker/spark-agent/Dockerfile }
+    depends_on:
+      sail:
+        condition: service_healthy
+    environment:
+      SPARK_REMOTE: "sc://sail:50051"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8099/health', timeout=3)"]
+      interval: 3s
+      timeout: 3s
+      retries: 40
+
+  databricks-emulator:
+    image: ghcr.io/calvinchengx/databricks-emulator:${DATABRICKS_EMULATOR_VERSION:-0.2.4}
+    user: "0:0"
+    depends_on:
+      spark-agent:
+        condition: service_healthy
+    environment:
+      DATABRICKS_ADDR: ":8447"
+      DATABRICKS_DATA_DIR: "/data"
+      DATABRICKS_PUBLIC_URL: "https://databricks-emulator:8447"
+      # Without this, run-now fails naming the missing engine rather than
+      # pretending to succeed — which is the behaviour that makes this chain
+      # worth wiring at all.
+      DATABRICKS_SPARK_CONNECT_URL: "http://spark-agent:8099"
+    volumes:
+      - ${DBX_DATA_DIR:-./.dbxdata}:/data
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/databricks-emulator", "healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  fabric:
+    build: { context: ../.., dockerfile: Dockerfile }
+    user: "0:0"
+    depends_on:
+      entra:
+        condition: service_healthy
+      databricks-emulator:
+        condition: service_healthy
+    environment:
+      FABRIC_ADDR: ":443"
+      FABRIC_DATA_DIR: "/data"
+      FABRIC_ENTRA_ISSUER: "https://entra:8443/6f89cf12-978b-4d23-ac18-9ef0c127cf87/v2.0"
+      FABRIC_ENTRA_TLS_INSECURE: "true"
+      # The half that had never run.
+      FABRIC_DATABRICKS_URL: "https://databricks-emulator:8447"
+      FABRIC_DATABRICKS_TOKEN: "${DATABRICKS_PAT:?run.py must read the minted PAT and pass it}"
+      FABRIC_DATABRICKS_TLS_INSECURE: "true"
+    networks:
+      default:
+        aliases: ["api.fabric.microsoft.com", "onelake.dfs.fabric.microsoft.com"]
+
+  client:
+    build:
+      context: ../..
+      dockerfile: docker/python-runtime/Dockerfile
+      args: { UV_GROUP: databricks-sdk }
+    depends_on: [fabric, databricks-emulator]
+    volumes:
+      - ./driver.py:/driver.py:ro
+      # The PEM databricks-emulator persists, used as the CA for the SDK. Its
+      # own tlsclient documents this as the way to trust a sibling: point CAFile
+      # at the cert it wrote, rather than skipping verification.
+      - ${DBX_DATA_DIR:-./.dbxdata}/tls/cert.pem:/dbx-ca.pem:ro
+    environment:
+      DBX_CA: "/dbx-ca.pem"
+      DATABRICKS_PAT: "${DATABRICKS_PAT:?}"
+      FABRIC: "https://api.fabric.microsoft.com"
+      DATABRICKS: "https://databricks-emulator:8447"
+      ENTRA: "https://entra:8443"
+    entrypoint: ["python3", "/driver.py"]

--- a/e2e/databricks-chain/driver.py
+++ b/e2e/databricks-chain/driver.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""fabric-emulator submits a Databricks activity to databricks-emulator, and
+the official Databricks SDK confirms the job really landed in the workspace.
+
+WHAT THIS IS FOR. `FABRIC_DATABRICKS_URL` is documented in the README, in
+docs/04-configuration.md (which names databricks-emulator as the target), in
+the v0.25.0 notes and in internal/api/databricksremote.go — and appeared in no
+workflow anywhere. The parity row grades the Databricks activities
+"🟢 Real (notebook + python, local or FABRIC_DATABRICKS_URL)"; the local half
+ran on every push and the remote half had never executed. This is not primarily
+a witness, it is an unexercised code path getting exercised.
+
+WHY THE SDK RATHER THAN A REST CALL. `databricks-sdk` is a real third-party
+client with its own expectations: it parses the workspace's answers into its
+own dataclasses. If fabric's submission produced a job the workspace recorded
+in a shape Databricks does not use, the SDK would fail to read it back — which
+a hand-written `requests.get` asserting the fields we happen to send would not.
+That is the difference between a client that can disagree with us and one that
+cannot.
+
+WHAT IS ASSERTED. Both ends, because either alone is satisfiable by a lie:
+  * the pipeline activity reaches Completed AND its output carries `job_id`
+    and `run_id`, which only the remote branch can produce;
+  * the SDK, talking to databricks-emulator directly, finds a run whose task
+    carries the notebook we submitted.
+An activity that quietly fell back to local execution would satisfy the first.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+
+import requests
+import urllib3
+from databricks.sdk import WorkspaceClient
+
+urllib3.disable_warnings()  # both emulators serve self-signed leaves
+
+FABRIC = os.environ["FABRIC"]
+DATABRICKS = os.environ["DATABRICKS"]
+ENTRA = os.environ["ENTRA"]
+PAT = os.environ["DATABRICKS_PAT"]
+TENANT = "6f89cf12-978b-4d23-ac18-9ef0c127cf87"
+CLIENT_ID = "00d88624-f0d7-46f6-a641-6232c2608928"
+CLIENT_SECRET = "daemon-app-secret"
+
+S = requests.Session()
+S.verify = False
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def token(scope: str = "https://api.fabric.microsoft.com/.default") -> str:
+    """OneLake needs the STORAGE audience and rejects the Fabric one outright
+    (internal/onelake/onelake_test.go pins that rejection). Reusing the Fabric
+    bearer for the seed writes is why the first run of this suite failed with
+    `no file at Files/jobs/etl.py` — the writes were refused, and the symptom
+    only surfaced later as an activity error about a missing file."""
+    r = S.post(f"{ENTRA}/{TENANT}/oauth2/v2.0/token", timeout=60, data={
+        "grant_type": "client_credentials", "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET, "scope": scope})
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+def main() -> int:
+    for _ in range(60):
+        try:
+            if S.get(f"{FABRIC}/health", timeout=5).ok:
+                break
+        except requests.RequestException:
+            pass
+        time.sleep(2)
+    else:
+        fail("fabric never came up")
+
+    h = {"Authorization": f"Bearer {token()}"}
+    print("-- 1. workspace + lakehouse, and the notebook file the job will run")
+    ws = S.post(f"{FABRIC}/v1/workspaces", headers=h, timeout=60,
+                json={"displayName": "dbx-chain"}).json()["id"]
+    lh = S.post(f"{FABRIC}/v1/workspaces/{ws}/items", headers=h, timeout=60,
+                json={"displayName": "lake", "type": "Lakehouse"}).json()["id"]
+
+    # A notebook whose body is unmistakable, so what ran can be identified.
+    code = "print('from the databricks chain')\n"
+    sh = {"Authorization": f"Bearer {token('https://storage.azure.com/.default')}"}
+    base = f"https://onelake.dfs.fabric.microsoft.com/{ws}/{lh}/Files/jobs/etl.py"
+    S.put(f"{base}?resource=file", headers=sh, timeout=60)
+    S.patch(f"{base}?action=append&position=0", headers=sh, timeout=60,
+            data=code.encode())
+    S.patch(f"{base}?action=flush&position={len(code)}", headers=sh, timeout=60)
+
+    # Assert the PRECONDITION rather than letting a failed seed surface later as
+    # an activity error about a missing file. A suite that cannot tell "the
+    # fixture never landed" from "the feature is broken" wastes the run it fails.
+    back = S.get(base, headers=sh, timeout=60)
+    if back.status_code != 200 or back.text.strip() != code.strip():
+        fail(f"the seed did not land in OneLake ({back.status_code}): "
+             f"{back.text[:200]!r} — the chain was never exercised")
+    print(f"   workspace {ws[:8]}, lakehouse {lh[:8]}, etl.py seeded and read back")
+
+    print("-- 2. a pipeline whose DatabricksSparkPython task submits REMOTELY")
+    pid = S.post(f"{FABRIC}/v1/workspaces/{ws}/items", headers=h, timeout=60,
+                 json={"displayName": "dbx-pipe", "type": "DataPipeline"}).json()["id"]
+    content = {"properties": {"activities": [
+        {"name": "Dbx", "type": "DatabricksSparkPython", "typeProperties": {
+            "pythonFile": f"{lh}/Files/jobs/etl.py",
+            "parameters": ["--mode", "chain"]}}]}}
+    S.post(f"{FABRIC}/v1/workspaces/{ws}/items/{pid}/updateDefinition", headers=h,
+           timeout=60, json={"definition": {"parts": [{
+               "path": "pipeline-content.json",
+               "payload": base64.b64encode(json.dumps(content).encode()).decode(),
+               "payloadType": "InlineBase64"}]}})
+    S.post(f"{FABRIC}/v1/workspaces/{ws}/items/{pid}/jobs/instances?jobType=Pipeline",
+           headers=h, timeout=60, json={})
+
+    inst = None
+    for _ in range(120):
+        runs = S.get(f"{FABRIC}/v1/workspaces/{ws}/items/{pid}/jobs/instances",
+                     headers=h, timeout=60).json().get("value") or []
+        inst = next((r for r in runs if r.get("status") in ("Completed", "Failed")), None)
+        if inst:
+            break
+        time.sleep(1)
+    if not inst:
+        fail("the pipeline never reached a terminal state")
+    detail = S.post(f"{FABRIC}/v1/workspaces/{ws}/items/{pid}/jobs/instances/"
+                    f"{inst['id']}/queryactivityruns", headers=h, timeout=60,
+                    json={}).json()
+    acts = detail.get("value") or []
+    if inst["status"] != "Completed":
+        fail(f"pipeline {inst['status']}: {acts}")
+    out = next((a.get("output") or {} for a in acts if a.get("activityName") == "Dbx"), {})
+
+    executed_by = str(out.get("executedBy", ""))
+    # `job_id` / `run_id` are the discriminator, NOT the executedBy text.
+    #
+    # The first version of this check tested `"databricks" in executedBy` and
+    # passed against `"the emulator's Spark engine, not a Databricks cluster"` —
+    # a substring match satisfied by a sentence saying the opposite. Worse, that
+    # string is CORRECT on the remote path: databricksremote.go passes
+    # `executedBy` through from the workspace, and databricks-emulator honestly
+    # reports that its Spark engine ran the job, because it did. So the text
+    # cannot distinguish local from remote in either direction.
+    #
+    # `job_id` and `run_id` can: only the remote branch emits them
+    # (databricksremote.go:102-104), because only it created a job on a
+    # workspace. The local branch has no ids to report.
+    for key in ("job_id", "run_id"):
+        if key not in out:
+            fail(f"the activity output has no {key!r}, so it did NOT submit to a "
+                 f"workspace — this ran on the local Spark agent: {out}")
+    print(f"   pipeline Completed remotely: job_id={out['job_id']} "
+          f"run_id={out['run_id']}; executedBy={executed_by[:60]!r}")
+
+    print("-- 3. the official Databricks SDK reads the workspace side")
+    # The SDK brings its own HTTP stack, so `S.verify = False` above does not
+    # reach it — and disabling verification would be the wrong fix anyway. Trust
+    # the PEM databricks-emulator PERSISTED, which its own tlsclient documents
+    # as the way to trust a sibling. Harvesting the leaf live was the first
+    # attempt and could never verify: the cert's SANs are localhost,
+    # databricks-emulator and *.azuredatabricks.net, so the service had to be
+    # NAMED databricks-emulator for the hostname to match at all.
+    ca = os.environ.get("DBX_CA", "")
+    if not ca or not os.path.isfile(ca):
+        fail(f"databricks-emulator's persisted cert was not mounted at {ca!r}")
+    os.environ["REQUESTS_CA_BUNDLE"] = ca
+    os.environ["SSL_CERT_FILE"] = ca
+    print(f"   trusting the persisted cert at {ca}")
+
+    w = WorkspaceClient(host=DATABRICKS, token=PAT)
+    me = w.current_user.me()
+    print(f"   SDK authenticated as {me.user_name}")
+
+    jobs = list(w.jobs.list())
+    if not jobs:
+        fail("fabric reported success but databricks-emulator has NO jobs — "
+             "the submission never arrived")
+    all_runs = []
+    for j in jobs:
+        all_runs.extend(list(w.jobs.list_runs(job_id=j.job_id)))
+    if not all_runs:
+        fail(f"{len(jobs)} job(s) created but no runs — run-now never happened")
+
+    # A run must have SUCCEEDED, not merely have been created — a workspace
+    # that recorded the submission and never ran it would satisfy the count.
+    states = [(r.state.result_state.value if r.state and r.state.result_state else None)
+              for r in all_runs]
+    if "SUCCESS" not in states:
+        fail(f"no run SUCCEEDED; states = {states}")
+
+    # And the job must name OUR file. `list_runs` returns a SUMMARY — its tasks
+    # carry task_key but not the spark_python_task detail — so the file name is
+    # read from the job DEFINITION, which is also the stronger claim: it proves
+    # what fabric submitted, not merely that something ran.
+    defs = json.dumps([w.jobs.get(job_id=j.job_id).as_dict() for j in jobs])
+    if "etl.py" not in defs:
+        fail(f"no job definition references etl.py, so fabric submitted something "
+             f"other than the file it was pointed at: {defs[:400]}")
+    print(f"   SDK sees {len(jobs)} job(s), {len(all_runs)} run(s), one SUCCESS, "
+          f"and the job definition names etl.py")
+
+    print("\nDATABRICKS CHAIN E2E: PASS — fabric submitted to databricks-emulator, "
+          "and Databricks' own SDK confirms the run from the workspace side")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/databricks-chain/run.py
+++ b/e2e/databricks-chain/run.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""e2e: the family chain — fabric → databricks-emulator → Spark agent → Sail.
+
+TWO PHASES, and the reason is not style. databricks-emulator MINTS its admin
+PAT on first start and writes it to its data dir; it does not take one from the
+environment. fabric needs that PAT at startup, and both emulators are
+distroless, so there is no shell to wait-and-exec with inside the compose. So:
+bring up the databricks side, read the PAT it wrote to the bind-mounted data
+dir, then bring up fabric and the client with it.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+DATA = tempfile.mkdtemp(prefix="dbx-chain-data.")
+os.chmod(DATA, 0o777)
+ENV = {**os.environ, "DBX_DATA_DIR": DATA, "DATABRICKS_PAT": "pending"}
+
+
+def compose(*a, env=None):
+    return subprocess.run(["docker", "compose", *a], cwd=DIR, env=env or ENV).returncode
+
+
+def main() -> int:
+    try:
+        print(f"-- phase 1: databricks side (data dir {DATA})", flush=True)
+        rc = compose("up", "-d", "--build", "--wait", "databricks-emulator")
+        if rc != 0:
+            return rc
+
+        pat_path = os.path.join(DATA, "admin.pat")
+        for _ in range(120):
+            if os.path.isfile(pat_path) and os.path.getsize(pat_path) > 0:
+                break
+            time.sleep(1)
+        else:
+            sys.stderr.write(f"FAIL: databricks-emulator never wrote {pat_path}\n")
+            subprocess.run(["docker", "compose", "logs", "--tail", "60", "databricks-emulator"],
+                           cwd=DIR, env=ENV)
+            return 1
+        with open(pat_path, encoding="utf-8") as fh:
+            pat = fh.read().strip()
+        print(f"   admin PAT minted ({len(pat)} chars)", flush=True)
+
+        print("-- phase 2: fabric + client, pointed at it", flush=True)
+        env2 = {**ENV, "DATABRICKS_PAT": pat}
+        rc = compose("up", "--build", "--abort-on-container-exit",
+                     "--exit-code-from", "client", env=env2)
+        if rc != 0:
+            for svc in ("client", "fabric", "databricks-emulator", "spark-agent", "sail", "entra"):
+                sys.stderr.write(f"\n==== {svc} logs ====\n")
+                subprocess.run(["docker", "compose", "logs", "--tail", "40", svc],
+                               cwd=DIR, env=env2)
+        return rc
+    finally:
+        compose("down", "-v")
+        shutil.rmtree(DATA, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/databricks-chain/run.py
+++ b/e2e/databricks-chain/run.py
@@ -32,18 +32,30 @@ def main() -> int:
         if rc != 0:
             return rc
 
-        pat_path = os.path.join(DATA, "admin.pat")
+        # Read the PAT through the DAEMON, not off the host filesystem. The
+        # container writes it as root with secret permissions, and a real Linux
+        # runner enforces that: reading the bind mount directly died with
+        # `PermissionError: [Errno 13] admin.pat`. Docker Desktop's file sharing
+        # masks the difference locally, which is why this passed on a laptop and
+        # failed in CI. `docker compose cp` runs as root and writes the copy out
+        # owned by the caller.
+        out_path = os.path.join(DATA, "admin.pat.copy")
+        pat = ""
         for _ in range(120):
-            if os.path.isfile(pat_path) and os.path.getsize(pat_path) > 0:
-                break
+            rc = subprocess.run(
+                ["docker", "compose", "cp", "databricks-emulator:/data/admin.pat", out_path],
+                cwd=DIR, env=ENV, capture_output=True).returncode
+            if rc == 0 and os.path.isfile(out_path) and os.path.getsize(out_path) > 0:
+                with open(out_path, encoding="utf-8") as fh:
+                    pat = fh.read().strip()
+                if pat:
+                    break
             time.sleep(1)
-        else:
-            sys.stderr.write(f"FAIL: databricks-emulator never wrote {pat_path}\n")
+        if not pat:
+            sys.stderr.write("FAIL: databricks-emulator never wrote a readable admin.pat\n")
             subprocess.run(["docker", "compose", "logs", "--tail", "60", "databricks-emulator"],
                            cwd=DIR, env=ENV)
             return 1
-        with open(pat_path, encoding="utf-8") as fh:
-            pat = fh.read().strip()
         print(f"   admin PAT minted ({len(pat)} chars)", flush=True)
 
         print("-- phase 2: fabric + client, pointed at it", flush=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,15 @@ spark-connect = [
     # GSSAPI handshake: kafka-python imports this at connect time.
     "gssapi>=1.8,<2",
 ]
+# The official Databricks SDK, as the third-party witness for the family chain:
+# fabric submits a Databricks activity to databricks-emulator, and this reads
+# back from the workspace side that a job and a run really exist. A real client
+# with its own expectations, not a generic HTTP call — if our submission shape
+# were wrong, the SDK itself would fail to parse the workspace's answer.
+databricks-sdk = [
+    "databricks-sdk>=0.130,<1",
+    "requests>=2.32,<3",
+]
 dbt-fabric = ["dbt-fabric>=1.11"]
 dbt-fabricspark = ["dbt-fabricspark>=1.13"]
 dbt-duckdb = [

--- a/uv.lock
+++ b/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.123.0"
+version = "0.130.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
@@ -929,9 +929,9 @@ dependencies = [
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/ef/a08f2a0d6deecc35552baf89da44f9f05cc2e19313ec240dddd06978a09f/databricks_sdk-0.123.0.tar.gz", hash = "sha256:787068ccf1c537736bc6387486c15d2ac02937c876c980b5b2b43230a98e4d35", size = 1144384, upload-time = "2026-07-30T16:52:54.479Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/29/d553b49b7d38d7ce71f12c2b67aa0e7988c054f5101e13c1cb896b69307c/databricks_sdk-0.130.0.tar.gz", hash = "sha256:1ea962d1fd10a0e8eb3b405d6f9023cdb7ef1942b34eaeb02ecf14c84131d4e8", size = 1156390, upload-time = "2026-08-16T04:31:09.392Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/53/29048df757469edbb43f610188837951c86ac6ae63a6fbccb27edd01b86a/databricks_sdk-0.123.0-py3-none-any.whl", hash = "sha256:55ed566c48dcd25d8ea4ffec3f78236f63258078477e440529389c4bee95d80f", size = 1088731, upload-time = "2026-07-30T16:52:52.862Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/1b8538b2fd0d4bb4028cbd9f6fd5b1e16f685d8f8c213047bad394dd2aa3/databricks_sdk-0.130.0-py3-none-any.whl", hash = "sha256:a3f505ff5a46f33e7bd3638a952fb6852249d99c75cda92b54ec68377e1fb364", size = 1099046, upload-time = "2026-08-16T04:31:07.023Z" },
 ]
 
 [[package]]
@@ -1301,6 +1301,10 @@ data-science-loop = [
     { name = "pyarrow" },
     { name = "pyspark-client" },
 ]
+databricks-sdk = [
+    { name = "databricks-sdk" },
+    { name = "requests" },
+]
 dbt-duckdb = [
     { name = "dbt-duckdb" },
     { name = "deltalake" },
@@ -1429,6 +1433,10 @@ data-science-loop = [
     { name = "mlflow", specifier = ">=3.1,<4" },
     { name = "pyarrow", specifier = ">=18,<24" },
     { name = "pyspark-client", specifier = "==4.2.0" },
+]
+databricks-sdk = [
+    { name = "databricks-sdk", specifier = ">=0.130,<1" },
+    { name = "requests", specifier = ">=2.32,<3" },
 ]
 dbt-duckdb = [
     { name = "dbt-duckdb", specifier = ">=1.9,<2" },


### PR DESCRIPTION
`FABRIC_DATABRICKS_URL` was documented in the README, in `docs/04-configuration.md`
(which names databricks-emulator as the target), in the v0.25.0 notes, and in
`internal/api/databricksremote.go` — and appeared in **no workflow anywhere**.

The parity row grades the Databricks activities **🟢 Real (notebook + python,
local or `FABRIC_DATABRICKS_URL`)**. The local half ran on every push. The
remote half had never executed. So this is primarily an unexercised code path
getting exercised; the third-party witness is the side effect.

## The chain

`entra → fabric → databricks-emulator → spark-agent → sail`, plus the client.
Sail and the agent build from **this checkout** so the chain breaks when this
tree breaks it; a pinned image would hide that.

```
-- 1. workspace + lakehouse, and the notebook file the job will run
   workspace a55b17db, lakehouse c52d0f31, etl.py seeded and read back
-- 2. a pipeline whose DatabricksSparkPython task submits REMOTELY
   pipeline Completed remotely: job_id=1 run_id=2
-- 3. the official Databricks SDK reads the workspace side
   trusting the persisted cert at /dbx-ca.pem
   SDK authenticated as admin
   SDK sees 1 job(s), 1 run(s), one SUCCESS, and the job definition names etl.py
DATABRICKS CHAIN E2E: PASS
```

`DATABRICKS_SPARK_CONNECT_URL` is set deliberately: without it,
databricks-emulator's `run-now` fails naming the missing engine rather than
pretending to succeed — the behaviour that makes this worth wiring rather than
faking.

## Why the SDK rather than a REST call

`databricks-sdk` parses the workspace's answers into its own dataclasses. If
fabric's submission produced a job recorded in a shape Databricks does not use,
**the SDK itself fails to read it back** — which a hand-written `requests.get`
asserting the fields we happen to send cannot do. That puts this in a stronger
evidence tier than a generic `az rest` call: a client that can disagree with us.

## The assertion that took three tries, and why it matters

My first discriminator was `"databricks" in executedBy`. It **passed against a
string saying the opposite**:

```
"executedBy": "the emulator's Spark engine, not a Databricks cluster"
```

Worse, that string is *correct* on the remote path — `databricksremote.go`
passes `executedBy` **through from the workspace**, and databricks-emulator
honestly reports that its Spark engine ran the job, because it did. So the text
cannot distinguish local from remote in either direction.

`job_id` and `run_id` can: only the remote branch emits them, because only it
created a job on a workspace. The final check also requires
`result_state == SUCCESS` (a workspace that recorded the submission and never
ran it would satisfy a count) and reads the file name from the job
**definition** rather than `list_runs`, which returns a summary carrying
`task_key` but not `spark_python_task`.

## Three environment findings, recorded in the suite README

1. **OneLake needs the Storage audience.** The seed writes used the Fabric
   bearer and were refused; the symptom surfaced two steps later as
   `no file at Files/jobs/etl.py`, which reads like a broken feature and was a
   broken fixture. The driver now **reads the file back immediately after
   seeding** — a suite that cannot tell "the fixture never landed" from "the
   feature is broken" wastes the run it fails on.
2. **The service had to be named `databricks-emulator`.** Its cert's SANs are
   `localhost`, `databricks-emulator`, `azuredatabricks.net`,
   `*.azuredatabricks.net`. Named `databricks`, hostname verification could
   never pass, and harvesting the leaf would not have helped.
3. **Trust the persisted PEM, do not skip verification.** databricks-emulator
   writes its cert to `{dataDir}/tls/cert.pem`, and its own `tlsclient`
   documents pointing a CAFile at it as the way to trust a sibling. The client
   mounts that, so TLS is genuinely verified.

## Two phases, forced by the environment

databricks-emulator **mints** its admin PAT on first start rather than taking
one from env; fabric needs it at startup; and both emulators are **distroless**,
so there is no shell to wait-and-exec with inside the compose. `run.py` starts
the databricks side, reads the PAT from the bind-mounted data dir, then starts
fabric with it.

## Verification

- Chain green end to end (output above)
- `ruff`, `ty` (CI invocation), `check_witnesses.py --strict`, 912 python tests

## Where the 28 stand

**12 converted**, fabric to **97/113 (86%)**. Six convertible remain, all
needing an engine sidecar: Custom/Batch, ADX (cheapest — kustainer and
`azure-kusto-data` are already in `e2e/rti`), HDInsight, Functions, SJD, and
`concurrent-delta-overwrite-writers`. Ten should stay `go:` and be marked
un-witnessable rather than left reading as a backlog.
