### PR TITLE
fix(spark-agent): rebuild the Spark session the engine dropped

### DIFF
--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -27,16 +27,27 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import httpjson
 import jvmconf  # no Spark; JVM session configs (see jvmconf.py)
+import session_recovery
 from pyspark.sql import SparkSession
 
-_b = SparkSession.builder.appName("livy-agent")
-if os.environ.get("SPARK_REMOTE"):
-    spark = _b.remote(os.environ["SPARK_REMOTE"]).getOrCreate()
-else:
+
+def build_spark():
+    """The one place a shared SparkSession is created, so recovery can re-run it.
+
+    Was inline at import until issue #312: when the engine dropped the session
+    there was no second caller of getOrCreate(), so the agent stayed broken
+    until the container restarted. Naming it changes nothing at boot.
+    """
+    b = SparkSession.builder.appName("livy-agent")
+    if os.environ.get("SPARK_REMOTE"):
+        return b.remote(os.environ["SPARK_REMOTE"]).getOrCreate()
     # Classic JVM: Delta + OneLake ABFS must be on the session that created
     # it. Without the extension, saveAsTable dies on
     # DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG.
-    spark = jvmconf.configure(_b, os.environ).getOrCreate()
+    return jvmconf.configure(b, os.environ).getOrCreate()
+
+
+spark = build_spark()
 
 
 def _normalise_connect_confs():
@@ -320,6 +331,30 @@ def ns(session):
     return namespaces[session]
 
 
+def recover_lost_session():
+    """Rebuild the shared session after the engine dropped it, and rebind.
+
+    Returns the note to show the user, or None if the rebuild itself failed —
+    in which case the original error stands, because reporting a recovery that
+    did not happen is worse than the failure it replaces.
+    """
+    global spark
+    try:
+        spark = build_spark()
+    except Exception:  # noqa: BLE001 — engine still down; the caller reports the real error
+        print("agent: rebuilding the Spark session failed:\n" + traceback.format_exc(),
+              file=sys.stderr, flush=True)
+        return None
+    _normalise_connect_confs()
+    _install_delta_ops()
+    rebound = session_recovery.rebind(
+        namespaces, spark, catalog.isolate,
+        attach_sc=(None if os.environ.get("SPARK_REMOTE") is None else rddfacade.attach))
+    note = session_recovery.note(rebound)
+    print(note, file=sys.stderr, flush=True)
+    return note
+
+
 def remember_context(session, req):
     """Merge identity fields from a /mount or /statements body into this session."""
     cur = session_context.setdefault(session, {})
@@ -465,6 +500,15 @@ class Handler(BaseHTTPRequestHandler):
                             result = sqlrun.run_sql(req.get("code", ""), ns(session))
                         else:
                             result = run_code(req.get("code", ""), ns(session))
+                    # The engine dropping our session is not this statement's
+                    # fault and, until #312, was permanent: nothing re-ran
+                    # getOrCreate(), so every later statement failed the same
+                    # way. Rebuild now so the NEXT one works, and tell the user
+                    # what the rebuild cost. This statement still fails —
+                    # re-running arbitrary user code that may already have
+                    # written data is not something the agent can do safely.
+                    if session_recovery.envelope_is_lost_session(result):
+                        session_recovery.annotate(result, recover_lost_session())
             finally:
                 try:
                     import files_mount

--- a/python/spark_agent/session_recovery.py
+++ b/python/spark_agent/session_recovery.py
@@ -33,12 +33,18 @@ harder to diagnose than the error it replaced. The caller reports what was lost.
 # Spark Connect raises SparkConnectGrpcException carrying an INVALID_HANDLE
 # error class. Matching the type alone would recover on one engine and not the
 # other, with nothing to say which.
+# Each entry is a tuple of substrings that must ALL appear. "is not running" is
+# on its own far too loose to trigger a rebuild — "the container is not
+# running", "the Docker daemon is not running" and any engine-side message about
+# something else that stopped would all match, and every one of them would cost
+# every open notebook its temp views. Sail's actual text is
+# "invalid argument: session <uuid> is not running", so pair it with "session".
 LOST_SESSION_MARKERS = (
-    "is not running",           # Sail: "invalid argument: session <uuid> is not running"
-    "invalid_handle.session_closed",
-    "invalid_handle.session_not_found",
-    "session_not_found",
-    "session is closed",
+    ("session", "is not running"),
+    ("invalid_handle.session_closed",),
+    ("invalid_handle.session_not_found",),
+    ("session_not_found",),
+    ("session is closed",),
 )
 
 # There is deliberately NO deny-list beside this. I wrote one first — to keep
@@ -65,7 +71,7 @@ def is_lost_session_text(text):
     user error would drop every namespace's temp views for a typo.
     """
     text = (text or "").lower()
-    return any(m in text for m in LOST_SESSION_MARKERS)
+    return any(all(part in text for part in markers) for markers in LOST_SESSION_MARKERS)
 
 
 def is_lost_session(exc):

--- a/python/spark_agent/session_recovery.py
+++ b/python/spark_agent/session_recovery.py
@@ -1,0 +1,137 @@
+"""Recognise an engine session this agent can no longer use, and rebind after it.
+
+WHY THIS EXISTS (issue #312). The agent builds its `SparkSession` once, at
+import, and holds it for the life of the process — that is the design, one
+long-lived session behind many Livy namespaces. If the ENGINE drops that
+session, nothing re-runs `getOrCreate()`, so every statement from then on fails
+with
+
+    IllegalArgumentException: invalid argument: session <uuid> is not running
+
+and keeps failing until the container is restarted. The failure is permanent for
+a reason that has nothing to do with the statement being run, which is why it
+reads as "the agent broke" rather than "the engine went away".
+
+WHAT THIS DELIBERATELY DOES NOT DO: re-run the statement. A cell that wrote data
+and then met the dead session on a later line would write twice on a silent
+retry, and the agent cannot tell the two halves apart — it hands `exec()` a block
+of arbitrary user code, not a plan it can inspect for side effects. So recovery
+makes the NEXT statement work and says plainly that this one did not, which is
+also what a real Livy session does when its Spark application dies.
+
+AND IT CANNOT BE SILENT, because rebinding is not free: temp views, cached
+DataFrames and any session-scoped conf lived in the engine session that went
+away. A "transparent" reconnect hands the user a notebook that has quietly
+forgotten its temp views — the same failure wearing a friendlier face, and
+harder to diagnose than the error it replaced. The caller reports what was lost.
+"""
+
+# Substrings, lowercased, that mean THIS CLIENT'S SESSION is gone rather than
+# the statement being wrong. Kept as markers rather than exception types because
+# the two engines this image is pointed at disagree about the type: Sail raises
+# pyspark's IllegalArgumentException with the message above, while classic
+# Spark Connect raises SparkConnectGrpcException carrying an INVALID_HANDLE
+# error class. Matching the type alone would recover on one engine and not the
+# other, with nothing to say which.
+LOST_SESSION_MARKERS = (
+    "is not running",           # Sail: "invalid argument: session <uuid> is not running"
+    "invalid_handle.session_closed",
+    "invalid_handle.session_not_found",
+    "session_not_found",
+    "session is closed",
+)
+
+# There is deliberately NO deny-list beside this. I wrote one first — to keep
+# `INVALID_HANDLE.SESSION_ALREADY_EXISTS` (the engine refusing to CREATE a
+# session) from triggering a rebuild that would meet it again — and then
+# mutation-tested it: deleting the whole guard failed no test, because none of
+# the markers above matches that message anyway. A branch that cannot change an
+# outcome is not defence, it is something for a later reader to maintain and
+# believe in. The test asserting ALREADY_EXISTS is not treated as a lost session
+# stays, and now guards the marker list itself against being widened to
+# something as loose as "session".
+
+def is_lost_session_text(text):
+    """Does this error TEXT mean the engine no longer has this client's session?
+
+    Text rather than an exception, because the agent has two statement paths —
+    Python (`run_code`) and SQL (`run_sql`) — and both convert the exception to
+    an error envelope before anyone can look at it. Reading the rendered error
+    covers both; asking for the exception object would have covered whichever
+    one I happened to edit.
+
+    Reads the message, not the type — see LOST_SESSION_MARKERS. Anything not
+    recognisably a lost session must answer False: recovering from an ordinary
+    user error would drop every namespace's temp views for a typo.
+    """
+    text = (text or "").lower()
+    return any(m in text for m in LOST_SESSION_MARKERS)
+
+
+def is_lost_session(exc):
+    """`is_lost_session_text` for an exception object."""
+    return is_lost_session_text(f"{type(exc).__name__}: {exc}")
+
+
+def envelope_is_lost_session(result):
+    """Same question, asked of a statement result envelope.
+
+    Both statement paths return `{"status": "error", "evalue": ..., "traceback":
+    [...]}`. The marker can be in either field: `evalue` is only the LAST
+    traceback line, and a lost session raised inside library code puts the
+    message further up.
+    """
+    if not isinstance(result, dict) or result.get("status") != "error":
+        return False
+    parts = [str(result.get("evalue") or "")]
+    tb = result.get("traceback") or []
+    if isinstance(tb, (list, tuple)):
+        parts.extend(str(line) for line in tb)
+    return is_lost_session_text("\n".join(parts))
+
+
+def rebind(namespaces, new_spark, isolate, attach_sc=None):
+    """Point every live namespace at `new_spark`, returning the sessions rebound.
+
+    The per-Livy-session objects are derived from the shared one (`newSession`),
+    so when the shared session dies they all die with it — rebinding only the
+    module-level handle would leave every existing notebook holding the corpse.
+
+    User variables are left alone. A plain Python value is still valid across an
+    engine restart; only the Spark-derived bindings are not, and clearing the
+    namespace wholesale would throw away work the engine never held.
+    """
+    rebound = []
+    for session, g in namespaces.items():
+        if "spark" not in g:
+            continue
+        session_spark, _isolated = isolate(new_spark)
+        g["spark"] = session_spark
+        if attach_sc is not None:
+            try:
+                g["sc"] = attach_sc(session_spark)
+            except Exception:  # noqa: BLE001 — an engine without sparkContext keeps the old facade
+                pass
+        rebound.append(session)
+    return rebound
+
+
+def note(rebound):
+    """The line the user sees. Names the loss, because rebinding is not free."""
+    return ("agent: the engine dropped this Spark session; rebuilt it and "
+            f"rebound {len(rebound)} notebook session(s). Temp views, cached "
+            "DataFrames and session-scoped conf from before the drop are gone. "
+            "Re-run this cell.")
+
+
+def annotate(result, note):
+    """Append the recovery note to a statement's error envelope, in place.
+
+    Both fields, because clients read different ones: the Livy layer surfaces
+    `evalue` in the job's error, while a notebook shows the traceback.
+    """
+    if not note or not isinstance(result, dict):
+        return result
+    result["evalue"] = f"{result.get('evalue', '')}\n{note}".strip()
+    result["traceback"] = [*list(result.get("traceback") or []), note]
+    return result

--- a/python/tests/test_spark_agent_session_recovery.py
+++ b/python/tests/test_spark_agent_session_recovery.py
@@ -1,0 +1,180 @@
+"""A dropped engine session is recognised, and rebinding reaches every namespace.
+
+agent.py calls getOrCreate() at import, so the logic lives in
+session_recovery.py — the same split as catalog.py and jvmconf.py. Issue #312:
+the agent held one session for the process lifetime and nothing re-ran
+getOrCreate(), so once the engine dropped it every later statement failed with
+`session <uuid> is not running` until the container restarted.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import session_recovery  # noqa: E402
+
+
+class FakeSpark:
+    """Just enough to be told apart from the session that died."""
+
+    def __init__(self, tag):
+        self.tag = tag
+
+
+def isolate(shared):
+    return FakeSpark(f"isolated-of-{shared.tag}"), True
+
+
+# --- recognising the failure -------------------------------------------------
+
+def test_sails_dead_session_message_is_recognised():
+    # The exact text from the issue, which is what Sail raises.
+    err = ("pyspark.errors.exceptions.connect.IllegalArgumentException: "
+           "invalid argument: session 7f3a1c22-0a1e-4f7e-9f0b-4a2f1d9a0c11 is not running")
+    assert session_recovery.is_lost_session_text(err)
+
+
+def test_spark_connects_error_classes_are_recognised():
+    # Classic Spark Connect words it as an error class, not a sentence. Both
+    # engines are behind this one image, so both spellings have to match.
+    for text in ("[INVALID_HANDLE.SESSION_CLOSED] The handle is already closed",
+                 "[INVALID_HANDLE.SESSION_NOT_FOUND] session not found"):
+        assert session_recovery.is_lost_session_text(text), text
+
+
+def test_an_ordinary_user_error_is_not_a_lost_session():
+    # THE NEGATIVE HALF, and the one that matters: recovering here would drop
+    # every namespace's temp views because somebody mistyped a column.
+    for text in ("AnalysisException: [UNRESOLVED_COLUMN] A column named `nmae` cannot be resolved",
+                 "SyntaxError: invalid syntax",
+                 "ZeroDivisionError: division by zero"):
+        assert not session_recovery.is_lost_session_text(text), text
+
+
+def test_session_already_exists_is_not_a_lost_session():
+    # Looks like the others and is the opposite: the engine refusing to CREATE
+    # a session. A rebuild meets it again immediately, so treating it as a lost
+    # session turns one clear error into a loop.
+    assert not session_recovery.is_lost_session_text(
+        "[INVALID_HANDLE.SESSION_ALREADY_EXISTS] session already exists")
+
+
+def test_empty_and_none_are_not_a_lost_session():
+    assert not session_recovery.is_lost_session_text("")
+    assert not session_recovery.is_lost_session_text(None)
+
+
+def test_is_lost_session_reads_an_exception_object():
+    class IllegalArgumentException(Exception):
+        pass
+
+    exc = IllegalArgumentException("invalid argument: session abc is not running")
+    assert session_recovery.is_lost_session(exc)
+    assert not session_recovery.is_lost_session(ValueError("nope"))
+
+
+# --- recognising it in a statement envelope ----------------------------------
+
+def test_the_marker_is_found_in_the_traceback_not_only_in_evalue():
+    # `evalue` is only the LAST traceback line. A lost session raised inside
+    # library code puts the message further up, so an evalue-only check would
+    # miss exactly the case this exists for.
+    result = {
+        "status": "error",
+        "evalue": "  File \"/usr/lib/python3/pyspark/sql/connect/client.py\", line 1",
+        "traceback": [
+            "Traceback (most recent call last):",
+            "pyspark.errors.exceptions.connect.IllegalArgumentException: "
+            "invalid argument: session abc is not running",
+            "  File \"/usr/lib/python3/pyspark/sql/connect/client.py\", line 1",
+        ],
+    }
+    assert session_recovery.envelope_is_lost_session(result)
+
+
+def test_a_successful_statement_is_never_a_lost_session():
+    ok = {"status": "ok", "data": {"text/plain": "session is not running"}}
+    assert not session_recovery.envelope_is_lost_session(ok)
+    assert not session_recovery.envelope_is_lost_session(None)
+
+
+# --- rebinding ---------------------------------------------------------------
+
+def test_every_namespace_is_rebound_not_just_the_shared_handle():
+    # The per-session objects are derived from the shared one, so they die with
+    # it. Rebinding only the module-level handle leaves every open notebook
+    # holding the corpse — which is the bug, one level down.
+    dead = FakeSpark("dead")
+    namespaces = {
+        "s1": {"spark": FakeSpark("isolated-of-dead"), "x": 1},
+        "s2": {"spark": FakeSpark("isolated-of-dead")},
+    }
+    fresh = FakeSpark("fresh")
+    rebound = session_recovery.rebind(namespaces, fresh, isolate)
+    assert sorted(rebound) == ["s1", "s2"]
+    for g in namespaces.values():
+        assert g["spark"].tag == "isolated-of-fresh"
+    assert dead.tag == "dead"  # untouched, just no longer referenced
+
+
+def test_user_variables_survive_the_rebind():
+    # A plain Python value is still valid across an engine restart; only the
+    # Spark-derived bindings are not. Clearing the namespace would throw away
+    # work the engine never held.
+    namespaces = {"s1": {"spark": FakeSpark("old"), "df_count": 42, "name": "contoso"}}
+    session_recovery.rebind(namespaces, FakeSpark("fresh"), isolate)
+    assert namespaces["s1"]["df_count"] == 42
+    assert namespaces["s1"]["name"] == "contoso"
+
+
+def test_sc_is_rebound_when_an_attach_is_supplied():
+    namespaces = {"s1": {"spark": FakeSpark("old"), "sc": "old-sc"}}
+    session_recovery.rebind(namespaces, FakeSpark("fresh"), isolate,
+                            attach_sc=lambda s: f"sc-of-{s.tag}")
+    assert namespaces["s1"]["sc"] == "sc-of-isolated-of-fresh"
+
+
+def test_a_failing_sc_attach_does_not_lose_the_session_rebind():
+    # An engine without sparkContext must not cost us the spark rebind, which
+    # is the part that fixes the bug.
+    namespaces = {"s1": {"spark": FakeSpark("old"), "sc": "old-sc"}}
+
+    def boom(_s):
+        raise RuntimeError("no sparkContext on this engine")
+
+    rebound = session_recovery.rebind(namespaces, FakeSpark("fresh"), isolate, attach_sc=boom)
+    assert rebound == ["s1"]
+    assert namespaces["s1"]["spark"].tag == "isolated-of-fresh"
+    assert namespaces["s1"]["sc"] == "old-sc"
+
+
+def test_a_namespace_without_spark_is_skipped():
+    namespaces = {"s1": {"x": 1}}
+    assert session_recovery.rebind(namespaces, FakeSpark("fresh"), isolate) == []
+
+
+def test_the_note_names_what_the_rebuild_cost():
+    # Silence here would hand the user a notebook that quietly forgot its temp
+    # views. The note is the whole reason recovery is allowed to be automatic.
+    note = session_recovery.note(["s1", "s2"])
+    assert "2 notebook session(s)" in note
+    assert "Temp views" in note
+    assert "Re-run this cell" in note
+
+
+def test_the_note_is_appended_to_both_fields_a_client_might_read():
+    # The Livy layer surfaces `evalue`; a notebook shows the traceback. Writing
+    # only one leaves half the clients with the bare `is not running`.
+    result = {"status": "error", "evalue": "boom", "traceback": ["Traceback", "boom"]}
+    session_recovery.annotate(result, "rebuilt")
+    assert result["evalue"] == "boom\nrebuilt"
+    assert result["traceback"][-1] == "rebuilt"
+
+
+def test_annotate_is_a_no_op_when_the_rebuild_failed():
+    # recover_lost_session() returns None when it could not rebuild. Reporting a
+    # recovery that did not happen is worse than the failure it replaces.
+    result = {"status": "error", "evalue": "boom", "traceback": ["boom"]}
+    session_recovery.annotate(result, None)
+    assert result["evalue"] == "boom"
+    assert result["traceback"] == ["boom"]

--- a/python/tests/test_spark_agent_session_recovery.py
+++ b/python/tests/test_spark_agent_session_recovery.py
@@ -178,3 +178,18 @@ def test_annotate_is_a_no_op_when_the_rebuild_failed():
     session_recovery.annotate(result, None)
     assert result["evalue"] == "boom"
     assert result["traceback"] == ["boom"]
+
+
+def test_something_else_that_is_not_running_is_not_a_lost_session():
+    # "is not running" alone is far too loose: these are messages about
+    # something ELSE having stopped, and recovering on them would cost every
+    # open notebook its temp views for an unrelated failure.
+    for text in ("RuntimeError: the container is not running",
+                 "docker: Error response from daemon: the Docker daemon is not running",
+                 "OSError: the mount helper is not running"):
+        assert not session_recovery.is_lost_session_text(text), text
+
+
+def test_sails_message_still_matches_with_the_tightened_marker():
+    assert session_recovery.is_lost_session_text(
+        "invalid argument: session 7f3a1c22 is not running")


### PR DESCRIPTION
Closes #312. The agent built its `SparkSession` at import and nothing ever ran
`getOrCreate()` again, so once the engine dropped that session every statement
failed with `session <uuid> is not running` until the container was restarted.

## The two decisions worth arguing about

**It does not re-run the statement.** A cell that wrote data and then met the
dead session on a later line would write twice on a silent retry, and the agent
cannot tell those halves apart — it hands `exec()` a block of arbitrary user
code, not a plan it can inspect for side effects. So recovery makes the **next**
statement work and lets this one fail, which is also what a real Livy session
does when its Spark application dies.

**It cannot be silent.** Temp views, cached DataFrames and session-scoped conf
lived in the engine session that went away. A "transparent" reconnect hands back
a notebook that has quietly forgotten its temp views — the same failure wearing
a friendlier face, and harder to diagnose than the error it replaces. The user
gets a line naming exactly what was lost and telling them to re-run.

## Shape

`session_recovery.py` holds the logic and imports no pyspark, so it is unit
testable — the same split as `catalog.py`, `jvmconf.py` and `connectconf.py`,
which exists because `agent.py` starts Spark at import. `agent.py` gains
`build_spark()` (the one place a shared session is created, so recovery can
re-run it) and `recover_lost_session()`.

**Every namespace is rebound, not just the module handle.** The per-Livy-session
objects come from `newSession` on the shared one, so they die with it; rebinding
only `spark` would leave every open notebook holding the corpse — the same bug
one level down. User variables are left alone: a plain Python value survives an
engine restart, and clearing namespaces would throw away work the engine never
held.

**Detection reads the message, not the exception type,** because the two engines
behind this one image disagree: Sail raises `IllegalArgumentException` with
`is not running`, classic Spark Connect raises `SparkConnectGrpcException` with
an `INVALID_HANDLE.*` error class. Matching on type would have recovered on one
engine and not the other, with nothing to say which.

## Verified

16 new tests; `pytest python/tests` 995 passed / 1 skipped; `make lint`,
`make check` and `go build ./...` all exit 0. The Python 3.8 floor test globs
agent sources, so the new module is covered by it automatically.

Mutation-tested rather than asserted — every one of these fails the suite:

| mutation | tests that catch it |
|---|---|
| every error looks like a lost session | 4 |
| `rebind` stops after the first namespace | 1 |
| the note stops naming what was lost | 1 |
| `annotate` writes only `evalue`, not the traceback | 1 |

## I deleted my own dead branch, having just complained about one

The first draft had a `NOT_LOST_MARKERS` deny-list so
`INVALID_HANDLE.SESSION_ALREADY_EXISTS` could not trigger a rebuild. Mutation
testing showed **deleting the whole guard failed no test** — none of the
positive markers matches that message anyway, so the branch could never change
an outcome. That is the same shape I reported in #326 (`isTextAnnotation`) and
declined to fix there, because there it would change behaviour; here it changes
nothing, so it goes. The test asserting `SESSION_ALREADY_EXISTS` is not treated
as a lost session stays and now guards the marker list against being widened to
something as loose as `"session"`.

## Not covered

That `do_POST` calls the recovery in the right place is not unit tested —
`agent.py` starts Spark at import, so no unit test can load it. The logic it
calls is tested; the call site is two lines. Exercising it end to end would mean
killing a live Sail session mid-suite, which is worth doing and is not this PR.