### PR TITLE
build(deps): great-expectations 1.20.0 — and numpy 2

### DIFF
--- a/e2e/great-expectations/driver.py
+++ b/e2e/great-expectations/driver.py
@@ -48,6 +48,11 @@ def query(dax):
     return df
 
 
+# ty reports every keyword below as `unknown-argument`: GE 1.x builds its
+# Expectation classes from pydantic models, so a static checker sees no declared
+# parameters on them. The keywords are correct — the offline harness and CI both
+# execute these calls — so the suppressions are about the checker's view of a
+# third-party library, not about the calls.
 def batch(df):
     """A GE 1.x Batch over `df`, ready to validate single Expectations.
 
@@ -77,19 +82,19 @@ results = []
 # Retail Store Suite: row count in range + valid 5-digit zip.
 b = batch(query(dax["Store Asset"]))
 results.append(("Retail Store", "row_count_between(1,10)",
-                b.validate(gxe.ExpectTableRowCountToBeBetween(min_value=1, max_value=10)).success))
+                b.validate(gxe.ExpectTableRowCountToBeBetween(min_value=1, max_value=10)).success))  # ty: ignore[unknown-argument]
 results.append(("Retail Store", "valid_zip5(PostalCode)",
-                b.validate(gxe.ExpectColumnValuesToMatchRegex(column="PostalCode", regex=r"^\d{5}$")).success))
+                b.validate(gxe.ExpectColumnValuesToMatchRegex(column="PostalCode", regex=r"^\d{5}$")).success))  # ty: ignore[unknown-argument]
 
 # Retail Measure Suite: TotalUnits above threshold.
 b = batch(query(dax["Total Units Asset"]))
 results.append(("Retail Measure", "TotalUnits >= 50000",
-                b.validate(gxe.ExpectColumnValuesToBeBetween(column="TotalUnits", min_value=50000)).success))
+                b.validate(gxe.ExpectColumnValuesToBeBetween(column="TotalUnits", min_value=50000)).success))  # ty: ignore[unknown-argument]
 
 # Retail DAX Suite: the YoY ratio must be within band — the tutorial's failing asset.
 b = batch(query(dax["Total Units YoY Asset"]))
 ratio = b.validate(gxe.ExpectColumnValuesToBeBetween(
-    column="Total Units Ratio", min_value=0.8, max_value=1.5))
+    column="Total Units Ratio", min_value=0.8, max_value=1.5))  # ty: ignore[unknown-argument]
 results.append(("Retail DAX", "Total Units Ratio in [0.8, 1.5]", ratio.success))
 
 for suite, exp, ok in results:

--- a/e2e/great-expectations/driver.py
+++ b/e2e/great-expectations/driver.py
@@ -82,19 +82,19 @@ results = []
 # Retail Store Suite: row count in range + valid 5-digit zip.
 b = batch(query(dax["Store Asset"]))
 results.append(("Retail Store", "row_count_between(1,10)",
-                b.validate(gxe.ExpectTableRowCountToBeBetween(min_value=1, max_value=10)).success))  # ty: ignore[unknown-argument]
+                b.validate(gxe.ExpectTableRowCountToBeBetween(min_value=1, max_value=10)).success))
 results.append(("Retail Store", "valid_zip5(PostalCode)",
-                b.validate(gxe.ExpectColumnValuesToMatchRegex(column="PostalCode", regex=r"^\d{5}$")).success))  # ty: ignore[unknown-argument]
+                b.validate(gxe.ExpectColumnValuesToMatchRegex(column="PostalCode", regex=r"^\d{5}$")).success))
 
 # Retail Measure Suite: TotalUnits above threshold.
 b = batch(query(dax["Total Units Asset"]))
 results.append(("Retail Measure", "TotalUnits >= 50000",
-                b.validate(gxe.ExpectColumnValuesToBeBetween(column="TotalUnits", min_value=50000)).success))  # ty: ignore[unknown-argument]
+                b.validate(gxe.ExpectColumnValuesToBeBetween(column="TotalUnits", min_value=50000)).success))
 
 # Retail DAX Suite: the YoY ratio must be within band — the tutorial's failing asset.
 b = batch(query(dax["Total Units YoY Asset"]))
 ratio = b.validate(gxe.ExpectColumnValuesToBeBetween(
-    column="Total Units Ratio", min_value=0.8, max_value=1.5))  # ty: ignore[unknown-argument]
+    column="Total Units Ratio", min_value=0.8, max_value=1.5))
 results.append(("Retail DAX", "Total Units Ratio in [0.8, 1.5]", ratio.success))
 
 for suite, exp, ok in results:

--- a/e2e/great-expectations/driver.py
+++ b/e2e/great-expectations/driver.py
@@ -19,6 +19,7 @@ import re
 import urllib.request
 
 import great_expectations as gx
+import great_expectations.expectations as gxe
 import pandas as pd
 
 FABRIC = os.environ["FABRIC_URL"]
@@ -47,13 +48,23 @@ def query(dax):
     return df
 
 
-def validator(df):
+def batch(df):
+    """A GE 1.x Batch over `df`, ready to validate single Expectations.
+
+    Ported from 0.18's `ctx.get_validator(...)` + `v.expect_*()`, which 1.0
+    removed: `context.sources` is now `context.data_sources`, an asset yields a
+    BATCH DEFINITION rather than a batch request, and expectations are objects
+    passed to `batch.validate(...)` instead of methods on a validator. The
+    tutorial's shape is unchanged — one batch per asset, one result per
+    expectation — because `validate()` returns the same
+    ExpectationValidationResult, with `.success` and `partial_unexpected_list`.
+    """
     ctx = gx.get_context()
     n = next(_names)
-    src = ctx.sources.add_pandas(f"src{n}")
-    asset = src.add_dataframe_asset(f"asset{n}")
-    br = asset.build_batch_request(dataframe=df)
-    return ctx.get_validator(batch_request=br, create_expectation_suite_with_name=f"suite{n}")
+    bd = (ctx.data_sources.add_pandas(f"src{n}")
+          .add_dataframe_asset(f"asset{n}")
+          .add_batch_definition_whole_dataframe(f"batch{n}"))
+    return bd.get_batch(batch_parameters={"dataframe": df})
 
 
 # DAX per asset — single-sourced from the semantic-model golden fixture.
@@ -64,20 +75,21 @@ dax = {q["name"]: q["dax"] for q in golden["queries"]}
 results = []
 
 # Retail Store Suite: row count in range + valid 5-digit zip.
-v = validator(query(dax["Store Asset"]))
+b = batch(query(dax["Store Asset"]))
 results.append(("Retail Store", "row_count_between(1,10)",
-                v.expect_table_row_count_to_be_between(min_value=1, max_value=10).success))
+                b.validate(gxe.ExpectTableRowCountToBeBetween(min_value=1, max_value=10)).success))
 results.append(("Retail Store", "valid_zip5(PostalCode)",
-                v.expect_column_values_to_match_regex("PostalCode", r"^\d{5}$").success))
+                b.validate(gxe.ExpectColumnValuesToMatchRegex(column="PostalCode", regex=r"^\d{5}$")).success))
 
 # Retail Measure Suite: TotalUnits above threshold.
-v = validator(query(dax["Total Units Asset"]))
+b = batch(query(dax["Total Units Asset"]))
 results.append(("Retail Measure", "TotalUnits >= 50000",
-                v.expect_column_values_to_be_between("TotalUnits", min_value=50000).success))
+                b.validate(gxe.ExpectColumnValuesToBeBetween(column="TotalUnits", min_value=50000)).success))
 
 # Retail DAX Suite: the YoY ratio must be within band — the tutorial's failing asset.
-v = validator(query(dax["Total Units YoY Asset"]))
-ratio = v.expect_column_values_to_be_between("Total Units Ratio", min_value=0.8, max_value=1.5)
+b = batch(query(dax["Total Units YoY Asset"]))
+ratio = b.validate(gxe.ExpectColumnValuesToBeBetween(
+    column="Total Units Ratio", min_value=0.8, max_value=1.5))
 results.append(("Retail DAX", "Total Units Ratio in [0.8, 1.5]", ratio.success))
 
 for suite, exp, ok in results:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ demo = [
     "requests>=2.32,<3",
 ]
 great-expectations = [
-    "great-expectations>=0.18,<1",
+    "great-expectations>=0.18,<2",
     "pandas>=2.2,<4",
 ]
 runtime = []

--- a/uv.lock
+++ b/uv.lock
@@ -2,69 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.13' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra != 'group-22-fabric-emulator-python-databricks-sdk' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
 ]
 conflicts = [[
     { package = "fabric-emulator-python", group = "dbt-fabric" },
@@ -238,19 +184,19 @@ wheels = [
 
 [[package]]
 name = "altair"
-version = "4.2.2"
+version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "entrypoints" },
     { name = "jinja2" },
     { name = "jsonschema" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "toolz" },
+    { name = "narwhals" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark') or (extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt')" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/bf/781b607da4c1a2a7211cd570bd7e22e0accd4deaf1074c32ac7344a09339/altair-4.2.2.tar.gz", hash = "sha256:39399a267c49b30d102c10411e67ab26374156a84b1aeb9fcd15140429ba49c5", size = 740430, upload-time = "2023-01-27T22:51:11.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/a1/5e6cc638a66da48cfc89a79c2f4810dfec00b63385f9b009ab1f069779bb/altair-6.2.2.tar.gz", hash = "sha256:a1ff9d9cfe81c75414641826312b9471780e19d39293ba0b012933f6b6cba0fe", size = 766606, upload-time = "2026-06-23T12:47:13.384Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/62/47452306e84d4d2e67f9c559380aeb230f5e6ca84fafb428dd36b96a99ba/altair-4.2.2-py3-none-any.whl", hash = "sha256:8b45ebeaf8557f2d760c5c77b79f02ae12aee7c46c27c06014febab6f849bc87", size = 813630, upload-time = "2023-01-27T22:51:08.935Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/99/d6031f4f146298951c46b1bf1cc160c2a63f6e44b3c13a30054add100d5f/altair-6.2.2-py3-none-any.whl", hash = "sha256:94014f8ad8617c3cb163d1137359cd6db5ba134b9b46d93cfd8b609fd245a583", size = 797613, upload-time = "2026-06-23T12:47:11.451Z" },
 ]
 
 [[package]]
@@ -780,7 +726,8 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1011,16 +958,19 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "google-auth" },
-    { name = "protobuf" },
-    { name = "requests" },
-    { name = "urllib3" },
+    { name = "google-auth", marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "protobuf", marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "requests", marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "urllib3", marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/29/d553b49b7d38d7ce71f12c2b67aa0e7988c054f5101e13c1cb896b69307c/databricks_sdk-0.130.0.tar.gz", hash = "sha256:1ea962d1fd10a0e8eb3b405d6f9023cdb7ef1942b34eaeb02ecf14c84131d4e8", size = 1156390, upload-time = "2026-08-16T04:31:09.392Z" }
 wheels = [
@@ -1392,15 +1342,6 @@ wheels = [
 ]
 
 [[package]]
-name = "entrypoints"
-version = "0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/8d/a7121ffe5f402dc015277d2d31eb82d2187334503a011c18f2e78ecbb9b2/entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4", size = 13974, upload-time = "2022-02-02T21:30:28.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f", size = 5294, upload-time = "2022-02-02T21:30:26.024Z" },
-]
-
-[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1641,7 +1582,7 @@ governance = [
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 great-expectations = [
-    { name = "great-expectations", specifier = ">=0.18,<1" },
+    { name = "great-expectations", specifier = ">=0.18,<2" },
     { name = "pandas", specifier = ">=2.2,<4" },
 ]
 jupyter = [
@@ -2029,24 +1970,17 @@ wheels = [
 
 [[package]]
 name = "great-expectations"
-version = "0.18.22"
+version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "altair" },
-    { name = "click" },
-    { name = "colorama" },
     { name = "cryptography" },
-    { name = "ipython" },
-    { name = "ipywidgets" },
     { name = "jinja2" },
-    { name = "jsonpatch" },
     { name = "jsonschema" },
-    { name = "makefun" },
     { name = "marshmallow" },
     { name = "mistune" },
-    { name = "nbformat" },
-    { name = "notebook" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark') or (extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt')" },
     { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "pandas" },
@@ -2054,18 +1988,16 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "pyparsing" },
     { name = "python-dateutil" },
-    { name = "pytz" },
     { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "scipy" },
     { name = "tqdm" },
     { name = "typing-extensions" },
     { name = "tzlocal" },
-    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/c2/020af2512b0482ccdb833b816568bb66ad41d8a4386252a3161323b656cc/great_expectations-0.18.22.tar.gz", hash = "sha256:fc7008ddb55bda37ff9e8f3e3030e65cda2b73eb0e3b0f346454385f7f9e918b", size = 32324098, upload-time = "2024-10-25T17:30:23.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/07e8ad9775826c2e261e28e2d572eb1fe80bd19d1858f2b068311dac2f8a/great_expectations-1.20.0.tar.gz", hash = "sha256:d6d6ed6a6437b81a452b6dbc201bd4403c3f96562788a1fcaf10848e96629864", size = 36310883, upload-time = "2026-08-07T14:08:14.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/ad/68c55d2b0df64f843306446a49b4a5edda251248b2fce122b43e6aeebbec/great_expectations-0.18.22-py3-none-any.whl", hash = "sha256:2980bb31172d1f5ae741cc99992e7a9fbacb55d60d503d8ffed57f3ebd5b3a5f", size = 5382652, upload-time = "2024-10-25T17:30:20.841Z" },
+    { url = "https://files.pythonhosted.org/packages/74/57/351beba1b367e86183ee1e00cf64c286bac22dbc23b6ea02d971db06108a/great_expectations-1.20.0-py3-none-any.whl", hash = "sha256:cb6948e287826a039ea32f2f33add10fe276faf4278439431750250d46d74dd1", size = 4953172, upload-time = "2026-08-07T14:08:11.392Z" },
 ]
 
 [[package]]
@@ -2214,8 +2146,8 @@ name = "gunicorn"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark') or (extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt')" },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-databricks-sdk') or (sys_platform != 'win32' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt') or (sys_platform != 'win32' and extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra != 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
@@ -2423,22 +2355,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ipywidgets"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "comm" },
-    { name = "ipython" },
-    { name = "jupyterlab-widgets" },
-    { name = "traitlets" },
-    { name = "widgetsnbextension" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
-]
-
-[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2526,18 +2442,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
-]
-
-[[package]]
-name = "jsonpatch"
-version = "1.33"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonpointer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
 ]
 
 [[package]]
@@ -2770,15 +2674,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jupyterlab-widgets"
-version = "3.0.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
-]
-
-[[package]]
 name = "kafka-python"
 version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2932,15 +2827,6 @@ wheels = [
 ]
 
 [[package]]
-name = "makefun"
-version = "1.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/cf/6780ab8bc3b84a1cce3e4400aed3d64b6db7d5e227a2f75b6ded5674701a/makefun-1.16.0.tar.gz", hash = "sha256:e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947", size = 73565, upload-time = "2025-05-09T15:00:42.313Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/c0/4bc973defd1270b89ccaae04cef0d5fa3ea85b59b108ad2c08aeea9afb76/makefun-1.16.0-py2.py3-none-any.whl", hash = "sha256:43baa4c3e7ae2b17de9ceac20b669e9a67ceeadff31581007cca20a07bbe42c4", size = 22923, upload-time = "2025-05-09T15:00:41.042Z" },
-]
-
-[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -3054,7 +2940,8 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark') or (extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt')" },
     { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "pillow" },
@@ -3188,7 +3075,8 @@ dependencies = [
     { name = "matplotlib" },
     { name = "mlflow-skinny" },
     { name = "mlflow-tracing" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "scikit-learn" },
@@ -3603,23 +3491,6 @@ wheels = [
 ]
 
 [[package]]
-name = "notebook"
-version = "7.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jupyter-builder" },
-    { name = "jupyter-server" },
-    { name = "jupyterlab" },
-    { name = "jupyterlab-server" },
-    { name = "notebook-shim" },
-    { name = "tornado" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/62/34df9b5f6cef6a3e71301cd2f5525fe93a983ae46bd217e7cca27374a037/notebook-7.6.1.tar.gz", hash = "sha256:0b45fd1010668dd4808c40914d957706dbf044a677d28764dc881b74dfcede82", size = 5499443, upload-time = "2026-07-22T12:39:05.432Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/19/003ac39eae3a88b80631f93eb954b61d0f1fc1dce4c84602eb0bf4802466/notebook-7.6.1-py3-none-any.whl", hash = "sha256:6ea1e4c926f0dc490444ddcc335797a3dacda470a805d01031872fb119988ba2", size = 5546368, upload-time = "2026-07-22T12:39:02.287Z" },
-]
-
-[[package]]
 name = "notebook-shim"
 version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3635,6 +3506,11 @@ wheels = [
 name = "numpy"
 version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
@@ -3645,6 +3521,87 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
     { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
     { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/72/dccb0aaf40972777283303919f613964227266d0c13adebb79ac124f1c3e/numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c", size = 16891693, upload-time = "2026-08-09T13:44:51.702Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03", size = 11903109, upload-time = "2026-08-09T13:44:55.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f4/29e78102a80601cf034d4e9767022cffeca2c3b4c926e1754572ca95593d/numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb", size = 5350202, upload-time = "2026-08-09T13:44:58.401Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4b/dcd3b7eadaf4035d2c7a4289d232523a6964f602598ef7674e4bd7291f93/numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414", size = 6687736, upload-time = "2026-08-09T13:45:00.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/21/4947e0e9d6c9fc2e2ff15b8949049ee44f63adb9cacc729ab8793f97e712/numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9", size = 15612696, upload-time = "2026-08-09T13:45:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8", size = 16722264, upload-time = "2026-08-09T13:45:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/3f0be4c1b9fdf5dd5e708a6806978564d7c46a055c000496309ff2a2f8af/numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab", size = 16974396, upload-time = "2026-08-09T13:45:11.316Z" },
+    { url = "https://files.pythonhosted.org/packages/22/72/6262cbdeeb45da9d971e40715f579d791603ba8ec0b5e2db1ac55454421d/numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7", size = 18476044, upload-time = "2026-08-09T13:45:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/29208b8b075bde62d26a81d14b358c42b0f69b6cabd98d4ff97f37f22b05/numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a", size = 6072817, upload-time = "2026-08-09T13:45:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4", size = 12464674, upload-time = "2026-08-09T13:45:20.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/032b97e00461ab0809bbe4c588b035620e5a14b8cdee47ecddefc7b17d33/numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1", size = 10397131, upload-time = "2026-08-09T13:45:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c6/28de0191c5f82b7d42a0a51390ba98587048aa93a39fafb05bdbe6e8d00c/numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f", size = 16885274, upload-time = "2026-08-09T13:47:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/973ca116000d244897e468ea1aff30b589e5022e3c8744b71706fe33bd57/numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842", size = 11907846, upload-time = "2026-08-09T13:47:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d9/8c4b3937ef204cb2fd88d389ccd0f265a2ffb11f35a01d2064cf46714bd6/numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6", size = 5354892, upload-time = "2026-08-09T13:47:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/b6ee65ea2999fdb7023935e108e6fb776ee4082aa15f159acfa857e578c8/numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8", size = 6679309, upload-time = "2026-08-09T13:47:20.456Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f3/acb18d8b137a393c8e7803a8c994c9e64bde3930692a69d826993113a159/numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69", size = 15625850, upload-time = "2026-08-09T13:47:24.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bf/a8e9bb0db815a0e265b5744ebedd3af0bd5faad8604e5b50a1cd012f3c91/numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab", size = 16713664, upload-time = "2026-08-09T13:47:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/6e913736b3dd6582344af32418b5fb9dab34282e8a8174ae1d54ceb0fc13/numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514", size = 16986749, upload-time = "2026-08-09T13:47:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/7d3b23eff5c7428ef6c01e6f7052bb60d504c4d33e317b36b8959c24ad97/numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710", size = 18470495, upload-time = "2026-08-09T13:47:35.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a4/68a321d825374f6eb677ffe8ef8c6b9a328304e6fd2e39d9530822776607/numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617", size = 6120696, upload-time = "2026-08-09T13:47:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/deafbb1700f79fae9cd1e91220f133d124cc267de1b584da3fbf6db2f6cd/numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7", size = 12597324, upload-time = "2026-08-09T13:47:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cd/3272ba105e3bbbdaeb11357eda31e7a6825ffe159e8171665660299a948f/numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788", size = 10680466, upload-time = "2026-08-09T13:47:44.873Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/58370637b1bb70a5c9ce2b43f4b521ccb224e36ccb76a6596b17ae4b447c/numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b", size = 16993947, upload-time = "2026-08-09T13:47:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/93/2abcb807712b289d6d60fe4cf30532f98974a8396d885650f3ba5a13026e/numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e", size = 12025331, upload-time = "2026-08-09T13:47:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3a/2898e003a5fbaf87e76c039b4ee1f5eb390471b4ffe74887c1f34c4e791e/numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a", size = 5472336, upload-time = "2026-08-09T13:47:55.403Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/23f69d07c544597b29758b31b55c27dc9d541012a2c1496189fef702aec2/numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8", size = 6788387, upload-time = "2026-08-09T13:47:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ea/c0dbdbcf22f43782510a3e492dd3da73c6112b69cac8929d16d127536fc4/numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc", size = 15667096, upload-time = "2026-08-09T13:48:01.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/29c73c31748cdb0f7566642125ba17fd5b56780cddf891b085dab27e4466/numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec", size = 16751730, upload-time = "2026-08-09T13:48:05.706Z" },
+    { url = "https://files.pythonhosted.org/packages/47/95/02501e8454796bb58dadf7a99d3181e0b464bf264e1003039572f9779fac/numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0", size = 17038686, upload-time = "2026-08-09T13:48:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/53a681d91b5c82687067d8ea5035e02d917b5509d6f334cb06484a954714/numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2", size = 18507727, upload-time = "2026-08-09T13:48:13.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
 ]
 
 [[package]]
@@ -3755,10 +3712,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
@@ -3770,7 +3730,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -4282,10 +4243,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "annotated-types", marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
@@ -4387,10 +4351,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "typing-extensions", marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
@@ -4575,7 +4542,8 @@ dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
     { name = "grpcio-status" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pyyaml" },
@@ -5116,7 +5084,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "narwhals" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
@@ -5153,7 +5122,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5232,7 +5202,8 @@ name = "skops"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark') or (extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt')" },
     { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-22-fabric-emulator-python-databricks-sdk' or extra != 'group-22-fabric-emulator-python-spark-agent-dbt' or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "prettytable" },
@@ -5466,15 +5437,6 @@ wheels = [
 ]
 
 [[package]]
-name = "toolz"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
-]
-
-[[package]]
 name = "tornado"
 version = "6.5.7"
 source = { registry = "https://pypi.org/simple" }
@@ -5671,15 +5633,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
-]
-
-[[package]]
-name = "widgetsnbextension"
-version = "4.0.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
One quarter of #319, and **the one carrying the real risk**.

`great-expectations` 0.18.22 → **1.20.0** does not come alone:

```
great-expectations  0.18.22 -> 1.20.0
altair              4.2.2   -> 6.2.2
numpy               1.26.4  -> 2.5.2      <- the whole point of splitting
```

**numpy 2 is the change here**, not Great Expectations. It sits under pandas,
pyarrow, Spark's Python side and every notebook the emulator runs, so its blast
radius is the entire Python surface. In #319 it arrived as one of 25 moving
packages, which is why three Great-Expectations jobs failing said nothing about
whether GE 1.x or numpy 2 was responsible.

Splitting isolates it: if this PR is red and the other three are green, numpy 2
is the answer. That is the question #319 could not ask.

Also note GE 0.18 → 1.x is a documented rewrite of the API surface
(`great_expectations.dataset` → the new fluent/context API), so the suite may
need source changes rather than just a bump. If so, this PR should become that
work rather than a version line.

Widening `great-expectations>=0.18,<1` to `<2` is a no-op by itself, so this
widens the bound *and* runs `uv lock --upgrade-package great-expectations`.

Local: `pytest python/tests` 997 passed / 1 skipped — which proves only that
*our own* Python tests survive numpy 2, not that the GE suite does. The three
`Real Great Expectations validates semantic-model data` jobs are the judge.