### PR TITLE
docs: cite the sail race probe for the concurrent-Delta-overwrite claim

### DIFF
--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -124,7 +124,8 @@
     "section": "Data Engineering (`data-engineering/`)",
     "claim": "Concurrent Delta overwrite writers",
     "witnesses": [
-      "go:TestConcurrentDeltaCommitRace"
+      "go:TestConcurrentDeltaCommitRace",
+      "ci:sail"
     ]
   },
   "connection-by-item-name-vs-guid": {

--- a/e2e/sail/driver.py
+++ b/e2e/sail/driver.py
@@ -344,6 +344,11 @@ def concurrent_overwrite(value):
                   flush=True)
 
 
+# This block is the third-party witness for the `Concurrent Delta overwrite
+# writers` parity row (docs/witnesses.json). The Go test races 24 blob PUTs
+# and asserts the conditional-create contract directly; this races two REAL
+# pyspark sessions and asserts the property that survives every interleaving,
+# so the two are different levels of the same claim rather than duplicates.
 step("race two overwrite writers on one Delta version")
 with ThreadPoolExecutor(max_workers=2) as executor:
     outcomes = list(executor.map(concurrent_overwrite, (100, 200)))


### PR DESCRIPTION
`concurrent-delta-overwrite-writers` moves off `go:`-only **without a line of
new test code**, because a real third-party probe for it has been running in
`ci:sail` all along and the ledger simply never named it.

## Why this is a citation, not badge-farming

The bar I have been applying: a witness must be able to **disagree** with us.
This one can.

`e2e/sail/driver.py` races two genuine pyspark sessions overwriting the same
Delta table, released at one barrier, and asserts:

- `len(new_versions) == committed` — **one new `_delta_log` version per
  successful commit**. Fewer means two writers landed on the same version and an
  update was lost, which is precisely what the conditional PUT exists to prevent
- versions are **contiguous**, so a commit did not skip one and leave a hole a
  reader stops at
- the surviving table is **one writer's full overwrite**, not a blend of both

Any of those fails if the emulator's conditional-create contract is wrong.

## The two witnesses are different levels, not duplicates

| witness | level |
|---|---|
| `go:TestConcurrentDeltaCommitRace` | 24 blob PUTs with `If-None-Match: *`, asserting 1 created / 23 conflict directly |
| `ci:sail` | two real pyspark sessions, asserting the invariant that survives every interleaving |

I added a comment at the probe saying which parity row it witnesses, so the
relationship is discoverable from the code rather than only from the ledger.

## The trap the probe already documents, and why the assertion is shaped this way

The probe deliberately does **not** assert "exactly one commits":

> The barrier synchronises the START of the two writes, not their overlap. If
> writer A finishes its commit before writer B reads the table version, B
> legitimately commits on top of A: two successes, no conflict, and nothing is
> wrong. Serialisation is a VALID outcome of racing two writers, and an
> assertion that forbids it fails on a correct server — this suite asserted
> `outcomes.count("committed") == 1` and went red on exactly that, **1 run in 13**.

That is why the invariant is "one version per commit" rather than "one commit".
Worth reading before anyone tightens it back.

## Verification

`check_witnesses.py --strict` passes; `ci:sail` resolves to a real job
(`ci.yml:1185`). No behaviour change — one ledger entry and one comment.