### PR TITLE
fix(deps): hold dbt-core below 2.0, a beta with no stable release

### DIFF
--- a/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
 
 [tool.uv]
 package = false
+# dbt-core, held below 2.0. See the root repo's pyproject.toml for why:
+# dbt-fabric declares no upper bound on it, and dbt-core 1.12.0 pins
+# sqlparse<0.6.0, so a routine sqlparse bump can only be satisfied by
+# jumping to dbt-core 2.0.0b1, still a beta with no stable release.
+constraint-dependencies = ["dbt-core<2"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-advanced-dbt-fabricspark/uv.lock
+++ b/examples/medallion-advanced-dbt-fabricspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "dbt-core", specifier = "<2" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"

--- a/examples/medallion-advanced-pyspark/pyproject.toml
+++ b/examples/medallion-advanced-pyspark/pyproject.toml
@@ -35,6 +35,11 @@ dependencies = [
 
 [tool.uv]
 package = false
+# dbt-core, held below 2.0. See the root repo's pyproject.toml for why:
+# dbt-fabric declares no upper bound on it, and dbt-core 1.12.0 pins
+# sqlparse<0.6.0, so a routine sqlparse bump can only be satisfied by
+# jumping to dbt-core 2.0.0b1, still a beta with no stable release.
+constraint-dependencies = ["dbt-core<2"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-advanced-pyspark/uv.lock
+++ b/examples/medallion-advanced-pyspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "dbt-core", specifier = "<2" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"

--- a/examples/medallion-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-dbt-fabricspark/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
 
 [tool.uv]
 package = false
+# dbt-core, held below 2.0. See the root repo's pyproject.toml for why:
+# dbt-fabric declares no upper bound on it, and dbt-core 1.12.0 pins
+# sqlparse<0.6.0, so a routine sqlparse bump can only be satisfied by
+# jumping to dbt-core 2.0.0b1, still a beta with no stable release.
+constraint-dependencies = ["dbt-core<2"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-dbt-fabricspark/uv.lock
+++ b/examples/medallion-dbt-fabricspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "dbt-core", specifier = "<2" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"

--- a/examples/medallion-pyspark/pyproject.toml
+++ b/examples/medallion-pyspark/pyproject.toml
@@ -26,6 +26,11 @@ dependencies = [
 
 [tool.uv]
 package = false
+# dbt-core, held below 2.0. See the root repo's pyproject.toml for why:
+# dbt-fabric declares no upper bound on it, and dbt-core 1.12.0 pins
+# sqlparse<0.6.0, so a routine sqlparse bump can only be satisfied by
+# jumping to dbt-core 2.0.0b1, still a beta with no stable release.
+constraint-dependencies = ["dbt-core<2"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-pyspark/uv.lock
+++ b/examples/medallion-pyspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "dbt-core", specifier = "<2" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,17 @@ conflicts = [
         { group = "dbt-fabricspark" },
     ],
 ]
+# dbt-core, held below 2.0. TRANSITIVE, not a direct dependency, which is
+# exactly how it got away from us: dbt-fabric/dbt-fabricspark declare no
+# upper bound on it, so a routine sqlparse patch bump (dependabot#307/#308)
+# widened the solver's search space enough to land on 2.0.0b1, the only
+# release past 1.12.0, and still a BETA: no stable 2.0 exists yet. It broke
+# `e2e/dbt-fabric/runner.py`'s profiles.yml: `access_token_expires_on: 0`
+# parsed fine under 1.x and fails 2.0's stricter schema, which wants a
+# string. Constraining rather than adding a direct dependency keeps
+# dbt-fabric's own version selection free; it only forecloses the one
+# transitive jump that broke CI.
+constraint-dependencies = ["dbt-core<2"]
 
 [tool.uv.sources]
 fabric-emulator-notebookutils = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ members = [
     "fabric-emulator-python",
     "fabric-target",
 ]
+constraints = [{ name = "dbt-core", specifier = "<2" }]
 
 [[package]]
 name = "agate"


### PR DESCRIPTION
Both open Dependabot PRs (#307, #308) titled themselves as a `sqlparse` patch bump, but the actual resolved diff pulls `dbt-core` from **1.12.0 to 2.0.0b1**, a pre-release with no stable 2.0 out yet (checked PyPI directly: `2.0.0a1` through `2.0.0a5`, then `2.0.0b1`, nothing past it). Neither PR is safe to merge.

## Root cause, verified rather than assumed

`dbt-core` 1.12.0's own metadata declares `sqlparse<0.6.0,>=0.5.5`. `dbt-fabric`/`dbt-fabricspark` declare no upper bound on `dbt-core` itself, in the root `pyproject.toml` and independently in all four `examples/medallion-*` directories. So a plain sqlparse patch bump has exactly one resolvable outcome once it crosses 0.6.0: drag `dbt-core` forward too. **There is no independent "just bump sqlparse" available** — I tried `uv lock --upgrade-package sqlparse` against a `dbt-core<2` constraint and it correctly refused to move sqlparse at all, which is uv confirming the coupling rather than a bug.

That's what broke 9 CI jobs across the two PRs: `e2e/dbt-fabric/runner.py` writes `access_token_expires_on: 0` (an int) into `profiles.yml`, which 1.x parsed fine and 2.0.0b1's stricter schema rejects with `invalid type: integer `0`, expected a string`.

## Fix

`constraint-dependencies = ["dbt-core<2"]` in `[tool.uv]`, in the root `pyproject.toml` and all four example `pyproject.toml`s. A constraint, not a direct dependency, so `dbt-fabric`'s own version selection stays free; it only forecloses the one transitive jump that broke CI. Every lockfile diff is purely additive, the new constraint's metadata line, with zero version churn otherwise, confirming this restores exactly the combination that was passing before.

## Verified

`go build ./...` clean. Full Python suite in a scrubbed environment (`env -i`): 1002 passed, 1 pre-existing unrelated failure. That failure (`test_apply_notebook_env_wires_the_shim_for_this_process`, a port-string mismatch) reproduces identically on unmodified `origin/main` with no changes of mine in the tree, so it's a pre-existing test-isolation bug independent of this fix. Not something I'm fixing here, flagging separately since it's real.

Not run against the actual containerized dbt-fabric/dbt-fabricspark e2e jobs locally (they need the full Docker stack); confidence here comes from the lockfiles resolving to exactly the pre-regression versions, not from re-running the failing jobs myself. CI will confirm.

Closes the two Dependabot PRs as unmergeable in their current form; commenting on both with this PR as the reason.