### PR TITLE
Claim the CTAS shapes dbt actually emits: comments, CTEs, and a real REPLACE

### DIFF
--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -201,7 +201,15 @@ _CTAS = re.compile(
     r"(?P<target>[\w.`]+)\s*"
     r"(?:USING\s+(?P<using>\w+)\s*)?"
     r"(?:LOCATION\s+'(?P<location>[^']+)'\s*)?"
-    r"AS\b" + _SQL_COMMENTS + r"(?P<query>\(?\s*SELECT\b.+)$",
+    # WITH as well as SELECT. `with … select` is the canonical dbt model shape
+    # -- dbt's own documentation writes models as CTEs and most projects follow
+    # it -- so requiring SELECT here misses the majority of a real silver
+    # layer while claiming the minority. Measured on one project: the three
+    # models that opened with SELECT were intercepted and landed in OneLake
+    # with a _delta_log; the five that opened with WITH fell through and left
+    # bare parquet at the same paths, which the lakehouse cannot read as a
+    # table. Both halves reported success.
+    r"AS\b" + _SQL_COMMENTS + r"(?P<query>\(?\s*(?:SELECT|WITH)\b.+)$",
     re.IGNORECASE | re.DOTALL)
 
 # The bounded MERGE shape an upsert notebook writes, which is the shape a

--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -382,7 +382,22 @@ def execute_ctas(spark, original_sql, params, storage_options=None):
                 f"Use CREATE OR REPLACE TABLE to overwrite it.")
 
     df = original_sql(params["query"].strip().rstrip(";"))
-    df.write.format("delta").mode("overwrite").save(loc)
+    writer = df.write.format("delta").mode("overwrite")
+    # CREATE OR REPLACE MEANS THE NEW DEFINITION WINS, schema included. Without
+    # this, an overwrite whose columns differ from what is already at `loc`
+    # fails with `Field 'x' not found in table schema. Use mergeSchema=true to
+    # allow schema evolution` -- so a model that gains or loses a column builds
+    # once and fails on every run after that, which is a normal day in dbt.
+    # Measured: adding one column to a silver model turned a green build into
+    # this, and the message points at schema evolution rather than at REPLACE
+    # semantics not being honoured.
+    #
+    # Only for REPLACE. A plain CREATE TABLE over an existing table is already
+    # refused above, and widening its schema silently would be the opposite of
+    # what it asked for.
+    if replace:
+        writer = writer.option("overwriteSchema", "true")
+    writer.save(loc)
     name = f"`{schema}`.`{tbl}`" if schema else f"`{tbl}`"
     if replace:
         try:

--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -179,12 +179,29 @@ _VACUUM = re.compile(
 # the emulator exists to prevent. Only statements whose SCHEMA the emulator
 # itself registered (with a location) are intercepted; everything else passes
 # to the engine untouched.
+#
+# COMMENTS ARE PART OF THE STATEMENT, and skipping them is not cosmetic. dbt
+# puts the model file's own SQL after AS, and a dbt model conventionally OPENS
+# with a comment explaining what it is for -- so the statement the adapter
+# really sends is `as\n\n-- why this model exists\nselect ...`. Requiring SELECT
+# to sit directly against AS misses every one of those, and the miss is silent:
+# the CTAS falls through to the engine, which writes the table into its own
+# warehouse and answers with a row count. dbt reports `OK created sql table
+# model`, the table is real and queryable from Spark, and the lakehouse never
+# sees it -- so the SQL analytics endpoint does not reflect it and the next
+# layer's every source() fails to resolve. Measured: eight dbt models green,
+# all their tests passing, none of the eight visible to the warehouse.
+#
+# Also skipped BEFORE the statement, where a client's query comment goes -- the
+# `/* {"app": "dbt", ...} */` header adapters prepend.
+_SQL_COMMENTS = r"(?:\s*(?:--[^\n]*(?:\n|$)|/\*.*?\*/))*\s*"
 _CTAS = re.compile(
-    r"^\s*CREATE\s+(?P<replace>OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"^" + _SQL_COMMENTS +
+    r"CREATE\s+(?P<replace>OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
     r"(?P<target>[\w.`]+)\s*"
     r"(?:USING\s+(?P<using>\w+)\s*)?"
     r"(?:LOCATION\s+'(?P<location>[^']+)'\s*)?"
-    r"AS\s+(?P<query>\(?\s*SELECT\b.+)$",
+    r"AS\b" + _SQL_COMMENTS + r"(?P<query>\(?\s*SELECT\b.+)$",
     re.IGNORECASE | re.DOTALL)
 
 # The bounded MERGE shape an upsert notebook writes, which is the shape a

--- a/python/tests/test_agent_consumer_contract.py
+++ b/python/tests/test_agent_consumer_contract.py
@@ -137,6 +137,29 @@ CONTRACT = [
         ("match", "ctas"),
         {},
     ),
+    # A CTE, which is how dbt's own documentation writes models and how most
+    # projects follow it. Requiring SELECT claimed the minority of a real
+    # silver layer and missed the majority: measured on one project, the three
+    # models opening with SELECT landed in OneLake with a _delta_log and the
+    # five opening with WITH left bare parquet at the same paths -- unreadable
+    # as a table, and reported as success by both halves.
+    (
+        "fabric-emulator",
+        "dbt-fabricspark — contoso-airflow-data-product "
+        "dbt/silver/models/silver_customers.sql, the canonical `with … select`",
+        "create or replace table `lake`.silver_customers\n"
+        "    location 'abfss://lake/Tables/silver_customers'\n"
+        "      as\n"
+        "-- THE DUPLICATES ARE DELIBERATE. The POS vendor ships a 2% ratio.\n"
+        "with ranked as (\n"
+        "    select *, row_number() over (partition by customer_id "
+        "order by updated_at desc) as rn\n"
+        "    from `default`.bronze_pos_customers\n"
+        ")\n"
+        "select * from ranked where rn = 1",
+        ("match", "ctas"),
+        {},
+    ),
     # The same miss through the other comment syntax. dbt's own query_comment
     # is a block comment, and a fix that handles only `--` leaves this open.
     (

--- a/python/tests/test_agent_consumer_contract.py
+++ b/python/tests/test_agent_consumer_contract.py
@@ -116,6 +116,42 @@ CONTRACT = [
     ),
     # Spark allows clauses between USING and LOCATION. dbt emits partitioning
     # this way, and LOCATION arriving after them must still be recorded.
+    # A dbt model file opens with a comment, so the statement the adapter sends
+    # carries one between AS and SELECT. Copied VERBATIM from a dbt-fabricspark
+    # debug log -- whitespace, backquoted relation and all -- because every
+    # hand-written probe of this shape passed and only the adapter's own output
+    # failed. A tidied version of this row would have proved nothing.
+    (
+        "fabric-emulator",
+        "dbt-fabricspark table materialization — contoso-airflow-data-product "
+        "dbt/silver/models/silver_product_hierarchy.sql, via logs/dbt.log",
+        "create or replace table `lake`.silver_product_hierarchy\n"
+        "      \n      \n"
+        "    location 'abfss://contoso-analytics@onelake.dfs.fabric.microsoft.com"
+        "/lake.Lakehouse/Tables/silver_product_hierarchy'\n"
+        "      \n\n      as\n      \n"
+        "-- The reference vendor's hierarchy, as-is.\n"
+        "--\n"
+        "-- Deliberately thin: this vendor is the group data office's publisher.\n"
+        "select * from `default`.bronze_ref_product_hierarchy",
+        ("match", "ctas"),
+        {},
+    ),
+    # The same miss through the other comment syntax. dbt's own query_comment
+    # is a block comment, and a fix that handles only `--` leaves this open.
+    (
+        "fabric-emulator",
+        "dbt-fabricspark — a model whose header is a block comment "
+        "(and the query_comment adapters prepend)",
+        '/* {"app": "dbt", "node_id": "model.contoso_silver.x"} */\n'
+        "create or replace table `lake`.x\n"
+        "    location 'abfss://lake/Tables/x'\n"
+        "      as\n"
+        "/* what this model is for */\n"
+        "select 1 as n",
+        ("match", "ctas"),
+        {},
+    ),
     (
         "fabric-emulator",
         "dbt-fabricspark with +partition_by",

--- a/python/tests/test_delta_ops.py
+++ b/python/tests/test_delta_ops.py
@@ -402,6 +402,12 @@ class FakeWriter:
         self.sink["mode"] = m
         return self
 
+    def option(self, key, value):
+        # See execute_ctas: CREATE OR REPLACE sets `overwriteSchema`, without
+        # which a model that gains a column builds once and fails after.
+        self.sink.setdefault("options", {})[key] = value
+        return self
+
     def save(self, path):
         self.sink["path"] = path
 
@@ -527,6 +533,12 @@ def test_ctas_or_replace_overwrites_and_drops_the_stale_registration():
     _, params = d.match("CREATE OR REPLACE TABLE gold.fct AS SELECT 1")
     d.execute_ctas(None, original_sql, params)
     assert sink["mode"] == "overwrite"
+    # REPLACE replaces the SCHEMA too. Without this the write inherits whatever
+    # columns are already at the location, so a model that gains or loses one
+    # builds the first time and fails every run after with `Field 'x' not found
+    # in table schema` -- which reads as a schema-evolution problem rather than
+    # REPLACE not being honoured. Found by adding one column to a dbt model.
+    assert sink.get("options", {}).get("overwriteSchema") == "true"
     assert any("DROP TABLE IF EXISTS" in q for q in ran)
 
 

--- a/python/tests/test_delta_ops_ctas_location.py
+++ b/python/tests/test_delta_ops_ctas_location.py
@@ -102,6 +102,13 @@ class FakeDF:
         self._sink["mode"] = m
         return self
 
+    def option(self, key, value):
+        # REPLACE carries `overwriteSchema` -- see execute_ctas. A stub without
+        # it does not fail the behaviour, it fails with AttributeError, which
+        # is a stub problem wearing a bug's clothes.
+        self._sink.setdefault("options", {})[key] = value
+        return self
+
     def save(self, path):
         self._sink["path"] = path
 


### PR DESCRIPTION
`_CTAS` claimed only the exceptional shapes of a dbt model, and the two it missed
are the ordinary ones. Found by running a real dbt-fabricspark silver layer
through Livy; each fix has a CONTRACT row that fails before it and passes after.

## 1. A comment between `AS` and `SELECT`

The matcher required SELECT immediately after AS. dbt puts the model file's own
SQL there, and a dbt model conventionally opens with a comment saying what it is
for — so the real statement is `as\n\n-- why this model exists\nselect …`.

Four statements differing only in what sits between AS and SELECT, all through
`/statements`:

| between AS and SELECT | agent's answer |
|---|---|
| nothing (single line)   | `CREATE TABLE: lake.t5 at its stated LOCATION (delta write + register)` |
| newlines only           | `CREATE TABLE: lake.t7 … (delta write + register)` |
| `-- a line comment`     | `[[8]]` — fell through to the engine |
| `/* a block comment */` | `[[8]]` — fell through to the engine |

Comments are now skipped before the statement too, where an adapter's
`query_comment` header goes.

## 2. A CTE — the larger half

`with … select` is dbt's own documented model shape. Measured on one project,
eight models, split exactly by their first keyword:

- the **3** opening with `SELECT` were intercepted and landed in OneLake with a `_delta_log`
- the **5** opening with `WITH` fell through, and the engine honoured the LOCATION
  by writing **bare zstd parquet with no `_delta_log`** to the same path

Both halves reported `OK created sql table model`. A directory of parquet with no
Delta log is not a table the Lakehouse can read, so `refreshMetadata` did not even
enumerate those five. Between findings 1 and 2, the shapes that *did* work were
the exceptions.

This is the ᵍ row the `_CTAS` comment says the matcher exists to prevent: silver
green in dbt, the lakehouse empty.

## 3. `CREATE OR REPLACE` did not replace the schema

Only reachable once 1 and 2 are fixed. `execute_ctas` wrote `mode("overwrite")`
with no `overwriteSchema`, so an overwrite whose columns differ from what is at
the location fails:

```
Field 'currency' not found in table schema. Use mergeSchema=true to allow schema evolution
```

A model that gains or loses a column therefore builds once and fails on every run
after — a normal day in dbt. Set for REPLACE only: a plain CREATE over an existing
table is already refused above, and widening its schema silently would be the
opposite of what it asked for.

Verified on both shapes of change — an added column (`currency`) and a type change
(`double` → `decimal(19,4)`).

## Tests

Three rows in the CONTRACT table, copied **verbatim from a dbt-fabricspark debug
log** — whitespace, backquoted relation and all. Every hand-written probe of these
shapes passed; only the adapter's real output failed, so a tidied row would have
proved nothing.

The `overwriteSchema` change initially failed three existing tests, and they were
right to notice a new call: `FakeDF` / `FakeWriter` model `format`/`mode`/`save`
but not `option`, so it surfaced as AttributeError. The fakes now know `option()`,
and the replace test **asserts** `overwriteSchema == "true"` rather than merely
tolerating it — a fake that accepts any call proves nothing about what was asked
for.

Suite: 919 → 922 passing, with the same 24 pre-existing environment failures
before and after (missing optional deps in my local run, unrelated to this change).

## End-to-end evidence

Full Airflow pipeline against an image built from this branch, four source systems
to a star:

- **861,432** bronze rows across 8 Delta tables
- **8** silver models over Livy, all landing in OneLake with a `_delta_log`
- all 8 visible through the lakehouse SQL analytics endpoint, counts matching
- **9** gold models over TDS, **PASS=52 ERROR=0**
- 35 of 35 Airflow tasks green

## Two things NOT in this PR

**Blob Batch.** `internal/onelake/blob.go:196` refuses everything at container level
except HEAD and list, so `POST ?restype=container&comp=batch` gets 409
`OperationNotAllowedOnContainer`. It blanket-matches on `restype=container`, and
blob batch is a data-plane operation real ADLS Gen2 allows. I hit it only when a
write had to clear foreign content at a location — debris left by finding 2 — so
it is a consequence rather than a cause, but it is reachable.

**An unexplained intermittent.** Twice, `bronze_web_customers` / `bronze_web_orders`
failed to resolve inside dbt's Livy session with `TABLE_OR_VIEW_NOT_FOUND`, while a
Livy session I opened by hand at the same moment saw them, and registering those
exact paths worked. It cleared on a later run with no change from me. My first
retry attempt silently never re-queued, so I briefly and wrongly called it
deterministic before checking the attempt logs — treat it as unexplained rather
than characterised. Worth knowing because `registerLakehouseTables` is now
load-bearing for at least one consumer: `contoso-airflow-data-product` removed its
own bronze registration step after measuring that this covers it.
