### PR TITLE
feat(e2e): witness the Reflex event trigger with Microsoft's Blob SDK

### DIFF
--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -235,7 +235,8 @@
       "go:TestEventTriggerCRUD",
       "go:TestEventTriggerValidationAndRBAC",
       "go:TestRenameEmitsItsOwnEventType",
-      "go:TestSafeNavigationAndTriggerEvent"
+      "go:TestSafeNavigationAndTriggerEvent",
+      "ci:adls-sdk"
     ]
   },
   "real-time-intelligence-eventhouse-kql-database-real-time-intelligence": {

--- a/e2e/adls-sdk/driver.py
+++ b/e2e/adls-sdk/driver.py
@@ -13,6 +13,7 @@ Two independent oracles in one run:
 Driving the real SDK is what surfaced the x-ms-range gap (the Blob client
 sends its range as x-ms-range, not Range, and requires 206 + Content-Range).
 """
+import base64
 import json
 import os
 import ssl
@@ -116,5 +117,73 @@ with urllib.request.urlopen(req, context=_CTX) as r:
     dfs = [p["name"] for p in json.loads(r.read())["paths"]]
 assert any(n.endswith("cities.parquet") for n in dfs), dfs
 print(f"DFS surface sees the SDK-written blob: {len(dfs)} paths")
+
+# --------------------------------------- an SDK write FIRES an event trigger
+#
+# The parity row for Reflex event triggers was witnessed only by Go tests, on
+# the reading that the trigger BINDING is an emulator-native surface (Fabric
+# publishes no REST for it) so nothing external could witness it. That confuses
+# the definition with the effect. The binding is ours; the two things that
+# matter are not:
+#
+#   * the WRITE is Microsoft's Azure Blob SDK, already used above, and
+#   * the EFFECT is a real item job, readable over public Fabric REST.
+#
+# So the assertion is end to end through third-party surfaces: a file uploaded
+# by the SDK causes a job the Fabric API reports as EventTriggered.
+lake = post_json(f"{FABRIC}/v1/workspaces/{ws['id']}/items",
+                 {"displayName": "trig-lake", "type": "Lakehouse"}, fabric_token)
+reflex = post_json(f"{FABRIC}/v1/workspaces/{ws['id']}/items",
+                   {"displayName": "watcher", "type": "Reflex"}, fabric_token)
+pipe = post_json(f"{FABRIC}/v1/workspaces/{ws['id']}/items",
+                 {"displayName": "on-landing", "type": "DataPipeline"}, fabric_token)
+wait_def = base64.b64encode(json.dumps({"properties": {"activities": [
+    {"name": "Pause", "type": "Wait", "typeProperties": {"waitTimeInSeconds": 0}}]}}).encode()).decode()
+post_json(f"{FABRIC}/v1/workspaces/{ws['id']}/items/{pipe['id']}/updateDefinition",
+          {"definition": {"parts": [{"path": "pipeline-content.json",
+                                     "payload": wait_def,
+                                     "payloadType": "InlineBase64"}]}}, fabric_token)
+post_json(f"{FABRIC}/v1/workspaces/{ws['id']}/reflexes/{reflex['id']}/triggers", {
+    "displayName": "on-landing", "eventType": "Microsoft.Fabric.OneLake.FileCreated",
+    "source": {"itemId": lake["id"], "pathPrefix": "Files/landing"},
+    "action": {"itemId": pipe["id"], "jobType": "Pipeline"}}, fabric_token)
+
+
+def pipeline_runs():
+    req = urllib.request.Request(
+        f"{FABRIC}/v1/workspaces/{ws['id']}/items/{pipe['id']}/jobs/instances",
+        headers={"Authorization": "Bearer " + fabric_token})
+    with urllib.request.urlopen(req, context=_CTX) as r:
+        return json.loads(r.read()).get("value") or []
+
+
+def sdk_put(rel, body):
+    svc.get_blob_client(container=container,
+                        blob=f"trig-lake.Lakehouse/{rel}").upload_blob(body, overwrite=True)
+
+
+# The NEGATIVE half first: a write outside the watched prefix must start
+# nothing. Without it, a trigger that fires on every write would pass.
+sdk_put("Files/other/ignored.csv", b"x")
+time.sleep(2)
+assert not pipeline_runs(), f"a write outside the prefix started a run: {pipeline_runs()}"
+print("event trigger: an SDK write outside the prefix starts nothing")
+
+sdk_put("Files/landing/orders.csv", b"id\n1\n")
+runs = []
+for _ in range(60):
+    runs = pipeline_runs()
+    if runs:
+        break
+    time.sleep(0.5)
+assert len(runs) == 1, f"watched write started {len(runs)} runs, want 1: {runs}"
+assert runs[0].get("invokeType") == "EventTriggered", runs[0]
+for _ in range(60):
+    got = pipeline_runs()
+    if got and got[0].get("status") in ("Completed", "Failed"):
+        break
+    time.sleep(0.5)
+assert got[0]["status"] == "Completed", got[0]
+print(f"event trigger: the SDK's write ran the pipeline, invokeType={runs[0]['invokeType']}")
 
 print("ADLS-SDK E2E: PASS")


### PR DESCRIPTION
`event-triggers-reflex-data-activator-on-onelake-events` moves off `go:`-only.
No new service: `e2e/adls-sdk` already drives Microsoft's **Azure Blob SDK**
against OneLake, which is exactly the client that fires a file event.

## I had written this off, and the reasoning was wrong

I classified it as un-witnessable because the trigger **binding** is an
emulator-native surface — Fabric publishes no REST for it, so nothing external
can witness that route. True, and irrelevant to what the claim says.

The claim is that the trigger **fires**, and both ends of that are third-party
reachable:

- the **write** is Microsoft's Azure Blob SDK
- the **effect** is a real item job, readable over **public** Fabric REST as
  `invokeType: EventTriggered`

Only the setup call in the middle is ours, and setup is not the assertion. The
mistake was confusing the definition surface with the effect — which is the same
error that had `materialized-lake-views` on that list too.

## Both halves

```
event trigger: an SDK write outside the prefix starts nothing
event trigger: the SDK's write ran the pipeline, invokeType=EventTriggered
```

The negative half comes first deliberately. Without it, a trigger that fired on
**every** write would pass the positive case — the path prefix would be
decorative and nobody would know.

The pipeline is a bare `Wait` activity, so this needs no engine: what is being
witnessed is the trigger, not the work.

## Verification

Suite green end to end locally (`ADLS-SDK E2E: PASS`), `ruff` clean,
`check_witnesses.py --strict` passes.

## Revised view of what is left

This is the first of the three I said were reachable now. Remaining:

- **`materialized-lake-views`** — the refresh writes a real Delta table under
  `Tables/<name>`, and the parity row says so itself: *"a Delta reader ... see[s]
  a refresh exactly as they see any other write"*. `delta-rs` is already in CI,
  but the refresh needs the engine stack, so it is real work rather than a
  citation.
- **`asynchronous-outcomes-forced-fabricforcelro`** — the toggle is
  emulator-only, but what it produces is the standard 202 + `Location` + poll
  contract, and a client with its own polling (`fab`, Terraform) either follows
  it or does not.

After those, **two** claims are genuinely un-witnessable rather than ten:
`eventstream-operators` and `eventstream-eventhouse-destination`, where both the
route and the semantics are ours. The other five are gated on the real-Fabric
differential leg, which needs the three unset secrets.