### PR TITLE
test(cmd): give serve() the headroom poll() already has

### DIFF
--- a/cmd/fabric-emulator/main_test.go
+++ b/cmd/fabric-emulator/main_test.go
@@ -20,6 +20,27 @@ import (
 //     beforehand. Reserving one up front leaves a window — widened by opening
 //     the store and generating a certificate — for anything else binding :0
 //     to take it first.
+//
+// Neither of those is the budget, and the budget is what failed next: PR #303
+// (job 95436375580, a PYTHON-ONLY diff) reported "run never reported a listen
+// address" on windows-latest after 60s, with the server's own
+// `listening on https://127.0.0.1:55822` printed in the same log — it came up,
+// just later than the wait. That runner was contended enough that
+// `internal/store` took 93s and `internal/api` 244s, so the 60s was measuring
+// the runner rather than the code.
+//
+// So the budget follows poll()'s reasoning below, which the same file already
+// states and which was never extended up here: the select returns the instant
+// `ready` fires, so a fast machine pays NOTHING for the headroom, while a slow
+// one stops reporting a startup as a hang. The failure mode a longer wait
+// costs us is a genuine deadlock taking longer to surface — bounded, and
+// `case <-done` still catches the common case of run exiting early.
+//
+// 120s rather than a rounder, larger number, because there IS a ceiling: two
+// tests call serve(), and `go test` gives the package 10 minutes by default,
+// so a budget of 300s each would replace a clean "never reported a listen
+// address" with a whole-package timeout panic — a worse message for the same
+// event. 120s is double the wait that lapsed, and 240s worst case.
 func serve(t *testing.T, args ...string) string {
 	t.Helper()
 	stop, done, ready := make(chan struct{}), make(chan struct{}), make(chan net.Addr, 1)
@@ -37,7 +58,7 @@ func serve(t *testing.T, args ...string) string {
 		return addr.String()
 	case <-done:
 		t.Fatalf("run exited before it began serving: %v", runErr)
-	case <-time.After(60 * time.Second):
+	case <-time.After(120 * time.Second):
 		t.Fatal("run never reported a listen address")
 	}
 	return ""


### PR DESCRIPTION
`TestRunServesTLS` failed on windows-latest in
[job 95436375580](https://github.com/calvinchengx/fabric-emulator/actions/runs/32046768335/job/95436375580)
— on **#303, whose diff is five Python files**. There is no path from
`python/spark_agent/` to a Go test in `cmd/`, so the failure was the harness,
not the change under test:

```
--- FAIL: TestRunServesTLS (104.73s)
    main_test.go:110: run never reported a listen address
```

The line printed immediately before it is the server's own
`listening on https://127.0.0.1:55822`. It came up — later than `serve()`'s 60s
wait. That runner was contended enough that `internal/store` took 93s and
`internal/api` 244s in the same job, so the 60s was measuring the runner rather
than the code.

`serve()` has been hardened twice for this same Windows flake (`8b8d79c`,
`2d2a092`): run's error is surfaced so a bind collision is distinguishable from
a slow start, and the port comes from `run` rather than a pre-reserved listener.
Neither of those is the budget, and the budget is what failed next.

**The reasoning is already in this file, one function down.** `poll()` carries
30s with it written out — *"generous because a contended Windows runner can
spend seconds opening the store and generating a certificate before Serve;
polling returns the moment health answers, so a fast machine pays nothing for
the headroom."* Exactly the same holds for `serve()`'s `select`, which returns
the instant `ready` fires; the argument was just never extended up there.

**Why 120s and not something rounder.** There is a ceiling: two tests call
`serve()`, and `go test` gives the package 10 minutes by default, so a 300s
budget each would replace a clean "never reported a listen address" with a
whole-package timeout panic — a worse message for the same event. 120s is
double the wait that lapsed, 240s worst case.

What a longer wait costs is a genuine deadlock taking longer to surface. That is
bounded, and `case <-done` still catches the common case of `run` exiting early.

Local: `go vet ./cmd/...` clean, the five `TestRun*` tests pass — `TestRunServesTLS`
in **0.03s**, which is the "fast machine pays nothing" claim measured rather than
asserted.

#303's own failed job has been re-run separately; this PR is the durable half.