### PR TITLE
docs: split the seven own-only rows by whether they can be converted

### DIFF
--- a/docs/24-parity-completion.md
+++ b/docs/24-parity-completion.md
@@ -29,6 +29,43 @@ engine absent" holds the rest.
 | Generic item job status | 🟡 | Same reason. (DataPipeline jobs already run for real.) |
 | ~~Web / external-connector activity leaves~~ | — | **Reversed, and the reasoning was wrong.** This row argued that executing arbitrary URLs would destroy the offline guarantee. It protected the wrong thing: the offline promise is that the **emulator** makes no calls of its own, never that a user's pipeline cannot reach the service it names. A pipeline branching on `@activity('Ping').output.status` got a fabricated success from a URL nothing contacted — green locally, different in Fabric, which is the exact failure class this emulator exists to prevent. The Web activity now makes the real call; `RestSource`/`RestSink` read, page and write; Salesforce runs both Bulk API 2.0 lifecycles. Hermetic runs stay available and **explicit** (`FABRIC_WEB_ACTIVITY=stub`), labelled in the output so such a run cannot be mistaken for one that called. See [40-rest-connector-plan.md](40-rest-connector-plan.md) and [41-salesforce-connector-plan.md](41-salesforce-connector-plan.md) |
 
+## The seven own-only rows, split by whether they CAN be converted
+
+`family_parity.py fabric` reports **106 of 113** green claims independently
+evidenced, and the remaining seven read like a backlog. They are not one list.
+Sorted by what would actually close them — which is the only sort that tells a
+maintainer where to start:
+
+**Impossible, and now marked `boundary:` in the manifest.** No packaged
+third-party client speaks these surfaces, so a `ci:` witness cannot exist rather
+than not existing yet:
+
+| Row | Why no client can witness it |
+|---|---|
+| Eventstream operators | filter / groupBy / window are bound through Fabric's own portal and the internal authoring API; no released SDK or CLI exposes them |
+| Eventstream Eventhouse destination | same — the binding has no public client. The *ingest* half is separately witnessed against real Kusto (kustainer); what stays own-only is the eventstream-to-eventhouse binding, not the KQL |
+| `notebookutils.notebook.run` exit values OVER REST | real Fabric **404s this path**. It is a shim convenience the service does not offer, so there is nothing for a real client to agree with. The in-notebook contract it shadows is its own row, green on its own evidence |
+
+So the honest denominator is **110, not 113**, and 106/110 is a floor rather than
+a score with three items of debt hiding in it.
+
+**Gated on the real-Fabric differential leg — three rows.** Reference-run
+lakehouse rule, `runMultiple` failure contract, `runMultiple` retry and timeouts.
+Each asserts that our shim matches Fabric's own semantics, and the only oracle
+for "what Fabric does" is Fabric. These convert the day `real-fabric.yml` runs
+for real; today its `conformance` job is `skipped` in every run, because
+`AZURE_CLIENT_ID` and `FABRIC_TEST_WORKSPACE` are unset (`AZURE_TENANT_ID` is
+set, and OIDC needs no client secret).
+
+**Convertible today — one row, and it is the interesting one.** Class B strict
+mode (`-tsql-strict`) looks emulator-only because the *toggle* is ours. What the
+toggle produces is a **refusal over TDS**, and `ci:warehouse-tds` already drives
+that surface with a real client. This is exactly the shape of `FABRIC_FORCE_LRO`,
+which was own-only for the same mistaken reason until a real client's poll loop
+was pointed at it: separate "the engine is internal" from "the contract is
+internal". The oracle for *which* constructs Fabric rejects stays the reference
+(docs/29), the same as it is today.
+
 ## Tier 1 — Control plane only (no engine, no research risk)
 
 Pure CRUD + RBAC in patterns the repo has executed a dozen times.

--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -343,7 +343,8 @@
       "go:TestEventstreamStoredEventhouseOnLakehouseFailsLoud",
       "go:TestEventstreamDrainEventhouseNoopAndClosed",
       "go:TestEventstreamKustoMgmtAndIngest",
-      "go:TestEventstreamDestinationRefusesByName"
+      "go:TestEventstreamDestinationRefusesByName",
+      "boundary:same as eventstream-operators \u2014 the destination binding has no public client. The INGEST half is separately witnessed against real Kusto (kustainer) in the ADX command activity work; what stays own-only is the eventstream-to-eventhouse binding, not the KQL (docs/24-parity-completion.md)"
     ]
   },
   "eventstream-operators": {
@@ -362,7 +363,8 @@
       "go:TestEventstreamOperatorPropertiesOnGet",
       "go:TestEventstreamStoredOperatorFailsOnProduce",
       "go:TestEventstreamLoadPersistOperators",
-      "go:TestEventstreamOperatorHelpers"
+      "go:TestEventstreamOperatorHelpers",
+      "boundary:no packaged third-party client speaks this surface \u2014 filter/groupBy/window operators are bound through Fabric's own portal and the internal Eventstream authoring API, and no released SDK or CLI exposes them, so a ci: witness cannot exist rather than not existing yet (docs/24-parity-completion.md)"
     ]
   },
   "fabric-cicd-tool-publishing": {
@@ -636,7 +638,8 @@
     "section": "Data Engineering (`data-engineering/`)",
     "claim": "**`notebookutils.notebook.run` \u2014 exit values OVER REST**",
     "witnesses": [
-      "py:test_notebook_run"
+      "py:test_notebook_run",
+      "boundary:real Fabric 404s this path, so no third-party client can exercise it BY CONSTRUCTION \u2014 the row is a shim convenience the service does not offer, and the in-notebook contract it shadows is the row above, which is green on its own evidence (docs/24-parity-completion.md)"
     ]
   },
   "notebookutils-notebook-runmultiple-dag-structure-and-ordering": {


### PR DESCRIPTION
`family_parity.py fabric` reports **106 of 113** green claims independently
evidenced, and the remaining seven read like a backlog. They are not one list,
and sorting them by what would actually close them is the only sort that tells a
maintainer where to start.

## Impossible — 3 rows, now marked `boundary:`

No packaged third-party client speaks these surfaces, so a `ci:` witness **cannot
exist** rather than not existing yet:

| row | why no client can witness it |
|---|---|
| Eventstream operators | filter / groupBy / window are bound through Fabric's portal and the internal authoring API; no released SDK or CLI exposes them |
| Eventstream Eventhouse destination | same. The *ingest* half is separately witnessed against real Kusto (kustainer) — what stays own-only is the eventstream-to-eventhouse binding, not the KQL |
| `notebookutils.notebook.run` exit values OVER REST | real Fabric **404s this path**; it is a shim convenience the service does not offer, so there is nothing for a real client to agree with. The in-notebook contract it shadows is its own row, green on its own evidence |

The honest denominator is **110, not 113** — 106/110 is a floor, not a score with
three items of debt hiding in it. `boundary:` is the manifest's existing
vocabulary for exactly this ("the claim is scoped by a documented limitation,
with the reason"), and the checker already counts it apart from evidence that
runs. The count moves 2 → 5.

## Gated on the real-Fabric leg — 3 rows

Reference-run lakehouse rule, `runMultiple` failure contract, `runMultiple` retry
and timeouts. Each asserts our shim matches Fabric's semantics, and the only
oracle for "what Fabric does" is Fabric. Today `real-fabric.yml`'s `conformance`
job is **`skipped` in every run** — the gate works, the leg has never executed —
because `AZURE_CLIENT_ID` and `FABRIC_TEST_WORKSPACE` are unset. `AZURE_TENANT_ID`
is set and OIDC needs no client secret, so it is two secrets away.

## Convertible today — 1 row, and it is the interesting one

**Class B strict mode (`-tsql-strict`)** looks emulator-only because the *toggle*
is ours. What the toggle produces is a refusal over TDS, and `ci:warehouse-tds`
already drives that surface with a real client. That is precisely the shape of
`FABRIC_FORCE_LRO`, which sat own-only for the same mistaken reason until a real
client's poll loop was pointed at it. I have not converted it here — this PR is
the map, not the work — but it should not be filed under "impossible", which is
where a single undifferentiated list of seven was quietly putting it.

Local: `check_witnesses.py --strict` exits 0 (checked directly, not through a
pipe), `make check` exits 0.