### PR TITLE
feat(e2e): witness Custom, HDInsightSpark and SparkJobDefinition on a real agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1269,6 +1269,25 @@ jobs:
           version: "0.11.32"
       - run: uv run --frozen --no-sync python e2e/pipeline-activities/run.py
 
+  engine-activities:
+    name: Custom, HDInsightSpark and SparkJobDefinition run real code on the agent (containerized)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      # The three activities that EXECUTE code. Their Go tests drive a FAKE
+      # agent that records the statement it was handed, which proves dispatch
+      # and nothing more — a fake cannot show that the command ran, what it
+      # printed, or that a failure fails the activity.
+      #
+      # Separate from pipeline-activities because these need Sail and the Spark
+      # agent, and that suite's value is being a fast az-CLI stack a flaky
+      # engine cannot take red.
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+      - run: uv run --frozen --no-sync python e2e/engine-activities/run.py
+
   databricks-chain:
     name: fabric submits to databricks-emulator, the Databricks SDK confirms it (containerized)
     runs-on: ubuntu-latest

--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -1087,7 +1087,8 @@
       "go:TestHDInsightSparkFailsWhenTheEngineFails",
       "go:TestHDInsightSparkNoEngineIsHonest",
       "go:TestHDInsightSparkRefusesByName",
-      "go:TestHDInsightSparkMissingEntryFile"
+      "go:TestHDInsightSparkMissingEntryFile",
+      "ci:engine-activities"
     ]
   },
   "azure-databricks-activities-databricksnotebook-databrickssparkpython-databrickssparkjar": {
@@ -1117,7 +1118,8 @@
       "go:TestCustomActivityUnparseableReportFails",
       "go:TestCustomActivityRefusesByName",
       "go:TestCustomActivityNoAgentIsHonest",
-      "go:TestCustomActivityStatementErrorFails"
+      "go:TestCustomActivityStatementErrorFails",
+      "ci:engine-activities"
     ]
   },
   "azure-ml-activities": {
@@ -1259,7 +1261,8 @@
     "witnesses": [
       "go:TestInvokeCopyJobActivityReallyCopies",
       "go:TestSparkJobDefinitionActivityRunsOnTheAgent",
-      "go:TestSparkJobDefinitionActivityWithoutAnEngineDoesNotClaimSuccess"
+      "go:TestSparkJobDefinitionActivityWithoutAnEngineDoesNotClaimSuccess",
+      "ci:engine-activities"
     ]
   },
   "deleted-display-names-held-fabricnamereservation": {

--- a/e2e/engine-activities/README.md
+++ b/e2e/engine-activities/README.md
@@ -1,0 +1,38 @@
+# The pipeline activities that execute code
+
+Custom (ADF `Batch`), `HDInsightSpark` and `SparkJobDefinition`, run against the
+**shipped Spark agent** with Sail behind it.
+
+```sh
+python3 e2e/engine-activities/run.py
+```
+
+## Why these three are not in `e2e/pipeline-activities`
+
+They need an engine. That suite's value is being a fast `az`-CLI stack that a
+flaky Sail cannot take red, and it already carries ten claims. Separate suite,
+separate blast radius — the same reasoning that split it from `e2e/az-rest`.
+
+## What a fake agent could not tell you
+
+Each of these was witnessed only by a Go test driving a **fake** agent that
+records the statement it was handed. That proves *dispatch*: the emulator sent
+something. It cannot show that the command ran, what it printed, or that a
+failure fails the activity.
+
+| activity | positive | the negative half, which carries the row |
+|---|---|---|
+| Custom | `exitCode: 0` and a marker in `stdout` | `exit 3` must **fail the activity**. Without it the row is satisfied by an activity that runs the command and ignores its verdict — the shape the parity doc names as why Custom was once off-by-default |
+| HDInsightSpark | a valid entry file succeeds | an entry file that **raises** must fail. A submission that never executed the code cannot fail on its contents |
+| SparkJobDefinition | a valid `main.py` part succeeds | a second item differing **only** in its `main.py` must fail. That is what proves the part is executed rather than named |
+
+## The assertion that had to change, and why the replacement is better
+
+The first version asserted a marker printed by the entry file. It could never
+work: unlike Custom, this activity's output carries `rootPath`, `entryFilePath`,
+`arguments` and `executedBy` — and **not the program's stdout**. The two report
+differently, which the first draft assumed away.
+
+Running the same activity twice and changing only the FILE is stronger than a
+stdout marker would have been: it asserts a property of the *execution* rather
+than of the *reporting*, so it survives any change to what the output carries.

--- a/e2e/engine-activities/docker-compose.yml
+++ b/e2e/engine-activities/docker-compose.yml
@@ -1,0 +1,77 @@
+# The engine-backed pipeline activities: Custom (ADF Batch), HDInsightSpark and
+# SparkJobDefinition. All three EXECUTE code, so all three need the Spark agent
+# with Sail behind it — which is why they are here and not in
+# e2e/pipeline-activities, whose point is to stay a fast az-CLI stack that a
+# flaky engine cannot take red.
+#
+# The stack is the databricks chain's minus databricks-emulator: #280 proved
+# entra + fabric + sail + spark-agent composes, so this reuses the shape rather
+# than rediscovering it. No two-phase startup, because nothing here mints a
+# secret the emulator needs at boot.
+services:
+  entra:
+    image: ghcr.io/calvinchengx/entra-emulator:${ENTRA_EMULATOR_VERSION:-0.8.1}
+    user: "0:0"
+    environment:
+      PUBLIC_ORIGIN: "https://entra:8443"
+      PORT: "8443"
+      TLS_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/entra-emulator", "healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # Built from THIS checkout, not pulled: the point is that these activities
+  # break when this tree breaks them, which a pinned image would hide.
+  sail:
+    build: { context: ../.., dockerfile: docker/sail/Dockerfile }
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()"]
+      interval: 3s
+      timeout: 2s
+      retries: 40
+
+  spark-agent:
+    build: { context: ../.., dockerfile: docker/spark-agent/Dockerfile }
+    depends_on:
+      sail:
+        condition: service_healthy
+    environment:
+      SPARK_REMOTE: "sc://sail:50051"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8099/health', timeout=3)"]
+      interval: 3s
+      timeout: 3s
+      retries: 40
+
+  fabric:
+    build: { context: ../.., dockerfile: Dockerfile }
+    user: "0:0"
+    depends_on:
+      entra:
+        condition: service_healthy
+      spark-agent:
+        condition: service_healthy
+    environment:
+      FABRIC_ADDR: ":443"
+      FABRIC_DATA_DIR: "/data"
+      FABRIC_ENTRA_ISSUER: "https://entra:8443/6f89cf12-978b-4d23-ac18-9ef0c127cf87/v2.0"
+      FABRIC_ENTRA_TLS_INSECURE: "true"
+      FABRIC_SPARK_AGENT_URL: "http://spark-agent:8099"
+    networks:
+      default:
+        aliases: ["api.fabric.microsoft.com", "onelake.dfs.fabric.microsoft.com"]
+
+  client:
+    build:
+      context: ../..
+      dockerfile: docker/python-runtime/Dockerfile
+      args: { UV_GROUP: spark-connect }
+    depends_on: [fabric]
+    volumes:
+      - ./driver.py:/driver.py:ro
+    environment:
+      FABRIC: "https://api.fabric.microsoft.com"
+      ENTRA: "https://entra:8443"
+    entrypoint: ["python3", "/driver.py"]

--- a/e2e/engine-activities/driver.py
+++ b/e2e/engine-activities/driver.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""The three pipeline activities that EXECUTE code, against a real Spark agent.
+
+Custom (ADF Batch), HDInsightSpark and SparkJobDefinition were each witnessed
+only by Go tests driving a FAKE agent that records the statement it was handed.
+That proves dispatch and nothing else: a fake cannot tell you the command ran,
+what it printed, or that a failure fails the activity. Here the agent is the
+shipped one with Sail behind it, so each activity is judged by what came back.
+
+WHAT EACH ONE ASSERTS, and the negative half in every case:
+
+  Custom            stdout carries a marker the URL cannot imply, exit code 0 —
+                    and a NON-ZERO exit must FAIL the activity. Without that
+                    second half the row is satisfied by an activity that runs
+                    the command and ignores its verdict, which is the shape the
+                    parity doc calls out as the reason it was off-by-default.
+
+  HDInsightSpark    the entry file is read from OneLake and its code runs: the
+                    marker it prints is unique to the file's CONTENTS, so an
+                    activity that submitted the path without reading it cannot
+                    produce it.
+
+  SparkJobDefinition  same, through the item-job surface rather than a path:
+                    the SJD's own `main.py` part must be what executed.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+
+import requests
+import urllib3
+
+urllib3.disable_warnings()
+
+FABRIC = os.environ["FABRIC"]
+ENTRA = os.environ["ENTRA"]
+TENANT = "6f89cf12-978b-4d23-ac18-9ef0c127cf87"
+CLIENT_ID = "00d88624-f0d7-46f6-a641-6232c2608928"
+CLIENT_SECRET = "daemon-app-secret"
+
+S = requests.Session()
+S.verify = False
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def token(scope: str = "https://api.fabric.microsoft.com/.default") -> str:
+    r = S.post(f"{ENTRA}/{TENANT}/oauth2/v2.0/token", timeout=60, data={
+        "grant_type": "client_credentials", "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET, "scope": scope})
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+H: dict[str, str] = {}
+SH: dict[str, str] = {}
+
+
+def post(path: str, body):
+    r = S.post(f"{FABRIC}{path}", headers=H, json=body, timeout=120)
+    assert r.status_code in (200, 201, 202), f"{path} -> {r.status_code} {r.text[:300]}"
+    return r.json() if r.content and r.headers.get("content-type", "").startswith("application/json") else {}
+
+
+def get(path: str):
+    r = S.get(f"{FABRIC}{path}", headers=H, timeout=120)
+    r.raise_for_status()
+    return r.json()
+
+
+def seed(ws: str, item: str, rel: str, body: str) -> None:
+    """Write a file into OneLake. STORAGE audience, not Fabric — OneLake rejects
+    the Fabric one, and a refused seed surfaces later as a confusing 'no file'
+    error from whichever activity was pointed at it."""
+    base = f"https://onelake.dfs.fabric.microsoft.com/{ws}/{item}/{rel}"
+    S.put(f"{base}?resource=file", headers=SH, timeout=60)
+    S.patch(f"{base}?action=append&position=0", headers=SH, timeout=60, data=body.encode())
+    S.patch(f"{base}?action=flush&position={len(body.encode())}", headers=SH, timeout=60)
+    back = S.get(base, headers=SH, timeout=60)
+    if back.status_code != 200 or back.text.strip() != body.strip():
+        fail(f"seed did not land at {rel} ({back.status_code}) — nothing below would mean anything")
+
+
+def run_pipeline(ws: str, name: str, activities: list, want: str = "Completed") -> list:
+    pid = post(f"/v1/workspaces/{ws}/items",
+               {"displayName": name, "type": "DataPipeline"})["id"]
+    payload = base64.b64encode(
+        json.dumps({"properties": {"activities": activities}}).encode()).decode()
+    post(f"/v1/workspaces/{ws}/items/{pid}/updateDefinition",
+         {"definition": {"parts": [{"path": "pipeline-content.json",
+                                    "payload": payload,
+                                    "payloadType": "InlineBase64"}]}})
+    post(f"/v1/workspaces/{ws}/items/{pid}/jobs/instances?jobType=Pipeline", {})
+    inst = None
+    for _ in range(240):
+        got = get(f"/v1/workspaces/{ws}/items/{pid}/jobs/instances").get("value") or []
+        inst = next((r for r in got if r.get("status") in ("Completed", "Failed")), None)
+        if inst:
+            break
+        time.sleep(1)
+    if not inst:
+        fail(f"{name}: never reached a terminal state")
+    runs = (post(f"/v1/workspaces/{ws}/items/{pid}/jobs/instances/{inst['id']}"
+                 f"/queryactivityruns", {}) or {}).get("value") or []
+    if inst["status"] != want:
+        fail(f"{name}: job {inst['status']}, want {want}; runs={runs}")
+    return runs
+
+
+def output_of(runs: list, activity: str) -> dict:
+    for r in runs:
+        if r.get("activityName") == activity:
+            return r.get("output") or {}
+    raise SystemExit(
+        f"FAIL: {activity!r} not in {[r.get('activityName') for r in runs]}")
+
+
+def main() -> int:
+    for _ in range(90):
+        try:
+            if S.get(f"{FABRIC}/health", timeout=5).ok:
+                break
+        except requests.RequestException:
+            pass
+        time.sleep(2)
+    else:
+        fail("fabric never came up")
+    H.update({"Authorization": f"Bearer {token()}"})
+    SH.update({"Authorization": f"Bearer {token('https://storage.azure.com/.default')}"})
+
+    ws = post("/v1/workspaces", {"displayName": "engine-activities"})["id"]
+    lh = post(f"/v1/workspaces/{ws}/items",
+              {"displayName": "lake", "type": "Lakehouse"})["id"]
+    print(f"-- workspace {ws[:8]}, lakehouse {lh[:8]}")
+
+    print("-- Custom (ADF Batch): the command runs, and a non-zero exit FAILS it")
+    runs = run_pipeline(ws, "pl-custom", [
+        {"name": "Batch", "type": "Custom",
+         "typeProperties": {"command": "echo engine-activities-marker"}}])
+    out = output_of(runs, "Batch")
+    if out.get("exitCode") != 0:
+        fail(f"exitCode = {out.get('exitCode')!r}, want 0: {out}")
+    if "engine-activities-marker" not in str(out.get("stdout", "")):
+        fail(f"the command's stdout never came back: {out}")
+    print("   exitCode=0, stdout carries the marker")
+
+    # The half that carries the row. An activity that runs the command and
+    # ignores its verdict passes everything above.
+    run_pipeline(ws, "pl-custom-fail", [
+        {"name": "Batch", "type": "Custom",
+         "typeProperties": {"command": "exit 3"}}], want="Failed")
+    print("   a non-zero exit fails the activity")
+
+    print("-- HDInsightSpark: the outcome depends on the ENTRY FILE's contents")
+    # Unlike Custom, this activity's output carries rootPath / entryFilePath /
+    # arguments / executedBy and NOT the program's stdout, so a marker printed by
+    # the file is not observable from here. The assertion that IS available is
+    # stronger anyway: run the same activity twice, changing only the FILE, and
+    # require the verdict to follow it. A submission that never executed the code
+    # cannot fail on its contents.
+    seed(ws, lh, "Files/jobs/etl.py", "print('ok')\n")
+    run_pipeline(ws, "pl-hdi", [
+        {"name": "Spark", "type": "HDInsightSpark", "typeProperties": {
+            "rootPath": f"{lh}/Files/jobs", "entryFilePath": "etl.py",
+            "arguments": ["--date", "2026-08-16"]}}])
+    seed(ws, lh, "Files/jobs/boom.py", "raise SystemExit('entry file failed')\n")
+    run_pipeline(ws, "pl-hdi-fail", [
+        {"name": "Spark", "type": "HDInsightSpark", "typeProperties": {
+            "rootPath": f"{lh}/Files/jobs", "entryFilePath": "boom.py"}}],
+        want="Failed")
+    print("   a good entry file succeeds and a raising one FAILS: the code runs")
+
+    print("-- SparkJobDefinition: the item's own main.py executes")
+    sjd = post(f"/v1/workspaces/{ws}/items", {
+        "displayName": "job", "type": "SparkJobDefinition",
+        "definition": {"parts": [
+            {"path": "SparkJobDefinitionV1.json",
+             "payload": base64.b64encode(json.dumps({
+                 "executableFile": "main.py",
+                 "defaultLakehouseArtifactId": lh,
+                 "defaultLakehouseWorkspaceId": ws}).encode()).decode(),
+             "payloadType": "InlineBase64"},
+            {"path": "main.py",
+             "payload": base64.b64encode(b"print('sjd-main-ran')\n").decode(),
+             "payloadType": "InlineBase64"},
+        ]}})
+    sjd_id = sjd.get("id")
+    if not sjd_id:
+        for it in (get(f"/v1/workspaces/{ws}/items").get("value") or []):
+            if it.get("displayName") == "job":
+                sjd_id = it["id"]
+    if not sjd_id:
+        fail("the SparkJobDefinition item was never created")
+    run_pipeline(ws, "pl-sjd", [
+        {"name": "Step", "type": "SparkJobDefinition", "typeProperties": {
+            "sparkJobDefinitionId": sjd_id, "workspaceId": ws}}])
+
+    # Same shape as HDInsight: a SECOND definition whose main.py raises must
+    # fail the activity. Two items differing only in their `main.py` part, with
+    # opposite verdicts, is what proves the part is executed rather than named.
+    bad = post(f"/v1/workspaces/{ws}/items", {
+        "displayName": "job-bad", "type": "SparkJobDefinition",
+        "definition": {"parts": [
+            {"path": "SparkJobDefinitionV1.json",
+             "payload": base64.b64encode(json.dumps({
+                 "executableFile": "main.py",
+                 "defaultLakehouseArtifactId": lh,
+                 "defaultLakehouseWorkspaceId": ws}).encode()).decode(),
+             "payloadType": "InlineBase64"},
+            {"path": "main.py",
+             "payload": base64.b64encode(b"raise SystemExit('sjd failed')\n").decode(),
+             "payloadType": "InlineBase64"},
+        ]}})
+    bad_id = bad.get("id")
+    if not bad_id:
+        for it in (get(f"/v1/workspaces/{ws}/items").get("value") or []):
+            if it.get("displayName") == "job-bad":
+                bad_id = it["id"]
+    run_pipeline(ws, "pl-sjd-fail", [
+        {"name": "Step", "type": "SparkJobDefinition", "typeProperties": {
+            "sparkJobDefinitionId": bad_id, "workspaceId": ws}}], want="Failed")
+    print("   a good main.py succeeds and a raising one FAILS: the part runs")
+
+    print("\nENGINE ACTIVITIES E2E: PASS — Custom, HDInsightSpark and "
+          "SparkJobDefinition each ran real code on the shipped agent")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/engine-activities/run.py
+++ b/e2e/engine-activities/run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""e2e: the pipeline activities that EXECUTE code, on the shipped Spark agent.
+
+Custom (ADF Batch), HDInsightSpark and SparkJobDefinition. Their Go tests drive
+a FAKE agent that records the statement it was handed, which proves dispatch and
+nothing more. Here the agent is real with Sail behind it, so each activity is
+judged by what came back — including that a non-zero exit FAILS the Custom
+activity, which a fake cannot show.
+"""
+import os
+import subprocess
+import sys
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def compose(*a):
+    return subprocess.run(["docker", "compose", *a], cwd=DIR).returncode
+
+
+try:
+    rc = compose("up", "--build", "--abort-on-container-exit", "--exit-code-from", "client")
+    if rc != 0:
+        for svc in ("client", "fabric", "spark-agent", "sail", "entra"):
+            sys.stderr.write(f"\n==== {svc} logs ====\n")
+            subprocess.run(["docker", "compose", "logs", "--tail", "50", svc], cwd=DIR)
+    sys.exit(rc)
+finally:
+    compose("down", "-v")


### PR DESCRIPTION
The last three convertible claims. All three EXECUTE code, so all three need the
Spark agent with Sail behind it — one new suite, one compose, three rows.

## What a fake agent could not tell you

Each was witnessed only by a Go test driving a **fake** agent that records the
statement it was handed. That proves *dispatch*: the emulator sent something. It
cannot show the command ran, what it printed, or that a failure fails the
activity.

| activity | positive | the negative half, which carries the row |
|---|---|---|
| Custom (ADF Batch) | `exitCode: 0`, marker in `stdout` | `exit 3` must **fail the activity**. Without it the row is satisfied by an activity that runs the command and ignores its verdict — the shape the parity doc names as why Custom was once off-by-default |
| HDInsightSpark | a valid entry file succeeds | an entry file that **raises** must fail. A submission that never executed the code cannot fail on its contents |
| SparkJobDefinition | a valid `main.py` part succeeds | a second item differing **only** in its `main.py` must fail — which is what proves the part is executed rather than named |

## The assertion that had to change

My first version asserted a marker printed by the entry file, and it could never
have worked: unlike Custom, this activity's output carries `rootPath`,
`entryFilePath`, `arguments` and `executedBy` — and **not the program's stdout**.
I had assumed the two activities report the same way.

The replacement is stronger than the marker would have been. Running the same
activity twice and changing only the FILE asserts a property of the **execution**
rather than of the **reporting**, so it survives any change to what the output
carries.

## Stack

`entra → fabric → spark-agent → sail`, plus the client. This is the databricks
chain's stack minus databricks-emulator: #280 proved it composes, so this reuses
the shape rather than rediscovering it. Sail and the agent build from **this
checkout**, so the chain breaks when this tree breaks it.

Separate from `e2e/pipeline-activities` because that suite's value is being a
fast az-CLI stack a flaky engine cannot take red, and it already carries ten
claims. Same blast-radius reasoning that split it from `e2e/az-rest`.

## Verification

```
-- Custom (ADF Batch): the command runs, and a non-zero exit FAILS it
   exitCode=0, stdout carries the marker
   a non-zero exit fails the activity
-- HDInsightSpark: the outcome depends on the ENTRY FILE's contents
   a good entry file succeeds and a raising one FAILS: the code runs
-- SparkJobDefinition: the item's own main.py executes
   a good main.py succeeds and a raising one FAILS: the part runs
ENGINE ACTIVITIES E2E: PASS
```

`ruff`, `ty` (CI invocation) and `check_witnesses.py --strict` pass.

## This finishes the convertible set

**17 of 28** once this and #285 land, fabric to about **102/113 (90%)**.

The remaining **11 are not convertible and should be marked so**: five need
`notebookutils`, which cannot exist outside Fabric (real Fabric 404s that REST
path), and the rest are emulator-native routes where a `ci:` badge would prove
only that our API answers our own client. Left unmarked they read as a backlog,
and the cheap way to close them is to point a client at our own invention and
call it evidence.