### PR TITLE
A DAG-sync failure is not a DAG that failed

### DIFF
--- a/internal/api/airflow.go
+++ b/internal/api/airflow.go
@@ -164,7 +164,17 @@ func (a *API) runAirflow(ctx context.Context, it *store.Item, job *store.JobInst
 		err = &airflowError{"AirflowDAGFileRequired"}
 	}
 	if err == nil {
-		err = a.Airflow.SyncDAGs(ctx, it.ID, files)
+		// A SYNC FAILURE IS NOT A DAG FAILURE, and collapsing the two cost a
+		// consumer an afternoon. The DAG directory is a volume shared with the
+		// Airflow sidecar; if the emulator's uid cannot write there,
+		// `os.WriteFile` returns `permission denied`, the job is finalized as
+		// the generic `AirflowRunFailed`, and what the operator sees is "The
+		// job failed." beside an empty dags folder -- with the real reason
+		// discarded one line later. Its own code, so `jobFailureMessage` can
+		// say what to check.
+		if syncErr := a.Airflow.SyncDAGs(ctx, it.ID, files); syncErr != nil {
+			err = &airflowError{"AirflowDAGSyncFailed"}
+		}
 	}
 	if err == nil {
 		err = a.Airflow.TriggerAndWait(ctx, dagID, job.ID, conf)

--- a/internal/api/airflow_test.go
+++ b/internal/api/airflow_test.go
@@ -210,3 +210,80 @@ func pathTail(s string) string {
 	}
 	return s[i+1:]
 }
+
+// A DAG-SYNC FAILURE MUST NOT LOOK LIKE A DAG THAT FAILED. Both used to
+// finalize as `AirflowRunFailed`, whose message is the bare "The job failed."
+// -- so an operator whose emulator could not WRITE the DAG files saw a failed
+// run beside an empty dags folder and no reason at all. That is not
+// hypothetical: it is how a consumer platform's first end-to-end run failed,
+// and the cause (a shared volume the emulator's non-root uid could not write)
+// took a permissions audit to find rather than a read of the error.
+//
+// The distinction has to survive to the CODE, because the message is derived
+// from it.
+func TestAirflowDAGSyncFailureIsDistinctFromARunFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		runtime *airflowWitness
+		want    string
+	}{
+		{"sync", &airflowWitness{syncErr: errors.New("permission denied")}, "AirflowDAGSyncFailed"},
+		{"run", &airflowWitness{runErr: errors.New("task failed")}, "AirflowRunFailed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, st := newAPI(t)
+			a.Airflow = tc.runtime
+			ws := seedWorkspace(t, st)
+			it := &store.Item{WorkspaceID: ws.ID, Type: "ApacheAirflowJob", DisplayName: "air"}
+			if err := st.CreateItem(it, nil); err != nil {
+				t.Fatal(err)
+			}
+			_ = st.CreateOneLakePath(&store.OneLakePath{
+				WorkspaceID: ws.ID, ItemID: it.ID,
+				RelPath: "Files/dags/hello.py", Content: []byte("# dag"),
+			}, false)
+			body := `{"executionData":{"dagId":"hello"}}`
+			r := httptest.NewRequest("POST", "/x?jobType=Run", strings.NewReader(body))
+			r.SetPathValue("wid", ws.ID)
+			r.SetPathValue("iid", it.ID)
+			w := httptest.NewRecorder()
+			a.createJobInstance(w, r, admin)
+			if w.Code != 202 {
+				t.Fatalf("run = %d %s", w.Code, w.Body.String())
+			}
+			jid := strings.TrimPrefix(
+				w.Header().Get("Location"),
+				"https://example.com/v1/workspaces/"+ws.ID+"/items/"+it.ID+"/jobs/instances/")
+			deadline := time.Now().Add(2 * time.Second)
+			for {
+				job, err := st.GetJobInstance(it.ID, jid)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if job.FailWith != "" {
+					if job.FailWith != tc.want {
+						t.Fatalf("failure code = %q, want %q", job.FailWith, tc.want)
+					}
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("job never failed: %+v", job)
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		})
+	}
+
+	// And the code has to carry a message that names what to check. A distinct
+	// code whose message is still "The job failed." would have moved the
+	// problem rather than fixed it.
+	msg := jobFailureMessage("AirflowDAGSyncFailed")
+	if msg == "The job failed." {
+		t.Fatal("AirflowDAGSyncFailed has no message of its own")
+	}
+	for _, want := range []string{"DAG", "writable", "uid"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message does not mention %q: %s", want, msg)
+		}
+	}
+}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -59,6 +59,15 @@ func jobFailureMessage(code string) string {
 		return "This Copy job's DESTINATION is an external connection (SQL, " +
 			"Blob, …). The emulator executes Lakehouse-to-Lakehouse legs only; " +
 			"external stores need credentials and drivers it does not hold."
+	case "AirflowDAGSyncFailed":
+		return "The job's DAG files could not be written to the Airflow DAG " +
+			"directory. That directory is a volume shared with the Airflow " +
+			"sidecar, and the emulator runs as a non-root uid: if the volume " +
+			"comes up owned by the Airflow user without group or world write, " +
+			"the emulator cannot write into it and the scheduler sees no DAGs. " +
+			"Check that FABRIC_AIRFLOW_DAG_DIR is writable by the emulator's " +
+			"uid — the shipped compose has the Airflow container widen it at " +
+			"startup, because it owns the directory."
 	case "CopyJobWriteBehaviorNotSupported":
 		return "This Copy job's writeBehavior needs key-based reconciliation " +
 			"(Merge/Upsert). Append and Overwrite execute for real; a Merge " +


### PR DESCRIPTION
## The symptom

A job whose DAG files could not be written reported:

```
"failureReason": {"errorCode": "AirflowRunFailed", "message": "The job failed."}
```

…beside an empty dags folder. The real error — `permission denied` from `os.WriteFile` — was returned by `SyncDAGs` and discarded one line later, because `runAirflow` collapses every non-`airflowError` into `AirflowRunFailed`.

## How it was found

A consumer platform's first end-to-end run against the pinned image failed exactly like this. The cause was the DAG volume shared with the Airflow sidecar: it comes up `0775 airflow:root`, and the emulator runs distroless as **uid 65532** — neither owner nor in group root, so it gets `r-x` and cannot write.

Finding that took a permissions audit rather than a read of the error. This repo's own `jobFailureMessage` comment already names that cost:

> Every failed job said "The job failed." … a refusal with a specific, fixable cause arrived indistinguishable from a cell that threw.

## The change

`AirflowDAGSyncFailed` gets its own code and a message naming what to check — following the established `jobFailureMessage` pattern rather than inventing a new mechanism.

Two tests pin it:
- sync failures and run failures stay **distinguishable in the code** (`AirflowDAGSyncFailed` vs `AirflowRunFailed`)
- the code **has a message of its own** — a distinct code still answering "The job failed." would have moved the problem rather than fixed it

`go build`, `go vet` and the `api` + `store` packages are green.

## Note

Independent of #320 (different files); either can merge first.