### PR TITLE
docs: v0.28.0 notes cover the Kusto table-name half too

### DIFF
--- a/docs/release-notes/v0.28.0.md
+++ b/docs/release-notes/v0.28.0.md
@@ -1,7 +1,7 @@
 # v0.28.0
 
 The range starts at `74bfd0a` (#282), the first commit after the `v0.27.0`
-tag: 15 commits. Two are bugs a consumer would have hit, one is a behaviour
+tag: 17 commits. Two are bugs a consumer would have hit, one is a behaviour
 change worth reading before you upgrade, and most of the rest are witnesses for
 rows that were already graded.
 
@@ -70,6 +70,16 @@ stand as a bare column name in a schema declaration: real Kusto answers with
 rather than the keywords this emulator happens to know. A keyword list in the
 emitter would have been a list of the names we had thought of, which is exactly
 the fault that let `kind` through.
+
+The **destination table name** in those same two commands had the identical
+fault and is quoted too. That half is witnessed rather than argued: quoting a
+table name touches every drain, not just one that names a keyword, so
+`e2e/rti` asks Microsoft's own engine directly. It records the engine refusing
+the bare form, accepts the quoted one in both commands, and then merges a fully
+quoted `['Readings']` into a table the suite created bare and filled with four
+rows, ending with three columns and four rows. Acceptance alone would not have
+ruled out a quoted name resolving somewhere else and stranding a drain's rows in
+a table its owner cannot see.
 
 ## The agent is gated on its other consumer now
 


### PR DESCRIPTION
#295 landed after the notes did, so they described the eventstream fix as the column half only and the range as 15 commits. It is 17, and the destination table name is quoted too.

The added paragraph says how that half is witnessed rather than asserting it: `e2e/rti` records Microsoft's own engine refusing the bare form, accepts the quoted one in both commands, and merges a fully quoted `['Readings']` into a table the suite created bare and filled with four rows, ending with three columns and four rows. Acceptance alone would not have ruled out a quoted name resolving somewhere else and stranding a drain's rows in a table its owner cannot see.

The `v0.28.0` tag will be created at this commit: its first attempt failed at `startup_failure` (fixed in #301) and published nothing.