### PR TITLE
docs: gate doc links as well as sidebar reachability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,10 @@ jobs:
       # out still builds and still has a URL, but nothing links to it, so it is
       # published and unreachable. Same drift, same guard.
       - run: uv run --frozen --no-sync python scripts/check_docs_sidebar.py
+      # The site build does NOT catch a dangling intra-doc link: measured, it
+      # exits 0 and publishes a 404. Nor can it see a page missing from the
+      # sidebar, which is published but unreachable by navigation.
+      - run: uv run --frozen --no-sync python scripts/check_docs_links.py --strict
       # THE ONE `make check` RAN AND CI DID NOT. Every example must resolve its
       # target through the `fabric-target` contract — no pinned seed principal,
       # no localhost endpoint outside the resolver, no emulator-only lever, and

--- a/python/tests/test_check_docs_links.py
+++ b/python/tests/test_check_docs_links.py
@@ -1,0 +1,121 @@
+"""Tests for the doc-link and sidebar-reachability check.
+
+The checker guards two things the site build does not: a link to a page that
+does not exist (the build exits 0 and publishes a 404) and a page missing from
+the sidebar (published, but unreachable by navigation).
+
+The interesting part is which files count as published. That is decided by
+`DOC_RE` in website/scripts/sync-docs.mjs and is DERIVED here rather than
+restated, so these tests pin the derivation itself: change the site's published
+set and the checker follows, and if the declaration ever moves the checker must
+fail loudly rather than guard the wrong set.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+import check_docs_links as c  # noqa: E402
+
+
+@pytest.fixture
+def site(tmp_path, monkeypatch):
+    """A docs tree, an astro config and a sync-docs.mjs we control."""
+
+    def build(docs=(), slugs=(), doc_re=r"^(\d{2}-.*|parity)\.md$", readme=None,
+              parity_versions=False, sync_body=None):
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir(exist_ok=True)
+        for name, *body in [(d,) if isinstance(d, str) else d for d in docs]:
+            (docs_dir / name).write_text(body[0] if body else "# doc\n")
+        config = tmp_path / "astro.config.mjs"
+        config.write_text("sidebar: [\n" + "\n".join(f"  {{ slug: '{s}' }}," for s in slugs) + "\n]\n")
+        sync = tmp_path / "sync-docs.mjs"
+        sync.write_text(sync_body if sync_body is not None else f"const DOC_RE = /{doc_re}/;\n")
+        root = tmp_path / "root"
+        root.mkdir(exist_ok=True)
+        if readme is not None:
+            (root / "README.md").write_text(readme)
+        monkeypatch.setattr(c, "DOCS", docs_dir)
+        monkeypatch.setattr(c, "CONFIG", config)
+        monkeypatch.setattr(c, "SYNC_DOCS", sync)
+        monkeypatch.setattr(c, "ROOT", root)
+        monkeypatch.setattr(c, "PARITY_VERSIONS", tmp_path / ("pv.mjs" if parity_versions else "absent.mjs"))
+        if parity_versions:
+            (tmp_path / "pv.mjs").write_text("// generator\n")
+
+    return build
+
+
+def test_clean_site_passes(site, monkeypatch):
+    site(docs=["01-quickstart.md", "parity.md"], slugs=["01-quickstart", "parity"])
+    assert c.problems() == []
+    # main() parses sys.argv, which under pytest holds pytest's own arguments.
+    monkeypatch.setattr(sys, "argv", ["check_docs_links.py"])
+    assert c.main() == 0
+
+
+def test_link_to_a_missing_page_is_reported(site):
+    site(docs=[("01-quickstart.md", "see [next](02-install.md)\n")], slugs=["01-quickstart"])
+    assert any("02-install.md" in p for p in c.problems())
+
+
+def test_page_missing_from_the_sidebar_is_reported(site):
+    site(docs=["01-quickstart.md", "02-install.md"], slugs=["01-quickstart"])
+    assert any("02-install.md is not in the sidebar" in p for p in c.problems())
+
+
+def test_sidebar_entry_without_a_page_is_reported(site):
+    site(docs=["01-quickstart.md"], slugs=["01-quickstart", "99-ghost"])
+    assert any("99-ghost" in p for p in c.problems())
+
+
+def test_readme_link_into_docs_is_checked(site):
+    site(docs=["01-quickstart.md"], slugs=["01-quickstart"],
+         readme="[gone](docs/99-nope.md)\n")
+    assert any("README.md links to docs/99-nope.md" in p for p in c.problems())
+
+
+def test_index_needs_no_sidebar_entry(site):
+    site(docs=["index.md", "01-quickstart.md"], slugs=["01-quickstart"],
+         doc_re=r"^(\d{2}-.*|parity|index)\.md$")
+    assert c.problems() == []
+
+
+def test_generated_parity_history_is_exempt_only_with_the_generator(site):
+    site(docs=["01-quickstart.md"], slugs=["01-quickstart", "parity-history"],
+         parity_versions=True)
+    assert c.problems() == []
+    site(docs=["01-quickstart.md"], slugs=["01-quickstart", "parity-history"],
+         parity_versions=False)
+    assert any("parity-history" in p for p in c.problems())
+
+
+def test_the_published_set_follows_the_sites_own_regex(site):
+    # A file the site does NOT publish is not required to be in the sidebar.
+    site(docs=["01-quickstart.md", "notes.md"], slugs=["01-quickstart"])
+    assert c.problems() == []
+
+
+def test_a_moved_declaration_fails_loudly(site):
+    site(docs=["01-quickstart.md"], slugs=["01-quickstart"],
+         sync_body="const PUBLISHED = /whatever/;\n")
+    with pytest.raises(SystemExit) as exc:
+        c.problems()
+    assert "DOC_RE" in str(exc.value)
+
+
+def test_an_uncompilable_declaration_fails_loudly(site):
+    site(docs=["01-quickstart.md"], slugs=["01-quickstart"], doc_re="(unclosed")
+    with pytest.raises(SystemExit) as exc:
+        c.problems()
+    assert "does not compile" in str(exc.value)
+
+
+def test_strict_returns_nonzero(site, capsys, monkeypatch):
+    site(docs=["01-quickstart.md", "02-install.md"], slugs=["01-quickstart"])
+    monkeypatch.setattr(sys, "argv", ["check_docs_links.py", "--strict"])
+    assert c.main() == 1
+    assert "not in the sidebar" in capsys.readouterr().out

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -69,7 +69,9 @@ def published_pattern() -> re.Pattern[str]:
     try:
         return re.compile(match.group("body"))
     except re.error as exc:
-        raise SystemExit(f"docs-links: DOC_RE does not compile as a Python regex ({exc})")
+        raise SystemExit(
+            f"docs-links: DOC_RE does not compile as a Python regex ({exc})"
+        ) from exc
 
 
 def problems() -> list[str]:

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Keep the documentation navigable: no broken links, no unreachable pages.
+
+Two failures, neither of which the site build catches:
+
+1. **A link to a page that is not there.** Measured: the Astro build exits 0 on
+   a dangling intra-doc link and publishes a 404. Renumbering or renaming a
+   chapter rewrites filenames and the links pointing at them drift silently.
+2. **A page missing from the sidebar.** Starlight's sidebar here is an EXPLICIT
+   list, so a doc left out still builds, still gets a URL, and still appears in
+   search. It is simply unreachable by navigation. Nothing fails.
+
+WHAT COUNTS AS PUBLISHED is decided by `DOC_RE` in
+`website/scripts/sync-docs.mjs`, and this **reads that regex rather than
+copying it**. A copy under a comment saying "keep in step with sync-docs" is a
+defect already filed, with no owner and no failing test: change the published
+set and the copy stays green while guarding the wrong thing.
+
+NOTE for this repo: `check_docs_sidebar.py` already guards the sidebar half and
+has its own tests, so the two overlap there deliberately. Retiring the older one
+is its owner's call, not a side effect of adding link checking.
+
+Run with --strict in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs"
+CONFIG = ROOT / "website" / "astro.config.mjs"
+SYNC_DOCS = ROOT / "website" / "scripts" / "sync-docs.mjs"
+
+# `const DOC_RE = /…/;` in sync-docs.mjs. The body is taken as written so this
+# guards exactly the set the site publishes.
+_DOC_RE_DECL = re.compile(r"^const\s+DOC_RE\s*=\s*/(?P<body>.+)/(?P<flags>[a-z]*);\s*$", re.M)
+
+# `](00-slug.md)`, `](./00-slug.md#anchor)`, `](parity.md)`, `](generated/x.md)`
+DOC_LINK = re.compile(r"\]\((?:\./)?((?:[a-z0-9-]+/)?[a-z0-9][a-z0-9.-]*\.md)(#[^)]*)?\)")
+README_LINK = re.compile(r"\]\(docs/((?:[a-z0-9-]+/)?[a-z0-9][a-z0-9.-]*\.md)(#[^)]*)?\)")
+SIDEBAR_SLUG = re.compile(r"slug:\s*'([^']+)'")
+
+# The landing page is reached by the site root, not by a sidebar entry.
+EXEMPT_FROM_SIDEBAR = {"index"}
+
+# Routes the site GENERATES rather than reads from docs/. `parity-versions.mjs`
+# writes a `parity-history/` index, a `parity-history/changelog`, and one page
+# per release tag, so a sidebar entry pointing at those has no file behind it
+# and is correct. Only exempted when that generator is actually present, so a
+# repo without it still gets a dangling slug reported.
+GENERATED_PREFIX = "parity-history"
+PARITY_VERSIONS = ROOT / "website" / "scripts" / "parity-versions.mjs"
+
+
+def published_pattern() -> re.Pattern[str]:
+    """Compile the site's own DOC_RE, so this guards exactly its set."""
+    if not SYNC_DOCS.exists():
+        raise SystemExit(f"docs-links: {SYNC_DOCS} not found; cannot derive the published set")
+    match = _DOC_RE_DECL.search(SYNC_DOCS.read_text())
+    if not match:
+        raise SystemExit(
+            f"docs-links: {SYNC_DOCS} no longer declares `const DOC_RE = /…/;`, so the "
+            "published set cannot be derived. Fix the derivation rather than copying it here."
+        )
+    try:
+        return re.compile(match.group("body"))
+    except re.error as exc:
+        raise SystemExit(f"docs-links: DOC_RE does not compile as a Python regex ({exc})")
+
+
+def problems() -> list[str]:
+    found: list[str] = []
+    published_re = published_pattern()
+
+    for page in sorted(DOCS.glob("*.md")):
+        for match in DOC_LINK.finditer(page.read_text()):
+            if not (DOCS / match.group(1)).exists():
+                found.append(f"{page.name} links to {match.group(1)}, which does not exist")
+
+    readme = ROOT / "README.md"
+    if readme.exists():
+        for match in README_LINK.finditer(readme.read_text()):
+            if not (DOCS / match.group(1)).exists():
+                found.append(f"README.md links to docs/{match.group(1)}, which does not exist")
+
+    if not CONFIG.exists():
+        found.append(f"{CONFIG} not found; the sidebar cannot be checked")
+        return found
+
+    slugs = set(SIDEBAR_SLUG.findall(CONFIG.read_text()))
+    generated = PARITY_VERSIONS.exists()
+    for slug in sorted(slugs):
+        if slug in EXEMPT_FROM_SIDEBAR:
+            continue
+        if generated and (slug == GENERATED_PREFIX or slug.startswith(GENERATED_PREFIX + "/")):
+            continue
+        if not (DOCS / f"{slug}.md").exists():
+            found.append(f"the sidebar lists {slug}, which has no page")
+
+    published = [p for p in sorted(DOCS.glob("*.md")) if published_re.match(p.name)]
+    for page in published:
+        if page.stem in EXEMPT_FROM_SIDEBAR or page.stem in slugs:
+            continue
+        found.append(f"{page.name} is not in the sidebar, so nothing on the site links to it")
+
+    return found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--strict", action="store_true", help="exit non-zero on any problem")
+    arguments = parser.parse_args()
+    found = problems()
+    for problem in found:
+        print(f"docs-links: {problem}")
+    if found and arguments.strict:
+        return 1
+    if not found:
+        published_re = published_pattern()
+        count = len([p for p in DOCS.glob("*.md") if published_re.match(p.name)])
+        print(f"docs-links: {count} published pages, every link resolves and every page is reachable")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `scripts/check_docs_links.py --strict` and wires it into CI, so the family's docs are gated the same way everywhere.

## Why the site build is not enough

Measured, not assumed: the Astro build **exits 0** on a link to a page that does not exist, and publishes a 404. It also cannot see a page missing from the sidebar, which still builds, still gets a URL and still turns up in search, while being unreachable by navigation.

## What it checks

- every intra-doc markdown link resolves
- every README link into `docs/` resolves
- every sidebar `slug:` has a page behind it
- every published page appears in the sidebar

**The published set is derived, not copied.** The checker reads `DOC_RE` out of `website/scripts/sync-docs.mjs`, so it guards exactly the set the site publishes. A second copy kept in step by a comment is a defect already filed, with no owner and no failing test. If that declaration ever moves, the checker fails loudly instead of silently guarding the wrong set.

Sidebar entries under `parity-history/` are exempt, because `parity-versions.mjs` generates those from git tags rather than from `docs/`. The exemption applies only when that generator is present, so a repo without it still has a dangling slug reported.

## Verification

Every failure mode was confirmed by deliberately introducing it, then reverting: a broken link, an orphan page, a sidebar entry with no page, and a moved `DOC_RE`. All four exit 1; the clean tree exits 0. The workflow YAML was parsed after editing.

## Overlap with `check_docs_sidebar.py`

This repo already guards the sidebar half, with its own tests. The new checker
covers that half too, so they overlap deliberately: both pass or both fail, and
retiring the older one is its owner's call rather than a side effect of adding
link checking. The docstring says so.

This repo passes cleanly as it stands: 54 published pages.
