### PR TITLE
Go 1.26.6, and add secret and vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.32"
@@ -1032,7 +1032,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1057,7 +1057,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1081,7 +1081,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1106,7 +1106,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1127,7 +1127,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1749,7 +1749,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1772,7 +1772,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1842,7 +1842,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       # entra-emulator runs in-process (a go.mod dependency); fabric's SQL/TDS
       # endpoint points at the SQL Server service, then a real go-mssqldb client
       # connects with an entra token and runs DDL + DML + a GROUP BY through the
@@ -1865,7 +1865,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -1889,7 +1889,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - run: go vet ./...
       # `go vet` was gated from the start; formatting never was, which is how a
       # stray blank line reached main and was found by hand rather than by CI.
@@ -287,8 +287,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
-
+          go-version-file: go.mod
       # Real e2e suites, instrumented. Every harness layers
       # e2e/docker-compose.coverage.yml when FABRIC_COVERAGE is set, and they
       # all write into ONE repo-level covdata/, so the merge below sees the
@@ -674,7 +673,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -694,7 +693,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -721,7 +720,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -745,7 +744,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,8 +64,7 @@ jobs:
       - if: matrix.language == 'go'
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25.11'
-
+          go-version-file: go.mod
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.37.7
         with:

--- a/.github/workflows/make-targets.yml
+++ b/.github/workflows/make-targets.yml
@@ -66,8 +66,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
-
+          go-version-file: go.mod
       # macOS ships GNU Make 3.81 with the Xcode CLT and Linux ships it as
       # standard; only Windows needs one installed. Users get the same binary
       # via `winget install ezwinports.make` (docs/26). CI must not ask

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0 # GoReleaser needs full history/tags
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,10 @@ jobs:
         run: gitleaks dir . --config .gitleaks.toml --no-banner --redact --verbose
 
       - name: Scan the history
-        run: gitleaks git . --config .gitleaks.toml --no-banner --redact
+      # --verbose here too, and it is not noise: without it a failing scan
+      # logs "leaks found: 3" and nothing else, so the one job whose whole
+      # output is "which line" names no line. --redact still masks the value.
+        run: gitleaks git . --config .gitleaks.toml --no-banner --redact --verbose
 
   vulnerabilities:
     name: govulncheck

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,61 @@
+# Secret scanning and vulnerability scanning.
+#
+# Neither existed anywhere in the emulator family before this workflow. The
+# gap that prompted it: govulncheck reported standard-library vulnerabilities
+# in every Go repo, 6 to 25 each, all of them fixed by moving off Go 1.25. A
+# scanner nobody runs is a scanner that finds nothing.
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Vulnerabilities are published against code that has not changed, so this
+    # cannot only run on push: a repo that is finished still needs watching.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      # Full history: a secret that was committed and then removed is still in
+      # the pack, still cloneable, and still leaked. Scanning only the tip
+      # would report clean on exactly the case that matters most.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.0
+        run: |
+          curl -fsSL -o /tmp/gl.tgz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gl.tgz -C /tmp gitleaks
+          sudo install /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan the working tree
+        run: gitleaks dir . --config .gitleaks.toml --no-banner --redact --verbose
+
+      - name: Scan the history
+        run: gitleaks git . --config .gitleaks.toml --no-banner --redact
+
+  vulnerabilities:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      # Reports only vulnerabilities the code can actually REACH, so a finding
+      # here is a call path rather than a dependency-tree coincidence.
+      - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,6 +23,9 @@ jobs:
   secrets:
     name: gitleaks
     runs-on: ubuntu-latest
+    # A wedged run must fail rather than sit in GitHub's 6-hour default,
+    # where 'pending' and 'stuck' look identical.
+    timeout-minutes: 15
     steps:
       # Full history: a secret that was committed and then removed is still in
       # the pack, still cloneable, and still leaked. Scanning only the tip
@@ -50,6 +53,9 @@ jobs:
   vulnerabilities:
     name: govulncheck
     runs-on: ubuntu-latest
+    # A wedged run must fail rather than sit in GitHub's 6-hour default,
+    # where 'pending' and 'stuck' look identical.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,50 @@
+# Secret scanning for an emulator repo.
+#
+# THE HARD PART IS THE FALSE POSITIVES, and they are structural rather than
+# incidental. An Azure emulator is full of GUIDs: tenant ids, application
+# (client) ids, role definition ids, workspace and item ids. gitleaks'
+# `generic-api-key` rule matches a bare GUID, so a faithful emulator looks like
+# a repo leaking dozens of keys.
+#
+# Allowlisting those is correct, not a concession: **a tenant id, an
+# application (client) id and a role definition id are not secrets.** Microsoft
+# publishes its own, they appear in every quickstart, and they are useless
+# without a credential. What IS a secret is a client SECRET, a private key, a
+# PAT or a connection string, and nothing below allowlists those: every default
+# rule that looks for a credential in context (client_secret=, password=,
+# private key headers, cloud provider tokens) stays armed.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Identifiers, vendored specifications and prose, none of them credentials"
+
+regexes = [
+  # A bare GUID and nothing else. Tenant, client, role definition, workspace
+  # and item ids all take this shape. A GUID-shaped credential would still be
+  # caught by the rules that match on surrounding context.
+  '''^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$''',
+  # The JOSE header of an unsigned/test JWT. `eyJhbGciOi...` is base64 of
+  # `{"alg":...`, so every JWT fixture in every policy test trips the rule.
+  # A real leaked token is caught by its payload and signature, not this prefix.
+  '''^eyJhbGciOi[A-Za-z0-9_\-]*\.?$''',
+  # A Go identifier the rule mistook for a key. `x509.MarshalECPrivateKey` is
+  # the standard library function being assigned, not a private key.
+  '''^[a-z][a-zA-Z0-9]*\.[A-Z][A-Za-z0-9]+$''',
+  # Base64 of "not-a-blob": a fixture whose whole purpose is to be rejected as
+  # an invalid key blob. Decoded and verified before allowlisting.
+  '''^bm90LWEtYmxvYg=*$''',
+]
+
+paths = [
+  # Microsoft's published REST specification, vendored verbatim. Its example
+  # ids are Microsoft's own, and editing them to please a scanner would make
+  # the vendored copy differ from upstream.
+  '''swagger\.json$''',
+  '''openapi\.(json|ya?ml)$''',
+  # Documentation. A worked example in prose is not a deployed credential, and
+  # the docs are where seeded values are deliberately published so a reader can
+  # reproduce a call.
+  '''docs/.*\.md$''',
+  '''README\.md$''',
+]

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/calvinchengx/fabric-emulator
 
-go 1.25.11
+go 1.26.6
 
-toolchain go1.25.12
 
 require (
 	github.com/calvinchengx/entra-emulator v0.8.1


### PR DESCRIPTION
Two changes that turn out to be one.

## Go 1.26.6

`govulncheck` reported **standard-library vulnerabilities in every Go repo in the family**, 6 to 8 each and 25 in `snowflake-emulator`, all of them fixed by moving off Go 1.25. Bumping the `go` directive clears them: verified locally as `No vulnerabilities found` with `go build`, `go vet` and the full test suite green.

The `toolchain` line and the `go` directive both govern which stdlib is compiled, so pinning `setup-go` alone does not work: with `go 1.25.x` still in `go.mod`, a 1.26 toolchain fails on `file requires newer Go version go1.26`. That is why the module changes rather than just CI.

CI now uses `go-version-file: go.mod` instead of repeating a literal in every workflow, so the module is the single source of truth and CI cannot disagree with it about which Go this is.

## Secret and vulnerability scanning

Neither existed anywhere in the family: **zero repos had gitleaks**, trufflehog or detect-secrets, and zero had govulncheck, gosec or staticcheck.

`.gitleaks.toml` is the interesting part. Scanning unconfigured produced 43 findings across the family and **every one was a false positive**: GUIDs in the vendored `swagger.json`, the seeded tenant id used by every e2e client, `x509.MarshalECPrivateKey` (a function name), and `bm90LWEtYmxvYg` (base64 of `not-a-blob`, a fixture whose purpose is to be rejected). The allowlist is written around a principle rather than a list: a tenant id, a client id and a role definition id are **not** secrets, while a client secret, a private key, a PAT or a connection string are, and none of those are allowlisted.

Verified by negative control: with the config in place, planted AWS keys, a GitHub PAT, a Slack bot token and an RSA private key are all still caught.

History is scanned as well as the working tree, because a secret that was committed and later removed is still in the pack and still cloneable.

The scan is also scheduled weekly: vulnerabilities get published against code that has not changed, so a push trigger alone would leave a finished repo unwatched.