### PR TITLE
Give each Livy session its own sys.argv and os.environ

### DIFF
--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -28,7 +28,13 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import httpjson
 import jvmconf  # no Spark; JVM session configs (see jvmconf.py)
 import session_recovery
+import task_scope
 from pyspark.sql import SparkSession
+
+# Before any statement can bind a scope, and before this module's own
+# `os.environ` reads below — with nothing bound both attributes resolve exactly
+# as they did before (task_scope.py).
+task_scope.install()
 
 
 def build_spark():
@@ -271,9 +277,24 @@ session_isolated = {}  # Livy session id -> did it get a private SparkSession
 # it; each statement binds it into notebookutils.runtime so two notebooks in
 # one agent cannot read each other's workspace.
 session_context = {}
+# Per-session argv and environment (task_scope.py). A task's parameters and its
+# resolved secrets arrive as writes to `sys` and `os`, one object each per
+# interpreter: without a per-session view, two tasks dispatched in the same wave
+# overwrite each other and both read the winner's, reporting SUCCESS either way.
+session_scopes = {}
 catalog_claims = catalog.Claims()  # only consulted when isolation is unavailable
 
 
+def scope_for(session):
+    """This session's argv/env view, made on first use and held until /close.
+
+    Per SESSION rather than per statement, because a session stands in for the
+    task process: a second statement must still see the argv the first was given.
+    """
+    scope = session_scopes.get(session)
+    if scope is None:
+        scope = session_scopes[session] = task_scope.TaskScope()
+    return scope
 
 
 def _notebookutils():
@@ -493,22 +514,34 @@ class Handler(BaseHTTPRequestHandler):
                 print("files_mount: refresh before statement failed:\n"
                       + traceback.format_exc(), flush=True)
             try:
-                with cell_context(req.get("jobId"), req.get("cellIndex")):
-                    session = req.get("session", "default")
-                    with runtime_scope(session, req):
-                        if (req.get("kind") or "").lower() == "sql":
-                            result = sqlrun.run_sql(req.get("code", ""), ns(session))
-                        else:
-                            result = run_code(req.get("code", ""), ns(session))
-                    # The engine dropping our session is not this statement's
-                    # fault and, until #312, was permanent: nothing re-ran
-                    # getOrCreate(), so every later statement failed the same
-                    # way. Rebuild now so the NEXT one works, and tell the user
-                    # what the rebuild cost. This statement still fails —
-                    # re-running arbitrary user code that may already have
-                    # written data is not something the agent can do safely.
-                    if session_recovery.envelope_is_lost_session(result):
-                        session_recovery.annotate(result, recover_lost_session())
+                session = req.get("session", "default")
+                # OUTERMOST, so everything inside resolves against this task.
+                # cell_context's FABRIC_JOB_ID export is an `os.environ` write
+                # too: its save/restore kept one cell's identity off the NEXT
+                # statement, but overlapping statements are what the agent
+                # actually serves, and there restore-on-exit put the other
+                # statement's value back under a still-running one.
+                # The noqa stays: combining these needs a parenthesised
+                # multi-context `with`, which is 3.9+ syntax, and this file runs
+                # on 3.8 in the JVM overlay image
+                # (test_spark_agent_runs_on_python38.py) — ruff is right about
+                # the target it was told about, not the one that ships.
+                with task_scope.scoped(scope_for(session)):  # noqa: SIM117
+                    with cell_context(req.get("jobId"), req.get("cellIndex")):
+                        with runtime_scope(session, req):
+                            if (req.get("kind") or "").lower() == "sql":
+                                result = sqlrun.run_sql(req.get("code", ""), ns(session))
+                            else:
+                                result = run_code(req.get("code", ""), ns(session))
+                        # The engine dropping our session is not this statement's
+                        # fault and, until #312, was permanent: nothing re-ran
+                        # getOrCreate(), so every later statement failed the same
+                        # way. Rebuild now so the NEXT one works, and tell the
+                        # user what the rebuild cost. This statement still fails
+                        # — re-running arbitrary user code that may already have
+                        # written data is not something the agent can do safely.
+                        if session_recovery.envelope_is_lost_session(result):
+                            session_recovery.annotate(result, recover_lost_session())
             finally:
                 try:
                     import files_mount
@@ -544,6 +577,7 @@ class Handler(BaseHTTPRequestHandler):
                       + traceback.format_exc(), flush=True)
             namespaces.pop(req.get("session", ""), None)
             session_context.pop(req.get("session", ""), None)
+            session_scopes.pop(req.get("session", ""), None)
             self._send(200, {"closed": True})
         else:
             self._send(404, {"error": "not found"})

--- a/python/spark_agent/task_scope.py
+++ b/python/spark_agent/task_scope.py
@@ -1,0 +1,209 @@
+"""Per-session `sys.argv` and `os.environ` — the process boundary a task assumes.
+
+The agent already gives every Livy session its own globals dict, so user
+variables are isolated. MODULE state is not: `sys` and `os` are one object each
+per interpreter, and the driver preamble writes a task's parameters and
+environment straight into them (databricks-emulator `internal/server/jobs.go`,
+`pythonPreamble`):
+
+    sys.argv = json.loads("[\\"/task.py\\", \\"AAA\\"]")
+    os.environ.update(json.loads("{...}"))
+
+On real Databricks each task is its OWN PROCESS, so both are private to it.
+Here one interpreter serves every task of every job, and `jobs.go` dispatches a
+wave of independent tasks CONCURRENTLY. Two parameterised `spark_python_task`s
+therefore overwrite each other and both read whichever assignment landed last.
+Both still report SUCCESS, because nothing failed — the wrong parameters are
+simply processed. `SparkEnvVars` carries RESOLVED SECRETS, so the environment
+half of this is one task reading another task's secrets.
+
+WHY NOT SAVE/RESTORE AROUND EACH STATEMENT. It is a stack discipline and these
+do not stack. The agent is a `ThreadingHTTPServer`: statements genuinely
+overlap, so B's assignment lands while A is still running, and A then restores
+over B on the way out. It fixes the sequential case, which is not the broken
+one. `storage.cell_context` is the worked example — it save/restores
+FABRIC_JOB_ID for precisely this reason and is defeated by precisely this
+concurrency, which is why it is routed through this module now.
+
+WHY NOT REBIND LOCALLY in the preamble. User code legitimately runs its own
+`import sys`, which re-fetches the one module object from `sys.modules` and
+walks straight past any name bound in the session's globals.
+
+WHAT THIS DOES instead is give both attributes a per-session VIEW, the shape
+`notebookutils/runtime.py` already uses for the session's notebook identity:
+truth lives per session, and a ContextVar makes the RUNNING statement's session
+the one that resolves. Each `ThreadingHTTPServer` thread gets its own context,
+so concurrent statements cannot see each other's binding.
+
+The two are installed differently, and the asymmetry is the point. `sys.argv`
+becomes a property on a ModuleType subclass. `os.environ` instead keeps its
+IDENTITY and gains a session-aware class, because the stdlib and the wild both
+do `from os import environ` at import time and that capture has to stay live —
+swapping the `os` MODULE's class would leave every such capture pointing at the
+unshimmed mapping, which is a split brain rather than a fix. Keeping the object
+also means `os.getenv`, `os.path.expandvars` and `os.environ.copy()` are
+session-aware for free: they all go through this one mapping.
+
+Unbound — the agent's own startup, `/environment` installs, anything outside a
+statement — both fall through to the real process values, so nothing that ran
+before this module existed changes behaviour.
+
+BOUNDARY, deliberately not papered over: a subprocess spawned by a task does
+NOT inherit that task's session env. A scoped write is private to the session
+and never reaches the C-level environ that `fork_exec` copies, where real
+Databricks would inherit it. Passing `env=os.environ` explicitly hands over the
+merged view and is exact. Nothing in-tree depends on the difference: the agent
+spawns subprocesses only for package installs at startup, never from a
+statement.
+"""
+import os
+import sys
+import types
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+# The agent runs on Python 3.8 in the JVM overlay image
+# (test_spark_agent_runs_on_python38.py), so: no `X | None` annotations and no
+# subscripted ContextVar.
+_bound = ContextVar("spark_agent_task_scope", default=None)
+
+# A scoped `del os.environ[k]` must hide a PROCESS variable from this session
+# without unsetting it for the agent. Storing a tombstone keeps the delete
+# private; actually deleting it would be the same class of bug this module
+# exists to remove.
+_DELETED = object()
+
+
+class TaskScope:
+    """One task's private view of argv and environment.
+
+    Created per Livy session and kept for that session's lifetime, because a
+    session is the agent's stand-in for the task PROCESS: a second statement in
+    the same session must still see the argv the first one was given, the way a
+    driver would.
+    """
+
+    __slots__ = ("argv", "env")
+
+    def __init__(self):
+        self.argv = None  # never assigned; reads fall through to the process
+        self.env = {}  # overlay over the process environment
+
+
+class _AgentSys(types.ModuleType):
+    """`sys`, with an `argv` that resolves to the running statement's session."""
+
+    @property
+    def argv(self):
+        scope = _bound.get()
+        if scope is None:
+            return sys.__dict__["argv"]
+        if scope.argv is None:
+            # Copy on first read: a task doing `sys.argv.append(...)` before it
+            # ever assigns must not mutate the list every other session reads.
+            scope.argv = list(sys.__dict__["argv"])
+        return scope.argv
+
+    @argv.setter
+    def argv(self, value):
+        scope = _bound.get()
+        if scope is None:
+            sys.__dict__["argv"] = value
+            return
+        if scope.argv is None:
+            scope.argv = []
+        # In place, so a caller holding a reference from earlier in the same
+        # statement observes the assignment — as it would with the real
+        # `sys.argv`, which is one list for the life of the process.
+        scope.argv[:] = list(value)
+
+
+# Named rather than `type(os.environ)`: both resolve to the same class on every
+# supported interpreter, but a dynamic base is one a static checker cannot follow
+# (ty: "only class objects are supported as class bases"), and this class is the
+# whole mechanism -- it should be the checked part, not the excused part.
+_EnvironBase = os._Environ  # noqa: SLF001
+
+
+class _SessionEnviron(_EnvironBase):
+    """`os.environ` resolving against the running statement's session.
+
+    Subclasses the real mapping and is installed by swapping the INSTANCE's
+    class, so `os.environ` remains the object every earlier `from os import
+    environ` already captured.
+    """
+
+    def _overlay(self):
+        scope = _bound.get()
+        return None if scope is None else scope.env
+
+    def __getitem__(self, key):
+        overlay = self._overlay()
+        if overlay is not None and key in overlay:
+            value = overlay[key]
+            if value is _DELETED:
+                raise KeyError(key)
+            return value
+        return _EnvironBase.__getitem__(self, key)
+
+    def __setitem__(self, key, value):
+        overlay = self._overlay()
+        if overlay is None:
+            _EnvironBase.__setitem__(self, key, value)
+            return
+        # Raises the same TypeError the real mapping raises for a non-str, so a
+        # scoped write is not quietly more permissive than an unscoped one.
+        self.encodekey(key)
+        self.encodevalue(value)
+        overlay[key] = value
+
+    def __delitem__(self, key):
+        overlay = self._overlay()
+        if overlay is None:
+            _EnvironBase.__delitem__(self, key)
+            return
+        if key not in self:
+            raise KeyError(key)
+        overlay[key] = _DELETED
+
+    def __iter__(self):
+        overlay = self._overlay() or {}
+        for key in overlay:
+            if overlay[key] is not _DELETED:
+                yield key
+        for key in _EnvironBase.__iter__(self):
+            if key not in overlay:
+                yield key
+
+    def __len__(self):
+        return sum(1 for _ in self)
+
+
+def install():
+    """Make `sys.argv` and `os.environ` session-aware. Idempotent.
+
+    Safe to call before anything binds a scope, and safe for code that never
+    binds one: with no scope bound both resolve exactly as they did before.
+    """
+    if not isinstance(sys, _AgentSys):
+        sys.__class__ = _AgentSys
+    if not isinstance(os.environ, _SessionEnviron):
+        os.environ.__class__ = _SessionEnviron
+
+
+def bind(scope):
+    """Resolve argv and environment against `scope` until unbind. Returns a token."""
+    return _bound.set(scope)
+
+
+def unbind(token):
+    _bound.reset(token)
+
+
+@contextmanager
+def scoped(scope):
+    token = bind(scope)
+    try:
+        yield scope
+    finally:
+        unbind(token)

--- a/python/tests/test_spark_agent_task_scope.py
+++ b/python/tests/test_spark_agent_task_scope.py
@@ -1,0 +1,284 @@
+"""Two tasks in one interpreter must not see each other's argv or environment.
+
+The agent isolates per-session user globals but not MODULE state. A
+`spark_python_task`'s parameters arrive as `sys.argv = [...]` and its
+environment as `os.environ.update({...})` (databricks-emulator
+`internal/server/jobs.go`, `pythonPreamble`), and `sys`/`os` are one object
+each per interpreter. Real Databricks runs each task in its own process, so
+both are private; here a wave of independent tasks is dispatched CONCURRENTLY
+into one agent, and the second assignment wins for both. Both tasks then report
+SUCCESS, because nothing failed — the wrong parameters were simply processed.
+
+THE INTERLEAVING IS AN INPUT, NOT A SAMPLE. Every test here releases its
+threads from a `Barrier` placed between the write and the read, which is the
+order that breaks: both tasks have assigned before either looks. Stress-looping
+for it would pass on a broken tree most of the time, and a fix graded that way
+is graded by luck. With the barrier the unfixed agent fails every run.
+
+`install()` is process-global and these tests share an interpreter with the
+rest of the suite. That is safe by construction: with no scope bound both
+attributes fall through to the real process values, which the
+`unbound_*` tests below assert directly rather than assume.
+"""
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import task_scope  # noqa: E402
+
+task_scope.install()
+
+
+def run_concurrently(bodies):
+    """Run each body in its own thread, released together, and return results.
+
+    Every body takes a `sync` callable to be invoked between writing its state
+    and reading it back; that is the barrier the defect needs.
+    """
+    barrier = threading.Barrier(len(bodies))
+    results = {}
+    errors = []
+
+    def wrap(name, body):
+        def go():
+            try:
+                results[name] = body(barrier.wait)
+            except BaseException as exc:  # noqa: BLE001 - re-raised in the parent
+                errors.append(exc)
+                barrier.abort()
+        return go
+
+    threads = [threading.Thread(target=wrap(n, b)) for n, b in bodies.items()]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    if errors:
+        raise errors[0]
+    return results
+
+
+# --- argv --------------------------------------------------------------------
+
+def test_concurrent_tasks_each_read_their_own_argv():
+    """The reported defect: two parameterised tasks, dispatched in one wave."""
+    def task(params):
+        def body(sync):
+            with task_scope.scoped(task_scope.TaskScope()):
+                sys.argv = ["/task.py", *params]
+                sync()  # the other task has now assigned too
+                return list(sys.argv)
+        return body
+
+    got = run_concurrently({
+        "a": task(["AAA"]),
+        "b": task(["BBB"]),
+    })
+    assert got["a"] == ["/task.py", "AAA"]
+    assert got["b"] == ["/task.py", "BBB"]
+
+
+def test_user_code_reimporting_sys_still_sees_its_own_argv():
+    """`import sys` in the task body is what defeats rebinding a local name.
+
+    It re-fetches the one module object out of `sys.modules`, walking past
+    anything the preamble bound in the session's globals — so the isolation has
+    to live on that shared object, which is what makes this the load-bearing case.
+    """
+    def task(marker):
+        def body(sync):
+            with task_scope.scoped(task_scope.TaskScope()):
+                exec_globals = {}
+                exec(f"import sys\nsys.argv = ['/t.py', {marker!r}]", exec_globals)
+                sync()
+                seen = {}
+                exec("import sys\nout['v'] = sys.argv[-1]",
+                     {"out": seen})
+                return seen["v"]
+        return body
+
+    got = run_concurrently({"a": task("AAA"), "b": task("BBB")})
+    assert got["a"] == "AAA"
+    assert got["b"] == "BBB"
+
+
+def test_argv_persists_across_statements_in_one_session():
+    """A session stands in for the task process, so argv outlives one statement."""
+    scope = task_scope.TaskScope()
+    with task_scope.scoped(scope):
+        sys.argv = ["/task.py", "once"]
+    with task_scope.scoped(scope):  # the session's next statement
+        assert sys.argv == ["/task.py", "once"]
+
+
+def test_unbound_argv_is_the_process_argv():
+    assert sys.argv == sys.__dict__["argv"]
+
+
+def test_a_task_cannot_mutate_the_process_argv():
+    """Including by appending, which never assigns and so never looks like a write."""
+    before = list(sys.__dict__["argv"])
+    with task_scope.scoped(task_scope.TaskScope()):
+        sys.argv.append("/injected")
+    assert sys.__dict__["argv"] == before
+
+
+# --- environment -------------------------------------------------------------
+
+def test_concurrent_tasks_each_read_their_own_env():
+    """`SparkEnvVars` carries RESOLVED SECRETS, so this leak crosses a trust
+    boundary rather than merely confusing a parameter."""
+    def task(secret):
+        def body(sync):
+            with task_scope.scoped(task_scope.TaskScope()):
+                os.environ.update({"TASK_SECRET": secret})
+                sync()
+                return os.environ["TASK_SECRET"]
+        return body
+
+    got = run_concurrently({"a": task("secret-a"), "b": task("secret-b")})
+    assert got["a"] == "secret-a"
+    assert got["b"] == "secret-b"
+
+
+@pytest.mark.parametrize("read", [
+    pytest.param(lambda k: os.environ[k], id="os.environ"),
+    pytest.param(lambda k: os.getenv(k), id="os.getenv"),
+    pytest.param(lambda k: os.environ.copy()[k], id="copy"),
+    pytest.param(lambda k: os.path.expandvars("$" + k), id="expandvars"),
+    pytest.param(lambda k: __import__("os").environ[k], id="reimported-os"),
+])
+def test_every_route_to_the_environment_agrees(read):
+    """One split-brain route is a leak: whichever one a task happens to use wins.
+
+    `os.getenv` and `os.path.expandvars` both resolve through the `os.environ`
+    MAPPING, so isolation has to be on that object. Shimming the `os` module
+    instead would leave each of these reading the unscoped environment.
+    """
+    with task_scope.scoped(task_scope.TaskScope()):
+        os.environ["ROUTE_CHECK"] = "scoped"
+        assert read("ROUTE_CHECK") == "scoped"
+    assert os.environ.get("ROUTE_CHECK") is None
+
+
+def test_a_capture_taken_before_the_task_started_is_still_live():
+    """`from os import environ` at import time is everywhere in the stdlib.
+
+    It binds the OBJECT, so the fix has to preserve that object's identity.
+    """
+    from os import environ as captured
+    with task_scope.scoped(task_scope.TaskScope()):
+        os.environ["CAPTURED_CHECK"] = "scoped"
+        assert captured["CAPTURED_CHECK"] == "scoped"
+    assert captured.get("CAPTURED_CHECK") is None  # and it left with the task
+
+
+def test_a_task_write_does_not_reach_the_process_or_a_subprocess():
+    with task_scope.scoped(task_scope.TaskScope()):
+        os.environ["LEAK_CHECK"] = "from-task"
+        # Documented boundary (task_scope.py): a subprocess does NOT inherit
+        # the task's env, and passing `env=os.environ` is the exact workaround.
+        inherited = subprocess.run(
+            ["sh", "-c", "echo ${LEAK_CHECK:-<unset>}"],
+            capture_output=True, text=True).stdout.strip()
+        explicit = subprocess.run(
+            ["sh", "-c", "echo ${LEAK_CHECK:-<unset>}"], env=dict(os.environ),
+            capture_output=True, text=True).stdout.strip()
+    assert inherited == "<unset>"
+    assert explicit == "from-task"
+    assert "LEAK_CHECK" not in os.environ
+
+
+def test_a_task_reads_process_variables_it_did_not_set():
+    """The overlay falls through; it does not replace the environment."""
+    os.environ["PROCESS_LEVEL"] = "from-process"
+    try:
+        with task_scope.scoped(task_scope.TaskScope()):
+            assert os.environ["PROCESS_LEVEL"] == "from-process"
+            assert "PROCESS_LEVEL" in os.environ
+    finally:
+        del os.environ["PROCESS_LEVEL"]
+
+
+def test_a_task_deleting_a_process_variable_hides_it_only_from_itself():
+    """Otherwise the fix reintroduces its own bug in the opposite direction."""
+    os.environ["SHARED_VAR"] = "shared"
+    try:
+        def task(should_delete):
+            def body(sync):
+                with task_scope.scoped(task_scope.TaskScope()):
+                    if should_delete:
+                        del os.environ["SHARED_VAR"]
+                    sync()
+                    return os.environ.get("SHARED_VAR", "<gone>")
+            return body
+
+        got = run_concurrently({"deleter": task(True), "bystander": task(False)})
+        assert got["deleter"] == "<gone>"
+        assert got["bystander"] == "shared"
+        assert os.environ["SHARED_VAR"] == "shared"
+    finally:
+        os.environ.pop("SHARED_VAR", None)
+
+
+def test_a_scoped_write_rejects_a_non_string_like_the_real_mapping():
+    """A scoped write must not be quietly more permissive than an unscoped one."""
+    with task_scope.scoped(task_scope.TaskScope()), pytest.raises(TypeError):
+        # Deliberately the wrong type: the assertion IS that this is rejected.
+        os.environ["BAD"] = 1  # ty: ignore[invalid-assignment]
+
+
+def test_env_persists_across_statements_in_one_session():
+    scope = task_scope.TaskScope()
+    with task_scope.scoped(scope):
+        os.environ["SESSION_VAR"] = "set-once"
+    with task_scope.scoped(scope):
+        assert os.environ["SESSION_VAR"] == "set-once"
+    assert "SESSION_VAR" not in os.environ  # the session's, not the agent's
+
+
+# --- the case the agent hits ------------------------------------------------
+
+def test_cell_identity_survives_an_overlapping_statement():
+    """`storage.cell_context` save/restores FABRIC_JOB_ID around a statement.
+
+    Its docstring's goal is that one cell's identity must not be attributed to
+    the NEXT statement. Save/restore delivers that sequentially; the agent is a
+    ThreadingHTTPServer and runs statements CONCURRENTLY, where the restore put
+    the other statement's value back underneath a still-running one. Binding a
+    scope outside cell_context makes its writes per-session, so this holds.
+
+    TWO barriers, and the second one is the whole test. With only the first the
+    threads serialise: one reads and RESTORES before the other reads, so the
+    second sees its own value handed back and the assertion passes against the
+    UNFIXED agent -- measured, not supposed. One barrier synchronises the start
+    of the read phase, not the reads. The second holds both past their reads,
+    so neither can restore under the other.
+    """
+    def task(job):
+        def body(sync):
+            with task_scope.scoped(task_scope.TaskScope()):
+                prev = os.environ.get("FABRIC_JOB_ID")
+                os.environ["FABRIC_JOB_ID"] = job
+                try:
+                    sync()  # both statements have exported their identity
+                    seen = os.environ["FABRIC_JOB_ID"]
+                    sync()  # ... and NEITHER has restored yet
+                    return seen
+                finally:
+                    if prev is None:
+                        os.environ.pop("FABRIC_JOB_ID", None)
+                    else:
+                        os.environ["FABRIC_JOB_ID"] = prev
+        return body
+
+    got = run_concurrently({"a": task("job-a"), "b": task("job-b")})
+    assert got["a"] == "job-a"
+    assert got["b"] == "job-b"
+    assert "FABRIC_JOB_ID" not in os.environ


### PR DESCRIPTION
The statement agent isolates per-session user globals but not **module state**. `sys` and `os` are one object each per interpreter, and databricks-emulator's `pythonPreamble` delivers a task's parameters and environment by writing straight into them:

```python
sys.argv = json.loads('["/task.py", "AAA"]')
os.environ.update(json.loads('{...}'))
```

On real Databricks each task is its own process, so both are private to it. Here one interpreter serves every task, and `runJob` dispatches a wave of independent tasks as concurrent goroutines. Two parameterised `spark_python_task`s overwrite each other and both read whichever assignment landed last — **both still reporting SUCCESS**, because nothing failed. The wrong parameters are simply processed.

`spark_env_vars` is resolved through `{{secrets/...}}` before it is baked in, so the environment half is one task reading another task's **resolved secret**.

## Why not the two simpler fixes

- **Save/restore around each statement** is a stack discipline, and these do not stack. The agent is a `ThreadingHTTPServer`: statements genuinely overlap, so B's assignment lands while A is still running and A restores over B on the way out. It fixes the sequential case, which is not the broken one. `storage.cell_context` is the worked example — it save/restores `FABRIC_JOB_ID` for exactly this reason and is defeated by exactly this concurrency, so it is routed through the new module here.
- **Rebinding locally in the preamble** fails because user code runs its own `import sys`, which re-fetches the one module object from `sys.modules` and walks past anything bound in the session's globals.

## What this does

`python/spark_agent/task_scope.py` gives both attributes a per-session view — the shape `notebookutils/runtime.py` already uses for notebook identity: truth per session, a `ContextVar` making the running statement's session the one that resolves.

The two are installed differently and the asymmetry is the point. `sys.argv` becomes a property on a `ModuleType` subclass. `os.environ` instead keeps its **identity** and gains a session-aware class, because the stdlib and the wild do `from os import environ` at import time and that capture has to stay live — swapping the `os` module's class would leave every such capture reading the unshimmed mapping, which is a split brain rather than a fix. Keeping the object also makes `os.getenv`, `os.path.expandvars` and `os.environ.copy()` session-aware for free.

Unbound — agent startup, `/environment` installs, anything outside a statement — both fall through to the real process values.

**Boundary, not papered over:** a subprocess spawned by a task does not inherit that task's session env, where real Databricks would. Passing `env=os.environ` gives the merged view and is exact. The agent spawns subprocesses only for package installs at startup, never from a statement.

## Evidence

- 18 new tests; **14 of them fail without the fix** (verified by neutering `install()` and confirming the mutation landed).
- The interleaving is an input, not a sample: every concurrent test releases its threads from a barrier placed between the write and the read.
- The cell-identity test needs **two** barriers. With one, the threads serialise — one reads and restores before the other reads, so it passed against the unfixed agent. Measured, not supposed; the docstring records it.
- Full suite: 1018 passed, 1 skipped. `make lint` clean. Python 3.8 floor respected (the `# noqa: SIM117` is there because a parenthesised multi-context `with` is 3.9+ syntax).
- End to end, via databricks-emulator's new `e2e/task-parameters` suite driven by the unmodified SDK: **red** against published `4.2.0` (`both tasks observed param='param-beta'`), **green** against an agent built from this branch.

Companion PR: databricks-emulator `test/spark-python-task-argv-isolation`. That suite stays out of CI until this ships and `SPARK_CLIENT_DIGEST` bumps.
