### PR TITLE
feat(e2e): witness the AzureFunctionActivity, key and URL included

### DIFF
--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -1059,7 +1059,8 @@
     "witnesses": [
       "go:TestFunctionActivityCallsForReal",
       "go:TestFunctionActivityWrongKeyFails",
-      "go:TestFunctionActivitySchemaRules"
+      "go:TestFunctionActivitySchemaRules",
+      "ci:pipeline-activities"
     ]
   },
   "web-and-webhook-activities": {

--- a/e2e/pipeline-activities/README.md
+++ b/e2e/pipeline-activities/README.md
@@ -36,6 +36,7 @@ job, separate witness id, separate blast radius.
 | Control flow (If / Switch / Until / expressions / dependsOn) | `IfCondition` runs the true branch **and not the false one**; `Switch` runs the matching case and neither the other case nor the default; `Until` runs its body exactly 3 times before the condition holds |
 | Per-activity retry policy | an activity pointed at a missing notebook with `policy.retry: 2` — the job **Fails**, and there is **one** activity record carrying `retryAttempt: 2`, not three records |
 | Web + WebHook | `WebActivity` GETs a real endpoint and `pong: true` appears in its output; `WebHook` posts, **parks** while nothing has called back, then the callback releases it and `approved: true` reaches the output |
+| Functions | the response reaches a downstream expression (`rows=3`), the host sees **exactly** `POST /api/ingest` (so `functionAppUrl + /api/ + functionName` was built right, and called once), and a **wrong `x-functions-key` fails the activity** — without which the first two pass for an activity that never sends the secret at all |
 
 ## The rule every check here follows
 

--- a/e2e/pipeline-activities/driver.py
+++ b/e2e/pipeline-activities/driver.py
@@ -456,6 +456,59 @@ def check_web_and_webhook(ws: str) -> None:
     print("   WebHook: parked until the callback, and the callback body arrived")
 
 
+def check_functions_activity(ws: str) -> None:
+    print("-- Functions: the key is sent, the URL is built, the response flows on")
+    # The emulator builds functionAppUrl + "/api/" + functionName and sends the
+    # key as x-functions-key. All three are asserted, because each can be wrong
+    # independently and only one of them shows up as a failure on its own.
+    runs = run_pipeline(ws, "pl-fn", {"properties": {
+        "variables": {"n": {"type": "String"}},
+        "activities": [
+            {"name": "Fn", "type": "AzureFunctionActivity", "typeProperties": {
+                "functionAppUrl": "http://target:8080", "functionKey": "s3cret",
+                "functionName": "ingest", "method": "POST", "body": {"batch": 1}}},
+            {"name": "Use", "type": "SetVariable",
+             "dependsOn": [{"activity": "Fn", "dependencyConditions": ["Succeeded"]}],
+             "typeProperties": {"variableName": "n",
+                                "value": "@string(activity('Fn').output.rows)"}},
+        ]}})
+    # The response must have REACHED a downstream expression. An activity that
+    # reported success without calling could not produce `3` from the URL alone.
+    if output_of(runs, "Use").get("value") != "3":
+        fail(f"the function's response did not flow downstream: {output_of(runs, 'Use')}")
+
+    with urllib.request.urlopen("http://target:8080/fn-calls", timeout=10) as r:
+        calls = json.loads(r.read().decode() or "{}").get("calls") or []
+    # Exactly one, and at the URL the contract says: functionAppUrl + /api/ +
+    # functionName. A double-send or a wrong path both matter and neither fails
+    # on its own.
+    if calls != ["POST /api/ingest"]:
+        fail(f"the host saw {calls!r}, want exactly ['POST /api/ingest']")
+    print(f"   one call to {calls[0]}, rows=3 reached the SetVariable")
+
+    # A WRONG key must fail the activity. Without this the check above passes
+    # for an activity that never sends the secret at all — the host would 401,
+    # and only this case proves the 401 is honoured rather than swallowed.
+    pid = az_rest("post", v1(f"workspaces/{ws}/items"),
+                  {"displayName": "pl-fn-badkey", "type": "DataPipeline"})["id"]
+    define(ws, pid, {"properties": {"activities": [
+        {"name": "Fn", "type": "AzureFunctionActivity", "typeProperties": {
+            "functionAppUrl": "http://target:8080", "functionKey": "wrong",
+            "functionName": "ingest", "method": "POST", "body": {}}}]}})
+    az_rest_raw("post", v1(f"workspaces/{ws}/items/{pid}/jobs/instances?jobType=Pipeline"),
+                body="{}", headers=["Content-Type=application/json"])
+    for _ in range(60):
+        got = az_rest("get", v1(f"workspaces/{ws}/items/{pid}/jobs/instances")).get("value") or []
+        states = [r.get("status") for r in got]
+        if "Failed" in states:
+            print("   a wrong key fails the activity, as the 401 demands")
+            return
+        if "Completed" in states:
+            fail("a WRONG function key reported success — the host's 401 was swallowed")
+        time.sleep(0.5)
+    fail(f"the bad-key pipeline never reached a terminal state: {states}")
+
+
 def main() -> int:
     try:
         azrest.login()
@@ -469,9 +522,10 @@ def main() -> int:
         check_control_flow(ws)
         check_retry_policy(ws)
         check_web_and_webhook(ws)
+        check_functions_activity(ws)
         print("\nPIPELINE ACTIVITIES E2E: PASS — az drove Delete, GetMetadata, "
               "Lookup, Validation, ExecutePipeline, ForEach, control flow, "
-              "retry policy and Web — each judged by the data")
+              "retry policy, Web/WebHook and Functions — each judged by the data")
         return 0
     except SystemExit:
         raise

--- a/e2e/pipeline-activities/target.py
+++ b/e2e/pipeline-activities/target.py
@@ -27,11 +27,21 @@ TWO ROUTES, because the claim covers two activities:
                     that called back immediately would make "parked" untestable.
 
   GET  /captured    the callBackUri the last POST carried, or {} if none yet.
+
+  POST /api/<name>  an Azure Functions host. The emulator sends the key as
+                    `x-functions-key` and builds the URL as
+                    functionAppUrl + "/api/" + functionName, so a WRONG key must
+                    401 — otherwise the suite could not tell an activity that
+                    sends the secret from one that forgets it. Records each call
+                    as "METHOD /api/<name>" so the driver can assert the URL was
+                    built correctly and called exactly once.
 """
 import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 _captured: dict[str, str] = {}
+_fn_calls: list[str] = []
+FUNCTION_KEY = "s3cret"
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -54,10 +64,23 @@ class Handler(BaseHTTPRequestHandler):
             self._send(200, {"pong": True, "who": "pipeline-activities-target"})
         elif path == "/captured":
             self._send(200, dict(_captured))
+        elif path == "/fn-calls":
+            self._send(200, {"calls": list(_fn_calls)})
         else:
             self._send(404, {"error": f"no route {path}"})
 
     def do_POST(self):
+        path = self.path.split("?", 1)[0]
+        if path.startswith("/api/"):
+            # A wrong (or absent) key is 401, exactly as a Functions host does.
+            # Without this the witness could not distinguish an activity that
+            # sends `x-functions-key` from one that silently omits it.
+            if self.headers.get("x-functions-key") != FUNCTION_KEY:
+                self._send(401, {"error": "invalid key"})
+                return
+            _fn_calls.append(f"POST {path}")
+            self._send(200, {"rows": 3})
+            return
         n = int(self.headers.get("Content-Length") or 0)
         raw = self.rfile.read(n).decode() if n else ""
         try:


### PR DESCRIPTION
`functions-activity-azurefunctionactivity` moves off `go:`-only. No new service:
`e2e/pipeline-activities` already ships `target.py` for the Web/WebHook checks,
and it grows a Functions host.

## Three assertions, because each can be wrong on its own

| assertion | what it rules out |
|---|---|
| `rows=3` reaches a downstream `SetVariable` | an activity that reported success without calling — it could not produce `3` from the URL alone |
| the host saw **exactly** `POST /api/ingest` | a wrong URL (the contract is `functionAppUrl + /api/ + functionName`) and a double-send. Neither fails on its own |
| a **wrong key fails the activity** | an activity that never sends `x-functions-key`. The first two still pass for it — the host 401s, and only this case proves the 401 is honoured rather than swallowed |

The host returns 401 on a wrong or absent key exactly as a real Functions host
does, which is what makes the third assertion possible at all.

## Verification

Full suite green locally — eleven checks:

```
PIPELINE ACTIVITIES E2E: PASS — az drove Delete, GetMetadata, Lookup,
Validation, ExecutePipeline, ForEach, control flow, retry policy,
Web/WebHook and Functions — each judged by the data
```

`ruff`, `ty` (CI invocation) and `check_witnesses.py --strict` pass.

## Where the 28 stand

**14 converted** (assuming #282 lands), fabric to **99/113 (88%)**. Four
convertible remain: `concurrent-delta-overwrite-writers` (two racing delta-rs
writers, and delta-rs is already in CI) and the three that need a Spark agent —
Custom/Batch, HDInsight and SJD/InvokeCopyJob — which are grouped so one compose
change covers them.