### PR TITLE
fix(warehouse): read parquet-go 0.32's LogicalType union

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.25.12
 require (
 	github.com/calvinchengx/entra-emulator v0.8.1
 	github.com/microsoft/go-mssqldb v1.10.0
-	github.com/parquet-go/parquet-go v0.30.1
-	github.com/segmentio/kafka-go v0.4.49
+	github.com/parquet-go/parquet-go v0.32.0
+	github.com/segmentio/kafka-go v0.4.51
 	modernc.org/sqlite v1.56.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/parquet-go/bitpack v1.0.0 h1:AUqzlKzPPXf2bCdjfj4sTeacrUwsT7NlcYDMUQxP
 github.com/parquet-go/bitpack v1.0.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.0.0 h1:87QNdi56wOfsE5bdgas0vRzHPxfJgzrXGml1zZdd7VU=
 github.com/parquet-go/jsonlite v1.0.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
-github.com/parquet-go/parquet-go v0.30.1 h1:Oy6ganNrAdFiVwy7wNmWagfPTWA2X9Z3tVHBc7JtuX8=
-github.com/parquet-go/parquet-go v0.30.1/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
+github.com/parquet-go/parquet-go v0.32.0 h1:NWDqTUHfrCS4cJP/Fj2HlxvqsrVedWG3sayMkf+znzM=
+github.com/parquet-go/parquet-go v0.32.0/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
 github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
@@ -88,8 +88,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/russellhaering/goxmldsig v1.6.1 h1:SB7R5ttvrGIDB2juJAK/i7DQ2Ivr7agG+ohfNJjwyYU=
 github.com/russellhaering/goxmldsig v1.6.1/go.mod h1:haZkRcLs9W/Xp989fIjP3BrTdbFQveRF0QNZSYoH09w=
-github.com/segmentio/kafka-go v0.4.49 h1:GJiNX1d/g+kG6ljyJEoi9++PUMdXGAxb7JGPiDCuNmk=
-github.com/segmentio/kafka-go v0.4.49/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
+github.com/segmentio/kafka-go v0.4.51 h1:JgDPPG75tC1rWIS2Me6MwcvXJ6f49UQ4HjAOef71Hno=
+github.com/segmentio/kafka-go v0.4.51/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/internal/warehouse/delta.go
+++ b/internal/warehouse/delta.go
@@ -392,6 +392,34 @@ func leafCount(n parquet.Node) int {
 	return total
 }
 
+// logicalValue reads one member out of parquet-go 0.32's LogicalType union,
+// which replaced the old struct-of-optional-pointers. Generic because every
+// caller asks the same question of a different member, and a nil annotation
+// must answer "no" rather than panic.
+func logicalValue[T format.LogicalTypeValue](lt *format.LogicalType) (T, bool) {
+	var zero T
+	if lt == nil {
+		return zero, false
+	}
+	v, ok := lt.Value.(T)
+	return v, ok
+}
+
+// isTextAnnotation reports whether the schema SAYS these bytes are text.
+// Three annotations mean text — STRING, JSON and ENUM — and they are listed
+// here rather than inline so the byte-array branch keeps reading as one
+// question.
+func isTextAnnotation(lt *format.LogicalType) bool {
+	if lt == nil {
+		return false
+	}
+	switch lt.Value.(type) {
+	case *format.StringType, *format.JsonType, *format.EnumType:
+		return true
+	}
+	return false
+}
+
 // goValue converts a parquet Value to a Go value (nil for NULL). lt is the
 // column's logical annotation, which must win over the physical kind: the same
 // INT32 is a plain int or a date, the same INT64 a long, an unscaled decimal or
@@ -402,14 +430,17 @@ func goValue(v parquet.Value, lt *format.LogicalType) any {
 	if v.IsNull() {
 		return nil
 	}
+	// parquet-go 0.32 turned LogicalType from a struct of optional pointers
+	// into a real thrift union with one Value, so the annotation is read by
+	// type rather than by nil-check. Same three questions, same order.
 	if lt != nil {
-		switch {
-		case lt.Decimal != nil:
-			return decimalValue(v, lt.Decimal)
-		case lt.Date != nil:
+		switch t := lt.Value.(type) {
+		case *format.DecimalType:
+			return decimalValue(v, t)
+		case *format.DateType:
 			return Date{T: epochDay.AddDate(0, 0, int(v.Int32()))}
-		case lt.Timestamp != nil:
-			return Timestamp{T: timestampTime(v.Int64(), lt.Timestamp)}
+		case *format.TimestampType:
+			return Timestamp{T: timestampTime(v.Int64(), t)}
 		}
 	}
 	switch v.Kind() {
@@ -429,7 +460,7 @@ func goValue(v parquet.Value, lt *format.LogicalType) any {
 		// Unsigned is deliberately excluded. Delta has no unsigned types, so
 		// this is defensive — but a uint16 up to 65535 does not fit an int16,
 		// and reflecting one width too WIDE is lossless where narrowing is not.
-		if lt != nil && lt.Integer != nil && lt.Integer.BitWidth <= 16 && lt.Integer.IsSigned {
+		if it, ok := logicalValue[*format.IntType](lt); ok && it.BitWidth <= 16 && it.IsSigned {
 			return int16(v.Int32())
 		}
 		// int32, not int64: a widened int reflects as BIGINT where Fabric says
@@ -450,7 +481,7 @@ func goValue(v parquet.Value, lt *format.LogicalType) any {
 		// Only text when the schema SAYS it is text. Unannotated bytes are
 		// binary, and stringifying them both loses the distinction and can
 		// produce invalid UTF-8 in a string column.
-		if lt != nil && (lt.UTF8 != nil || lt.Json != nil || lt.Enum != nil) {
+		if isTextAnnotation(lt) {
 			return string(v.ByteArray())
 		}
 		if lt == nil {
@@ -468,10 +499,10 @@ var epochDay = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 // timestampTime applies the annotation's unit. Getting this wrong is silent:
 // microseconds read as milliseconds land in 1970 rather than failing.
 func timestampTime(n int64, ts *format.TimestampType) time.Time {
-	switch {
-	case ts.Unit.Nanos != nil:
+	switch ts.Unit.Value.(type) {
+	case *format.NanoSeconds:
 		return time.Unix(0, n).UTC()
-	case ts.Unit.Millis != nil:
+	case *format.MilliSeconds:
 		return time.UnixMilli(n).UTC()
 	default: // Micros is the Delta/Spark default
 		return time.UnixMicro(n).UTC()


### PR DESCRIPTION
Supersedes #313. That PR bumps `parquet-go` 0.30.1 → 0.32.0 and `kafka-go`
0.4.49 → 0.4.51, and **80 of its 93 jobs fail from a single compile error** —
everything downstream reports `Artifact not found for name:
silver-summary-medallion-advanced` because the build that produces it never ran.

```
internal/warehouse/delta.go:407: lt.Decimal undefined (type *format.LogicalType has no field or method Decimal)
… also .Date, .Timestamp, .Integer, .UTF8, .Json, .Enum, and ts.Unit.Nanos
```

## What changed upstream

`format.LogicalType` was a struct of optional pointers and is now a real thrift
union carrying one `Value LogicalTypeValue`; `format.TimeUnit` moved the same
way. So the annotation is read **by type** rather than by nil-check. Same three
questions in the same order — decimal, then date, then timestamp — because the
logical annotation still has to win over the physical kind.

Two small helpers keep the call sites reading as one question each:
`logicalValue[T]` (generic, because every caller asks the same thing of a
different member, and a nil annotation must answer "no" rather than panic) and
`isTextAnnotation`.

`kafka-go` needed no changes.

## Verified, including which branches the tests actually reach

`go build ./...`, `go vet ./...`, `go test ./...` (27 packages) and `make check`
all exit 0 — checked directly, not through a pipe.

Coverage alone would not say whether the *migrated decisions* are tested, so I
mutation-tested the three:

| mutation | result |
|---|---|
| date annotation ignored, fall through to physical kind | **killed** — `TestDateDecodesToTheCalendarDayNotTheDayCount`, `TestReflectedSQLTypesMatchFabric`, `TestMirrorRoundTripPreservesLogicalTypes` |
| int16 width rule disabled | **killed** — `TestNumericWidthsMatchFabric` |
| `isTextAnnotation` returns false for STRING/JSON/ENUM | **survived** |

## The surviving mutant is a pre-existing bug, and I have not fixed it here

It survives because the branch cannot change any outcome:

```go
if isTextAnnotation(lt) { return string(v.ByteArray()) }
if lt == nil          { return append([]byte(nil), v.ByteArray()...) }
return string(v.ByteArray())
```

For any non-nil `lt` the answer is `string` either way, so the first condition
only ever agrees with the third. The comment above it says *"Only text when the
schema SAYS it is text"*, but in practice **any** annotation stringifies — a
`UUID` or `BSON` annotated BYTE_ARRAY column is stringified rather than kept as
bytes, which is the exact loss the comment warns about. The old code had the
same shape (`lt.UTF8 != nil || lt.Json != nil || lt.Enum != nil`), so this PR
neither causes nor fixes it.

Left alone deliberately: changing it alters what a UUID/BSON column reflects as,
there is no test either way, and the oracle for what Fabric does with those
columns is Fabric — which is a parity question, not a dependency bump. Worth its
own issue.