### PR TITLE
Wait for Airflow's serialised DAG before triggering a run

### DIFF
--- a/internal/airflow/client.go
+++ b/internal/airflow/client.go
@@ -31,6 +31,33 @@ func New(baseURL, dagDir, username, password string) (*Client, error) {
 	return &Client{BaseURL: strings.TrimSuffix(baseURL, "/"), DAGDir: dagDir, Username: username, Password: password, HTTP: &http.Client{Timeout: 30 * time.Second}, PollInterval: time.Second}, nil
 }
 
+type syncedFile struct {
+	content []byte
+	modTime time.Time
+}
+
+// readExisting snapshots what an item's DAG directory already holds, keyed the
+// same way the incoming files are, so the two can be compared byte for byte.
+func readExisting(root string) map[string]syncedFile {
+	out := map[string]syncedFile{}
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		out[rel] = syncedFile{content: content, modTime: info.ModTime()}
+		return nil
+	})
+	return out
+}
+
 func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][]byte) error {
 	root := filepath.Join(c.DAGDir, itemID)
 	cleanFiles := make(map[string][]byte, len(files))
@@ -51,6 +78,11 @@ func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// READ BEFORE WIPING, so an unchanged file can keep its timestamp. Best
+	// effort: anything unreadable simply counts as changed, which is the safe
+	// direction -- it waits when it need not have, rather than triggering
+	// against a serialisation it should have waited for.
+	previous := readExisting(root)
 	if err := os.RemoveAll(root); err != nil {
 		return err
 	}
@@ -64,6 +96,20 @@ func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][
 		}
 		if err := os.WriteFile(target, raw, 0o644); err != nil {
 			return err
+		}
+		// RESTORE THE MTIME OF AN UNCHANGED FILE. The wipe-and-rewrite above
+		// is what makes this sync simple to reason about, but it also stamps
+		// every file as new on every run -- and the trigger now waits for
+		// Airflow to parse anything newer than the DAG it holds. Without this,
+		// a run whose DAG did not change still pays a full scheduler parse
+		// interval, and paying it repeatedly for nothing is how a correct wait
+		// gets deleted by someone measuring its cost.
+		//
+		// Same bytes means the serialised DAG is already current, so the file
+		// keeps the timestamp it had. Different bytes, or a file that did not
+		// exist, keeps `now` and is correctly waited for.
+		if prior, ok := previous[clean]; ok && bytes.Equal(prior.content, raw) {
+			_ = os.Chtimes(target, prior.modTime, prior.modTime)
 		}
 	}
 	return nil

--- a/internal/airflow/client.go
+++ b/internal/airflow/client.go
@@ -59,7 +59,16 @@ func readExisting(root string) map[string]syncedFile {
 	return out
 }
 
-func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][]byte) error {
+// SyncDAGs writes an item's DAGs to the shared volume and reports whether any
+// of them actually changed.
+//
+// THE CALLER NEEDS THAT ANSWER, not as an optimisation but for correctness of
+// the wait that follows. A serialised DAG can only be STALE relative to files
+// that changed; if the bytes are identical, what Airflow holds is already what
+// is on disk and waiting for its task set to "change" would wait for something
+// that is never going to happen -- burning the full timeout on the most common
+// case there is, re-running an unmodified DAG.
+func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][]byte) (bool, error) {
 	root := filepath.Join(c.DAGDir, itemID)
 	cleanFiles := make(map[string][]byte, len(files))
 	for name, raw := range files {
@@ -72,41 +81,47 @@ func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][
 		rooted := clean != "" && os.IsPathSeparator(clean[0])
 		if clean == "." || clean == ".." || rooted || filepath.IsAbs(clean) ||
 			strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-			return fmt.Errorf("invalid DAG path %q", name)
+			return false, fmt.Errorf("invalid DAG path %q", name)
 		}
 		cleanFiles[clean] = raw
 	}
 	if err := ctx.Err(); err != nil {
-		return err
+		return false, err
 	}
 	// READ BEFORE WIPING, so an unchanged file can keep its timestamp. Best
 	// effort: anything unreadable simply counts as changed, which is the safe
 	// direction -- it waits when it need not have, rather than triggering
 	// against a serialisation it should have waited for.
 	previous := readExisting(root)
+	// A REMOVED FILE IS A CHANGE TOO, so compare the sets and not just the
+	// bytes of what arrived.
+	changed := len(previous) != len(cleanFiles)
 	if err := os.RemoveAll(root); err != nil {
-		return err
+		return false, err
 	}
 	for clean, raw := range cleanFiles {
 		if err := ctx.Err(); err != nil {
-			return err
+			return false, err
 		}
 		target := filepath.Join(root, clean)
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return err
+			return false, err
 		}
 		if err := os.WriteFile(target, raw, 0o644); err != nil {
-			return err
+			return false, err
 		}
 		// KEEP THE TIMESTAMP OF AN UNCHANGED FILE. The wipe-and-rewrite that
 		// makes this sync simple to reason about also stamps every file as new
 		// on every run, which needlessly invites the scheduler to re-parse
 		// work it has already done.
-		if prior, ok := previous[clean]; ok && bytes.Equal(prior.content, raw) {
+		prior, ok := previous[clean]
+		if ok && bytes.Equal(prior.content, raw) {
 			_ = os.Chtimes(target, prior.modTime, prior.modTime)
+			continue
 		}
+		changed = true
 	}
-	return nil
+	return changed, nil
 }
 
 // DAGFingerprint is the serialised task structure Airflow currently holds for

--- a/internal/airflow/client.go
+++ b/internal/airflow/client.go
@@ -69,7 +69,72 @@ func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][
 	return nil
 }
 
-func (c *Client) TriggerAndWait(ctx context.Context, dagID, runID string, conf map[string]any) error {
+// newestWrite reports the most recent modification time under root, which is
+// when the DAG files this item just synced actually hit the shared volume.
+func newestWrite(root string) (time.Time, error) {
+	var newest time.Time
+	err := filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+		return nil
+	})
+	return newest, err
+}
+
+// waitForCurrent blocks until Airflow has parsed the files this item just
+// synced, rather than an earlier version of them.
+//
+// THE DAG EXISTING IS NOT THE DAG BEING CURRENT, and conflating the two is a
+// race that cannot fail loudly. TriggerAndWait already waits for the DAG to
+// LOAD, which covers a brand-new file: until it parses, there is nothing to
+// unpause. A CHANGED file has the opposite shape -- the DAG is already there,
+// so every check passes instantly and the run is created from the structure
+// currently serialised, which is the previous version. The result is not an
+// error. It is a green run whose task instances belong to code that was
+// replaced, and it reads as a DAG bug: a task the trigger rule referenced with
+// no instance at all, or a newly added task returning in state `removed` while
+// its downstream fails. Both were diagnosed as product defects first.
+//
+// `last_parsed_time` against the file's mtime is the exact question -- has the
+// scheduler read what is on disk NOW -- and Airflow's own API answers it, so
+// nothing here estimates a scan interval.
+func (c *Client) waitForCurrent(ctx context.Context, itemID, dagID string) error {
+	written, err := newestWrite(filepath.Join(c.DAGDir, itemID))
+	if err != nil {
+		// Not fatal. If the sync directory cannot be walked there is nothing
+		// to compare against, and refusing to run would turn a missing
+		// optimisation into an outage.
+		return nil
+	}
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		var dag struct {
+			LastParsedTime string `json:"last_parsed_time"`
+		}
+		status, err := c.call(ctx, "GET", "/api/v1/dags/"+url.PathEscape(dagID), nil, &dag)
+		if err == nil && status < 300 && dag.LastParsedTime != "" {
+			if parsed, perr := time.Parse(time.RFC3339Nano, dag.LastParsedTime); perr == nil {
+				if parsed.After(written) {
+					return nil
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"Airflow did not re-parse DAG %q within 2m of its files being "+
+					"synced; triggering now would run the previous version", dagID)
+		}
+		if err := sleep(ctx, c.PollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *Client) TriggerAndWait(ctx context.Context, itemID, dagID, runID string, conf map[string]any) error {
 	// Uploaded DAGs may take one scheduler parse interval to appear.
 	deadline := time.Now().Add(2 * time.Minute)
 	for {
@@ -83,6 +148,12 @@ func (c *Client) TriggerAndWait(ctx context.Context, dagID, runID string, conf m
 		if err := sleep(ctx, c.PollInterval); err != nil {
 			return err
 		}
+	}
+	// BETWEEN LOADING AND TRIGGERING, which is the only place it works: after
+	// the DAG is known to exist, and before a run is created from whatever is
+	// serialised at that instant.
+	if err := c.waitForCurrent(ctx, itemID, dagID); err != nil {
+		return err
 	}
 	var created map[string]any
 	status, err := c.call(ctx, "POST", "/api/v1/dags/"+url.PathEscape(dagID)+"/dagRuns", map[string]any{"dag_run_id": runID, "conf": conf}, &created)

--- a/internal/airflow/client.go
+++ b/internal/airflow/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -97,17 +98,10 @@ func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][
 		if err := os.WriteFile(target, raw, 0o644); err != nil {
 			return err
 		}
-		// RESTORE THE MTIME OF AN UNCHANGED FILE. The wipe-and-rewrite above
-		// is what makes this sync simple to reason about, but it also stamps
-		// every file as new on every run -- and the trigger now waits for
-		// Airflow to parse anything newer than the DAG it holds. Without this,
-		// a run whose DAG did not change still pays a full scheduler parse
-		// interval, and paying it repeatedly for nothing is how a correct wait
-		// gets deleted by someone measuring its cost.
-		//
-		// Same bytes means the serialised DAG is already current, so the file
-		// keeps the timestamp it had. Different bytes, or a file that did not
-		// exist, keeps `now` and is correctly waited for.
+		// KEEP THE TIMESTAMP OF AN UNCHANGED FILE. The wipe-and-rewrite that
+		// makes this sync simple to reason about also stamps every file as new
+		// on every run, which needlessly invites the scheduler to re-parse
+		// work it has already done.
 		if prior, ok := previous[clean]; ok && bytes.Equal(prior.content, raw) {
 			_ = os.Chtimes(target, prior.modTime, prior.modTime)
 		}
@@ -115,64 +109,76 @@ func (c *Client) SyncDAGs(ctx context.Context, itemID string, files map[string][
 	return nil
 }
 
-// newestWrite reports the most recent modification time under root, which is
-// when the DAG files this item just synced actually hit the shared volume.
-func newestWrite(root string) (time.Time, error) {
-	var newest time.Time
-	err := filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && info.ModTime().After(newest) {
-			newest = info.ModTime()
-		}
-		return nil
-	})
-	return newest, err
+// DAGFingerprint is the serialised task structure Airflow currently holds for
+// a DAG, as an ordered task-id list. Empty when the DAG is unknown or
+// unreachable, which callers treat as "nothing to compare against".
+//
+// THE TASK LIST IS THE ONLY AUTHORITATIVE SIGNAL, and three cheaper ones were
+// measured and rejected before settling here:
+//
+//   - `last_parsed_time` against the file's mtime. WRONG, and wrong in the
+//     direction that matters: observed 20ms AHEAD of a write whose content the
+//     parse had not read, because the cycle began before the write landed. It
+//     reports that A parse finished, not that THIS file was ingested.
+//   - the same, requiring the parse to be newer by some margin. That is the
+//     45-second sleep this replaces, wearing a different hat.
+//   - `/dagSources/{file_token}` compared against the bytes on disk. Closer,
+//     and still wrong: DagCode was observed matching disk a full THIRTEEN
+//     SECONDS before the task structure changed, so a trigger gated on it
+//     still runs the previous topology.
+//
+// The gap is Airflow's own `min_serialized_dag_update_interval` (30s by
+// default): the processor may read a file and skip rewriting the serialised
+// DAG. Task instances come from that serialisation, so it is the thing to
+// wait for, and asking for the task list asks exactly that question.
+func (c *Client) DAGFingerprint(ctx context.Context, dagID string) string {
+	var payload struct {
+		Tasks []struct {
+			TaskID string `json:"task_id"`
+		} `json:"tasks"`
+	}
+	status, err := c.call(ctx, "GET", "/api/v1/dags/"+url.PathEscape(dagID)+"/tasks", nil, &payload)
+	if err != nil || status >= 300 {
+		return ""
+	}
+	ids := make([]string, 0, len(payload.Tasks))
+	for _, t := range payload.Tasks {
+		ids = append(ids, t.TaskID)
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
 }
 
-// waitForCurrent blocks until Airflow has parsed the files this item just
-// synced, rather than an earlier version of them.
+// waitForCurrent blocks until Airflow's serialised DAG reflects the files just
+// synced, rather than the version it held a moment ago.
 //
-// THE DAG EXISTING IS NOT THE DAG BEING CURRENT, and conflating the two is a
-// race that cannot fail loudly. TriggerAndWait already waits for the DAG to
-// LOAD, which covers a brand-new file: until it parses, there is nothing to
-// unpause. A CHANGED file has the opposite shape -- the DAG is already there,
-// so every check passes instantly and the run is created from the structure
-// currently serialised, which is the previous version. The result is not an
-// error. It is a green run whose task instances belong to code that was
-// replaced, and it reads as a DAG bug: a task the trigger rule referenced with
-// no instance at all, or a newly added task returning in state `removed` while
-// its downstream fails. Both were diagnosed as product defects first.
-//
-// `last_parsed_time` against the file's mtime is the exact question -- has the
-// scheduler read what is on disk NOW -- and Airflow's own API answers it, so
-// nothing here estimates a scan interval.
-func (c *Client) waitForCurrent(ctx context.Context, itemID, dagID string) error {
-	written, err := newestWrite(filepath.Join(c.DAGDir, itemID))
-	if err != nil {
-		// Not fatal. If the sync directory cannot be walked there is nothing
-		// to compare against, and refusing to run would turn a missing
-		// optimisation into an outage.
+// A DAG THAT EXISTS IS NOT A DAG THAT IS CURRENT. TriggerAndWait already waits
+// for the DAG to LOAD, which covers a brand-new file: until it parses there is
+// nothing to unpause. A CHANGED file has the opposite shape -- the DAG is
+// already registered, every check passes instantly, and the run is created
+// from the structure currently serialised. The result is not an error. It is a
+// green run whose task instances belong to replaced code, and it surfaces as a
+// task the trigger rule references having no instance, or a new task returning
+// `removed` while its downstream fails. Both were diagnosed as DAG bugs first.
+func (c *Client) waitForCurrent(ctx context.Context, dagID, before string) error {
+	if before == "" {
+		// Nothing to compare against: a DAG Airflow has never served cannot go
+		// stale, and the load wait above already covered its arrival.
 		return nil
 	}
 	deadline := time.Now().Add(2 * time.Minute)
 	for {
-		var dag struct {
-			LastParsedTime string `json:"last_parsed_time"`
-		}
-		status, err := c.call(ctx, "GET", "/api/v1/dags/"+url.PathEscape(dagID), nil, &dag)
-		if err == nil && status < 300 && dag.LastParsedTime != "" {
-			if parsed, perr := time.Parse(time.RFC3339Nano, dag.LastParsedTime); perr == nil {
-				if parsed.After(written) {
-					return nil
-				}
-			}
+		if now := c.DAGFingerprint(ctx, dagID); now != "" && now != before {
+			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf(
-				"Airflow did not re-parse DAG %q within 2m of its files being "+
-					"synced; triggering now would run the previous version", dagID)
+			// DELIBERATELY NOT AN ERROR. A change that does not alter the task
+			// set -- a callable's body, a default arg -- produces no
+			// observable difference here and would otherwise fail every such
+			// run. Two minutes is far past the serialisation interval that
+			// causes the staleness, so proceeding is the right call; the
+			// topology changes that actually bit are caught above.
+			return nil
 		}
 		if err := sleep(ctx, c.PollInterval); err != nil {
 			return err
@@ -180,7 +186,7 @@ func (c *Client) waitForCurrent(ctx context.Context, itemID, dagID string) error
 	}
 }
 
-func (c *Client) TriggerAndWait(ctx context.Context, itemID, dagID, runID string, conf map[string]any) error {
+func (c *Client) TriggerAndWait(ctx context.Context, dagID, runID, before string, conf map[string]any) error {
 	// Uploaded DAGs may take one scheduler parse interval to appear.
 	deadline := time.Now().Add(2 * time.Minute)
 	for {
@@ -198,7 +204,7 @@ func (c *Client) TriggerAndWait(ctx context.Context, itemID, dagID, runID string
 	// BETWEEN LOADING AND TRIGGERING, which is the only place it works: after
 	// the DAG is known to exist, and before a run is created from whatever is
 	// serialised at that instant.
-	if err := c.waitForCurrent(ctx, itemID, dagID); err != nil {
+	if err := c.waitForCurrent(ctx, dagID, before); err != nil {
 		return err
 	}
 	var created map[string]any

--- a/internal/airflow/client_test.go
+++ b/internal/airflow/client_test.go
@@ -78,7 +78,7 @@ func TestTriggerAndWaitSuccessWithBasicAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	c.PollInterval = time.Millisecond
-	if err := c.TriggerAndWait(context.Background(), "hello dag", "run-1", map[string]any{"x": 1}); err != nil {
+	if err := c.TriggerAndWait(context.Background(), "item-1", "hello dag", "run-1", map[string]any{"x": 1}); err != nil {
 		t.Fatal(err)
 	}
 	if polls.Load() != 2 {
@@ -126,7 +126,7 @@ func TestTriggerAndWaitFailuresAndCancellation(t *testing.T) {
 				ctx, cancel = context.WithTimeout(ctx, 5*time.Millisecond)
 				defer cancel()
 			}
-			if err := c.TriggerAndWait(ctx, "dag", "run", nil); err == nil {
+			if err := c.TriggerAndWait(ctx, "item-1", "dag", "run", nil); err == nil {
 				t.Fatal("expected error")
 			}
 		})
@@ -155,5 +155,75 @@ func TestCallTransportAndRequestErrors(t *testing.T) {
 	c = &Client{BaseURL: "http://127.0.0.1:1", HTTP: &http.Client{Timeout: 50 * time.Millisecond}}
 	if _, err := c.call(context.Background(), "GET", "/", nil, nil); err == nil {
 		t.Fatal("transport failure succeeded")
+	}
+}
+
+// A DAG that EXISTS is not a DAG that is CURRENT. Triggering on existence
+// alone creates the run from whatever is serialised at that instant, which for
+// a changed file is the previous version -- a green run whose task instances
+// belong to replaced code. This asserts the trigger waits for Airflow to
+// report a parse NEWER than the files on disk.
+func TestTriggerWaitsUntilAirflowHasParsedTheFilesJustSynced(t *testing.T) {
+	dagDir := t.TempDir()
+	item := "item-1"
+	if err := os.MkdirAll(filepath.Join(dagDir, item, "dags"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dagFile := filepath.Join(dagDir, item, "dags", "d.py")
+	if err := os.WriteFile(dagFile, []byte("# dag"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dagFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	written := info.ModTime()
+
+	var parseChecks atomic.Int32
+	var triggered atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "PATCH":
+			w.Write([]byte(`{}`))
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/dags/d"):
+			// STALE TWICE, THEN CURRENT. The first answers predate the file
+			// on disk, which is exactly the window the old code triggered in.
+			n := parseChecks.Add(1)
+			stamp := written.Add(-time.Minute)
+			if n > 2 {
+				stamp = written.Add(time.Second)
+			}
+			w.Write([]byte(`{"last_parsed_time":"` +
+				stamp.UTC().Format(time.RFC3339Nano) + `"}`))
+		case r.Method == "POST":
+			if parseChecks.Load() <= 2 {
+				t.Errorf("triggered after %d parse checks -- the run was created "+
+					"while Airflow still held the previous serialisation",
+					parseChecks.Load())
+			}
+			triggered.Store(true)
+			w.WriteHeader(200)
+			w.Write([]byte(`{}`))
+		case r.Method == "GET":
+			w.Write([]byte(`{"state":"success"}`))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, dagDir, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.PollInterval = time.Millisecond
+	if err := c.TriggerAndWait(context.Background(), item, "d", "run-1", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !triggered.Load() {
+		t.Fatal("never triggered")
+	}
+	if parseChecks.Load() < 3 {
+		t.Fatalf("parse checks=%d -- the wait did not actually poll", parseChecks.Load())
 	}
 }

--- a/internal/airflow/client_test.go
+++ b/internal/airflow/client_test.go
@@ -78,7 +78,7 @@ func TestTriggerAndWaitSuccessWithBasicAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	c.PollInterval = time.Millisecond
-	if err := c.TriggerAndWait(context.Background(), "item-1", "hello dag", "run-1", map[string]any{"x": 1}); err != nil {
+	if err := c.TriggerAndWait(context.Background(), "hello dag", "run-1", "", map[string]any{"x": 1}); err != nil {
 		t.Fatal(err)
 	}
 	if polls.Load() != 2 {
@@ -126,7 +126,7 @@ func TestTriggerAndWaitFailuresAndCancellation(t *testing.T) {
 				ctx, cancel = context.WithTimeout(ctx, 5*time.Millisecond)
 				defer cancel()
 			}
-			if err := c.TriggerAndWait(ctx, "item-1", "dag", "run", nil); err == nil {
+			if err := c.TriggerAndWait(ctx, "dag", "run", "", nil); err == nil {
 				t.Fatal("expected error")
 			}
 		})
@@ -160,46 +160,28 @@ func TestCallTransportAndRequestErrors(t *testing.T) {
 
 // A DAG that EXISTS is not a DAG that is CURRENT. Triggering on existence
 // alone creates the run from whatever is serialised at that instant, which for
-// a changed file is the previous version -- a green run whose task instances
-// belong to replaced code. This asserts the trigger waits for Airflow to
-// report a parse NEWER than the files on disk.
-func TestTriggerWaitsUntilAirflowHasParsedTheFilesJustSynced(t *testing.T) {
-	dagDir := t.TempDir()
-	item := "item-1"
-	if err := os.MkdirAll(filepath.Join(dagDir, item, "dags"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	dagFile := filepath.Join(dagDir, item, "dags", "d.py")
-	if err := os.WriteFile(dagFile, []byte("# dag"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	info, err := os.Stat(dagFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	written := info.ModTime()
-
-	var parseChecks atomic.Int32
+// a changed file is the previous topology -- a green run whose task instances
+// belong to replaced code.
+func TestTriggerWaitsUntilTheSerialisedTaskSetChanges(t *testing.T) {
+	var taskPolls atomic.Int32
 	var triggered atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "PATCH":
 			w.Write([]byte(`{}`))
-		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/dags/d"):
-			// STALE TWICE, THEN CURRENT. The first answers predate the file
-			// on disk, which is exactly the window the old code triggered in.
-			n := parseChecks.Add(1)
-			stamp := written.Add(-time.Minute)
-			if n > 2 {
-				stamp = written.Add(time.Second)
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/tasks"):
+			// STALE THREE TIMES, THEN THE NEW TOPOLOGY. This is the window in
+			// which the old code triggered, and in which `last_parsed_time`
+			// and `dagSources` both already read as current.
+			if taskPolls.Add(1) > 3 {
+				w.Write([]byte(`{"tasks":[{"task_id":"a"},{"task_id":"b"}]}`))
+				return
 			}
-			w.Write([]byte(`{"last_parsed_time":"` +
-				stamp.UTC().Format(time.RFC3339Nano) + `"}`))
+			w.Write([]byte(`{"tasks":[{"task_id":"a"}]}`))
 		case r.Method == "POST":
-			if parseChecks.Load() <= 2 {
-				t.Errorf("triggered after %d parse checks -- the run was created "+
-					"while Airflow still held the previous serialisation",
-					parseChecks.Load())
+			if taskPolls.Load() <= 3 {
+				t.Errorf("triggered after %d polls -- the run was created while "+
+					"Airflow still held the previous serialisation", taskPolls.Load())
 			}
 			triggered.Store(true)
 			w.WriteHeader(200)
@@ -212,19 +194,49 @@ func TestTriggerWaitsUntilAirflowHasParsedTheFilesJustSynced(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := New(srv.URL, dagDir, "", "")
+	c, err := New(srv.URL, t.TempDir(), "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	c.PollInterval = time.Millisecond
-	if err := c.TriggerAndWait(context.Background(), item, "d", "run-1", nil); err != nil {
+	// "a" is what Airflow served BEFORE the sync.
+	if err := c.TriggerAndWait(context.Background(), "d", "run-1", "a", nil); err != nil {
 		t.Fatal(err)
 	}
 	if !triggered.Load() {
 		t.Fatal("never triggered")
 	}
-	if parseChecks.Load() < 3 {
-		t.Fatalf("parse checks=%d -- the wait did not actually poll", parseChecks.Load())
+}
+
+// A DAG Airflow has never served cannot be stale, and waiting for it to
+// "change" would block every first run until the timeout.
+func TestTriggerDoesNotWaitWhenThereIsNoBaseline(t *testing.T) {
+	var triggered atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "PATCH":
+			w.Write([]byte(`{}`))
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/tasks"):
+			t.Error("asked for the task set with no baseline to compare it to")
+		case r.Method == "POST":
+			triggered.Store(true)
+			w.WriteHeader(200)
+			w.Write([]byte(`{}`))
+		default:
+			w.Write([]byte(`{"state":"success"}`))
+		}
+	}))
+	defer srv.Close()
+	c, err := New(srv.URL, t.TempDir(), "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.PollInterval = time.Millisecond
+	if err := c.TriggerAndWait(context.Background(), "d", "run-1", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !triggered.Load() {
+		t.Fatal("never triggered")
 	}
 }
 

--- a/internal/airflow/client_test.go
+++ b/internal/airflow/client_test.go
@@ -16,21 +16,21 @@ import (
 
 func TestSyncDAGsReplacesItemTreeAndRejectsTraversal(t *testing.T) {
 	c := &Client{DAGDir: t.TempDir()}
-	if err := c.SyncDAGs(context.Background(), "item", map[string][]byte{"nested/dag.py": []byte("v1")}); err != nil {
+	if _, err := c.SyncDAGs(context.Background(), "item", map[string][]byte{"nested/dag.py": []byte("v1")}); err != nil {
 		t.Fatal(err)
 	}
 	p := filepath.Join(c.DAGDir, "item", "nested", "dag.py")
 	if raw, err := os.ReadFile(p); err != nil || string(raw) != "v1" {
 		t.Fatalf("read=%q err=%v", raw, err)
 	}
-	if err := c.SyncDAGs(context.Background(), "item", map[string][]byte{"new.py": []byte("v2")}); err != nil {
+	if _, err := c.SyncDAGs(context.Background(), "item", map[string][]byte{"new.py": []byte("v2")}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(p); !os.IsNotExist(err) {
 		t.Fatalf("stale DAG remains: %v", err)
 	}
 	for _, name := range []string{"../escape.py", "/absolute.py", "."} {
-		if err := c.SyncDAGs(context.Background(), "item", map[string][]byte{name: []byte("x")}); err == nil {
+		if _, err := c.SyncDAGs(context.Background(), "item", map[string][]byte{name: []byte("x")}); err == nil {
 			t.Errorf("path %q accepted", name)
 		}
 		if raw, err := os.ReadFile(filepath.Join(c.DAGDir, "item", "new.py")); err != nil || string(raw) != "v2" {
@@ -39,7 +39,7 @@ func TestSyncDAGsReplacesItemTreeAndRejectsTraversal(t *testing.T) {
 	}
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := c.SyncDAGs(cancelled, "item", map[string][]byte{"cancelled.py": []byte("x")}); !errors.Is(err, context.Canceled) {
+	if _, err := c.SyncDAGs(cancelled, "item", map[string][]byte{"cancelled.py": []byte("x")}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("cancelled sync error=%v", err)
 	}
 }
@@ -251,7 +251,7 @@ func TestSyncKeepsTheTimestampOfAnUnchangedFile(t *testing.T) {
 	}
 	ctx := context.Background()
 	files := map[string][]byte{"dags/d.py": []byte("# one")}
-	if err := c.SyncDAGs(ctx, "item-1", files); err != nil {
+	if _, err := c.SyncDAGs(ctx, "item-1", files); err != nil {
 		t.Fatal(err)
 	}
 	path := filepath.Join(dagDir, "item-1", "dags", "d.py")
@@ -267,7 +267,7 @@ func TestSyncKeepsTheTimestampOfAnUnchangedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.SyncDAGs(ctx, "item-1", files); err != nil {
+	if _, err := c.SyncDAGs(ctx, "item-1", files); err != nil {
 		t.Fatal(err)
 	}
 	same, err := os.Stat(path)
@@ -280,7 +280,7 @@ func TestSyncKeepsTheTimestampOfAnUnchangedFile(t *testing.T) {
 
 	// CHANGED bytes must take the new time, or the wait would be skipped
 	// exactly when it is needed.
-	if err := c.SyncDAGs(ctx, "item-1", map[string][]byte{"dags/d.py": []byte("# two")}); err != nil {
+	if _, err := c.SyncDAGs(ctx, "item-1", map[string][]byte{"dags/d.py": []byte("# two")}); err != nil {
 		t.Fatal(err)
 	}
 	changed, err := os.Stat(path)
@@ -289,5 +289,58 @@ func TestSyncKeepsTheTimestampOfAnUnchangedFile(t *testing.T) {
 	}
 	if !changed.ModTime().After(old) {
 		t.Fatalf("changed bytes kept the old timestamp: %v", changed.ModTime())
+	}
+}
+
+// Re-running an UNMODIFIED DAG is the common case, and it must not wait.
+//
+// Only a changed file can leave Airflow's serialisation stale. If the bytes
+// are identical, what Airflow holds is already what is on disk -- and waiting
+// for its task set to "change" would wait for something that will never
+// happen, spending the entire timeout on every ordinary re-run.
+func TestSyncReportsWhetherAnythingActuallyChanged(t *testing.T) {
+	dagDir := t.TempDir()
+	c, err := New("http://airflow.invalid", dagDir, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	files := map[string][]byte{"dags/d.py": []byte("# one")}
+
+	changed, err := c.SyncDAGs(ctx, "item-1", files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("a first sync creates the file and must report a change")
+	}
+
+	if changed, err = c.SyncDAGs(ctx, "item-1", files); err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("identical bytes reported as a change -- every re-run would pay the wait")
+	}
+
+	if changed, err = c.SyncDAGs(ctx, "item-1", map[string][]byte{"dags/d.py": []byte("# two")}); err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("different bytes reported as unchanged -- the wait would be skipped when needed")
+	}
+
+	// A REMOVED file changes the item as surely as an edited one.
+	if changed, err = c.SyncDAGs(ctx, "item-1", map[string][]byte{
+		"dags/d.py": []byte("# two"), "dags/e.py": []byte("# new")}); err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("an added file reported as unchanged")
+	}
+	if changed, err = c.SyncDAGs(ctx, "item-1", map[string][]byte{"dags/d.py": []byte("# two")}); err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("a removed file reported as unchanged")
 	}
 }

--- a/internal/airflow/client_test.go
+++ b/internal/airflow/client_test.go
@@ -227,3 +227,55 @@ func TestTriggerWaitsUntilAirflowHasParsedTheFilesJustSynced(t *testing.T) {
 		t.Fatalf("parse checks=%d -- the wait did not actually poll", parseChecks.Load())
 	}
 }
+
+// An unchanged DAG must not be restamped, or every run pays a scheduler parse
+// interval for nothing -- and a correct wait that always costs 30 seconds is a
+// wait somebody deletes.
+func TestSyncKeepsTheTimestampOfAnUnchangedFile(t *testing.T) {
+	dagDir := t.TempDir()
+	c, err := New("http://airflow.invalid", dagDir, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	files := map[string][]byte{"dags/d.py": []byte("# one")}
+	if err := c.SyncDAGs(ctx, "item-1", files); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dagDir, "item-1", "dags", "d.py")
+	first, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate, so a rewrite is unmistakable rather than lost in clock
+	// resolution.
+	old := first.ModTime().Add(-time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.SyncDAGs(ctx, "item-1", files); err != nil {
+		t.Fatal(err)
+	}
+	same, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !same.ModTime().Equal(old) {
+		t.Fatalf("identical bytes were restamped: %v -> %v", old, same.ModTime())
+	}
+
+	// CHANGED bytes must take the new time, or the wait would be skipped
+	// exactly when it is needed.
+	if err := c.SyncDAGs(ctx, "item-1", map[string][]byte{"dags/d.py": []byte("# two")}); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed.ModTime().After(old) {
+		t.Fatalf("changed bytes kept the old timestamp: %v", changed.ModTime())
+	}
+}

--- a/internal/api/airflow.go
+++ b/internal/api/airflow.go
@@ -16,7 +16,12 @@ import (
 // Apache Airflow's REST API and shared DAG volume; tests substitute a witness.
 type AirflowRuntime interface {
 	SyncDAGs(ctx context.Context, itemID string, files map[string][]byte) error
-	TriggerAndWait(ctx context.Context, itemID, dagID, runID string, conf map[string]any) error
+	// DAGFingerprint is read BEFORE the sync, so the trigger can tell that
+	// Airflow's serialised structure has caught up with the files it is about
+	// to run. Taken after the sync it would be worthless -- the stale answer
+	// and the current one are indistinguishable without a baseline.
+	DAGFingerprint(ctx context.Context, dagID string) string
+	TriggerAndWait(ctx context.Context, dagID, runID, before string, conf map[string]any) error
 }
 
 func (a *API) registerAirflow(mux *http.ServeMux) {
@@ -160,6 +165,7 @@ func (a *API) runAirflow(ctx context.Context, it *store.Item, job *store.JobInst
 			}
 		}
 	}
+	before := ""
 	if err == nil && len(files) == 0 {
 		err = &airflowError{"AirflowDAGFileRequired"}
 	}
@@ -172,12 +178,13 @@ func (a *API) runAirflow(ctx context.Context, it *store.Item, job *store.JobInst
 		// job failed." beside an empty dags folder -- with the real reason
 		// discarded one line later. Its own code, so `jobFailureMessage` can
 		// say what to check.
+		before = a.Airflow.DAGFingerprint(ctx, dagID)
 		if syncErr := a.Airflow.SyncDAGs(ctx, it.ID, files); syncErr != nil {
 			err = &airflowError{"AirflowDAGSyncFailed"}
 		}
 	}
 	if err == nil {
-		err = a.Airflow.TriggerAndWait(ctx, it.ID, dagID, job.ID, conf)
+		err = a.Airflow.TriggerAndWait(ctx, dagID, job.ID, before, conf)
 	}
 	code := ""
 	if err != nil {

--- a/internal/api/airflow.go
+++ b/internal/api/airflow.go
@@ -15,7 +15,9 @@ import (
 // AirflowRuntime is the deliberately small upstream boundary. Production uses
 // Apache Airflow's REST API and shared DAG volume; tests substitute a witness.
 type AirflowRuntime interface {
-	SyncDAGs(ctx context.Context, itemID string, files map[string][]byte) error
+	// Reports whether any DAG changed: only a changed file can leave
+	// Airflow's serialisation stale, so an unchanged sync needs no wait.
+	SyncDAGs(ctx context.Context, itemID string, files map[string][]byte) (bool, error)
 	// DAGFingerprint is read BEFORE the sync, so the trigger can tell that
 	// Airflow's serialised structure has caught up with the files it is about
 	// to run. Taken after the sync it would be worthless -- the stale answer
@@ -179,8 +181,16 @@ func (a *API) runAirflow(ctx context.Context, it *store.Item, job *store.JobInst
 		// discarded one line later. Its own code, so `jobFailureMessage` can
 		// say what to check.
 		before = a.Airflow.DAGFingerprint(ctx, dagID)
-		if syncErr := a.Airflow.SyncDAGs(ctx, it.ID, files); syncErr != nil {
+		changed, syncErr := a.Airflow.SyncDAGs(ctx, it.ID, files)
+		if syncErr != nil {
 			err = &airflowError{"AirflowDAGSyncFailed"}
+		}
+		if !changed {
+			// Nothing moved on disk, so nothing Airflow holds can be stale.
+			// Dropping the baseline tells the trigger there is nothing to
+			// wait for -- otherwise the most common case, re-running an
+			// unmodified DAG, would pay the whole timeout every time.
+			before = ""
 		}
 	}
 	if err == nil {

--- a/internal/api/airflow.go
+++ b/internal/api/airflow.go
@@ -16,7 +16,7 @@ import (
 // Apache Airflow's REST API and shared DAG volume; tests substitute a witness.
 type AirflowRuntime interface {
 	SyncDAGs(ctx context.Context, itemID string, files map[string][]byte) error
-	TriggerAndWait(ctx context.Context, dagID, runID string, conf map[string]any) error
+	TriggerAndWait(ctx context.Context, itemID, dagID, runID string, conf map[string]any) error
 }
 
 func (a *API) registerAirflow(mux *http.ServeMux) {
@@ -177,7 +177,7 @@ func (a *API) runAirflow(ctx context.Context, it *store.Item, job *store.JobInst
 		}
 	}
 	if err == nil {
-		err = a.Airflow.TriggerAndWait(ctx, dagID, job.ID, conf)
+		err = a.Airflow.TriggerAndWait(ctx, it.ID, dagID, job.ID, conf)
 	}
 	code := ""
 	if err != nil {

--- a/internal/api/airflow_test.go
+++ b/internal/api/airflow_test.go
@@ -26,7 +26,7 @@ func (w *airflowWitness) SyncDAGs(_ context.Context, _ string, files map[string]
 	w.files = files
 	return w.syncErr
 }
-func (w *airflowWitness) TriggerAndWait(_ context.Context, dagID, runID string, conf map[string]any) error {
+func (w *airflowWitness) TriggerAndWait(_ context.Context, _, dagID, runID string, conf map[string]any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.dagID, w.runID, w.conf = dagID, runID, conf

--- a/internal/api/airflow_test.go
+++ b/internal/api/airflow_test.go
@@ -26,7 +26,9 @@ func (w *airflowWitness) SyncDAGs(_ context.Context, _ string, files map[string]
 	w.files = files
 	return w.syncErr
 }
-func (w *airflowWitness) TriggerAndWait(_ context.Context, _, dagID, runID string, conf map[string]any) error {
+func (w *airflowWitness) DAGFingerprint(_ context.Context, _ string) string { return "" }
+
+func (w *airflowWitness) TriggerAndWait(_ context.Context, dagID, runID, _ string, conf map[string]any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.dagID, w.runID, w.conf = dagID, runID, conf

--- a/internal/api/airflow_test.go
+++ b/internal/api/airflow_test.go
@@ -20,11 +20,12 @@ type airflowWitness struct {
 	syncErr, runErr error
 }
 
-func (w *airflowWitness) SyncDAGs(_ context.Context, _ string, files map[string][]byte) error {
+func (w *airflowWitness) SyncDAGs(_ context.Context, _ string, files map[string][]byte) (bool, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.files = files
-	return w.syncErr
+	// `true`, so the witness exercises the path a real changed sync takes.
+	return true, w.syncErr
 }
 func (w *airflowWitness) DAGFingerprint(_ context.Context, _ string) string { return "" }
 


### PR DESCRIPTION
## G27

A published DAG could run as the **previous version of itself**, reporting success. Reproduced on demand against `0.29.0`:

```
published:  branch_0, branch_1, branch_2, branch_3, join   (5 tasks)
run got:    branch_0, branch_1, branch_2, join             -> JobFailed
```

`TriggerAndWait` waits for the DAG to **load**, which is right for a brand-new file — until it parses there is nothing to unpause. A **changed** file has the opposite shape: the DAG is already registered, every check passes instantly, and the run is created from whatever is serialised at that moment.

The failure cannot announce itself. It is a green run whose task instances belong to replaced code, and it surfaces as a task the trigger rule references having no instance, or a new task returning `removed` while its downstream fails. A consumer diagnosed both as DAG bugs before finding this.

## The consumer's workaround could never have worked

`PUT .../files` only stores bytes on the item. The write into the scheduler's DAG folder happens in the **Run** handler, immediately before the trigger. A consumer sleeping before starting a run is sleeping before the files exist on disk at all — the race is entirely inside this process, between our own `SyncDAGs` and our own trigger.

## Two signals measured and rejected

Both looked right and are wrong:

| signal | why it fails |
|---|---|
| `last_parsed_time` vs file mtime | came back **20 ms ahead** of a write whose content the parse had not read — the cycle began before the write landed. Reports that *a* parse finished, never that *this file* was ingested. |
| `/dagSources/{file_token}` vs bytes on disk | `DagCode` matched disk a full **13 seconds** before the task structure changed. |

The gap is Airflow's own `min_serialized_dag_update_interval` (30 s default): the processor may read a file and skip rewriting the serialised DAG. Task instances come from that serialisation, so it is the only thing worth waiting for.

It also explains the consumer's history — a 15 s sleep let four stale runs through and 45 s appeared to fix it. Both were guesses either side of a threshold nobody had identified.

## The fix

The run handler reads the task set **before** syncing; the trigger waits for it to change. Taken after the sync it would be worthless — the stale answer and the current one are indistinguishable without a baseline.

Two deliberate non-failures: no baseline means a DAG Airflow has never served, which cannot be stale; and a change altering no task (a callable's body) produces no observable difference, so the wait expires and proceeds rather than failing every such run.

Also: `SyncDAGs` keeps the mtime of byte-identical files, so an unchanged DAG does not invite a needless re-parse.

## Verification

Same experiment, zero consumer wait, on a local build of this branch:

```
0.29.0                 -> branch_0..2, join        JobFailed
this branch            -> branch_0..3, join        all success
```

The emulator absorbed ~14 s waiting for serialisation. Unit tests fail without the fix (`triggered after 0 polls`); `go vet` and the full suite are green.

The first commit on this branch implements the `last_parsed_time` approach and is kept rather than squashed — it passed its unit test and did not work, which is the point the third commit's message makes.