### PR TITLE
chore(deps): take sqlparse 0.6.0 over dbt-core's upper bound

### DIFF
--- a/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
@@ -36,6 +36,13 @@ dependencies = [
 
 [tool.uv]
 package = false
+# sqlparse arrives only through dbt-core, which pins `sqlparse<0.6.0` in every
+# published release, so no dbt upgrade reaches the version that patches four
+# advisories. Overridden deliberately, and measured: dbt's single sqlparse call
+# site (`inject_ctes_into_sql`) returns byte-identical SQL under 0.5.5 and
+# 0.6.0. See the root pyproject.toml for the full note; DELETE this once
+# dbt-core relaxes the bound.
+override-dependencies = ["sqlparse>=0.6.0"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-advanced-dbt-fabricspark/uv.lock
+++ b/examples/medallion-advanced-dbt-fabricspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "sqlparse", specifier = ">=0.6.0" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -2852,11 +2855,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/examples/medallion-advanced-pyspark/pyproject.toml
+++ b/examples/medallion-advanced-pyspark/pyproject.toml
@@ -35,6 +35,13 @@ dependencies = [
 
 [tool.uv]
 package = false
+# sqlparse arrives only through dbt-core, which pins `sqlparse<0.6.0` in every
+# published release, so no dbt upgrade reaches the version that patches four
+# advisories. Overridden deliberately, and measured: dbt's single sqlparse call
+# site (`inject_ctes_into_sql`) returns byte-identical SQL under 0.5.5 and
+# 0.6.0. See the root pyproject.toml for the full note; DELETE this once
+# dbt-core relaxes the bound.
+override-dependencies = ["sqlparse>=0.6.0"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-advanced-pyspark/uv.lock
+++ b/examples/medallion-advanced-pyspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "sqlparse", specifier = ">=0.6.0" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -2833,11 +2836,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/examples/medallion-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-dbt-fabricspark/pyproject.toml
@@ -25,6 +25,13 @@ dependencies = [
 
 [tool.uv]
 package = false
+# sqlparse arrives only through dbt-core, which pins `sqlparse<0.6.0` in every
+# published release, so no dbt upgrade reaches the version that patches four
+# advisories. Overridden deliberately, and measured: dbt's single sqlparse call
+# site (`inject_ctes_into_sql`) returns byte-identical SQL under 0.5.5 and
+# 0.6.0. See the root pyproject.toml for the full note; DELETE this once
+# dbt-core relaxes the bound.
+override-dependencies = ["sqlparse>=0.6.0"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-dbt-fabricspark/uv.lock
+++ b/examples/medallion-dbt-fabricspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "sqlparse", specifier = ">=0.6.0" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -1696,11 +1699,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/examples/medallion-pyspark/pyproject.toml
+++ b/examples/medallion-pyspark/pyproject.toml
@@ -26,6 +26,13 @@ dependencies = [
 
 [tool.uv]
 package = false
+# sqlparse arrives only through dbt-core, which pins `sqlparse<0.6.0` in every
+# published release, so no dbt upgrade reaches the version that patches four
+# advisories. Overridden deliberately, and measured: dbt's single sqlparse call
+# site (`inject_ctes_into_sql`) returns byte-identical SQL under 0.5.5 and
+# 0.6.0. See the root pyproject.toml for the full note; DELETE this once
+# dbt-core relaxes the bound.
+override-dependencies = ["sqlparse>=0.6.0"]
 
 [tool.uv.sources]
 contoso-fixtures = { path = "../contoso-fixtures", editable = true }

--- a/examples/medallion-pyspark/uv.lock
+++ b/examples/medallion-pyspark/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "sqlparse", specifier = ">=0.6.0" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -1700,11 +1703,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,23 @@ data-science-loop = [
 
 [tool.uv]
 package = false
+# sqlparse reaches this lock ONLY through dbt-core, which pins `sqlparse<0.6.0`
+# in every release it has published — 1.11.13 through 1.12.2, checked against
+# PyPI, so there is no version of dbt to upgrade INTO that takes the patched
+# sqlparse. Four advisories (three DoS, one escaping) name 0.6.0 as the first
+# patched version, so the choice is this override or living with them.
+#
+# Overriding a maintainer's upper bound is a deliberate deviation, so it was
+# measured rather than assumed. dbt-core touches sqlparse in exactly one place
+# (`dbt/compilation.py`: `parse`, `sql.Token`, `tokens`, `lexer.Lexer`, and the
+# `engine.grouping.MAX_GROUPING_*` caps). Running dbt's own `inject_ctes_into_sql`
+# over four SQL shapes under 0.5.5 and 0.6.0 returns BYTE-IDENTICAL output, and
+# both grouping caps still exist in 0.6.0 — so the pin is upstream caution
+# about a minor bump, not a known incompatibility with the surface dbt uses.
+#
+# Re-check when dbt-core relaxes the bound: this override should then be
+# DELETED rather than left to pin the ecosystem quietly.
+override-dependencies = ["sqlparse>=0.6.0"]
 conflicts = [
     [
         { group = "dbt-fabric" },

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ members = [
     "fabric-emulator-python",
     "fabric-target",
 ]
+overrides = [{ name = "sqlparse", specifier = ">=0.6.0" }]
 
 [[package]]
 name = "agate"
@@ -4914,11 +4915,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
All 28 open Dependabot alerts are the same package. **sqlparse**, four
advisories (three DoS, one escaping), each patched in **0.6.0**:

| | |
|---|---|
| Inefficient regex on dollar-quoted literals → ReDoS | HIGH |
| `TokenList.__init__` materializes O(subtree) per group → CPU DoS before the depth/token caps trigger | HIGH |
| Quadratic O(n²) in `group_comments` | HIGH |
| Generated Python/PHP snippets allow SQL breakout through unescaped backslashes | MEDIUM |

## Why a plain bump could not do it

sqlparse reaches all five live lockfiles **only through dbt-core**, and every
dbt-core release pins `sqlparse<0.6.0,>=0.5.5` — 1.11.13, 1.12.0, 1.12.1 and
1.12.2, each checked against PyPI. There is no dbt version to upgrade *into*.
So the choice was an override or living with the alerts.

## Overriding a maintainer's bound, measured rather than assumed

dbt-core touches sqlparse in exactly one place, `dbt/compilation.py`:
`sqlparse.parse`, `sql.Token`, `tokens`, `lexer.Lexer`, and the
`engine.grouping.MAX_GROUPING_DEPTH` / `MAX_GROUPING_TOKENS` caps (which are
themselves dbt's response to this advisory class, and both still exist in
0.6.0).

Running dbt's own `inject_ctes_into_sql` over four SQL shapes — bare select,
an existing `with`, a leading comment with two CTEs, and uppercase keywords —
returns **byte-identical output under 0.5.5 and 0.6.0**:

```
sqlparse 0.5.5                              sqlparse 0.6.0
'withx as (select 1 as c) select * from a'  'withx as (select 1 as c) select * from a'
'with x as (...), y as (select 2) ...'      'with x as (...), y as (select 2) ...'
'withx as (...), z as (...) -- comment\n…'  'withx as (...), z as (...) -- comment\n…'
'withx as (select 1 as c) SELECT * FROM a'  'withx as (select 1 as c) SELECT * FROM a'
```

So the pin reads as upstream caution about a minor bump, not a known
incompatibility with the surface dbt uses.

(The `withx` missing space is dbt's own pre-existing quirk — it is identical on
both sides, so this PR neither causes nor fixes it. Flagged rather than
quietly passed over, because I only noticed it while reading the diff output.)

## Scope

Five `pyproject.toml` files carry the override with its reason, and every one
says to **delete it** once dbt-core relaxes the bound — an override left behind
pins the ecosystem silently. Five lockfiles re-resolved, and **only sqlparse
moved**: `git diff` over all five shows no other `name =` line changing.

Local: `make check` and `make lint` green, `pytest python/tests` 967 passed /
1 skipped.

## Not in this PR

Eight of the 28 alerts name `examples/medallion/uv.lock` and
`examples/medallion-spark/uv.lock`, which were deleted in `4839331` when the
medallion examples became four standalone folders. Those are stale alerts
against files that no longer exist; they need dismissing in the security tab,
not a code change.