### PR TITLE
Run CeleryExecutor in the built-in Airflow sidecar, as Fabric does

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,17 +226,41 @@ services:
   # the bug the spark-agent profile shipped once, which is why the terminal
   # overlay is split the same way.
   #
-  # SequentialExecutor on SQLite: this is a local fidelity target, not a
-  # throughput one, and it keeps the sidecar to one container.
+  # CELERY, BECAUSE FABRIC GIVES A DAG AUTHOR NO CHOICE. This ran
+  # SequentialExecutor on SQLite, argued as "a local fidelity target, not a
+  # throughput one" -- but the executor is not a throughput knob here.
+  # Microsoft documents Fabric's default as `CeleryExecutor` AND lists
+  # `AIRFLOW__CORE__EXECUTOR` among the configurations a user cannot override,
+  # so on real Fabric it is always Celery and no DAG can opt out.
+  #
+  # Sequential runs ONE TASK AT A TIME. A DAG with four parallel ingests and
+  # seven concurrent models serialises, passes, and demonstrates behaviour no
+  # Fabric user can have -- and a one-task witness DAG cannot see the
+  # difference, which is why this was green for as long as it was. Fidelity
+  # that only holds for trivial DAGs is the kind worth not claiming.
+  #
+  # The cost is two more containers, both profile-gated with this one: Celery
+  # needs a broker, and a parallel executor needs a metadata database SQLite
+  # cannot be (concurrent writers get `database is locked`).
   airflow:
     profiles: [airflow]
     image: apache/airflow:2.10.5-python3.12
+    depends_on:
+      airflow-db:
+        condition: service_healthy
+      airflow-broker:
+        condition: service_healthy
     environment:
       AIRFLOW__CORE__LOAD_EXAMPLES: "false"
-      AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
+      # FABRIC'S DEFAULT IS False, and the emulator's client PATCHes
+      # `is_paused: false` before every trigger anyway, so this only removes a
+      # difference nothing depended on.
+      AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "false"
       AIRFLOW__API__AUTH_BACKENDS: airflow.api.auth.backend.basic_auth
-      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: sqlite:////opt/airflow/airflow.db
-      AIRFLOW__CORE__EXECUTOR: SequentialExecutor
+      AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow-db/airflow
+      AIRFLOW__CELERY__BROKER_URL: redis://airflow-broker:6379/0
+      AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@airflow-db/airflow
       # The emulator writes a DAG and then waits for Airflow to notice it; the
       # defaults (5 min) make that look like a hang.
       AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: "2"
@@ -245,6 +269,10 @@ services:
       - airflow-dags:/opt/airflow/dags
     ports:
       - "8085:8080" # the Airflow UI, for looking at what a job actually did
+    # Scheduler, WORKER and webserver in one container. Three processes rather
+    # than three services: the topology that matters for fidelity is Celery's
+    # queue between scheduler and worker, which is present either way, and
+    # splitting them would add a service without adding a behaviour.
     command:
       - bash
       - -ec
@@ -253,12 +281,42 @@ services:
         airflow users create --username admin --password admin \
           --firstname Fabric --lastname Emulator --role Admin --email admin@example.com
         airflow scheduler &
+        airflow celery worker &
         exec airflow webserver
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
       interval: 5s
       timeout: 3s
       retries: 60
+
+  # Celery's metadata database. NOT a preference: a parallel executor needs
+  # concurrent writers and SQLite answers `database is locked`, which is why
+  # the executor and the database had to move together.
+  airflow-db:
+    profiles: [airflow]
+    image: postgres:16.4
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    volumes:
+      - airflow-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U airflow -d airflow"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # Celery's broker: the queue the scheduler puts tasks on and the worker takes
+  # them off. This is the part that makes the executor Celery rather than Local.
+  airflow-broker:
+    profiles: [airflow]
+    image: redis:7.4-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
   # ---- Real-Time Intelligence (optional): Kusto engine, profile-gated -------
   # Microsoft's own KQL engine container (the Azure Data Explorer "Kusto
@@ -479,3 +537,5 @@ volumes:
   # reads them from the same volume. One volume is what makes the sync a file
   # copy rather than an upload API.
   airflow-dags:
+  # Airflow's own metadata database, separate from OpenMetadata's.
+  airflow-db-data:

--- a/e2e/airflow/docker-compose.yml
+++ b/e2e/airflow/docker-compose.yml
@@ -25,17 +25,28 @@ services:
       timeout: 2s
       retries: 30
 
+  # THE SAME EXECUTOR THE SHIPPED SIDECAR USES. This carried its own copy of
+  # the service and the two drifted: docker-compose.yml moved to Celery for
+  # fidelity with Fabric while this stayed Sequential, so the e2e would have
+  # gone on witnessing a topology nobody runs. Kept in step deliberately --
+  # `test_airflow_e2e_matches_the_shipped_sidecar` fails if they diverge again.
   airflow:
     image: apache/airflow:2.10.5-python3.12
     depends_on:
       volume-init:
         condition: service_healthy
+      airflow-db:
+        condition: service_healthy
+      airflow-broker:
+        condition: service_healthy
     environment:
       AIRFLOW__CORE__LOAD_EXAMPLES: "false"
-      AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
+      AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "false"
       AIRFLOW__API__AUTH_BACKENDS: airflow.api.auth.backend.basic_auth
-      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: sqlite:////opt/airflow/airflow.db
-      AIRFLOW__CORE__EXECUTOR: SequentialExecutor
+      AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow-db/airflow
+      AIRFLOW__CELERY__BROKER_URL: redis://airflow-broker:6379/0
+      AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@airflow-db/airflow
       AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: "2"
       AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: "1"
     volumes:
@@ -48,12 +59,33 @@ services:
         airflow db migrate
         airflow users create --username admin --password admin --firstname Fabric --lastname Emulator --role Admin --email admin@example.com
         airflow scheduler &
+        airflow celery worker &
         exec airflow webserver
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
       interval: 5s
       timeout: 3s
       retries: 60
+
+  airflow-db:
+    image: postgres:16.4
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U airflow -d airflow"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  airflow-broker:
+    image: redis:7.4-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
   fabric-emulator:
     build:

--- a/e2e/airflow/witness.py
+++ b/e2e/airflow/witness.py
@@ -57,13 +57,38 @@ _, _, item = request(
 dag = b'''from airflow import DAG
 from airflow.operators.python import PythonOperator
 from datetime import datetime
+import json, os, time
 
-def witness():
-    with open("/results/passed", "w", encoding="utf-8") as result:
-        result.write("real airflow 2.10.5")
+# THREE TASKS THAT OVERLAP, not one that runs.
+#
+# This DAG had a single task, and a single task cannot tell CeleryExecutor from
+# SequentialExecutor -- which is exactly how the sidecar ran Sequential against
+# a green witness for as long as it did. Fabric forbids overriding
+# AIRFLOW__CORE__EXECUTOR and its default is Celery, so an emulator that
+# serialises is offering behaviour no Fabric user can have, and the witness has
+# to be able to SEE that.
+#
+# Each branch records when it started and stopped. Under a parallel executor
+# their windows overlap; under Sequential they cannot, because the second task
+# does not begin until the first returns. The assertion is made on the
+# consumer side, from these files.
+def branch(name):
+    def run():
+        started = time.time()
+        time.sleep(3)
+        with open(f"/results/{name}.json", "w", encoding="utf-8") as fh:
+            json.dump({"started": started, "ended": time.time()}, fh)
+    return run
 
 with DAG("fabric_emulator_witness", start_date=datetime(2024, 1, 1), schedule=None, catchup=False) as dag:
-    PythonOperator(task_id="write_witness", python_callable=witness)
+    fan = [PythonOperator(task_id=f"branch_{i}", python_callable=branch(f"branch_{i}"))
+           for i in range(3)]
+
+    def witness():
+        with open("/results/passed", "w", encoding="utf-8") as result:
+            result.write("real airflow 2.10.5")
+
+    PythonOperator(task_id="write_witness", python_callable=witness) << fan
 '''
 files = f"{FABRIC}/v1/workspaces/{workspace['id']}/apacheAirflowJobs/{item['id']}/files"
 request("PUT", files + "/dags/witness.py?beta=true", token, dag, "application/octet-stream")
@@ -88,4 +113,25 @@ else:
 
 assert job["status"] == "Completed", job
 assert Path("/results/passed").read_text() == "real airflow 2.10.5"
-print("PASS: real Apache Airflow 2.10.5 loaded, scheduled, and executed the Fabric DAG")
+
+# THE EXECUTOR IS PARALLEL, witnessed rather than configured. Three independent
+# branches each sleep 3s and record their window. Under CeleryExecutor -- which
+# is what Fabric runs and forbids changing -- those windows overlap. Under
+# SequentialExecutor they are strictly ordered, because the next task does not
+# start until the previous returns, and the whole DAG takes 3x as long.
+#
+# Asserting the CONFIG says Celery would prove only that a string is in a file.
+# This proves the scheduler actually handed work to a worker concurrently.
+windows = [json.loads(Path(f"/results/branch_{i}.json").read_text()) for i in range(3)]
+span = max(w["ended"] for w in windows) - min(w["started"] for w in windows)
+serial = sum(w["ended"] - w["started"] for w in windows)
+assert span < serial * 0.75, (
+    f"the three branches did not overlap: wall span {span:.1f}s against "
+    f"{serial:.1f}s of work. That is SequentialExecutor's signature -- a "
+    f"parallel executor finishes all three in roughly one branch's time. "
+    f"windows={windows}"
+)
+print(
+    f"PASS: real Apache Airflow 2.10.5 loaded, scheduled and executed the Fabric DAG, "
+    f"and ran 3 branches CONCURRENTLY ({span:.1f}s wall for {serial:.1f}s of work)"
+)

--- a/python/tests/test_airflow_sidecar_parity.py
+++ b/python/tests/test_airflow_sidecar_parity.py
@@ -1,0 +1,118 @@
+"""The built-in Airflow sidecar must match what real Fabric runs.
+
+Fabric's Apache Airflow job is upstream Airflow, so "parity" here is checkable
+against Microsoft's published configuration rather than inferred. Two of these
+properties were WRONG for as long as this sidecar existed, and neither could be
+seen by the e2e that exercises it:
+
+  * the executor was `SequentialExecutor`. Microsoft documents Fabric's default
+    as `CeleryExecutor` and lists `AIRFLOW__CORE__EXECUTOR` among the settings a
+    user CANNOT override -- so on Fabric it is always Celery and no DAG can opt
+    out. Sequential runs one task at a time, so a DAG with parallel branches
+    serialises, passes, and demonstrates behaviour no Fabric user can have.
+  * `DAGS_ARE_PAUSED_AT_CREATION` was "true"; Fabric's default is False.
+
+A ONE-TASK WITNESS DAG CANNOT SEE EITHER. That is why they survived a green
+end-to-end test, and why these assertions are made against the file rather than
+against a run: the run would have to be a parallel DAG to notice, and the e2e's
+is not.
+
+The two compose files are checked TOGETHER because the e2e carries its own copy
+of the service. They had already drifted once in the making of this change.
+"""
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SHIPPED = ROOT / "docker-compose.yml"
+E2E = ROOT / "e2e" / "airflow" / "docker-compose.yml"
+
+# What Microsoft documents for Fabric's Apache Airflow job:
+#   https://learn.microsoft.com/en-us/fabric/data-factory/apache-airflow-jobs-concepts
+#   https://learn.microsoft.com/en-us/fabric/data-factory/apache-airflow-jobs-supported-apache-airflow-configurations
+FABRIC_AIRFLOW_IMAGE = "apache/airflow:2.10.5-python3.12"
+FABRIC_EXECUTOR = "CeleryExecutor"
+
+
+def airflow_block(path: pathlib.Path) -> str:
+    """The `airflow:` service, to the start of the next top-level service.
+
+    Hand-rolled rather than via PyYAML, as the sibling checks in this directory
+    are: this repository's tests do not carry a YAML dependency.
+    """
+    text = path.read_text(encoding="utf-8")
+    start = re.search(r"^  airflow:$", text, re.MULTILINE)
+    assert start, f"no airflow service in {path}"
+    rest = text[start.end():]
+    nxt = re.search(r"^  [a-z][a-z0-9-]*:$", rest, re.MULTILINE)
+    block = rest[: nxt.start()] if nxt else rest
+    # COMMENTS STRIPPED, because these assertions are about configuration and a
+    # comment is prose. The first version of this test failed on the sentence
+    # explaining WHY SQLite cannot back a parallel executor -- it read the word
+    # and concluded the file still used it. An assertion that cannot tell code
+    # from the text describing it will fire on its own documentation.
+    return "\n".join(
+        line for line in block.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+@pytest.mark.parametrize("path", [SHIPPED, E2E], ids=["shipped", "e2e"])
+def test_the_executor_is_the_one_fabric_forces(path):
+    block = airflow_block(path)
+    assert f"AIRFLOW__CORE__EXECUTOR: {FABRIC_EXECUTOR}" in block, (
+        f"{path.name} does not run {FABRIC_EXECUTOR}. Fabric forbids overriding "
+        f"AIRFLOW__CORE__EXECUTOR, so an emulator on any other executor is "
+        f"offering behaviour no Fabric user can have -- and SequentialExecutor "
+        f"specifically serialises every parallel DAG while still passing."
+    )
+    assert "SequentialExecutor" not in block, f"{path.name} is back on SequentialExecutor"
+
+
+@pytest.mark.parametrize("path", [SHIPPED, E2E], ids=["shipped", "e2e"])
+def test_celery_has_a_broker_and_a_real_metadata_database(path):
+    block = airflow_block(path)
+    assert "AIRFLOW__CELERY__BROKER_URL" in block, f"{path.name}: Celery with no broker"
+    # SQLite cannot serve concurrent writers -- a parallel executor on it fails
+    # with `database is locked`, so the database is not a separable choice.
+    assert "sqlite" not in block.lower(), (
+        f"{path.name} pairs a parallel executor with SQLite, which answers "
+        f"`database is locked` under concurrent writers"
+    )
+    assert "postgresql" in block, f"{path.name}: no Postgres metadata database"
+    assert "celery worker" in block, f"{path.name} starts no Celery worker"
+
+
+@pytest.mark.parametrize("path", [SHIPPED, E2E], ids=["shipped", "e2e"])
+def test_the_version_is_the_one_fabric_supports(path):
+    """Fabric supports exactly 2.10.5 on Python 3.12, and no Airflow 3.x."""
+    assert FABRIC_AIRFLOW_IMAGE in airflow_block(path), (
+        f"{path.name} does not run {FABRIC_AIRFLOW_IMAGE}"
+    )
+
+
+@pytest.mark.parametrize("path", [SHIPPED, E2E], ids=["shipped", "e2e"])
+def test_dags_are_not_paused_at_creation_as_fabric_leaves_them(path):
+    assert 'AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "false"' in airflow_block(path), (
+        f"{path.name} pauses DAGs at creation; Fabric's default is False"
+    )
+
+
+def test_the_e2e_sidecar_matches_the_shipped_one():
+    """The e2e carries its own copy, so it can witness a topology nobody runs.
+
+    That is not hypothetical: this pair drifted while the executor was being
+    changed, leaving the e2e green against Sequential after the shipped sidecar
+    had moved to Celery.
+    """
+    shipped, e2e = airflow_block(SHIPPED), airflow_block(E2E)
+    keys = (
+        "AIRFLOW__CORE__EXECUTOR",
+        "AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION",
+        "AIRFLOW__CELERY__BROKER_URL",
+    )
+    for key in keys:
+        a = [ln.strip() for ln in shipped.splitlines() if key in ln]
+        b = [ln.strip() for ln in e2e.splitlines() if key in ln]
+        assert a == b, f"{key} differs: shipped={a} e2e={b}"


### PR DESCRIPTION
Closes the executor half of the built-in-Airflow parity gap.

## The gap

The sidecar ran `SequentialExecutor` on SQLite. Its own comment argued this was fine — *"a local fidelity target, not a throughput one"* — but the executor is not a throughput knob here:

- Microsoft documents Fabric's default as **`CeleryExecutor`**
- and lists **`AIRFLOW__CORE__EXECUTOR` among the configurations a user cannot override**

So on real Fabric it is *always* Celery and no DAG can opt out. `SequentialExecutor` runs one task at a time, so a DAG with parallel branches serialises, passes, and demonstrates behaviour no Fabric user can have.

## Why the e2e was green anyway

**The witness DAG had one task, and one task cannot distinguish the two executors.** That is the whole reason this survived.

It now fans out to three branches, each sleeping 3s and recording its own window; the consumer asserts the wall span is well under the sum of the work:

```
PASS: real Apache Airflow 2.10.5 loaded, scheduled and executed the Fabric DAG,
      and ran 3 branches CONCURRENTLY (3.0s wall for 9.0s of work)
```

Under `SequentialExecutor` that reads `9.0s for 9.0s` and the assertion fails. This proves the scheduler handed work to a worker concurrently — checking the config would only prove a string is in a file.

## What moved together

| | before | after |
|---|---|---|
| executor | `SequentialExecutor` | **`CeleryExecutor`** |
| metadata DB | sqlite | **Postgres** |
| broker | — | **Redis** |
| `DAGS_ARE_PAUSED_AT_CREATION` | `"true"` | **`"false"`** (Fabric's default) |
| version | `apache/airflow:2.10.5-python3.12` | unchanged — already exact |

The database was never a separable choice: SQLite answers `database is locked` under concurrent writers. Both new services are profile-gated with the sidecar, so `docker compose up` is unaffected.

Scheduler, worker and webserver stay in one container. The topology that matters for fidelity is Celery's queue between scheduler and worker, which is present either way; splitting them would add a service without adding a behaviour.

`DAGS_ARE_PAUSED_AT_CREATION` is safe to flip because `internal/airflow/client.go` PATCHes `is_paused: false` before every trigger — it removes a difference nothing depended on.

## Drift guard

The e2e carries its own copy of the service, and **the two drifted during this change** — the e2e stayed green on Sequential after the shipped sidecar had moved. `test_airflow_sidecar_parity` now pins them together and asserts the executor, broker, version and paused default against what Microsoft documents.

## Verification

- `e2e/airflow` passes with the concurrency assertion above
- 976 python tests, `go build`, `go vet`, `go test ./internal/api/` all pass

Version parity was checked against [Microsoft's docs](https://learn.microsoft.com/en-us/fabric/data-factory/apache-airflow-jobs-concepts) (updated 2026-06) rather than assumed: Fabric supports Airflow **2.10.5** on Python **3.12**, and no Airflow 3.x.