### PR TITLE
docs: the missing v0.26.0 and v0.27.0 release notes

### DIFF
--- a/docs/release-notes/v0.26.0.md
+++ b/docs/release-notes/v0.26.0.md
@@ -1,0 +1,143 @@
+# v0.26.0
+
+The range starts at `fb1e6aa` (#254), the first commit after the `v0.25.0`
+tag: 26 commits. Most of them are one thing done repeatedly. **DAX scalars
+were pinned against Power BI Desktop captures**, function family by function
+family, and the exercise found a parity defect that no local test could have
+reported. Alongside that the Spark engine moved to Sail 0.7.0, `arm-emulator`
+became a default service in this repo's compose, and the compute images gained
+names that say what is inside them.
+
+One of these changes what `docker compose up` starts, and one changes what a
+DAX expression returns. Read the first section before you pull.
+
+---
+
+## Behaviour changes, read this one first
+
+- **`arm-emulator` now starts with `docker compose up` in this repo.** Fabric
+  capacities are ARM resources, and without arm there was nowhere for
+  `Microsoft.Fabric/capacities` to go: `GET /v1/capacities` served only the
+  seeded local one, which is a visibly smaller Fabric than the documentation
+  describes. arm is now wired exactly as the family BOM wires it, same issuer,
+  tenant and subscription, so the two stacks cannot disagree.
+
+  `FABRIC_ARM_URL` uses `-` rather than `:-`, matching `KV_ARM_URL` in the BOM,
+  so an **explicitly empty** value opts back out to the seeded capacity and
+  standalone `fabric-cicd` still works. **The binary default is unchanged**:
+  still empty, still standalone. Only this compose file changed, and
+  `docs/04-configuration.md` and `docs/07-control-plane-api.md` now distinguish
+  the two rather than calling the feature opt-in.
+
+- **`DIVIDE`'s third argument is now honoured.** `DIVIDE(numerator,
+  denominator [, alternateResult])` returns `alternateResult` when the
+  denominator is 0. The arity guard was `len(args) < 2`, so a third argument
+  was accepted and then never read: `DIVIDE(x, 0, 0)` answered BLANK where
+  Fabric answers 0.
+
+  This is the failure direction that ships. The query parses, evaluates and
+  returns a plausible number, so there is no local symptom at all and nothing
+  to investigate until someone compares against a tenant. `IF`, twelve lines
+  below, has the same `< 2` guard and does read `args[2]`, which is what makes
+  this an oversight rather than a decision. The guard is now `< 2 || > 3`, so a
+  fourth argument is rejected rather than silently dropped.
+
+  **Provenance, stated because it differs from the goldens next door:** the
+  `alternateResult` semantics come from Microsoft's DAX reference, not from a
+  Desktop capture. Nobody ran the msmdsrv oracle for this, so the assertions
+  live in `dax_arity_test.go` and deliberately not in `desktop_goldens.json`,
+  whose every entry means "Desktop answered this".
+
+- **The Spark engine is Sail 0.7.0**, and the Connect client moves with it to
+  `pyspark-client` 4.2.0. The UDF runs inside the Sail server's embedded
+  CPython, so server and client must agree; pysail 0.7.0's own `test` extra
+  pins 4.2.0 where 0.6.6 pinned 4.1.1. The client is pinned in **five** groups,
+  not one (`sail`, `sail-delta`, `jupyter`, `spark-connect`, `data-science-loop`),
+  and all five move together. The JVM overlay is unaffected: it never uses
+  `pyspark-client` at all, going through spark-submit and Livy with the image's
+  own pyspark.
+
+## DAX pinned against Desktop, not against our reading
+
+The bulk of the range. Each of these is a family of scalars whose answers now
+come from a Power BI Desktop capture rather than from our interpretation of the
+reference:
+
+`SIGN`, `ASIN`, `ATAN`, `PI`, `SIN`, `COS`, `TAN`, `DEGREES`, `RADIANS`,
+`DATE`, `YEAR`, `MONTH`, `DAY`, `TIME`, `HOUR`, `MINUTE`, `SECOND`, `INT`,
+`MIN`, `AVERAGE`, `COUNT`, `POWER`, the remaining Phase 3 scalars, and `ROW`.
+
+Three additions are about the edges rather than the happy path: `SWITCH` with
+no else branch, the `1.0 == 1` comparison, and eight BLANK and error edges that
+the numeric goldens cannot express. The `DIVIDE` fix above also salvaged 16
+Desktop probes that had been captured but were unusable while the third
+argument was being dropped.
+
+## Engine claims corrected
+
+Two notes that were true of an engine this repo no longer pins:
+
+- The `localRelationSizeLimit` preset is dropped. On 0.7.0 evidence it capped
+  3 GiB to 64 MiB, so it was making things worse rather than better. (v0.27.0
+  revisits this: the preset was measured while a separate defect masked the
+  case that needed it, and the fix is to ask the engine rather than assume
+  either constant.)
+- The `VALUES` behaviour was credited to an engine that is no longer pinned.
+  The credit is removed rather than reassigned, because nobody re-measured it.
+
+## Compute images say what is inside them
+
+Both sidecars now also publish under names that describe their contents rather
+than the repo that builds them, tagged with the version of the dependency each
+is pinned for:
+
+```
+ghcr.io/calvinchengx/emulator-sail:0.7.0            # the pysail pin
+ghcr.io/calvinchengx/emulator-spark-agent:4.2.0     # the pyspark-client pin
+```
+
+The old naming conflated two things. `fabric-emulator-sail` carries upstream
+Sail, and `databricks-emulator` consumes it with no Fabric in the picture at
+all; and the tag was fabric's release number while the Sail inside was 0.6.6,
+so `0.22.0` and `0.25.0` contained the same engine with nothing in either tag
+saying so.
+
+Tags are read from `pyproject.toml` by `scripts/image_tags.py` rather than
+typed into the workflow, because a version written in `release.yml` is a second
+copy of a number: the release that bumps `pysail` without editing the workflow
+publishes a tag naming the version it no longer contains, and nothing fails.
+
+**This is step one, and it moves no consumer.** Both names publish, and the old
+names keep their release-version tags, so `fabric-emulator-sail:0.26.0` and
+`fabric-emulator-spark-agent:0.26.0` exist as before.
+
+## Witnesses
+
+- **Microsoft's `az` CLI** drives git integration, CopyJob, and four pipeline
+  activities.
+- `ty` can now see pyspark, so the statement agent is actually type-checked
+  rather than silently skipped.
+
+## Family alignment
+
+- `entra-emulator` 0.8.1: the Go library, the pin, and the three composes the
+  pins gate cannot see.
+- The consumer repository is now `contoso-fabric-platform`, named in
+  `release.yml` and in the acceptance dispatch.
+
+## Upgrading
+
+**`docker compose up` in this repo now starts `arm-emulator` as well.** If you
+want the previous shape, set `FABRIC_ARM_URL=` explicitly empty and capacities
+fall back to the seeded local one. Running the binary is unchanged.
+
+**If you pin `pyspark-client` yourself, move it to 4.2.0** alongside Sail
+0.7.0. Server and client share the embedded CPython and must agree. The JVM
+overlay needs nothing.
+
+**If a DAX expression relies on `DIVIDE` ignoring its third argument**, it now
+returns that argument on a zero denominator. That is the direction of the
+truth, and any query written against Fabric was already expecting it.
+
+Image names are additive. Nothing that pins `fabric-emulator-sail` or
+`fabric-emulator-spark-agent` by release version needs to change.

--- a/docs/release-notes/v0.27.0.md
+++ b/docs/release-notes/v0.27.0.md
@@ -1,0 +1,94 @@
+# v0.27.0
+
+The range starts at `53a09f6` (#279), the first commit after the `v0.26.0`
+tag: 3 commits. Small, and all three are about the same thing from different
+directions: **code paths that were documented, graded, or shared, and never
+actually run.**
+
+Nothing here changes a contract. There is no upgrade step.
+
+---
+
+## The spark-agent stops assuming one consumer's habits
+
+`databricks-emulator` pulls this repo's spark-agent image, and its delta
+witness died on a statement it never wrote:
+
+```
+MERGE INTO events AS t ...
+IllegalArgumentException: invalid argument: found DETAIL at 9:15
+```
+
+Three defects, each hidden behind the one before it, and the first two are the
+same mistake: **the agent is shared by two emulators, and each defect took one
+consumer's habits for the world.**
+
+1. **`_CREATE_DELTA_LOCATION` required `USING` immediately after the table
+   name.** That is dbt-fabricspark's shape, so every witness in this repo was
+   green. The ordinary `CREATE TABLE events (id INT, name STRING) USING delta
+   LOCATION '…'` did not match, so the location was never recorded, and a MERGE
+   two statements later fell through to a `DESCRIBE DETAIL` that Sail has no
+   grammar for. A missed record has no symptom at the point it happens. The
+   pattern now takes an optional column list, paren-aware so `DECIMAL(10,2)`
+   survives, and clauses between `USING` and `LOCATION`. Writing the shapes
+   down found a second, latent one in this repo: `PARTITIONED BY` before
+   `LOCATION` was unrecorded too.
+
+2. **`resolve()` let the engine's parse error escape.** The module's own
+   comments say Sail cannot parse `DESCRIBE DETAIL`, and then it issued one
+   anyway and let `found DETAIL at 9:15` surface, pointing at column 9 of the
+   user's MERGE. It now raises `DeltaOpError` naming the table, keeping the
+   engine's words as detail rather than as the headline.
+
+3. **`localRelationSizeLimit` is now asked for, not assumed.** With the
+   fall-through fixed, MERGE reached delta-rs and failed while returning its
+   result: `delta_ops` answers via `spark.createDataFrame`, and pyspark calls
+   `int()` on the served conf. Sail 0.7.0 serves `'3221225472'`; the older Sail
+   that databricks-emulator pins serves `'3GB'`.
+
+   v0.26.0 removed the preset on 0.7.0 evidence, which was correct for this
+   repo, **and that measurement was taken while defect 1 masked the case that
+   needed it.** Neither constant is right for a shared image, so `connectconf.py`
+   now reads the value and rewrites only what will not parse, to the same size.
+   No engine's limit is reduced, and no client is handed a string it chokes on.
+
+**The guard is the interesting part.** `python/tests/test_agent_consumer_contract.py`
+records each statement shape a named consumer actually sends, cited to the file
+it comes from, with the answer the agent owes it. No engine, milliseconds, runs
+on every PR. It fails in the repo that would **ship** the regression rather
+than the repo that would suffer it, which is the property a shared artifact
+needs. Four of its rows fail against the code before this change.
+
+Verified on both engines rather than only the one this repo pins:
+databricks-emulator's `e2e/delta` on Sail 0.22.0 advances the log to v4,
+confirmed by delta-rs; this repo's `e2e/sail` on Sail 0.7.0 passes.
+
+## `FABRIC_DATABRICKS_URL` is finally exercised
+
+It was documented in the README, in `docs/04-configuration.md`, in the v0.25.0
+notes and in `internal/api/databricksremote.go`, and it appeared in **no
+workflow anywhere**.
+
+That matters because the parity row grades the Databricks activities 🟢 Real
+(notebook + python, local or `FABRIC_DATABRICKS_URL`). The local half ran on
+every push. The remote half had never executed once. So this is primarily an
+unexercised code path getting exercised; the third-party witness is a side
+effect.
+
+The chain is `entra → fabric → databricks-emulator → spark-agent → sail`, plus
+the client. Sail and the agent build **from this checkout**, so the chain
+breaks when this tree breaks it. A pinned image would have hidden exactly that.
+
+## Five more pipeline activities witnessed
+
+Including the WebHook park, which is the one that holds a run open waiting for
+a callback rather than completing on its own.
+
+## Upgrading
+
+Nothing to do.
+
+If you consume this repo's spark-agent image from another emulator, you get the
+`CREATE TABLE … LOCATION` and `localRelationSizeLimit` fixes above, and a
+`DeltaOpError` that names the table instead of an engine parse error pointing
+at the wrong column.


### PR DESCRIPTION
Both tags published with only the bare GoReleaser `## Changelog`, and
`docs/release-notes/` stopped at v0.25.0. So **two behaviour changes shipped
undocumented**, which is how I found this: sweeping the family BOM to fabric
0.27.0, there was no Upgrading section to read, and the rule for that sweep is
to read one.

Written from the 29 commits and the PRs behind them, not from the commit
subjects.

## What was undocumented

**v0.26.0 (26 commits) has two behaviour changes and neither was recorded:**

- `arm-emulator` now starts with `docker compose up` in this repo, because
  Fabric capacities are ARM resources and without it `GET /v1/capacities`
  served only the seeded one. `FABRIC_ARM_URL=` explicitly empty opts back out.
  The binary default is unchanged, and the notes say so, because the PR found
  the docs had been calling the feature opt-in.
- `DIVIDE`'s third argument is now honoured. It had been accepted and never
  read, so `DIVIDE(x, 0, 0)` answered BLANK where Fabric answers 0. Worth its
  own paragraph because it is the failure direction that ships: the query
  parses, evaluates, and returns a plausible number, so there is no local
  symptom until someone compares against a tenant.

Plus the engine move to Sail 0.7.0 with `pyspark-client` 4.2.0, which anyone
pinning the client themselves needs to know, and the additive `emulator-sail` /
`emulator-spark-agent` image names.

**v0.27.0 (3 commits)** needs no upgrade step, and the notes say so plainly
rather than padding. Its interesting content is that all three commits are the
same shape: code paths documented, graded, or shared, and never actually run.
`FABRIC_DATABRICKS_URL` is the sharpest case, graded 🟢 while its remote half
had never executed once.

## Provenance kept where it differs

The `DIVIDE` semantics come from Microsoft's DAX reference, not a Desktop
capture, and the notes say so, matching the PR's own care to keep that entry
out of `desktop_goldens.json` where every row means "Desktop answered this".

## Next

The published release bodies still show the GoReleaser changelog. I will
replace both from these files once this merges, so the repo file and the
published body match, which is the convention for this repo.

`check_docs_sidebar.py` exit 0: 53 published docs, all reachable.