### PR TITLE
docs: v0.31.0 notes name 5 commits, and #329 among them

### DIFF
--- a/docs/release-notes/v0.31.0.md
+++ b/docs/release-notes/v0.31.0.md
@@ -1,7 +1,7 @@
 # v0.31.0
 
 The range starts at `322d20d` (#325), the first commit after the `v0.30.0`
-tag: 4 commits. One is the headline and the rest are repairs — two of them
+tag: 5 commits. One is the headline and the rest are repairs — two of them
 dependency bumps that broke something on the way in, which is the more useful
 half of a dependency bump.
 
@@ -107,6 +107,12 @@ bump that required it, rather than after it.
 
 Also in the range: svelte 5.56.9 with `portal/dist` rebuilt (#325), and
 kafka-go 0.4.51.
+
+CI bounds the package installs that could consume an entire job (#329). Nothing
+in the shipped emulator changes, but it is the reason a run of this release's
+own branch was cancelled rather than completed — a job spent its whole budget
+installing packages, and three unrelated jobs were still in flight when the run
+stopped.
 
 ## Upgrading
 


### PR DESCRIPTION
The v0.31.0 notes were written and merged while [#329](https://github.com/calvinchengx/fabric-emulator/pull/329) was still in flight, so they claim a 4-commit range and omit it.

#329 changes nothing in the shipped emulator, but it earns a line: it bounds the package installs that can consume a whole CI job, which is what cancelled a run of this release's own branch and left three unrelated jobs reported as failures.

Blocks tagging `v0.31.0` — the notes in this repo name their commit range precisely and this one was off by one.