### PR TITLE
fix(warehouse): a UUID or BSON column reflects as varbinary, not varchar

### DIFF
--- a/docs/16-warehouse-tds.md
+++ b/docs/16-warehouse-tds.md
@@ -142,6 +142,30 @@ Inferring from the decoded Go value alone answers all of those wrong.
 | `binary` | `varbinary` |
 | `decimal(p,s)` | `decimal(p,s)` |
 
+**A BYTE_ARRAY is text only when the annotation says so, and UUID/BSON do not
+say so.** `string` and `binary` share a physical encoding, so the logical
+annotation is the only separator. Three annotations mean text: STRING, JSON and
+ENUM. Every other one is bytes, including UUID (16 raw bytes), BSON, FLOAT16,
+INTERVAL and the geometry types.
+
+This was wrong until #339: the reader returned a Go `string` for EVERY non-nil
+annotation, so a UUID column surfaced as `varchar` holding invalid UTF-8
+(`"\xde\xad\xbe\xef…"`) instead of `varbinary`. The branch that reads as the
+decision could not change the outcome, which is why a mutation to it failed no
+test.
+
+**Derived, not measured, and the derivation is the point.** Delta declares no
+UUID or BSON type — the left column above is the whole list — so a Delta column
+carrying either annotation is `binary` in the log, and `binary` -> `varbinary`
+is already measured against a real endpoint. Asking Fabric directly is close to
+unaskable: there is no Delta schema that declares a UUID column, so the
+annotation only appears when a writer (pyarrow, say) annotates more finely than
+Delta requires *underneath* a `binary` column. If someone with tenant access
+wants the direct confirmation anyway, the check is: write a Delta table with a
+`binary` column using pyarrow with a UUID extension type, then read
+`INFORMATION_SCHEMA.DATA_TYPE` from the SQL analytics endpoint; `varbinary`
+confirms this row.
+
 This was wrong for the first four rows until 2026-08-04, reported from
 contoso-data-platform: `date`, `timestamp` and `integer` all arrived as Go
 `int64` and all three surfaced as `bigint`, while `binary` arrived as a Go

--- a/internal/warehouse/delta.go
+++ b/internal/warehouse/delta.go
@@ -478,16 +478,21 @@ func goValue(v parquet.Value, lt *format.LogicalType) any {
 	case parquet.Double:
 		return v.Double()
 	case parquet.ByteArray, parquet.FixedLenByteArray:
-		// Only text when the schema SAYS it is text. Unannotated bytes are
-		// binary, and stringifying them both loses the distinction and can
-		// produce invalid UTF-8 in a string column.
+		// Only text when the schema SAYS it is text. Everything else is bytes,
+		// including UUID and BSON: stringifying them loses the distinction and
+		// can produce invalid UTF-8 in a string column.
+		//
+		// This used to fall through to string for EVERY non-nil annotation, so
+		// isTextAnnotation could not change an outcome and a mutation to it
+		// failed no test (#339). The oracle is not a new Fabric measurement:
+		// Delta declares no UUID or BSON type, so a column carrying either
+		// annotation is `binary` in the Delta log, and docs/16 already measures
+		// `binary` -> `varbinary` against the real endpoint. Text is one type too
+		// permissive, which is the direction that ships quietly.
 		if isTextAnnotation(lt) {
 			return string(v.ByteArray())
 		}
-		if lt == nil {
-			return append([]byte(nil), v.ByteArray()...)
-		}
-		return string(v.ByteArray())
+		return append([]byte(nil), v.ByteArray()...)
 	default:
 		return v.String()
 	}

--- a/internal/warehouse/types_test.go
+++ b/internal/warehouse/types_test.go
@@ -998,3 +998,108 @@ func TestTimestampAndIdentifierRendering(t *testing.T) {
 			"unpaired one, or the identifier can be escaped from", body)
 	}
 }
+
+// byteArrayShapes is one column per BYTE_ARRAY annotation that a Delta table
+// can carry, in the encodings parquet-go writes for each tag.
+//
+// Physically these are all BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY, so the
+// annotation is the ONLY thing separating a varchar column from a varbinary
+// one. That is the whole reason goValue consults it.
+type byteArrayShapes struct {
+	Txt string   `parquet:"txt"`     // STRING  -> text
+	Js  string   `parquet:"js,json"` // JSON    -> text
+	En  string   `parquet:"en,enum"` // ENUM    -> text
+	UU  [16]byte `parquet:"uu,uuid"` // UUID    -> BYTES
+	Raw []byte   `parquet:"raw"`     // none    -> bytes
+}
+
+// TestByteArrayAnnotationDecidesTextOrBytes pins the question #339 found
+// unanswerable: the byte-array branch promised to return text "only when the
+// schema SAYS it is text" and then returned text for every non-nil annotation,
+// so isTextAnnotation could not change an outcome and a mutation to it failed
+// no test.
+//
+// Asserting the Go type is what makes the mutation visible. Asserting only the
+// value would not: `string(b)` and `[]byte(b)` compare equal under a
+// string()-conversion, so a test that reads the cell as text passes either way
+// — the same "assert the substance, not something that co-occurs with it"
+// failure this package has hit before.
+//
+// UUID and BSON are the cases that matter. Delta declares no such types, so a
+// column annotated either way is `binary` in the Delta log, which docs/16
+// measures against real Fabric as `varbinary`. Surfacing it as varchar is the
+// permissive direction: locally a SELECT returns a plausible-looking string,
+// and it diverges only on a real deploy.
+func TestByteArrayAnnotationDecidesTextOrBytes(t *testing.T) {
+	uu := [16]byte{0xde, 0xad, 0xbe, 0xef, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xfe, 0xff}
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[byteArrayShapes](&buf)
+	if _, err := w.Write([]byteArrayShapes{{
+		Txt: "plain", Js: `{"a":1}`, En: "GREEN", UU: uu, Raw: []byte{0x00, 0xff},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := readParquet(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// wantText says whether the ANNOTATION makes this column text; wantSQL is
+	// what the endpoint must then surface, so the assertion spans the decision
+	// and its user-visible consequence rather than stopping at the Go value.
+	for _, c := range []struct {
+		col      string
+		wantText bool
+		wantSQL  string
+	}{
+		{"txt", true, varcharType},
+		{"js", true, varcharType},
+		{"en", true, varcharType},
+		{"uu", false, "VARBINARY(4000)"},
+		{"raw", false, "VARBINARY(4000)"},
+	} {
+		idx := -1
+		for i, name := range tbl.Columns {
+			if name == c.col {
+				idx = i
+			}
+		}
+		if idx < 0 {
+			t.Fatalf("column %q missing from %v", c.col, tbl.Columns)
+		}
+		got := tbl.Rows[0][idx]
+		switch v := got.(type) {
+		case string:
+			if !c.wantText {
+				t.Errorf("%s: reflected as string %q, want []byte — a binary "+
+					"annotation surfaced as text", c.col, v)
+			}
+		case []byte:
+			if c.wantText {
+				t.Errorf("%s: reflected as []byte %v, want string", c.col, v)
+			}
+		default:
+			t.Errorf("%s: reflected as %T, want string or []byte", c.col, got)
+		}
+		if sql := sqlType(tbl, idx); sql != c.wantSQL {
+			t.Errorf("%s: sqlType = %s, want %s", c.col, sql, c.wantSQL)
+		}
+	}
+
+	// The UUID's bytes must survive intact. A string round-trip through
+	// invalid UTF-8 replaces bad sequences with U+FFFD, so this fails loudly
+	// on the old behaviour rather than merely reporting the wrong type.
+	idx := -1
+	for i, name := range tbl.Columns {
+		if name == "uu" {
+			idx = i
+		}
+	}
+	if b, ok := tbl.Rows[0][idx].([]byte); ok && !bytes.Equal(b, uu[:]) {
+		t.Errorf("uuid bytes = % x, want % x", b, uu[:])
+	}
+}


### PR DESCRIPTION
Closes #339.

`goValue`'s byte-array branch promised text "only when the schema SAYS it is
text" and then returned a Go `string` for **every** non-nil annotation. So
`isTextAnnotation` could not change any outcome — the first condition only ever
agreed with the third — and a UUID column surfaced as `varchar` holding invalid
UTF-8 rather than `varbinary`.

```go
if isTextAnnotation(lt) { return string(v.ByteArray()) }
if lt == nil            { return append([]byte(nil), v.ByteArray()...) }
return string(v.ByteArray())   // <- UUID, BSON, everything else landed here
```

## The decision, and why it did not need a new Fabric measurement

The issue asked for the intended behaviour "ideally measured against a real
Warehouse". It is derivable instead, from two things already in the repo:

1. **Delta declares no UUID or BSON type.** The mapping table in `docs/16` is
   the whole list. A Delta column carrying either annotation can only be
   `binary` in the log — the annotation appears when a writer (pyarrow, say)
   annotates more finely than Delta requires *underneath* a `binary` column.
2. **`binary` -> `varbinary` is already measured** against a real endpoint, and
   was one of the four rows corrected on 2026-08-04.

So asking Fabric directly is close to unaskable: there is no Delta schema that
declares a UUID column to ask about. `docs/16` records the derivation and, for
anyone with tenant access who wants the direct confirmation anyway, the exact
check that would produce it.

Text was the **permissive** direction, which is the one that ships: locally a
`SELECT` returns a plausible-looking string and it diverges only on a real
deploy. Same shape as the date bug, which at least announced itself with an
`Operand type clash`.

## The fix

Three branches collapse to two, and `isTextAnnotation` becomes load-bearing:

```go
if isTextAnnotation(lt) { return string(v.ByteArray()) }
return append([]byte(nil), v.ByteArray()...)
```

Text is STRING, JSON, ENUM. Everything else is bytes: UUID, BSON, FLOAT16,
INTERVAL, the geometry types. DECIMAL never reaches here, the annotation switch
above catches it first.

## The test, and the mutations it kills

`TestByteArrayAnnotationDecidesTextOrBytes` writes one column per annotation and
asserts **the Go type and the reflected SQL type**, not the value. Asserting the
value would not work: `string(b)` and `[]byte(b)` compare equal through a
`string()` conversion, so a test that reads the cell as text passes either way —
the "assert the substance, not something that co-occurs with it" failure this
package has hit before.

Both mutations verified to land (`git diff` checked) before believing the result:

| mutation | before | after |
|---|---|---|
| `isTextAnnotation` returns `false` for STRING/JSON/ENUM — the exact one #339 reports as surviving | passed | **fails** |
| the original fall-through to `string` | passed | **fails**, naming the bug: `uu: reflected as string "ޭ\xbe\xef\x00…", want []byte` |

## Verification

`make check` exit 0, `go build ./...` 0, `go vet` 0, `go test ./internal/warehouse/... ./internal/api/...` 0 — exit codes captured directly rather than through a pipe.

No parity row, no witness entry, no Go API change.
