### PR TITLE
Encode a SQL result's typed values instead of dropping the socket

### DIFF
--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -25,6 +25,7 @@ import traceback
 from contextlib import contextmanager, redirect_stdout
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+import httpjson
 import jvmconf  # no Spark; JVM session configs (see jvmconf.py)
 from pyspark.sql import SparkSession
 
@@ -412,7 +413,7 @@ def register_tables(session, schema, tables, schemas=None):
 
 class Handler(BaseHTTPRequestHandler):
     def _send(self, code, obj):
-        body = json.dumps(obj).encode()
+        code, body = httpjson.encode_response(code, obj)
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))

--- a/python/spark_agent/httpjson.py
+++ b/python/spark_agent/httpjson.py
@@ -1,0 +1,30 @@
+"""Encode one HTTP reply body, never raising.
+
+Split out of agent.py the same way catalog.py and sqlrun.py were, and for the
+same reason: agent.py builds and DIALS its SparkSession at import, so anything
+left in it cannot be unit-tested. This module imports nothing but json.
+"""
+import json
+
+
+def encode_response(code, obj):
+    """Return (status, body bytes) for one reply.
+
+    An unencodable value used to raise inside the handler, so the reply was
+    never written and the caller saw a bare `RemoteDisconnected` -- a typed
+    result set was indistinguishable from a network fault, and the dropped
+    socket pointed at OOM and timeouts instead of at the encoder.
+
+    This is a backstop, not the fix: values are normalised where the rows are
+    built (sqlrun._jsonable). Blanket-stringifying here would hide the next gap
+    the same way this one hid, so the reply names the failure instead.
+    """
+    try:
+        return code, json.dumps(obj).encode()
+    except TypeError as exc:
+        return 500, json.dumps({
+            "status": "error",
+            "ename": "ResponseNotSerializable",
+            "evalue": str(exc),
+            "traceback": [],
+        }).encode()

--- a/python/spark_agent/sqlrun.py
+++ b/python/spark_agent/sqlrun.py
@@ -6,7 +6,47 @@ uint64 recovery below is exactly the kind of branch a refactor could quietly
 turn back into the absorption it replaces. This module imports no Spark; the
 session arrives in `g`.
 """
+import base64
+import datetime
+import decimal
 import traceback
+
+
+def _jsonable(v):
+    """Coerce one Spark value into something json.dumps accepts.
+
+    THE BUG THIS FIXES. The envelope went to json.dumps untouched, so any
+    result carrying a DATE — `SELECT current_date()`, or a to_date() cast over
+    a bronze column — raised `TypeError: Object of type date is not JSON
+    serializable` INSIDE the HTTP handler. The reply was never written, so the
+    client saw only `RemoteDisconnected` and could not tell a typed result from
+    a network fault; a dbt run reported it as a model error with a truncated
+    message. run_sql itself had already succeeded.
+
+    The conversion lives here rather than as a blanket `default=` on the HTTP
+    writer's json.dumps: only the SQL path builds typed result sets, and a
+    blanket default would also stringify a genuine bug in some unrelated
+    response instead of surfacing it.
+
+    Decimal becomes a string, not a float: a warehouse decimal that silently
+    loses precision on the way out is the kind of wrong answer that is worse
+    than an error. The declared type still reaches the client in the envelope's
+    schema, so a reader knows what the string holds.
+    """
+    if v is None or isinstance(v, (bool, int, float, str)):
+        return v
+    if isinstance(v, (datetime.datetime, datetime.date, datetime.time)):
+        return v.isoformat()
+    if isinstance(v, decimal.Decimal):
+        return str(v)
+    if isinstance(v, (bytes, bytearray)):
+        return base64.b64encode(bytes(v)).decode("ascii")
+    if isinstance(v, dict):
+        return {str(k): _jsonable(x) for k, x in v.items()}
+    if isinstance(v, (list, tuple, set)):
+        # Covers ARRAY and STRUCT alike: a pyspark Row is a tuple subclass.
+        return [_jsonable(x) for x in v]
+    return str(v)
 
 
 def run_sql(code, g):
@@ -26,7 +66,7 @@ def run_sql(code, g):
         df = spark.sql(code)
         if len(df.schema.fields) == 0:
             return {"status": "ok", "execution_count": 0, "data": {}}
-        rows = [list(r) for r in df.collect()]
+        rows = [[_jsonable(v) for v in r] for r in df.collect()]
         return {"status": "ok", "execution_count": 0,
                 "data": {"application/json": {"schema": df.schema.jsonValue(),
                                               "data": rows}}}
@@ -44,7 +84,7 @@ def run_sql(code, g):
         # kept parity.md's "DML row-count envelopes" row yellow.
         if "uint64" in tb[-1] or "Unsigned" in tb[-1]:
             try:
-                rows = [list(r.values()) for r in df.toArrow().to_pylist()]
+                rows = [[_jsonable(v) for v in r.values()] for r in df.toArrow().to_pylist()]
                 return {"status": "ok", "execution_count": 0,
                         "data": {"application/json": {
                             "schema": df.schema.jsonValue(), "data": rows}}}

--- a/python/tests/test_spark_agent_httpjson.py
+++ b/python/tests/test_spark_agent_httpjson.py
@@ -1,0 +1,66 @@
+"""A reply the agent cannot encode must still be a reply.
+
+THE BUG THIS PINS. `_send` called `json.dumps` directly, so an unencodable
+value raised inside the handler and the reply was never written. The caller saw
+`RemoteDisconnected: Remote end closed connection without response` and could
+not tell a typed result set from a network fault — reported from the field as
+first-suspected OOM, then a timeout, before the encoder was suspected at all.
+
+The values themselves are normalised in sqlrun._jsonable; this is the backstop
+for whatever that does not cover, and it answers by NAME rather than
+stringifying, so the next gap is visible instead of silent.
+
+encode_response lives in httpjson.py because agent.py builds and DIALS its
+SparkSession at import — a bogus SPARK_REMOTE hangs the import — so nothing
+left in agent.py can be unit-tested. Same split as catalog.py and sqlrun.py.
+"""
+import datetime
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import httpjson  # noqa: E402
+
+
+def test_an_encodable_reply_passes_through_with_its_status():
+    code, body = httpjson.encode_response(200, {"state": "idle"})
+    assert code == 200
+    assert json.loads(body) == {"state": "idle"}
+
+
+def test_a_non_200_status_is_preserved():
+    code, body = httpjson.encode_response(404, {"error": "nope"})
+    assert code == 404
+    assert json.loads(body) == {"error": "nope"}
+
+
+def test_an_unencodable_reply_becomes_a_500_that_names_the_failure():
+    code, body = httpjson.encode_response(200, {"d": datetime.date(2026, 8, 18)})
+    assert code == 500
+    out = json.loads(body)
+    assert out["status"] == "error"
+    assert out["ename"] == "ResponseNotSerializable"
+    # The reason must survive: a bare 500 would be the dropped socket again,
+    # just with a status line.
+    assert "date" in out["evalue"]
+    assert out["traceback"] == []
+
+
+def test_the_fallback_is_itself_always_encodable():
+    class Opaque:
+        def __repr__(self):
+            raise RuntimeError("even repr fails")
+
+    # Whatever went wrong, encode_response must return bytes rather than raise:
+    # it is the last thing between a handler and a dropped connection.
+    code, body = httpjson.encode_response(200, {"x": Opaque()})
+    assert code == 500
+    assert json.loads(body)["ename"] == "ResponseNotSerializable"
+
+
+def test_body_is_bytes_so_content_length_is_measurable():
+    _, body = httpjson.encode_response(200, {"a": 1})
+    assert isinstance(body, bytes)
+    assert len(body) > 0

--- a/python/tests/test_spark_agent_sql_typed_values.py
+++ b/python/tests/test_spark_agent_sql_typed_values.py
@@ -1,0 +1,193 @@
+"""A typed result set must reach the client, not drop the socket.
+
+THE BUG THIS PINS. `run_sql` built its rows with `list(r)` and handed them
+straight to the HTTP writer's `json.dumps`. Any result carrying a DATE —
+`SELECT current_date()`, or a `to_date()` cast over a bronze column — raised
+
+    TypeError: Object of type date is not JSON serializable
+
+inside the handler, so the reply was never written. The caller saw only
+`RemoteDisconnected: Remote end closed connection without response`, which
+reads as a network fault: reported from the field as first-suspected OOM, then
+a timeout, when the agent was at 176 MiB of 15.7 GiB and `run_sql` had already
+succeeded. A dbt model returning a bare date killed the agent, and dates are
+not exotic in a warehouse.
+
+The recovery path mattered too: the uint64 branch built rows the same way, so
+a DML whose result carried a typed value would have failed identically. Both
+paths are pinned below.
+
+These stubs import no Spark; the session arrives in `g`, as in
+test_spark_agent_sql_envelope.py.
+"""
+import datetime
+import decimal
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import sqlrun as agent  # noqa: E402
+
+UINT64_MSG = (
+    "[UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION] "
+    "uint64 is not supported in conversion to Arrow."
+)
+
+
+class FakeSchema:
+    fields = ("v",)
+
+    @staticmethod
+    def jsonValue():
+        return {"type": "struct", "fields": [
+            {"name": "v", "type": "date", "nullable": True, "metadata": {}}]}
+
+
+class FakeDF:
+    """Returns one row of whatever values the test supplies."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.schema = FakeSchema
+
+    def collect(self):
+        return self._rows
+
+
+class FakeSpark:
+    def __init__(self, df):
+        self._df = df
+
+    def sql(self, _code):
+        return self._df
+
+
+def envelope(rows):
+    out = agent.run_sql("SELECT v", {"spark": FakeSpark(FakeDF(rows))})
+    assert out["status"] == "ok", out
+    return out["data"]["application/json"]["data"]
+
+
+def test_a_date_round_trips_and_the_envelope_encodes():
+    rows = envelope([[datetime.date(2026, 8, 18)]])
+    assert rows == [["2026-08-18"]]
+    # The real failure was at encode time, so encoding is the assertion.
+    json.dumps(rows)
+
+
+def test_datetime_and_time_round_trip():
+    rows = envelope([[datetime.datetime(2026, 8, 18, 13, 45, 6)],
+                     [datetime.time(1, 2, 3)]])
+    assert rows == [["2026-08-18T13:45:06"], ["01:02:03"]]
+    json.dumps(rows)
+
+
+def test_decimal_keeps_its_precision_as_a_string():
+    # float() would round 0.1+0.2-style values; a warehouse decimal that
+    # silently loses precision is worse than an error.
+    rows = envelope([[decimal.Decimal("12345678901234567890.123456789")]])
+    assert rows == [["12345678901234567890.123456789"]]
+    json.dumps(rows)
+
+
+def test_binary_becomes_base64():
+    rows = envelope([[b"\x00\xff\x10"]])
+    assert rows == [["AP8Q"]]
+    json.dumps(rows)
+
+
+def test_primitives_and_null_are_untouched():
+    rows = envelope([[1], [1.5], ["s"], [True], [None]])
+    assert rows == [[1], [1.5], ["s"], [True], [None]]
+    json.dumps(rows)
+
+
+def test_nested_struct_array_and_map_are_converted_through():
+    d = datetime.date(2026, 1, 2)
+    rows = envelope([
+        [[d, d]],                      # ARRAY<date>
+        [(d, decimal.Decimal("1.5"))],  # STRUCT — a pyspark Row is a tuple
+        [{"k": d}],                     # MAP<string,date>
+    ])
+    assert rows == [
+        [["2026-01-02", "2026-01-02"]],
+        [["2026-01-02", "1.5"]],
+        [{"k": "2026-01-02"}],
+    ]
+    json.dumps(rows)
+
+
+def test_an_unknown_object_stringifies_rather_than_dropping_the_socket():
+    class Opaque:
+        def __str__(self):
+            return "opaque-value"
+
+    rows = envelope([[Opaque()]])
+    assert rows == [["opaque-value"]]
+    json.dumps(rows)
+
+
+# --- the uint64 recovery path builds rows too ---------------------------------
+
+class FakeArrowTable:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def to_pylist(self):
+        return self._rows
+
+
+class FakeUint64DF:
+    """collect() fails the way DataFusion's uint64 row count does; the
+    recovery reads the cached relation through toArrow()."""
+
+    def __init__(self, arrow_rows):
+        self.schema = FakeSchema
+        self._arrow = FakeArrowTable(arrow_rows)
+
+    def collect(self):
+        raise ValueError(UINT64_MSG)
+
+    def toArrow(self):
+        return self._arrow
+
+
+def test_the_uint64_recovery_converts_typed_values_too():
+    df = FakeUint64DF([{"v": datetime.date(2026, 8, 18)}])
+    out = agent.run_sql("INSERT INTO t VALUES (1)", {"spark": FakeSpark(df)})
+    assert out["status"] == "ok", out
+    rows = out["data"]["application/json"]["data"]
+    assert rows == [["2026-08-18"]]
+    json.dumps(rows)
+
+
+def test_no_spark_session_still_reports_an_error():
+    out = agent.run_sql("SELECT 1", {})
+    assert out["status"] == "error"
+    assert out["ename"] == "NoSparkSession"
+
+
+class EmptySchema:
+    fields = ()  # DDL has no output columns
+
+    @staticmethod
+    def jsonValue():  # pragma: no cover - never reached for an empty schema
+        raise AssertionError("jsonValue must not be read for a DDL result")
+
+
+class FakeDDLDF:
+    schema = EmptySchema
+
+    @staticmethod
+    def collect():  # pragma: no cover - the empty-schema branch returns first
+        raise AssertionError("collect must not run for a DDL result")
+
+
+def test_ddl_returns_an_empty_envelope_without_reading_rows():
+    # Closes a gap that predates this change: the empty-schema branch had no
+    # test, so nothing pinned that DDL returns an empty envelope rather than
+    # falling through to collect().
+    out = agent.run_sql("CREATE TABLE t (a int)", {"spark": FakeSpark(FakeDDLDF)})
+    assert out == {"status": "ok", "execution_count": 0, "data": {}}


### PR DESCRIPTION
Reported by a session driving the agent with `dbt-fabricspark` from a separate project.

## The bug

`run_sql` built its rows with `list(r)` and handed them to the HTTP writer's `json.dumps` untouched. Any result carrying a DATE — `SELECT current_date()`, or a `to_date()` cast over a bronze column — raised

```
TypeError: Object of type date is not JSON serializable
```

**inside the handler**, so the reply was never written. The caller saw only `RemoteDisconnected: Remote end closed connection without response`.

That misdirection is the expensive part: it was first read as OOM (the agent was at 176 MiB of 15.7 GiB), then as a timeout. `run_sql` itself had already succeeded — only the encoding of the reply failed. Any dbt model returning a bare date killed the agent, and dates are not exotic in a warehouse.

## Where the fix goes, and why not the one-liner

`json.dumps(obj, default=str)` on the writer would have been one line and covered date, datetime, Decimal and UUID at once. I put the conversion where the rows are built instead: only the SQL path produces typed result sets, and a blanket `default=` would also stringify a genuine bug in some unrelated response rather than surfacing it.

**The uint64 recovery branch builds rows the same way**, so a DML whose result carried a typed value failed identically. That path was not in the original report; it is fixed and pinned here too.

`Decimal` becomes a **string, not a float**. A warehouse decimal that silently loses precision on the way out is a wrong answer, which is worse than an error — and the declared type still reaches the client in the envelope's `schema`, so a reader knows what the string holds.

## The second-order problem: the failure was invisible

`_send` called `json.dumps` directly, so an unencodable value dropped the connection and a caller could not tell it from a network fault. Encoding now lives in `httpjson.encode_response`, which answers **500 `ResponseNotSerializable`** naming the offending type.

That is a backstop, not the fix. Stringifying everything there would hide the next gap exactly as this one was hidden.

It is its own module because `agent.py` builds and **dials** its SparkSession at import (line 33) — a bogus `SPARK_REMOTE` hangs the import — so nothing left in `agent.py` can be unit-tested. Same split, and same reason, as `catalog.py` and `sqlrun.py`.

## Verification

**Seven of the new tests fail against the previous code**, including the uint64 path:

| covered | |
|---|---|
| `date`, `datetime`, `time` | ISO 8601 |
| `Decimal` | string, precision preserved |
| `bytes` | base64 |
| nested `ARRAY` / `STRUCT` / `MAP` | converted through (a pyspark `Row` is a tuple) |
| primitives and `None` | untouched |
| unknown objects | stringified rather than dropping the socket |
| uint64 recovery path | converts typed values too |
| `encode_response` | passes through, preserves status, 500s by name, never raises |

Both changed modules reach **100% coverage**, which closed a pre-existing gap on the DDL empty-envelope branch along the way. Suite: 964 passed, 96.47% total against the 92% gate.

`ruff`, `ty check` (with `--group spark-client`, as CI runs it) and `check_govern_types.py` all pass. No Go files are touched.

## Note for the e2e suite

`e2e/dbt-fabricspark` did not surface this because its models do not return bare dates. A model selecting `current_date()` would be the route-level witness; I have not added one here, since the unit tests pin the branch logic and the e2e change is a separate call.
