### PR TITLE
fix: the MLV refresh decoded its query twice, so it never ran on a real engine

### DIFF
--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -1214,7 +1214,8 @@
       "go:TestMLVViewerCannotDefineOrRefresh",
       "go:TestMLVWrongItemTypeIsRefused",
       "go:TestMLVRefreshUnknownView",
-      "go:TestMLVUnknownLakehouse"
+      "go:TestMLVUnknownLakehouse",
+      "ci:sail"
     ]
   },
   "servicenow-via-restsource": {

--- a/e2e/sail/docker-compose.yml
+++ b/e2e/sail/docker-compose.yml
@@ -33,6 +33,11 @@ services:
       FABRIC_DATA_DIR: "" # in-memory; the e2e needs no persistence
       FABRIC_DISABLE_TLS: "true"
       FABRIC_ENTRA_ISSUER: "http://entra-emulator:8443/6f89cf12-978b-4d23-ac18-9ef0c127cf87/v2.0"
+      # A materialized lake view's refresh RUNS ITS QUERY on the statement
+      # agent, so without this the refresh is an honest 502 ("no engine")
+      # rather than a silent success. That 502 is what this suite hit the first
+      # time the MLV witness ran here.
+      FABRIC_SPARK_AGENT_URL: "http://spark-agent:8099"
     healthcheck:
       test: ["CMD", "/usr/local/bin/fabric-emulator", "healthcheck"]
       interval: 3s
@@ -58,6 +63,25 @@ services:
       # Notebook-friendly session lifetime (default is 900s).
       SAIL_SPARK__SESSION_TIMEOUT_SECS: "3600"
       RUST_LOG: "info"
+
+  # The statement agent, which is how the emulator drives Sail for the surfaces
+  # that execute a query rather than proxy one. Added for the MLV refresh; Sail
+  # and its OneLake credentials above are unchanged and already proven by the
+  # Delta writes earlier in this suite.
+  spark-agent:
+    build:
+      context: ../..
+      dockerfile: docker/spark-agent/Dockerfile
+    depends_on:
+      sail:
+        condition: service_started
+    environment:
+      SPARK_REMOTE: "sc://sail:50051"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8099/health', timeout=3)"]
+      interval: 3s
+      timeout: 3s
+      retries: 40
 
   driver:
     build:

--- a/e2e/sail/driver.py
+++ b/e2e/sail/driver.py
@@ -96,6 +96,28 @@ def post_json(url, body, token=None):
         return json.loads(r.read() or b"{}")
 
 
+def post_json_verbose(url, body, token=None):
+    """post_json, but an HTTP error carries the SERVER'S MESSAGE.
+
+    `urllib` raises HTTPError with the body unread, so a failure here arrives as
+    a bare `HTTP Error 502: Bad Gateway` and says nothing about why. The MLV
+    refresh below returns its real reason in that body, and two runs were spent
+    guessing at it before this existed."""
+    try:
+        return post_json(url, body, token)
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode(errors="replace")[:600]
+        raise AssertionError(f"POST {url} -> {err.code}: {detail}") from None
+
+
+def get_json(url, token=None):
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read() or b"{}")
+
+
 def entra_token(scope):
     form = urllib.parse.urlencode({
         "grant_type": "client_credentials",
@@ -427,5 +449,66 @@ print("put-if-absent on an existing commit refused with 409")
 with urllib.request.urlopen(req, timeout=30) as r:
     assert r.read().decode() == first_commit, "the refused PUT modified the commit"
 print("the refused PUT left the existing commit byte-identical")
+
+# ------------------------------------------ materialized lake view REFRESH
+#
+# The MLV row was witnessed only by Go tests, on the reading that its DEFINITION
+# surface is emulator-native (Fabric defines these with Spark SQL DDL no capture
+# here has observed). That is true of the definition and false of the refresh:
+# the parity row says the rows "land in OneLake as a Delta table under
+# `Tables/`, so a Delta reader ... see[s] a refresh exactly as they see any
+# other write". So the refresh is witnessable by anything that reads Delta.
+#
+# What makes this worth asserting rather than assuming: the row also says a
+# refresh is reported successful ONLY IF a Delta commit actually landed,
+# "checked against OneLake rather than inferred from the statement's exit code,
+# because a cheerful statement that wrote nothing is precisely how a view whose
+# rows do not exist would be reported Materialized". `delta_log_versions` reads
+# `_delta_log` straight off OneLake, so it can tell those two apart.
+step("materialized lake view: create, refresh, and read the rows back")
+lakehouses = get_json(f"{FABRIC}/v1/workspaces/{ws['id']}/lakehouses", fabric_token)
+lake_id = next(i["id"] for i in (lakehouses.get("value") or [])
+               if i["displayName"] == "lake")
+mlv_base = f"{FABRIC}/v1/workspaces/{ws['id']}/lakehouses/{lake_id}/materializedlakeviews"
+
+# A DEDICATED source table, not the shared `events` one. The first version
+# aggregated over `events` and asserted {eu: 1, us: 1}; by the time this block
+# runs at the end of a long driver, earlier steps have rewritten that table and
+# the answer was {us: 1, ap: 1, eu: 1}. An assertion that depends on another
+# step's leftovers is a flake waiting for someone to reorder the file.
+spark.sql(
+    "SELECT * FROM VALUES (1,'signup','eu'), (2,'purchase','us'), (3,'signup','us')"
+    " AS t(id, kind, region)"
+).write.format("delta").mode("overwrite").save(
+    "az://sailws/lake.Lakehouse/Tables/mlv_src")
+
+created = post_json_verbose(mlv_base, {
+    "name": "signups_by_region",
+    "query": "SELECT region, count(*) AS n FROM mlv_src WHERE kind = 'signup' GROUP BY region",
+    "dependsOn": ["mlv_src"]}, fabric_token)
+
+# A DEFINITION IS NOT A TABLE. Asserting this first is the negative half: a
+# surface that created the table eagerly would pass every check below while
+# reporting a view as materialised before anything had run.
+assert created.get("state") == "NeverRefreshed", created
+assert not delta_log_versions("signups_by_region"), (
+    "a view that has never refreshed already has a Delta log — the definition "
+    "created a table")
+
+refreshed = post_json_verbose(f"{mlv_base}/signups_by_region/refresh", {}, fabric_token)
+assert refreshed.get("state") == "Materialized", refreshed
+assert refreshed.get("isStale") is False, refreshed
+
+# The commit must EXIST on OneLake, not merely be claimed by the API.
+versions = delta_log_versions("signups_by_region")
+assert versions, "refresh reported Materialized with no Delta commit on OneLake"
+
+# And a Delta reader must see the RIGHT ROWS. The aggregation is over the
+# `events` table written earlier: two signups, one eu and one us.
+mlv_rows = spark.read.format("delta").load(
+    "az://sailws/lake.Lakehouse/Tables/signups_by_region").collect()
+got = {row["region"]: row["n"] for row in mlv_rows}
+assert got == {"eu": 1, "us": 1}, got
+print(f"materialized lake view: {len(versions)} Delta commit(s) on OneLake, rows={got}")
 
 print("PASS: sail e2e")

--- a/internal/api/mlv.go
+++ b/internal/api/mlv.go
@@ -273,10 +273,18 @@ func (a *API) RefreshMaterializedLakeView(v *store.MaterializedLakeView) error {
 		v.WorkspaceID, v.LakehouseID, v.Name)
 	qj, _ := json.Marshal(v.Query)
 	tj, _ := json.Marshal(target)
+	// `qj`/`tj` are JSON string LITERALS, and a JSON string literal is already a
+	// valid Python one — so they are interpolated directly. They used to be
+	// wrapped in `json.loads(...)`, which is one decode too many: Python parses
+	// the literal first, so json.loads received bare SQL and raised
+	//   JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+	// on every refresh. The Go tests never saw it because their agent records
+	// statements without executing them; e2e/sail runs the real agent, and the
+	// first real execution of this path is what found it.
 	code := fmt.Sprintf(`import json
-__df = spark.sql(json.loads(%s))
+__df = spark.sql(%s)
 __n = __df.count()
-__df.write.format("delta").mode("overwrite").save(json.loads(%s))
+__df.write.format("delta").mode("overwrite").save(%s)
 print(json.dumps({"rowCount": __n}))
 `, string(qj), string(tj))
 


### PR DESCRIPTION
Witnessing `materialized-lake-views` with a real engine found that **the refresh
has never worked against one**. The row is graded **🟢 Real (refresh +
staleness)**.

## The defect

`RefreshMaterializedLakeView` generates Python for the statement agent:

```go
qj, _ := json.Marshal(v.Query)                       // → "SELECT region, ..."
code := fmt.Sprintf(`__df = spark.sql(json.loads(%s))`, string(qj))
```

`json.Marshal` emits a **quoted** JSON string. Interpolated into Python source,
the parser unquotes it as a string literal — so `json.loads` receives bare SQL:

```
json.loads("SELECT region, count(*) AS n FROM mlv_src ...")
→ JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

One decode too many, on both the query and the target path. Reproduced in
isolation before changing anything; it matches the CI error character for
character. A JSON string literal is already a valid Python one, so they are now
interpolated directly.

## Why no test caught it

The Go tests drive an agent that **records** statements rather than executing
them, so the generated Python was never run. `e2e/sail` runs the real agent.

Worth noting the emulator's own guard was correct and simply unreachable: the
refresh checks OneLake for a committed Delta table rather than trusting the
statement's exit code — *"a cheerful statement that wrote nothing is precisely
how a view whose rows do not exist would be reported Materialized"*. That check
sits after the statement, which always failed first.

## The witness

`e2e/sail` gains a `spark-agent` (Sail and its OneLake credentials there were
already proven by the Delta writes earlier in that suite), and the driver:

| assertion | what it rules out |
|---|---|
| a never-refreshed view has **no `_delta_log`** | a surface that creates the table eagerly, reporting a view materialised before anything ran |
| refresh reports `Materialized` / `isStale: false` | — |
| a **Delta commit exists on OneLake**, read from `_delta_log` | the API claiming success over nothing |
| a Delta reader returns the **right rows** (`{eu: 1, us: 1}`) | a table that exists but holds the wrong answer |

```
materialized lake view: 1 Delta commit(s) on OneLake, rows={'us': 1, 'eu': 1}
PASS: sail e2e
```

## Two test-side fixes, recorded because both cost a run

**Failures now carry the server's message.** `urllib` raises `HTTPError` with
the body unread, so the refresh failure arrived as a bare `502 Bad Gateway`. Two
runs were spent guessing at the cause before `post_json_verbose` existed. The
real reason was in that body all along.

**The view reads its own source table.** The first version aggregated over the
shared `events` table and asserted `{eu: 1, us: 1}`; by the time this block runs
at the end of a long driver, earlier steps have rewritten it and the answer was
`{us: 1, ap: 1, eu: 1}`. An assertion coupled to another step's leftovers is a
flake waiting for someone to reorder the file.

## Why this row was on the "un-witnessable" list an hour ago

I had classified it as impossible because its **definition** surface is
emulator-native. That confuses the definition with the effect: the refresh is a
real Delta write, and the parity row says so itself — *"a Delta reader ...
see[s] a refresh exactly as they see any other write"*. The moment something
real read it, the path turned out to be broken.