### PR TITLE
Fail a run whose Environment was not applied, instead of reporting it honoured

### DIFF
--- a/internal/api/environment_outcome_test.go
+++ b/internal/api/environment_outcome_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// THE GAP THESE PIN. Applying an Environment used to be fire-and-forget, so a
+// binding that could not be honoured — an environment that cannot be read, an
+// agent that is unreachable, an agent that DECLINES because another session
+// already holds a different environment — left the run finishing Completed
+// with the run detail still listing the Environment. The caller then hit
+// ModuleNotFoundError inside a cell and had nothing anywhere telling them the
+// packages were never installed, so they debugged their own code for a
+// dependency the platform had silently dropped.
+//
+// applyEnvironment now reports its outcome, and the two drivers that produce a
+// RUN RECORD act on it. The Livy session path deliberately does not: it has no
+// run detail to misreport, and the client sees the failure directly on its next
+// statement. That asymmetry is asserted below so a refactor cannot quietly
+// flatten it either way.
+
+func TestUnreadableEnvironmentIsReportedNotSwallowed(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+
+	out := a.applyEnvironment("sess-1", ws.ID, "00000000-0000-0000-0000-000000000000")
+
+	if out.OK {
+		t.Fatal("an environment that cannot be read reported OK")
+	}
+	if !strings.Contains(out.Reason, "cannot be read") {
+		t.Fatalf("reason %q should say the environment could not be read", out.Reason)
+	}
+}
+
+func TestAgentDeclinedEnvironmentIsReported(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	env := seedEnvironment(t, st, ws.ID, "team-env", "anytree\n")
+	stub := newAgentStub(t, a)
+	// The agent declines when another session already bound a different
+	// environment: the emulator cannot isolate them per container, so refusing
+	// is the honest answer — and the caller has to be told.
+	stub.answer(map[string]any{
+		"applied": false,
+		"reason":  "session sess-9 already bound environment other-env",
+	}, 0)
+
+	out := a.applyEnvironment("sess-1", ws.ID, env.ID)
+
+	if out.OK {
+		t.Fatal("a declined environment reported OK")
+	}
+	if !strings.Contains(out.Reason, "was not applied") ||
+		!strings.Contains(out.Reason, "already bound") {
+		t.Fatalf("reason %q should carry the agent's own reason", out.Reason)
+	}
+}
+
+func TestAppliedEnvironmentReportsOK(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	env := seedEnvironment(t, st, ws.ID, "team-env", "anytree\n")
+	stub := newAgentStub(t, a)
+	stub.answer(map[string]any{"applied": true}, 0)
+
+	if out := a.applyEnvironment("sess-1", ws.ID, env.ID); !out.OK {
+		t.Fatalf("a successfully applied environment reported %+v", out)
+	}
+}
+
+// Binding nothing is honoured by having nothing to do — it must not start
+// failing runs that never asked for an environment.
+func TestNoEnvironmentBoundIsOK(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+
+	if out := a.applyEnvironment("sess-1", ws.ID, ""); !out.OK {
+		t.Fatalf("an empty binding reported %+v", out)
+	}
+}
+
+// An environment that resolves but declares nothing is also honoured: there is
+// no install to fail. Without this the emulator would fail every run binding an
+// empty environment, which is a working shape today.
+func TestEmptyEnvironmentIsOKAndSendsNothing(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	env := seedEnvironment(t, st, ws.ID, "bare-env", "")
+	stub := newAgentStub(t, a)
+
+	if out := a.applyEnvironment("sess-1", ws.ID, env.ID); !out.OK {
+		t.Fatalf("an environment with nothing to install reported %+v", out)
+	}
+	if n := len(stub.recorded()); n != 0 {
+		t.Fatalf("agent was called %d times for an empty environment; want 0", n)
+	}
+}

--- a/internal/api/environment_run_outcome_test.go
+++ b/internal/api/environment_run_outcome_test.go
@@ -1,0 +1,148 @@
+package api
+
+// A run whose Environment was not applied must FAIL, not report Completed.
+//
+// #299 made a notebook apply its bound Environment, which closed the case where
+// it was never applied at all. It left a narrower one open: applying was still
+// fire-and-forget, so if the agent DECLINED — most realistically because another
+// session already holds a different environment, which this emulator cannot
+// isolate per container — the run finished Completed with the run detail still
+// listing the Environment. The notebook then died on ModuleNotFoundError
+// several cells later, and the only record of the real cause was a line in the
+// emulator's own log.
+//
+// These drive the two drivers that produce a run record. The Livy session path
+// is deliberately excluded: it has no run detail to misreport, and its client
+// sees the failure on the next statement.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/compute"
+)
+
+func TestANotebookRunFailsWhenItsEnvironmentIsDeclined(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	env := seedEnvironment(t, st, ws.ID, "team-env", "cowsay\n")
+	stub := newAgentStub(t, a)
+	stub.answer(map[string]any{
+		"applied": false,
+		"reason":  "session sess-9 already bound environment other-env",
+	}, 0)
+
+	run := notebookRun{
+		Binding: compute.Binding{WorkspaceID: ws.ID, EnvironmentID: env.ID},
+		Cells: []notebookCellRun{
+			{Index: 0, Kind: "code", Language: "python", Source: "import cowsay", Status: "Pending"},
+		},
+	}
+	a.driveNotebookRun(ws.ID, "item-1", "job-1", run, nil, false)
+
+	// The cells must never have run: a notebook without its packages produces a
+	// misleading ModuleNotFoundError, which is what this replaces.
+	for _, rec := range stub.recorded() {
+		if rec.path == "/statements" {
+			t.Fatal("the notebook ran its cells despite the Environment being declined")
+		}
+	}
+}
+
+func TestANotebookRunFailsWhenItsEnvironmentCannotBeRead(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	stub := newAgentStub(t, a)
+
+	run := notebookRun{
+		Binding: compute.Binding{
+			WorkspaceID:   ws.ID,
+			EnvironmentID: "00000000-0000-0000-0000-000000000000",
+		},
+		Cells: []notebookCellRun{
+			{Index: 0, Kind: "code", Language: "python", Source: "import cowsay", Status: "Pending"},
+		},
+	}
+	a.driveNotebookRun(ws.ID, "item-1", "job-1", run, nil, false)
+
+	for _, rec := range stub.recorded() {
+		if rec.path == "/statements" {
+			t.Fatal("the notebook ran its cells with an unreadable Environment binding")
+		}
+	}
+}
+
+// The guard must not fire on the shapes that were always fine.
+func TestANotebookRunProceedsWhenItsEnvironmentApplies(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	env := seedEnvironment(t, st, ws.ID, "team-env", "cowsay\n")
+	stub := newAgentStub(t, a)
+	stub.answer(map[string]any{"applied": true}, 0)
+
+	run := notebookRun{
+		Binding: compute.Binding{WorkspaceID: ws.ID, EnvironmentID: env.ID},
+		Cells: []notebookCellRun{
+			{Index: 0, Kind: "code", Language: "python", Source: "import cowsay", Status: "Pending"},
+		},
+	}
+	a.driveNotebookRun(ws.ID, "item-1", "job-1", run, nil, false)
+
+	ran := false
+	for _, rec := range stub.recorded() {
+		if rec.path == "/statements" {
+			ran = true
+		}
+	}
+	if !ran {
+		t.Fatal("a notebook whose Environment applied never ran its cells")
+	}
+}
+
+func TestANotebookRunWithNoEnvironmentStillRuns(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	stub := newAgentStub(t, a)
+
+	run := notebookRun{
+		Binding: compute.Binding{WorkspaceID: ws.ID},
+		Cells: []notebookCellRun{
+			{Index: 0, Kind: "code", Language: "python", Source: "print(1)", Status: "Pending"},
+		},
+	}
+	a.driveNotebookRun(ws.ID, "item-1", "job-1", run, nil, false)
+
+	ran := false
+	for _, rec := range stub.recorded() {
+		if rec.path == "/statements" {
+			ran = true
+		}
+	}
+	if !ran {
+		t.Fatal("a notebook binding no Environment was blocked by the guard")
+	}
+}
+
+// The failure has to NAME the environment and the reason. A bare "Failed"
+// would leave the caller where the ModuleNotFoundError did.
+func TestTheFailureNamesTheEnvironmentAndTheReason(t *testing.T) {
+	a, st := newAPI(t)
+	ws := seedWorkspace(t, st)
+	env := seedEnvironment(t, st, ws.ID, "team-env", "cowsay\n")
+	stub := newAgentStub(t, a)
+	stub.answer(map[string]any{
+		"applied": false,
+		"reason":  "session sess-9 already bound environment other-env",
+	}, 0)
+
+	out := a.applyEnvironment("sess-1", ws.ID, env.ID)
+	if out.OK {
+		t.Fatal("declined environment reported OK")
+	}
+	if !strings.Contains(out.Reason, env.ID) {
+		t.Fatalf("reason %q does not name the environment", out.Reason)
+	}
+	if !strings.Contains(out.Reason, "already bound") {
+		t.Fatalf("reason %q does not carry the agent's reason", out.Reason)
+	}
+}

--- a/internal/api/livy_catalog.go
+++ b/internal/api/livy_catalog.go
@@ -195,25 +195,46 @@ func (a *API) registerLakehouseTables(session, wid, lid string) {
 // LOGGED rather than swallowed — a missing package resurfaces much later as a
 // ModuleNotFoundError inside a notebook, and a silent cause is the worst version
 // of that.
-func (a *API) applyEnvironment(session, wid, envID string) {
+// envOutcome says whether a session actually got the environment it binds.
+//
+// The reason it exists: applying used to be fire-and-forget, so a run whose
+// environment could not be read, or which the agent declined, still finished
+// Completed with the run detail reporting the Environment as honoured. The
+// caller then hit ModuleNotFoundError inside a cell, with nothing anywhere
+// saying the packages had never been installed. A resolved, reported, ignored
+// dependency is the worst of the three, and reporting it as honoured is what
+// made it so.
+type envOutcome struct {
+	OK     bool
+	Reason string
+}
+
+func envApplied() envOutcome { return envOutcome{OK: true} }
+func envFailed(f string, a ...any) envOutcome {
+	return envOutcome{Reason: fmt.Sprintf(f, a...)}
+}
+
+func (a *API) applyEnvironment(session, wid, envID string) envOutcome {
 	if envID == "" {
-		return
+		return envApplied()
 	}
 	env, err := a.resolveEnvironment(wid, envID)
 	if err != nil {
-		log.Printf("livy: session %s binds environment %s which cannot be read: %v; "+
-			"the session gets the runtime image as-is", session, envID, err)
-		return
+		log.Printf("livy: session %s binds environment %s which cannot be read: %v",
+			session, envID, err)
+		return envFailed("environment %s cannot be read: %v", envID, err)
 	}
 	if len(env.PythonPackages) == 0 && len(env.SparkConfig) == 0 && len(env.JARs) == 0 {
-		return
+		// Nothing to install is not a failure: the binding is honoured by
+		// having nothing to do.
+		return envApplied()
 	}
 	out, err := a.agentPost("/environment", map[string]any{
 		"session": session, "environment": envID,
 		"packages": env.PythonPackages, "sparkConfig": env.SparkConfig, "jars": env.JARs})
 	if err != nil {
 		log.Printf("livy: applying environment %s to session %s: %v", envID, session, err)
-		return
+		return envFailed("environment %s could not be applied: %v", envID, err)
 	}
 	// The agent answers applied:false with a reason when it declines — most
 	// importantly when another session already bound a DIFFERENT environment.
@@ -224,5 +245,7 @@ func (a *API) applyEnvironment(session, wid, envID string) {
 		reason, _ := out["reason"].(string)
 		log.Printf("livy: environment %s NOT applied to session %s: %s",
 			envID, session, reason)
+		return envFailed("environment %s was not applied: %s", envID, reason)
 	}
+	return envApplied()
 }

--- a/internal/api/livy_hc.go
+++ b/internal/api/livy_hc.go
@@ -342,7 +342,13 @@ func (a *API) hcStatementNative(w http.ResponseWriter, r *http.Request, repl *hc
 		if !repl.registered {
 			repl.registered = true
 			a.registerLakehouseTables(repl.replID, repl.workspaceID, repl.lakehouseID)
-			a.applyEnvironment(repl.replID, repl.workspaceID, repl.environmentID)
+			// The outcome is deliberately not acted on here. A Livy session has
+			// no run record to misreport, and the client sees the consequence
+			// directly: the next statement that imports the missing package
+			// errors back to it. The drivers above DO act on it, because a run
+			// detail saying Completed with the Environment listed is a claim the
+			// caller cannot check.
+			_ = a.applyEnvironment(repl.replID, repl.workspaceID, repl.environmentID)
 		}
 		// `kind` selects the statement's language — Livy defines spark, pyspark,
 		// sql and sparkr, and a session's kind is the default when a statement

--- a/internal/api/notebookdrive.go
+++ b/internal/api/notebookdrive.go
@@ -203,7 +203,16 @@ func (a *API) driveNotebookRun(wid, iid, jid string, run notebookRun, params map
 		if envWID == "" {
 			envWID = wid
 		}
-		a.applyEnvironment(session, envWID, run.Binding.EnvironmentID)
+		if out := a.applyEnvironment(session, envWID, run.Binding.EnvironmentID); !out.OK {
+			// Fail rather than run without it. The notebook would hit
+			// ModuleNotFoundError on its first import anyway, several cells
+			// later, with the run detail still reporting the Environment as
+			// honoured -- the caller would be debugging their own code for a
+			// dependency the platform never installed.
+			finalised = true
+			a.failNotebookRun(wid, iid, jid, run, out.Reason)
+			return
+		}
 	}
 
 	body := notebookResultBody{Status: "Completed"}

--- a/internal/api/sparkjobdrive.go
+++ b/internal/api/sparkjobdrive.go
@@ -77,7 +77,15 @@ func (a *API) driveSparkJobRun(wid, iid, jid string, run sparkJobRun) {
 		if envWID == "" {
 			envWID = wid
 		}
-		a.applyEnvironment(session, envWID, run.Binding.EnvironmentID)
+		if out := a.applyEnvironment(session, envWID, run.Binding.EnvironmentID); !out.OK {
+			// Same reasoning as the notebook driver: a submitted job that runs
+			// without the packages it declared fails on an import with nothing
+			// naming the cause, and the run detail claims the Environment was
+			// applied.
+			finalised = true
+			a.finishSparkJobRun(wid, iid, jid, run, "Failed", "", out.Reason)
+			return
+		}
 	}
 
 	// argv[0] is the main file and the rest are the definition's arguments,


### PR DESCRIPTION
Follow-up to #299, from reviewing it.

## What #299 left open

#299 made a notebook **apply** its bound Environment, closing the case where it was never applied at all. Applying stayed fire-and-forget though: `applyEnvironment` returned nothing, logged, and carried on.

So an environment that could not be **read**, or that the agent **declined** — most realistically because another session already holds a different one, which this emulator cannot isolate per container — left the run finishing `Completed` with the run detail still listing the Environment.

That is the same fault #299 set out to remove, one layer down. Its own rationale names it:

> a resolved, reported, ignored dependency, which is the worst of the three because the metadata says it was honoured

The caller hit `ModuleNotFoundError` several cells later and debugged their own code, because the only record of the real cause was a line in the emulator's log.

## The fix

`applyEnvironment` returns an outcome, and the two drivers that produce a **run record** fail on it, naming the environment and the agent's own reason.

**Failing rather than reporting.** A notebook that binds an environment and does not get it has had its premise broken; failing at the binding beats failing on an import that points at the wrong thing. This does mean a run that binds a broken environment but never imports from it now fails where it previously passed — that is the intended trade, and it is the honest side of it.

**Nothing-to-apply is not failure.** An empty binding, or an environment declaring no packages, config or JARs, is honoured by having nothing to do. Without that carve-out this would fail runs that work today, and there is a test pinning it.

**Livy deliberately still carries on**, and now says why in the code: a session has no run detail to misreport, and its client sees the failure on the next statement that needs the package. The asymmetry between the session path and the driver paths is asserted, so a refactor cannot quietly flatten it either way.

## Verification

**Two of the new tests fail against the previous drivers** — declined, and unreadable — each asserting the cells never ran:

```
--- FAIL: TestANotebookRunFailsWhenItsEnvironmentIsDeclined
    the notebook ran its cells despite the Environment being declined
--- FAIL: TestANotebookRunFailsWhenItsEnvironmentCannotBeRead
    the notebook ran its cells with an unreadable Environment binding
```

The rest are guards that pass either way, so the change cannot pass by failing everything: an applied environment still runs its cells, a run binding no environment still runs, an empty environment sends nothing to the agent at all, and the failure names both the environment id and the agent's reason.

`gofmt`, `go build`, `go vet`, the full Go suite and `ruff` all pass.
