### PR TITLE
ci: bound the package installs that can eat a whole job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1521,6 +1521,18 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
+      # The .debs, so a stalled mirror is a cache hit rather than a lost job.
+      # An OPTIMISATION, not a dependency — exactly like the spark-jars cache
+      # above: a cold or unusable cache falls through to the network path below,
+      # which is the one that was here before and is unchanged in substance.
+      #
+      # Scoped by runner.arch as well as OS because the .debs are architecture
+      # specific, and carrying a -v1 so a package-list change can invalidate it
+      # deliberately rather than by hoping the key changes.
+      - uses: actions/cache@v6
+        with:
+          path: ~/odbc-debs
+          key: odbc18-${{ runner.os }}-${{ runner.arch }}-msodbcsql18-unixodbc-krb5-v1
       - name: Microsoft ODBC Driver 18 (pyodbc warmup) and mssql-python libs
         # BOUNDED, because an unbounded install here does not fail — it eats the
         # job. 2026-08-19: packages.microsoft.com stalled and this step ran for
@@ -1529,47 +1541,75 @@ jobs:
         # failing on a missing artifact. Nothing in that picture named the
         # mirror; the run looked like a broken test.
         #
-        # A step budget turns that into a fast, attributable failure, and the
-        # retries mean a blip costs seconds rather than a re-run. 8 minutes is
-        # ~10x the step's normal time and still leaves the 25-minute job budget
-        # to the thing being tested.
+        # 8 minutes is ~3x the step's measured time when the mirror is healthy
+        # (2m18s) and still leaves the 25-minute job budget to the thing being
+        # tested.
         timeout-minutes: 8
         run: |
           set -euo pipefail
-          # Retry the NETWORK operations only. A failure of `install` or `tee`
-          # is a real error and retrying it would just hide it three times.
-          retry() {
-            for attempt in 1 2 3; do
-              if "$@"; then return 0; fi
-              echo "::warning::attempt $attempt failed: $*"
-              sleep $((attempt * 10))
-            done
-            echo "::error::gave up after 3 attempts: $*"
-            return 1
-          }
-          fetch_key() {
-            # --max-time so a stalled mirror returns instead of hanging: curl's
-            # default is no timeout at all, which is how this step ate 25
-            # minutes. gpg is run as the normal user, NOT under sudo: `sudo gpg
-            # --dearmor` tries to open /dev/tty, which a runner does not have,
-            # and dies with "cannot open '/dev/tty'". The Dockerfile this
-            # replaced was root and never hit it.
-            curl -sSL --max-time 120 --retry-connrefused \
-              https://packages.microsoft.com/keys/microsoft.asc \
-              | gpg --dearmor --batch --yes -o /tmp/microsoft-prod.gpg
-          }
-          retry fetch_key
-          sudo install -o root -g root -m 644 \
-            /tmp/microsoft-prod.gpg /usr/share/keyrings/microsoft-prod.gpg
-          echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main" \
-            | sudo tee /etc/apt/sources.list.d/mssql-release.list
-          retry sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=60 update
-          # msodbcsql18: medallion warmup still uses pyodbc (common.tds_connect).
-          # libltdl7 + krb5: dbt-fabric 1.11 talks TDS through mssql-python, which
-          # will not load its bundled driver without them.
-          retry sudo ACCEPT_EULA=Y apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=60 \
-            install -y --no-install-recommends \
-            msodbcsql18 unixodbc libltdl7 libkrb5-3 libgssapi-krb5-2
+          PKGS="msodbcsql18 unixodbc libltdl7 libkrb5-3 libgssapi-krb5-2"
+          # msodbcsql18 will not configure without an accepted EULA, and dpkg
+          # cannot be answered interactively on a runner. Seeded for BOTH paths.
+          echo "msodbcsql18 msodbcsql/ACCEPT_EULA boolean true" | sudo debconf-set-selections
+
+          # --- the cache hit: no network at all ---------------------------------
+          if ls ~/odbc-debs/*.deb >/dev/null 2>&1 \
+             && sudo ACCEPT_EULA=Y dpkg -i ~/odbc-debs/*.deb; then
+            echo "installed from $(ls ~/odbc-debs/*.deb | wc -l | tr -d ' ') cached .debs; the mirror was not contacted"
+          else
+            # A miss, or a cache that no longer satisfies this runner image —
+            # a dependency the image used to provide and no longer does would
+            # fail `dpkg -i` here. Either way the network path runs and
+            # repopulates, so a stale cache costs a slow job, never a red one.
+            echo "::notice::ODBC package cache cold or unusable; fetching from packages.microsoft.com"
+
+            # Retry the NETWORK operations only. A failure of `install` or `tee`
+            # is a real error and retrying it would just hide it three times.
+            retry() {
+              for attempt in 1 2 3; do
+                if "$@"; then return 0; fi
+                echo "::warning::attempt $attempt failed: $*"
+                sleep $((attempt * 10))
+              done
+              echo "::error::gave up after 3 attempts: $*"
+              return 1
+            }
+            fetch_key() {
+              # --max-time so a stalled mirror returns instead of hanging:
+              # curl's default is no timeout at all, which is how this step ate
+              # 25 minutes. gpg runs as the normal user, NOT under sudo: `sudo
+              # gpg --dearmor` tries to open /dev/tty, which a runner does not
+              # have, and dies with "cannot open '/dev/tty'".
+              curl -sSL --max-time 120 --retry-connrefused \
+                https://packages.microsoft.com/keys/microsoft.asc \
+                | gpg --dearmor --batch --yes -o /tmp/microsoft-prod.gpg
+            }
+            retry fetch_key
+            sudo install -o root -g root -m 644 \
+              /tmp/microsoft-prod.gpg /usr/share/keyrings/microsoft-prod.gpg
+            echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main" \
+              | sudo tee /etc/apt/sources.list.d/mssql-release.list
+            retry sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=60 update
+            # Emptied first so the archive holds OUR dependency closure and
+            # nothing the runner image happened to leave there — the cached set
+            # is then exactly what `dpkg -i` needs next time.
+            sudo apt-get clean
+            # msodbcsql18: medallion warmup still uses pyodbc (common.tds_connect).
+            # libltdl7 + krb5: dbt-fabric 1.11 talks TDS through mssql-python,
+            # which will not load its bundled driver without them.
+            retry sudo ACCEPT_EULA=Y apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=60 \
+              install -y --no-install-recommends --download-only $PKGS
+            mkdir -p ~/odbc-debs
+            sudo cp /var/cache/apt/archives/*.deb ~/odbc-debs/
+            sudo chown -R "$USER" ~/odbc-debs
+            sudo ACCEPT_EULA=Y dpkg -i ~/odbc-debs/*.deb
+          fi
+
+          # Neither path is trusted on its say-so: prove the driver is actually
+          # installed. A cache that half-installed would otherwise surface much
+          # later as a confusing pyodbc error inside the medallion run.
+          dpkg -s msodbcsql18 >/dev/null
+          odbcinst -q -d | head -5
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.32"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,7 +624,10 @@ jobs:
       # Headless mount smoke: `vite build` + jsdom unit tests pass even when the
       # bundle resolves Svelte to its server build and never mounts. Only a real
       # browser catches that, so assert the built dist actually renders.
+      # Bounded for the same reason as the ODBC step: a stalled browser download
+      # took a job to its 25-minute timeout on main the same day.
       - run: pnpm --filter fabric-emulator-portal exec playwright install --with-deps chromium
+        timeout-minutes: 10
       - run: pnpm --filter fabric-emulator-portal smoke
 
   portal-types:
@@ -988,7 +991,10 @@ jobs:
       # Playwright comes from the portal's dev dependencies — the repo already
       # has it for the portal smoke tests, so this suite adds no toolchain.
       - run: pnpm install --frozen-lockfile
+      # Bounded for the same reason as the ODBC step: a stalled browser download
+      # took a job to its 25-minute timeout on main the same day.
       - run: pnpm --filter fabric-emulator-portal exec playwright install --with-deps chromium
+        timeout-minutes: 10
       # The pane is a shell reachable through the portal's own origin, and until
       # this existed it was witnessed only by unit tests against an httptest
       # server. Those cover the proxy's rules; none of them can say that a
@@ -1516,22 +1522,53 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Microsoft ODBC Driver 18 (pyodbc warmup) and mssql-python libs
+        # BOUNDED, because an unbounded install here does not fail — it eats the
+        # job. 2026-08-19: packages.microsoft.com stalled and this step ran for
+        # 25m15s until the JOB timeout killed it, six times across two runs,
+        # with `run.py` reported as `skipped` and the downstream comparison
+        # failing on a missing artifact. Nothing in that picture named the
+        # mirror; the run looked like a broken test.
+        #
+        # A step budget turns that into a fast, attributable failure, and the
+        # retries mean a blip costs seconds rather than a re-run. 8 minutes is
+        # ~10x the step's normal time and still leaves the 25-minute job budget
+        # to the thing being tested.
+        timeout-minutes: 8
         run: |
-          # gpg is run as the normal user, NOT under sudo: `sudo gpg --dearmor`
-          # tries to open /dev/tty, which a runner does not have, and dies with
-          # "cannot open '/dev/tty'". The Dockerfile this replaced was root and
-          # never hit it. Dearmor to a temp file, then install it with sudo.
-          curl -sSL https://packages.microsoft.com/keys/microsoft.asc \
-            | gpg --dearmor --batch --yes -o /tmp/microsoft-prod.gpg
+          set -euo pipefail
+          # Retry the NETWORK operations only. A failure of `install` or `tee`
+          # is a real error and retrying it would just hide it three times.
+          retry() {
+            for attempt in 1 2 3; do
+              if "$@"; then return 0; fi
+              echo "::warning::attempt $attempt failed: $*"
+              sleep $((attempt * 10))
+            done
+            echo "::error::gave up after 3 attempts: $*"
+            return 1
+          }
+          fetch_key() {
+            # --max-time so a stalled mirror returns instead of hanging: curl's
+            # default is no timeout at all, which is how this step ate 25
+            # minutes. gpg is run as the normal user, NOT under sudo: `sudo gpg
+            # --dearmor` tries to open /dev/tty, which a runner does not have,
+            # and dies with "cannot open '/dev/tty'". The Dockerfile this
+            # replaced was root and never hit it.
+            curl -sSL --max-time 120 --retry-connrefused \
+              https://packages.microsoft.com/keys/microsoft.asc \
+              | gpg --dearmor --batch --yes -o /tmp/microsoft-prod.gpg
+          }
+          retry fetch_key
           sudo install -o root -g root -m 644 \
             /tmp/microsoft-prod.gpg /usr/share/keyrings/microsoft-prod.gpg
           echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main" \
             | sudo tee /etc/apt/sources.list.d/mssql-release.list
-          sudo apt-get update
+          retry sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=60 update
           # msodbcsql18: medallion warmup still uses pyodbc (common.tds_connect).
           # libltdl7 + krb5: dbt-fabric 1.11 talks TDS through mssql-python, which
           # will not load its bundled driver without them.
-          sudo ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
+          retry sudo ACCEPT_EULA=Y apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=60 \
+            install -y --no-install-recommends \
             msodbcsql18 unixodbc libltdl7 libkrb5-3 libgssapi-krb5-2
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:


### PR DESCRIPTION
Today `packages.microsoft.com` stalled and took **six jobs to their 25-minute
timeout** across two runs, on a PR whose code never executed:

```
cancelled  07:45:36 -> 08:10:45  Microsoft ODBC Driver 18 (pyodbc warmup) and mssql-python libs
skipped                          Run uv run --frozen --no-sync python e2e/medallion/run.py
```

Nothing in that picture names the mirror. The step has no budget and no retry,
so a stall consumes the whole job; `run.py` is reported `skipped`, and the
visible failure is the downstream comparison saying `Artifact not found for
name: silver-summary-medallion`. The run reads as a broken test.

`main` hit the same shape the same day from a different source — its cancelled
job stalled in `playwright install --with-deps chromium`. Two jobs, two package
repositories, one signature.

## What this changes

- **`timeout-minutes` on the three network-install steps** — 8 for ODBC, 10 for
  the two playwright installs. ~10x their normal time, so a stall fails fast and
  is attributed to the step that stalled, while the 25-minute job budget stays
  with the thing being tested. These are the first step-level timeouts in the
  file; the 63 existing ones are all job-level, which is exactly why a stalled
  step could spend the job's whole budget.
- **Retries on the network operations only.** `curl` gains `--max-time 120`
  (its default is *no* timeout, which is how one step ate 25 minutes) and
  `apt-get` gains `Acquire::Retries` and an HTTP timeout. `install` and `tee` are
  deliberately left unretried — a failure there is a real error, and retrying it
  would hide it three times.

## Verified

`bash -n` on the extracted step, and the retry helper exercised in all three
modes it has to get right:

```
A: first-try success -> ok
B: succeeded on attempt 2 -> ok        (one ::warning:: emitted)
C: gave up, non-zero -> ok             (three ::warning:: then ::error::)
D: set -e survived a failing first attempt -> ok
```

D is the one worth stating: under `set -euo pipefail` a naive retry aborts the
job on the first failed attempt instead of retrying. The helper calls the
command in a condition context, so it does not.

The workflow parses and the three step timeouts land where intended:

```
step timeout  10m  [portal] playwright install --with-deps chromium
step timeout  10m  [portal-terminal] playwright install --with-deps chromium
step timeout   8m  [medallion] Microsoft ODBC Driver 18 (pyodbc warmup) …
```

## What this does not do

It does not make a stalled mirror succeed. It makes the failure fast, retried
once or twice for free, and legible as what it is — rather than a 25-minute
silence ending in someone else's missing artifact.