### PR TITLE
Grant id-token to the release's real-Fabric call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,21 @@ jobs:
 
   fabric-qualification:
     uses: ./.github/workflows/real-fabric.yml
+    # `id-token: write` because real-fabric authenticates by OIDC now (#296),
+    # and a CALLED workflow cannot request more than its caller grants. Without
+    # it GitHub refuses the whole run before any job starts, with a
+    # `startup_failure` and no job to read a log from. v0.28.0's first tag hit
+    # exactly that: #296 landed after v0.27.0, so this was the first release to
+    # call the OIDC version and the failure appeared at the tag rather than on
+    # any pull request.
+    #
+    # HERE AND NOT AT THE TOP OF THE FILE, so the jobs that push images and
+    # create the release do not also get the ability to mint identity tokens.
+    # `contents: read` is restated because a job-level block REPLACES the
+    # file-level default rather than adding to it.
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
 
   binaries:


### PR DESCRIPTION
**`v0.28.0`'s first tag failed at `startup_failure` with no job to read a log from.**

#296 gave `real-fabric.yml` OIDC auth, which needs `id-token: write` on its conformance job. `release.yml` calls that workflow and grants only `contents: write` and `packages: write`. A **called** workflow cannot request more permission than its caller, so GitHub refuses the run before any job starts.

That is why no pull request caught it: #296's own CI exercised `real-fabric.yml` directly, where the file-level grant applies. Only a tagged release goes through `release.yml`, and v0.28.0 is the first tag since #296 landed.

The grant goes on the `fabric-qualification` job rather than the top of the file, so the jobs that push images and create the GitHub Release do not also get the ability to mint identity tokens. `contents: read` is restated because a job-level block replaces the file-level default rather than adding to it.

No release was published by the failed run, so the `v0.28.0` tag will be moved to this commit once it lands.