### PR TITLE
Enable golangci-lint at zero findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1905,7 +1905,7 @@ jobs:
       # ratio DAX asset fails (out of band), mirroring the tutorial.
       - run: uv run --frozen --group great-expectations python e2e/great-expectations/run.py
 
-  lint:
+  golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
     # A wedged run must fail rather than sit in GitHub's 6-hour default, where

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1904,3 +1904,20 @@ jobs:
       # emulator's executeQueries results — Store/Measure suites pass, the YoY
       # ratio DAX asset fails (out of band), mirroring the tutorial.
       - run: uv run --frozen --group great-expectations python e2e/great-expectations/run.py
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    # A wedged run must fail rather than sit in GitHub's 6-hour default, where
+    # 'pending' and 'stuck' look identical.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      # Gated at zero. See .golangci.yml for what is excluded and why.
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,44 @@
+version: "2"
+linters:
+  default: none
+  enable: [errcheck, govet, ineffassign, staticcheck, unused]
+  settings:
+    errcheck:
+      # Deferred cleanup and writes to a response/stdout. The return value is
+      # unactionable at these call sites: the connection is already going away,
+      # or the client has already disconnected. Everything else must be checked.
+      exclude-functions:
+        - (io.Closer).Close
+        - (*database/sql.DB).Close
+        - (*database/sql.Rows).Close
+        - (*database/sql.Stmt).Close
+        - (*database/sql.Tx).Rollback
+        - (net.Conn).Close
+        - (net.Listener).Close
+        - (*net/http.Server).Close
+        - (io.ReadCloser).Close
+        - (net/http.ResponseWriter).Write
+        - fmt.Fprintf
+        - fmt.Fprint
+        - fmt.Fprintln
+  exclusions:
+    rules:
+      # ST1005 wants a lowercase first word, and exempts error strings that
+      # open with a proper noun or identifier. All 26 here do, and they name
+      # the thing that failed: the product (Airflow, Spark), the Fabric feature
+      # (Direct Lake), or the Eventstream operator kind the definition declared
+      # (Filter, Window). Lowercasing "Direct Lake table %q" to "direct Lake"
+      # would be wrong rather than merely ugly.
+      #
+      # Matched on the source line, not the path, so the exemption names which
+      # nouns are exempt and an ordinary capitalised error in the same file is
+      # still reported.
+      - linters: [staticcheck]
+        text: "ST1005"
+        source: '(Errorf|errors\.New)\("(Airflow|Direct Lake|Filter|Spark|Window) '
+issues:
+  # Defaults cap identical issues at 3 and each linter at 50, which turns a
+  # count into an underestimate: six identical unchecked Close calls reported
+  # as three. Uncapped, so the number means what it says.
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/cmd/fabric-emulator/main.go
+++ b/cmd/fabric-emulator/main.go
@@ -140,7 +140,7 @@ func run(args []string, stop <-chan struct{}, ready chan<- net.Addr) error {
 	if err != nil {
 		return err
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 
 	ln, err := net.Listen("tcp", cfg.Addr)
 	if err != nil {

--- a/internal/airflow/client_test.go
+++ b/internal/airflow/client_test.go
@@ -51,10 +51,10 @@ func TestTriggerAndWaitSuccessWithBasicAuth(t *testing.T) {
 		if !ok || u != "admin" || p != "secret" {
 			t.Errorf("basic auth=%q %q %v", u, p, ok)
 		}
-		switch {
-		case r.Method == "PATCH":
+		switch r.Method {
+		case "PATCH":
 			w.Write([]byte(`{}`))
-		case r.Method == "POST":
+		case "POST":
 			var body map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			if body["dag_run_id"] != "run-1" {
@@ -62,7 +62,7 @@ func TestTriggerAndWaitSuccessWithBasicAuth(t *testing.T) {
 			}
 			w.WriteHeader(200)
 			w.Write([]byte(`{}`))
-		case r.Method == "GET":
+		case "GET":
 			state := "running"
 			if polls.Add(1) > 1 {
 				state = "success"

--- a/internal/api/adxcommandactivity_test.go
+++ b/internal/api/adxcommandactivity_test.go
@@ -64,7 +64,7 @@ func TestADXCommandReachesTheRealEngine(t *testing.T) {
 	if s, _ := out["database"].(string); s != db.DisplayName {
 		t.Fatalf("output names %q, want the Fabric display name %q", s, db.DisplayName)
 	}
-	if raw, _ := out["tables"]; raw == nil {
+	if raw := out["tables"]; raw == nil {
 		t.Fatalf("the engine's result was dropped: %+v", out)
 	}
 	rendered, _ := json.Marshal(out)

--- a/internal/api/api_failure_test.go
+++ b/internal/api/api_failure_test.go
@@ -22,7 +22,7 @@ func newDiskAPI(t *testing.T) (*API, *store.Store, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	return New(st, nil, 1, 0), st, dir
 }
 

--- a/internal/api/api_p2_test.go
+++ b/internal/api/api_p2_test.go
@@ -50,7 +50,7 @@ func newRegisteredAPI(t *testing.T) (*http.ServeMux, *store.Store, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -23,7 +23,7 @@ func newAPI(t *testing.T) (*API, *store.Store) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	a := New(st, nil, 1, 0)
 	// The suite's `admin` principal is a declared Fabric administrator, so
 	// tests written before the tenant-admin gate still exercise the surfaces

--- a/internal/api/armcapacities_test.go
+++ b/internal/api/armcapacities_test.go
@@ -18,7 +18,7 @@ func TestARMCapacitiesRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 
 	const armID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 	feed := map[string]any{
@@ -72,7 +72,7 @@ func TestARMCapacitiesRefreshErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 
 	src := NewARMCapacities(st, "http://127.0.0.1:1", false, nil, 0)
 	if src.TTL != 5*time.Second {
@@ -105,7 +105,7 @@ func TestARMCapacitiesRefreshErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	closed.Close()
+	_ = closed.Close()
 	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"generated": 1,
@@ -144,7 +144,7 @@ func TestARMCapacitiesRunStops(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	var n atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n.Add(1)

--- a/internal/api/copyjob_test.go
+++ b/internal/api/copyjob_test.go
@@ -326,7 +326,7 @@ func TestCopyJobStatusReflectsTheCopyNotTheClock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	a := New(st, nil, 1, 3600) // an hour of LRO delay: the clock cannot finish this job
 
 	ws := seedWorkspace(t, st)

--- a/internal/api/credentials_test.go
+++ b/internal/api/credentials_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -296,14 +295,4 @@ func TestKeyCredentialResolvedFromKeyVault(t *testing.T) {
 	if w := do(a.createConnection, admin, "POST", skip, nil); w.Code != http.StatusCreated {
 		t.Errorf("skipTestConnection = %d; want 201", w.Code)
 	}
-}
-
-// mustHost is the host:port of a stub vault URL, for akv's vault allowlist.
-func mustHost(t *testing.T, raw string) string {
-	t.Helper()
-	u, err := url.Parse(raw)
-	if err != nil {
-		t.Fatalf("parse %q: %v", raw, err)
-	}
-	return u.Host
 }

--- a/internal/api/deployment_test.go
+++ b/internal/api/deployment_test.go
@@ -231,7 +231,7 @@ func TestUpdateDeploymentPipelinePatchSemantics(t *testing.T) {
 		t.Fatalf("patch = %d: %s", w.Code, w.Body)
 	}
 	got := &store.DeploymentPipeline{}
-	json.Unmarshal(w.Body.Bytes(), got)
+	_ = json.Unmarshal(w.Body.Bytes(), got)
 	if got.DisplayName != "renamed" || got.Description != "keep me" {
 		t.Fatalf("patch lost a field: %+v", got)
 	}
@@ -419,7 +419,7 @@ func TestUnassignStageWorkspaceAPI(t *testing.T) {
 		t.Fatalf("unassign = %d: %s", w.Code, w.Body)
 	}
 	got := &store.DeploymentStage{}
-	json.Unmarshal(w.Body.Bytes(), got)
+	_ = json.Unmarshal(w.Body.Bytes(), got)
 	if got.WorkspaceID != "" {
 		t.Fatalf("unassign response still assigned: %+v", got)
 	}
@@ -591,7 +591,7 @@ func TestDeploymentOperationsAPI(t *testing.T) {
 		t.Fatalf("get operation = %d: %s", got.Code, got.Body)
 	}
 	one := &store.DeploymentOperation{}
-	json.Unmarshal(got.Body.Bytes(), one)
+	_ = json.Unmarshal(got.Body.Bytes(), one)
 	if one.ID != opID || len(one.Items) != 1 {
 		t.Fatalf("get operation body = %+v", one)
 	}
@@ -741,7 +741,7 @@ func TestDeploymentStoreErrors(t *testing.T) {
 	if err := st.SetStageWorkspace(pl.ID, sts[0].ID, ws.ID); err != nil {
 		t.Fatal(err)
 	}
-	st.Close()
+	_ = st.Close()
 	ids := map[string]string{"pid": pl.ID, "sid": sts[0].ID}
 	for name, h := range map[string]handler{
 		"list":   a.listDeploymentPipelines,

--- a/internal/api/eventstream_ops_test.go
+++ b/internal/api/eventstream_ops_test.go
@@ -135,7 +135,7 @@ func TestEventstreamPropertiesClosedStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.Close()
+	_ = st.Close()
 	if got := a.eventstreamProperties(it); got != nil {
 		t.Fatalf("closed store properties: %v", got)
 	}
@@ -305,7 +305,7 @@ func TestEventstreamLoadPersistOperators(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	closed.Close()
+	_ = closed.Close()
 	if err := persistEventstreamOperators(closed, "missing", []eventstreamOperator{{Type: "Filter"}}); err == nil {
 		t.Fatal("persist on closed store succeeded")
 	}
@@ -675,7 +675,7 @@ func TestEventstreamDrainEventhouseNoopAndClosed(t *testing.T) {
 	stored := map[string]string{
 		propEventstreamDestinations: `[{"type":"Eventhouse","itemId":"` + eh.ID + `","table":"clicks","workspaceId":"` + ws.ID + `"}]`,
 	}
-	st.Close()
+	_ = st.Close()
 	if err := a.drainEventstreamToEventhouse(it, stored, eventBatch(`{"n":1}`)); err == nil {
 		t.Fatal("drain on a closed store succeeded")
 	}

--- a/internal/api/eventstream_test.go
+++ b/internal/api/eventstream_test.go
@@ -1148,7 +1148,7 @@ func TestEventstreamDrainWriteFailure(t *testing.T) {
 	stored := map[string]string{
 		propEventstreamDestinations: `[{"type":"Lakehouse","itemId":"` + lh.ID + `","table":"clicks","workspaceId":"` + ws.ID + `"}]`,
 	}
-	st.Close()
+	_ = st.Close()
 	if err := a.drainEventstreamToLakehouse(it, stored, eventBatch(`{"n":1}`)); err == nil {
 		t.Fatal("drain on a closed store succeeded")
 	}
@@ -1697,7 +1697,7 @@ func TestEventstreamDrainReflexClosedStore(t *testing.T) {
 	stored := map[string]string{
 		propEventstreamDestinations: `[{"type":"Reflex","itemId":"` + reflex.ID + `","workspaceId":"` + ws.ID + `"}]`,
 	}
-	st.Close()
+	_ = st.Close()
 	if err := a.drainEventstreamToReflex(it, stored, eventBatch(`{"n":1}`)); err == nil {
 		t.Fatal("drain on a closed store succeeded")
 	}
@@ -1801,7 +1801,7 @@ func TestEventsToDeltaTableAndLoadDestinations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	closed.Close()
+	_ = closed.Close()
 	if err := persistEventstreamDestinations(closed, "missing", []eventstreamDestination{{Type: "Lakehouse"}}); err == nil {
 		t.Fatal("persist on closed store succeeded")
 	}

--- a/internal/api/kafka_broker.go
+++ b/internal/api/kafka_broker.go
@@ -57,7 +57,7 @@ func (k *kafkaBroker) CreateTopic(topic string) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	controller, err := conn.Controller()
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (k *kafkaBroker) CreateTopic(topic string) error {
 	if err != nil {
 		return err
 	}
-	defer ctrl.Close()
+	defer func() { _ = ctrl.Close() }()
 	err = ctrl.CreateTopics(kafka.TopicConfig{
 		Topic:             topic,
 		NumPartitions:     1,
@@ -86,7 +86,7 @@ func (k *kafkaBroker) Produce(topic string, key, value []byte) error {
 		RequiredAcks: kafka.RequireOne,
 		BatchTimeout: 10 * time.Millisecond,
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return w.WriteMessages(ctx, kafka.Message{Key: key, Value: value})
@@ -108,7 +108,7 @@ func (k *kafkaBroker) Consume(topic string, max int, wait time.Duration) ([]Kafk
 		MaxWait:     200 * time.Millisecond,
 		StartOffset: kafka.FirstOffset,
 	})
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), wait)
 	defer cancel()

--- a/internal/api/kql.go
+++ b/internal/api/kql.go
@@ -119,7 +119,7 @@ func (a *API) kustoRelay(w http.ResponseWriter, r *http.Request, p *auth.Princip
 		return
 	}
 	ver, kind := r.PathValue("ver"), r.PathValue("kind")
-	if !(ver == "v1" && (kind == "query" || kind == "mgmt")) && !(ver == "v2" && kind == "query") {
+	if (ver != "v1" || (kind != "query" && kind != "mgmt")) && (ver != "v2" || kind != "query") {
 		writeKustoErr(w, http.StatusNotFound, "General_BadRequest",
 			"Only /v1/rest/query, /v1/rest/mgmt and /v2/rest/query exist.")
 		return

--- a/internal/api/kql_test.go
+++ b/internal/api/kql_test.go
@@ -97,8 +97,8 @@ func (e *kustoEngine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	switch {
-	case body.CSL == ".show databases":
+	switch body.CSL {
+	case ".show databases":
 		rows := make([][]any, 0, len(names))
 		for _, name := range names {
 			rows = append(rows, []any{name})

--- a/internal/api/livy.go
+++ b/internal/api/livy.go
@@ -32,14 +32,24 @@ func (a *API) SetLivyBackend(rawURL string) error {
 		return err
 	}
 	a.livyBackend = u
-	proxy := httputil.NewSingleHostReverseProxy(u)
-	// The default director joins the backend's base path with r.URL.Path, so
-	// the handler sets r.URL.Path to just the Livy-native suffix
-	// (/sessions, /batches, …) and the director prepends the backend base.
-	base := proxy.Director
-	proxy.Director = func(r *http.Request) {
-		base(r)
-		r.Host = u.Host
+	// Rewrite, not Director: Director is deprecated as of Go 1.26, which this
+	// module requires. Constructed directly because NewSingleHostReverseProxy
+	// installs a Director, and ReverseProxy refuses to have both.
+	//
+	// SetURL is the replacement for the wrapped default director: it joins the
+	// backend's base path with the inbound path, which is what the handler
+	// depends on when it sets r.URL.Path to just the Livy-native suffix
+	// (/sessions, /batches, …) and lets the proxy prepend the backend base.
+	//
+	// SetXForwarded is called explicitly because ReverseProxy adds
+	// X-Forwarded-For for a Director and NOT for a Rewrite, so omitting it
+	// would silently drop a header this proxy used to send.
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetXForwarded()
+			pr.SetURL(u)
+			pr.Out.Host = u.Host
+		},
 	}
 	a.livy = proxy
 	return nil

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -245,7 +245,7 @@ func TestNegativePageSizeDisablesPaging(t *testing.T) {
 	writePage(&API{ListPageSize: -1}, w, r, items)
 
 	var body map[string]any
-	json.Unmarshal(w.Body.Bytes(), &body)
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
 	if _, paged := body["continuationToken"]; paged {
 		t.Fatal("paging was disabled but a token was emitted")
 	}
@@ -265,7 +265,7 @@ func TestMaxPageSizeCannotExceedTheServerPageSize(t *testing.T) {
 	var body struct {
 		Value []map[string]string `json:"value"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &body)
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
 	if len(body.Value) != 3 {
 		t.Fatalf("maxPageSize widened the page to %d, want the server's 3", len(body.Value))
 	}

--- a/internal/api/register_reachable_test.go
+++ b/internal/api/register_reachable_test.go
@@ -32,6 +32,12 @@ import (
 // exists.
 func TestEveryRegistrationIsReachableFromRegister(t *testing.T) {
 	fset := token.NewFileSet()
+	// DEFERRED, not kept on principle. parser.ParseDir is deprecated as of Go
+	// 1.25; the replacement is reading the directory and calling ParseFile per
+	// file, which changes how this test discovers the package. This test is
+	// what keeps registration reachability DERIVED rather than declared, so it
+	// gets its own change rather than a rewrite inside a lint sweep.
+	//nolint:staticcheck // SA1019: ParseDir migration tracked separately
 	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
 		return !strings.HasSuffix(fi.Name(), "_test.go")
 	}, 0)

--- a/internal/api/salesforce_sink_test.go
+++ b/internal/api/salesforce_sink_test.go
@@ -67,7 +67,7 @@ func (o *sfIngestOrg) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			content = strings.TrimPrefix(content, "/")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"id":%q,"contentUrl":%q,"state":"Open"}`, id, content)))
+		fmt.Fprintf(w, `{"id":%q,"contentUrl":%q,"state":"Open"}`, id, content)
 
 	case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/batches"):
 		if ct := r.Header.Get("Content-Type"); ct != "text/csv" {
@@ -94,9 +94,9 @@ func (o *sfIngestOrg) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		state, failed := o.state, o.failed
 		o.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(fmt.Sprintf(
+		fmt.Fprintf(w,
 			`{"state":%q,"errorMessage":"boom","numberRecordsProcessed":%d,"numberRecordsFailed":%d}`,
-			state, 2, failed)))
+			state, 2, failed)
 
 	default:
 		http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusNotFound)

--- a/internal/api/salesforce_test.go
+++ b/internal/api/salesforce_test.go
@@ -94,7 +94,7 @@ func (o *sfOrg) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		o.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"id":"750xx000000005LAAQ","state":%q,"errorMessage":"boom"}`, state)))
+		fmt.Fprintf(w, `{"id":"750xx000000005LAAQ","state":%q,"errorMessage":"boom"}`, state)
 
 	default:
 		http.Error(w, "unexpected", http.StatusNotFound)

--- a/internal/api/schedules_test.go
+++ b/internal/api/schedules_test.go
@@ -254,7 +254,7 @@ func TestScheduleRequestValidation(t *testing.T) {
 	}
 	bad := `{"configuration":{"type":"Cron","interval":0,"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2024-02-01T00:00:00Z","localTimeZoneId":"UTC"}}`
 	w := f.create(admin, bad)
-	if w.Code != http.StatusBadRequest || !strings.Contains(string(w.Body.Bytes()), "interval") {
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "interval") {
 		t.Fatalf("bad interval = %d %s", w.Code, w.Body.Bytes())
 	}
 	if n, _ := f.st.CountItemSchedules(f.item.ID, "RunNotebook"); n != 0 {

--- a/internal/onelake/external_shortcut_test.go
+++ b/internal/onelake/external_shortcut_test.go
@@ -27,7 +27,7 @@ func TestResolveExternalShortcutCredentialsAndErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 
 	// These four exercise the plain HTTP read-through, so the target type is
@@ -83,7 +83,7 @@ func TestResolveReadExposesEmptyManagedFolders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	ws := &store.Workspace{DisplayName: "w"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "owner", Type: "User"}); err != nil {
 		t.Fatal(err)
@@ -118,7 +118,7 @@ func TestResolveExternalShortcutSignsS3WithSigV4(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 
 	// Fabric's S3 connector collects an Access Key Id and a Secret Access Key;
@@ -174,7 +174,7 @@ func TestExternalShortcutWriteAndDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 
 	conn := &store.Connection{DisplayName: "adls", CredentialsJSON: `{"credentialType":"Anonymous"}`}
@@ -232,7 +232,7 @@ func TestExternalShortcutWriteSurfacesUpstreamFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 	conn := &store.Connection{DisplayName: "adls", CredentialsJSON: `{"credentialType":"Anonymous"}`}
 	if err := st.CreateConnection(conn); err != nil {
@@ -253,7 +253,7 @@ func TestS3RegionOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 	if got := svc.S3Region(); got != "us-east-1" {
 		t.Fatalf("default region = %q", got)
@@ -271,7 +271,7 @@ func TestExternalWriteAndDeleteFailurePaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 
 	// A shortcut whose connection no longer exists.
@@ -346,7 +346,7 @@ func TestAnOversizedShortcutReadIsRefusedRatherThanServedShort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 
 	conn := &store.Connection{DisplayName: "anon", CredentialsJSON: `{"credentialType":"Anonymous"}`}
@@ -382,7 +382,7 @@ func TestAShortcutReadInsideTheCeilingIsUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	svc := New(st, nil)
 	conn := &store.Connection{DisplayName: "anon2", CredentialsJSON: `{"credentialType":"Anonymous"}`}
 	if err := st.CreateConnection(conn); err != nil {

--- a/internal/onelake/onelake_test.go
+++ b/internal/onelake/onelake_test.go
@@ -87,7 +87,7 @@ func newFixture(t *testing.T) *fixture {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 
 	ws := &store.Workspace{DisplayName: "datalake-ws"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "admin-1", Type: "ServicePrincipal"}); err != nil {
@@ -149,7 +149,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	v := &auth.Validator{}
 	s := New(st, v)
 	if s.Store != st || s.Auth != v {

--- a/internal/pipeline/expr.go
+++ b/internal/pipeline/expr.go
@@ -59,9 +59,10 @@ func evalString(s string, ctx *evalContext) (value, error) {
 		if strings.HasPrefix(s[i:], "@{") {
 			depth, j := 1, i+2
 			for ; j < len(s) && depth > 0; j++ {
-				if s[j] == '{' {
+				switch s[j] {
+				case '{':
 					depth++
-				} else if s[j] == '}' {
+				case '}':
 					depth--
 				}
 			}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -308,10 +308,10 @@ func depsReady(deps []Dependency, status map[string]string) (ready, satisfied bo
 			return false, false
 		}
 		if !conditionMet(d.DependencyConditions, st) {
-			satisfied = false
-			// Still ready (all deps final), just not satisfied.
-			ready = true
-			// Keep scanning to ensure all deps are final.
+			// Not satisfied. Still READY if every dependency is final, so keep
+			// scanning rather than returning here: a later missing dependency
+			// means the activity is not ready at all. The named returns are set
+			// by the returns below, not here.
 			for _, d2 := range deps {
 				if _, ok := status[d2.Activity]; !ok {
 					return false, false

--- a/internal/server/control_test.go
+++ b/internal/server/control_test.go
@@ -22,7 +22,7 @@ func newControlServer(t *testing.T) *Server {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 

--- a/internal/server/events_transport_test.go
+++ b/internal/server/events_transport_test.go
@@ -139,7 +139,6 @@ func (g *gatedWriter) hold()            { g.mu.Lock(); g.gate = make(chan struct
 func (g *gatedWriter) release()         { g.mu.Lock(); close(g.gate); g.gate = nil; g.mu.Unlock() }
 func (g *gatedWriter) failWith(e error) { g.mu.Lock(); g.err = e; g.mu.Unlock() }
 func (g *gatedWriter) text() string     { g.mu.Lock(); defer g.mu.Unlock(); return g.body.String() }
-func (g *gatedWriter) status() int      { g.mu.Lock(); defer g.mu.Unlock(); return g.code }
 
 // TestFlowStreamRefusesAConnectionItCannotStream: the handler asserts a Flusher
 // up front. Without the check it would stream into a writer that never reaches

--- a/internal/server/p1_test.go
+++ b/internal/server/p1_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/calvinchengx/fabric-emulator/internal/store"
 )
 
-const platformPart = `{"path":".platform","payload":"e30=","payloadType":"InlineBase64"}`
-
 func TestDefinitionRoundTripAndTypedAliases(t *testing.T) {
 	f := newFixture(t)
 	var ws struct{ ID string }

--- a/internal/server/p2_test.go
+++ b/internal/server/p2_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -260,14 +259,4 @@ func TestLivyPassthroughE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.mustStatus(f.call("GET", base+"sessions", f.token, nil, nil), http.StatusNotImplemented, "no backend")
-}
-
-// mustHost is the host:port of a test server URL, for akv's vault allowlist.
-func mustHost(t *testing.T, raw string) string {
-	t.Helper()
-	u, err := url.Parse(raw)
-	if err != nil {
-		t.Fatalf("parse %q: %v", raw, err)
-	}
-	return u.Host
 }

--- a/internal/server/pipeline_sql_test.go
+++ b/internal/server/pipeline_sql_test.go
@@ -40,7 +40,7 @@ func TestPipelineSQLActivitiesE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 	fabric := httptest.NewServer(srv.Handler())
 	t.Cleanup(fabric.Close)
 	token := forgeAppToken(t, emu, "https://api.fabric.microsoft.com")

--- a/internal/server/portal_test.go
+++ b/internal/server/portal_test.go
@@ -361,7 +361,7 @@ func TestPortalWarehouseTDSConfigured(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 	fabric := httptest.NewServer(srv.Handler())
 	t.Cleanup(fabric.Close)
 
@@ -426,7 +426,7 @@ func TestPortalSPAServing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	if resp.StatusCode != 200 || !strings.Contains(resp.Header.Get("Content-Type"), "javascript") {
 		t.Fatalf("asset %s: %d %s", asset, resp.StatusCode, resp.Header.Get("Content-Type"))
@@ -437,7 +437,7 @@ func TestPortalSPAServing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	if !strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
 		t.Fatal("/health should still serve JSON")

--- a/internal/server/portalmodels_test.go
+++ b/internal/server/portalmodels_test.go
@@ -21,7 +21,7 @@ func newPortalServer(t *testing.T) *Server {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	return &Server{Store: st, Clock: clock.New()}
 }
 

--- a/internal/server/routing_test.go
+++ b/internal/server/routing_test.go
@@ -123,7 +123,7 @@ func TestNewWiresDatabricksBackend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 	if srv.API.DatabricksURL != cfg.DatabricksURL || srv.API.DatabricksToken != cfg.DatabricksToken {
 		t.Fatalf("Databricks backend was not wired: url=%q token=%q", srv.API.DatabricksURL, srv.API.DatabricksToken)
 	}
@@ -139,7 +139,7 @@ func TestNewWiresMLflowBackend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 	if srv.API.MLflowURL == nil || srv.API.MLflowURL.String() != cfg.MLflowURL || srv.API.MLflowHTTP == nil {
 		t.Fatalf("MLflow backend was not wired: %+v", srv.API.MLflowURL)
 	}
@@ -155,7 +155,7 @@ func TestNewWiresAirflowBackend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 	if srv.API.Airflow == nil {
 		t.Fatal("Airflow backend was not wired")
 	}
@@ -172,7 +172,7 @@ func TestNewWiresWarehouseSQLBackend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 	if srv.TDS == nil || srv.TDS.Backend == nil || srv.TDS.OnConnect == nil {
 		t.Fatalf("TDS wiring incomplete: %+v", srv.TDS)
 	}
@@ -187,7 +187,7 @@ func TestNewWiresWarehouseSQLBackend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer stub.Close()
+	defer func() { _ = stub.Close() }()
 	if stub.TDS == nil || stub.TDS.Backend != nil {
 		t.Errorf("stub TDS wiring: %+v", stub.TDS)
 	}
@@ -246,7 +246,7 @@ func TestUnknownAPIPathIsJSON404(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 	h := srv.Handler()
 
 	for _, path := range []string{
@@ -295,7 +295,7 @@ func TestPortalStoreErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv.Close() // every subsequent store call errors
+	_ = srv.Close() // every subsequent store call errors
 	h := srv.Handler()
 	for _, path := range []string{
 		"/_emulator/portal/workspaces",
@@ -332,7 +332,7 @@ func TestNewAdvertisesTheSQLEndpointPortOnWarehouses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 	if got := srv.API.SQLEndpointPort; got != "11533" {
 		t.Fatalf("SQLEndpointPort = %q, want the port from SQLTDSAddr (11533)", got)
 	}
@@ -345,7 +345,7 @@ func TestNewAdvertisesTheSQLEndpointPortOnWarehouses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s2.Close()
+	defer func() { _ = s2.Close() }()
 	if got := s2.API.SQLEndpointPort; got != "" {
 		t.Fatalf("SQLEndpointPort = %q with no TDS listener; want empty", got)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -54,7 +54,7 @@ func newFixture(t *testing.T) *fixture {
 	// A short keepalive so a test that opens the flow stream does not wait a
 	// full interval at teardown (internal/server/events.go explains why).
 	srv.EventKeepalive = 100 * time.Millisecond
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 	fabric := httptest.NewServer(srv.Handler())
 	t.Cleanup(fabric.Close)
 
@@ -465,7 +465,7 @@ func newFixtureWithARM(t *testing.T, armURL string) *fixture {
 		t.Fatal(err)
 	}
 	srv.EventKeepalive = 100 * time.Millisecond
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 	fabric := httptest.NewServer(srv.Handler())
 	t.Cleanup(fabric.Close)
 

--- a/internal/server/sql_database_test.go
+++ b/internal/server/sql_database_test.go
@@ -45,7 +45,7 @@ func TestSQLDatabaseMirror(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 
 	ws := &store.Workspace{DisplayName: "sqldb-ws"}
 	if err := srv.Store.CreateWorkspace(ws, store.Principal{ID: entra.DaemonClientID, Type: "ServicePrincipal"}); err != nil {
@@ -61,7 +61,7 @@ func TestSQLDatabaseMirror(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.TDS.Serve(ln)
+	go func() { _ = srv.TDS.Serve(ln) }()
 	port := ln.Addr().(*net.TCPAddr).Port
 	token := forgeAppToken(t, emu, "https://database.windows.net")
 	conn := func() *sql.DB {

--- a/internal/server/tds_conformance_test.go
+++ b/internal/server/tds_conformance_test.go
@@ -47,7 +47,7 @@ func TestConformanceWriteLanding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 	if srv.TDS == nil || srv.TDS.Backend == nil {
 		t.Fatal("expected a TDS server with a SQL Server backend")
 	}
@@ -66,7 +66,7 @@ func TestConformanceWriteLanding(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.TDS.Serve(ln)
+	go func() { _ = srv.TDS.Serve(ln) }()
 
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;database=%s;encrypt=disable;dial timeout=5",

--- a/internal/server/tds_reflect_test.go
+++ b/internal/server/tds_reflect_test.go
@@ -51,7 +51,7 @@ func TestWarehouseDeltaReflectionE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 
 	// Seed a lakehouse and a Delta table (part-0.parquet + _delta_log) in OneLake.
 	ws := &store.Workspace{DisplayName: "wh-ws"}
@@ -82,7 +82,7 @@ func TestWarehouseDeltaReflectionE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.TDS.Serve(ln)
+	go func() { _ = srv.TDS.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 
 	// Connect with database=<lakehouse id> → reflection runs on login.

--- a/internal/server/tds_sqlserver_test.go
+++ b/internal/server/tds_sqlserver_test.go
@@ -58,7 +58,7 @@ func TestWarehouseSQLServerRelayE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 	if srv.TDS == nil || srv.TDS.Backend == nil {
 		t.Fatal("expected a TDS server with a SQL Server backend")
 	}
@@ -83,7 +83,7 @@ func TestWarehouseSQLServerRelayE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.TDS.Serve(ln)
+	go func() { _ = srv.TDS.Serve(ln) }()
 
 	// Connect the real SQL client to the emulator with a real entra token.
 	addr := ln.Addr().(*net.TCPAddr)

--- a/internal/server/tds_strict_test.go
+++ b/internal/server/tds_strict_test.go
@@ -47,7 +47,7 @@ func strictTDS(t *testing.T, backendDSN string, strict bool) *sql.DB {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 
 	ws := &store.Workspace{DisplayName: fmt.Sprintf("strict-ws-%t", strict)}
 	if err := srv.Store.CreateWorkspace(ws, store.Principal{
@@ -64,7 +64,7 @@ func strictTDS(t *testing.T, backendDSN string, strict bool) *sql.DB {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { ln.Close() })
-	go srv.TDS.Serve(ln)
+	go func() { _ = srv.TDS.Serve(ln) }()
 
 	// The client names its database, which is what takes the byte-splice path
 	// production uses — connecting with none would skip the RBAC wall and prove

--- a/internal/server/tds_surfaces_test.go
+++ b/internal/server/tds_surfaces_test.go
@@ -46,7 +46,7 @@ func TestWarehouseTwoSurfaces(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 
 	ws := &store.Workspace{DisplayName: "two-surface-ws"}
 	if err := srv.Store.CreateWorkspace(ws, store.Principal{ID: entra.DaemonClientID, Type: "ServicePrincipal"}); err != nil {
@@ -80,7 +80,7 @@ func TestWarehouseTwoSurfaces(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.TDS.Serve(ln)
+	go func() { _ = srv.TDS.Serve(ln) }()
 	port := ln.Addr().(*net.TCPAddr).Port
 	token := forgeAppToken(t, emu, "https://database.windows.net")
 	open := func(database string) *sql.DB {

--- a/internal/server/tds_test.go
+++ b/internal/server/tds_test.go
@@ -57,7 +57,7 @@ func TestWarehouseTDSEndpointE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 	if srv.TDS == nil {
 		t.Fatal("SQLTDSAddr set but srv.TDS is nil")
 	}
@@ -66,7 +66,7 @@ func TestWarehouseTDSEndpointE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.TDS.Serve(ln)
+	go func() { _ = srv.TDS.Serve(ln) }()
 
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;encrypt=disable;dial timeout=5", addr.Port)

--- a/internal/server/terminal.go
+++ b/internal/server/terminal.go
@@ -190,7 +190,7 @@ func (s *Server) terminalProxy(w http.ResponseWriter, r *http.Request) {
 	// Anything the client already sent past the header goes upstream first, or
 	// the first keystroke of a fast client is lost.
 	if n := buf.Reader.Buffered(); n > 0 {
-		if pending, rerr := buf.Reader.Peek(n); rerr == nil {
+		if pending, rerr := buf.Peek(n); rerr == nil {
 			_, _ = upstream.Write(pending)
 		}
 	}

--- a/internal/server/warehouse_internal_test.go
+++ b/internal/server/warehouse_internal_test.go
@@ -38,7 +38,7 @@ func TestWarehouseRouter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	ws := &store.Workspace{DisplayName: "w"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "u", Type: "User"}); err != nil {
 		t.Fatal(err)
@@ -173,7 +173,7 @@ func TestSQLDBFor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	ws := &store.Workspace{DisplayName: "w"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "u", Type: "User"}); err != nil {
 		t.Fatal(err)
@@ -217,7 +217,7 @@ func TestMirrorItem(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	ws := &store.Workspace{DisplayName: "w"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "u", Type: "User"}); err != nil {
 		t.Fatal(err)
@@ -261,7 +261,7 @@ func TestResolveSQLItem(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	ws := &store.Workspace{DisplayName: "analytics"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "u", Type: "User"}); err != nil {
 		t.Fatal(err)

--- a/internal/server/warehouselineage_test.go
+++ b/internal/server/warehouselineage_test.go
@@ -26,7 +26,7 @@ func newLineageFixture(t *testing.T) *lineageFixture {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	ws := &store.Workspace{DisplayName: "w"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "u", Type: "User"}); err != nil {
 		t.Fatal(err)

--- a/internal/store/bus_test.go
+++ b/internal/store/bus_test.go
@@ -18,7 +18,7 @@ func newBusStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 
@@ -368,7 +368,7 @@ func TestPublishAfterCloseIsSafe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Close()
+	_ = s.Close()
 	s.publish(Event{Kind: KindFile, Path: "Files/after-close.csv"})
 	s.emitFileEvent(EventFileCreated, "w", "i", "Files/after-close.csv", Attribution{})
 }
@@ -425,7 +425,7 @@ func TestPublishDuringCloseDoesNotPanic(t *testing.T) {
 		}
 		close(start)
 		runtime.Gosched() // let the publishers get going before shutting down
-		s.Close()         // concurrent with every publisher above
+		_ = s.Close()     // concurrent with every publisher above
 		stop.Store(true)
 		wg.Wait()
 	}
@@ -444,7 +444,7 @@ func TestPublishNeverBlocksWhenTheQueueIsFull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	// Wedge the dispatcher: a subscriber that never reads, plus enough events to
 	// overflow the 1024-deep raw queue several times over.

--- a/internal/store/datadir_test.go
+++ b/internal/store/datadir_test.go
@@ -28,7 +28,7 @@ func TestOpenCreatesTheDataDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open on a missing data dir: %v", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	if _, err := os.Stat(filepath.Join(dir, "fabric-emulator.db")); err != nil {
 		t.Fatalf("database not created in %s: %v", dir, err)
@@ -42,5 +42,5 @@ func TestOpenStillDefaultsToMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("in-memory Open: %v", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 }

--- a/internal/store/deploy_test.go
+++ b/internal/store/deploy_test.go
@@ -366,7 +366,7 @@ func TestDeployEmptySourceStage(t *testing.T) {
 func TestDeployClosedDBErrors(t *testing.T) {
 	f := newDeployFixture(t, []string{"orders"}, nil)
 	pl, sts := f.pl, f.stages
-	f.s.Close()
+	_ = f.s.Close()
 
 	if _, err := f.s.DeployStageContent(pl.ID, sts[0].ID, sts[1].ID, NewID(), "", "a", nil); err == nil {
 		t.Error("DeployStageContent on closed DB succeeded")

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -15,7 +15,7 @@ func newDeploymentStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 
@@ -481,7 +481,7 @@ func TestDeploymentClosedDBErrors(t *testing.T) {
 	pl := mkPipeline(t, s, "release", 2)
 	sts, _ := s.ListDeploymentStages(pl.ID)
 	stageID := sts[0].ID
-	s.Close()
+	_ = s.Close()
 
 	two := []*DeploymentStage{{DisplayName: "a"}, {DisplayName: "b"}}
 	if err := s.CreateDeploymentPipeline(&DeploymentPipeline{DisplayName: "x"}, two, Principal{ID: "p"}); err == nil {

--- a/internal/store/folders_test.go
+++ b/internal/store/folders_test.go
@@ -14,7 +14,7 @@ func TestFolderGetUpdateDeleteMove(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	ws := &Workspace{DisplayName: "w"}
 	if err := s.CreateWorkspace(ws, Principal{ID: "a", Type: "User"}); err != nil {
 		t.Fatal(err)
@@ -104,7 +104,7 @@ func TestFolderIsUnderDefensiveCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	ws := &Workspace{DisplayName: "w"}
 	if err := s.CreateWorkspace(ws, Principal{ID: "a", Type: "User"}); err != nil {
 		t.Fatal(err)

--- a/internal/store/lineage_test.go
+++ b/internal/store/lineage_test.go
@@ -11,7 +11,7 @@ func TestLineageEdgeLifecycleAndIdempotency(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 	ws := &Workspace{DisplayName: "w"}
 	if err := s.CreateWorkspace(ws, Principal{ID: "owner", Type: "User"}); err != nil {
 		t.Fatal(err)

--- a/internal/store/migrate_lineage_test.go
+++ b/internal/store/migrate_lineage_test.go
@@ -71,7 +71,7 @@ func TestRelaxLineageJobFKUpgradesAnOlderDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening a pre-migration database failed: %v", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	// 1. The existing edge survived, with its columns intact.
 	var activity, srcPath, producer string
@@ -132,13 +132,13 @@ func TestRelaxLineageJobFKIsIdempotent(t *testing.T) {
 		// A workspace FK may reject this; the edge is not the point of this test.
 		t.Logf("seed edge not inserted (%v); the reopen below is what matters", err)
 	}
-	s1.Close()
+	_ = s1.Close()
 
 	s2, err := Open(dir, clock.New())
 	if err != nil {
 		t.Fatalf("reopening an already-migrated database failed: %v", err)
 	}
-	defer s2.Close()
+	defer func() { _ = s2.Close() }()
 	if err := s2.relaxLineageJobFK(); err != nil {
 		t.Fatalf("running the migration a third time errored: %v", err)
 	}

--- a/internal/store/names_test.go
+++ b/internal/store/names_test.go
@@ -16,7 +16,7 @@ func namesStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 
@@ -103,7 +103,7 @@ func TestItemNameTaken(t *testing.T) {
 
 func TestNameTakenClosedDB(t *testing.T) {
 	s := namesStore(t)
-	s.Close()
+	_ = s.Close()
 	if _, err := s.WorkspaceNameTaken("x", ""); err == nil {
 		t.Fatal("WorkspaceNameTaken on closed DB should error")
 	}

--- a/internal/store/onelake_test.go
+++ b/internal/store/onelake_test.go
@@ -332,7 +332,7 @@ func TestClosedDBOneLakeErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Close()
+	_ = s.Close()
 	if err := s.CreateOneLakePath(&OneLakePath{WorkspaceID: "w", ItemID: "i", RelPath: "f", Content: []byte{}}, false); err == nil {
 		t.Error("CreateOneLakePath on closed DB succeeded")
 	}

--- a/internal/store/portal_test.go
+++ b/internal/store/portal_test.go
@@ -11,7 +11,7 @@ func TestListAllWorkspaces(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	all, err := s.ListAllWorkspaces()
 	if err != nil || len(all) != 0 {
@@ -44,7 +44,7 @@ func TestListJobInstances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	jobs, err := s.ListJobInstances(0)
 	if err != nil || len(jobs) != 0 {
@@ -93,7 +93,7 @@ func TestListOperations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	ops, err := s.ListOperations(0)
 	if err != nil || len(ops) != 0 {

--- a/internal/store/store_closed_test.go
+++ b/internal/store/store_closed_test.go
@@ -13,7 +13,7 @@ func TestClosedDBErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Close()
+	_ = s.Close()
 
 	p := Principal{ID: "p", Type: "User"}
 	if err := s.CreateWorkspace(&Workspace{DisplayName: "w"}, p); err == nil {
@@ -176,7 +176,7 @@ func TestClosedDBFolderErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Close()
+	_ = s.Close()
 	if err := s.CreateFolder(&Folder{WorkspaceID: "w", DisplayName: "f"}); err == nil {
 		t.Error("CreateFolder on closed DB succeeded")
 	}
@@ -202,7 +202,7 @@ func TestClosedDBIdentityErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Close()
+	_ = s.Close()
 	if err := s.SetWorkspaceIdentity(&WorkspaceIdentity{WorkspaceID: "w", IdentityID: "i", AppID: "a"}); err == nil {
 		t.Error("SetWorkspaceIdentity on closed DB succeeded")
 	}
@@ -219,7 +219,7 @@ func TestClosedDBCapacityErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Close()
+	_ = s.Close()
 	if _, err := s.GetCapacity("x"); err == nil {
 		t.Error("GetCapacity on closed DB succeeded")
 	}
@@ -239,7 +239,7 @@ func TestClosedDBShortcutErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Close()
+	_ = s.Close()
 	if err := s.CreateShortcut(&Shortcut{ItemID: "i", Path: "p", Name: "n"}); err == nil {
 		t.Error("CreateShortcut on closed DB succeeded")
 	}

--- a/internal/store/store_more_test.go
+++ b/internal/store/store_more_test.go
@@ -95,13 +95,13 @@ func TestOpenPersistsAcrossReopen(t *testing.T) {
 	if err := s1.CreateWorkspace(ws, Principal{ID: "p", Type: "User"}); err != nil {
 		t.Fatal(err)
 	}
-	s1.Close()
+	_ = s1.Close()
 
 	s2, err := Open(dir, clock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s2.Close()
+	defer func() { _ = s2.Close() }()
 	got, err := s2.GetWorkspace(ws.ID)
 	if err != nil || got.DisplayName != "durable" {
 		t.Fatalf("reopened workspace = %+v, %v", got, err)
@@ -125,7 +125,7 @@ func TestOpenBadDir(t *testing.T) {
 	}
 	s, err := Open(filepath.Join(file, "data"), clock.New())
 	if err == nil {
-		s.Close()
+		_ = s.Close()
 		t.Fatal("Open accepted a data dir underneath a regular file")
 	}
 }
@@ -137,7 +137,7 @@ func TestItemProperties(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 	ws := &Workspace{DisplayName: "w"}
 	if err := s.CreateWorkspace(ws, Principal{ID: "p", Type: "User"}); err != nil {
 		t.Fatal(err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13,7 +13,7 @@ func newTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 

--- a/internal/tds/client.go
+++ b/internal/tds/client.go
@@ -46,7 +46,8 @@ func clientLogin(conn net.Conn, user, password, database, serverName string) (lo
 	if err := WriteMessage(conn, PktLogin7, buildLogin7(user, password, database, serverName)); err != nil {
 		return nil, fmt.Errorf("sending LOGIN7: %w", err)
 	}
-	typ, data, err = ReadMessage(conn)
+	// The LOGIN7 response type is not inspected; only its payload is.
+	_, data, err = ReadMessage(conn)
 	if err != nil {
 		return nil, fmt.Errorf("reading the LOGIN7 response: %w", err)
 	}

--- a/internal/tds/observe.go
+++ b/internal/tds/observe.go
@@ -175,8 +175,8 @@ func leadingKeyword(sql string) string {
 			sql = rest
 		default:
 			end := strings.IndexFunc(sql, func(r rune) bool {
-				return !(r == '_' || r == '@' || r == '#' ||
-					(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+				return r != '_' && r != '@' && r != '#' &&
+					(r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9')
 			})
 			if end < 0 {
 				end = len(sql)

--- a/internal/tds/observe_test.go
+++ b/internal/tds/observe_test.go
@@ -69,13 +69,15 @@ func TestSpliceObservesAcceptedWrite(t *testing.T) {
 	clientA, clientB := net.Pipe()
 	backendA, backendB := net.Pipe()
 	seen := make(chan string, 4)
-	go spliceSession(clientA, backendA, false, false,
-		func(db string, flows []tsql.Flow) {
-			for _, f := range flows {
-				seen <- db + "|" + f.Kind + "|" + strings.Join(f.Target, ".") +
-					"<-" + strings.Join(f.Sources[0], ".")
-			}
-		}, "wh-guid")
+	go func() {
+		_ = spliceSession(clientA, backendA, false, false,
+			func(db string, flows []tsql.Flow) {
+				for _, f := range flows {
+					seen <- db + "|" + f.Kind + "|" + strings.Join(f.Target, ".") +
+						"<-" + strings.Join(f.Sources[0], ".")
+				}
+			}, "wh-guid")
+	}()
 
 	// Client sends a CTAS; the fake backend accepts it.
 	go func() {

--- a/internal/tds/query_test.go
+++ b/internal/tds/query_test.go
@@ -68,7 +68,7 @@ func TestBackendRelayResultSet(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;encrypt=disable;dial timeout=5", addr.Port)
 
@@ -135,7 +135,7 @@ func TestBackendQueryError(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;encrypt=disable;dial timeout=5", addr.Port)
 

--- a/internal/tds/server_test.go
+++ b/internal/tds/server_test.go
@@ -29,7 +29,7 @@ func TestServerFedAuthLogin(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;encrypt=disable;dial timeout=5", addr.Port)
@@ -63,7 +63,7 @@ func TestServerQuerySelect1(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;encrypt=disable;dial timeout=5", addr.Port)
 
@@ -93,7 +93,7 @@ func TestServerRejectsNonFedAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 
 	// A SQL-login DSN (user/password) presents no FedAuth token → login rejected.

--- a/internal/tds/splice_integration_test.go
+++ b/internal/tds/splice_integration_test.go
@@ -93,7 +93,7 @@ func TestSpliceEndToEnd(t *testing.T) {
 		t.Fatal(lerr)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 
 	// Serve until the connection closes, and ANSWER AN ATTENTION, because a real
 	// engine does. Answering exactly one batch and closing was the other half of
@@ -148,7 +148,7 @@ func TestServerHandshakeErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().String()
 	buf := make([]byte, 8)
 
@@ -219,7 +219,7 @@ func TestReEncodeReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;database=lh;encrypt=disable;dial timeout=5", addr.Port)
 	c, _ := mssql.NewAccessTokenConnector(dsn, func() (string, error) { return "a.b.c", nil })
@@ -253,7 +253,7 @@ func TestOnConnectRejects(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;database=x;encrypt=disable;dial timeout=5", addr.Port)
 	c, _ := mssql.NewAccessTokenConnector(dsn, func() (string, error) { return "a.b.c", nil })
@@ -318,7 +318,7 @@ func TestLoginWithoutDatabaseIsRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 
 	// No `database=` in the DSN: LOGIN7 carries an empty database name.
 	addr := ln.Addr().(*net.TCPAddr)
@@ -407,7 +407,7 @@ func TestConfiguredAuthorizerNeverReachesTheReEncodeRelay(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 
 	// The rejected session: no database, so the login must fail outright.
@@ -435,7 +435,8 @@ func TestConfiguredAuthorizerNeverReachesTheReEncodeRelay(t *testing.T) {
 	var dialed int
 	var ran []string
 	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
-		if dialed, ran = be.counts(); dialed > 0 {
+		// Only dialed is read here; ran is re-read after the loop.
+		if dialed, _ = be.counts(); dialed > 0 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -469,7 +470,7 @@ func TestReEncodeRelayRejectsStrictStatement(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;database=db;encrypt=disable;dial timeout=5", addr.Port)
 	c, _ := mssql.NewAccessTokenConnector(dsn, func() (string, error) { return "a.b.c", nil })
@@ -567,7 +568,7 @@ func TestReEncodeRelaySkipsNonBatchMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 
 	conn, err := net.Dial("tcp", ln.Addr().String())
 	if err != nil {
@@ -625,7 +626,7 @@ func TestSpliceDialRejectsLogin(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;database=lh;encrypt=disable;dial timeout=5", addr.Port)
@@ -660,7 +661,7 @@ func TestLoginWithNoValidatorIsRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;database=db;encrypt=disable;dial timeout=5", addr.Port)
 	c, _ := mssql.NewAccessTokenConnector(dsn, func() (string, error) { return "any.token.at.all", nil })

--- a/internal/tds/splice_test.go
+++ b/internal/tds/splice_test.go
@@ -19,7 +19,7 @@ func TestSpliceForward(t *testing.T) {
 	backendA, backendB := net.Pipe()
 	defer clientA.Close()
 	defer backendA.Close()
-	go spliceSession(clientA, backendA, false, false, nil, "")
+	go func() { _ = spliceSession(clientA, backendA, false, false, nil, "") }()
 
 	go func() { _ = WriteMessage(clientB, PktSQLBatch, batchMsg("SELECT 1")) }()
 	typ, data, err := ReadMessage(backendB)
@@ -41,7 +41,7 @@ func TestSpliceForwardsReadOnlySelect(t *testing.T) {
 	backendA, backendB := net.Pipe()
 	defer clientA.Close()
 	defer backendA.Close()
-	go spliceSession(clientA, backendA, true, false, nil, "") // read-only surface
+	go func() { _ = spliceSession(clientA, backendA, true, false, nil, "") }() // read-only surface
 
 	// A SELECT on a read-only surface is still forwarded to the engine.
 	go func() { _ = WriteMessage(clientB, PktSQLBatch, batchMsg("SELECT amount FROM sales")) }()
@@ -93,7 +93,7 @@ func TestSpliceReadOnlyRejectsWrite(t *testing.T) {
 	backendA, backendB := net.Pipe()
 	defer clientA.Close()
 	defer backendA.Close()
-	go spliceSession(clientA, backendA, true, false, nil, "") // read-only surface
+	go func() { _ = spliceSession(clientA, backendA, true, false, nil, "") }() // read-only surface
 
 	go func() { _ = WriteMessage(clientB, PktSQLBatch, batchMsg("INSERT INTO sales VALUES (1)")) }()
 	// The client receives a rejection...

--- a/internal/tds/typefidelity_test.go
+++ b/internal/tds/typefidelity_test.go
@@ -39,7 +39,7 @@ func TestResultTypeFidelity(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	go srv.Serve(ln)
+	go func() { _ = srv.Serve(ln) }()
 	addr := ln.Addr().(*net.TCPAddr)
 	dsn := fmt.Sprintf("server=127.0.0.1;port=%d;encrypt=disable;dial timeout=5", addr.Port)
 	c, err := mssql.NewAccessTokenConnector(dsn, func() (string, error) { return "a.b.c", nil })

--- a/internal/tlscert/tlscert_test.go
+++ b/internal/tlscert/tlscert_test.go
@@ -57,8 +57,8 @@ func TestLoadFailureModes(t *testing.T) {
 	if err := os.MkdirAll(dir2+"/tls", 0o755); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(dir2+"/tls/cert.pem", []byte("garbage"), 0o644)
-	os.WriteFile(dir2+"/tls/key.pem", []byte("garbage"), 0o600)
+	_ = os.WriteFile(dir2+"/tls/cert.pem", []byte("garbage"), 0o644)
+	_ = os.WriteFile(dir2+"/tls/key.pem", []byte("garbage"), 0o600)
 	if _, err := Load(dir2); err != nil {
 		t.Fatalf("Load over corrupt PEMs = %v; want regeneration", err)
 	}

--- a/internal/tsql/createtable.go
+++ b/internal/tsql/createtable.go
@@ -47,6 +47,10 @@ func checkCreateTableRestrictions(toks []Token) error {
 			// Fabric allows IDENTITY only on BIGINT. The type precedes the
 			// keyword: `id BIGINT IDENTITY(1,1)`.
 			if ty := previousTypeName(toks, i); ty != "" && ty != "BIGINT" {
+				// Opens with "Fabric Warehouse restriction", a proper noun, which
+				// ST1005 exempts. The string starts on the next line, so the
+				// source-matched rule in .golangci.yml cannot see it from here.
+				//nolint:staticcheck // ST1005: opens with a proper noun
 				return fmt.Errorf(
 					"Fabric Warehouse restriction: an IDENTITY column must be BIGINT, "+
 						"not %s — the tenant answers \"Identity column must be of data "+
@@ -55,6 +59,10 @@ func checkCreateTableRestrictions(toks []Token) error {
 			}
 		case "PRIMARY":
 			if i+1 < len(toks) && strings.EqualFold(nextWord(toks, i), "KEY") {
+				// Opens with "Fabric Warehouse restriction", a proper noun, which
+				// ST1005 exempts. The string starts on the next line, so the
+				// source-matched rule in .golangci.yml cannot see it from here.
+				//nolint:staticcheck // ST1005: opens with a proper noun
 				return fmt.Errorf(
 					"Fabric Warehouse restriction: PRIMARY KEY is not supported in " +
 						"CREATE TABLE — not even NOT ENFORCED. Create the table, then " +

--- a/internal/tsql/flatten_test.go
+++ b/internal/tsql/flatten_test.go
@@ -72,7 +72,7 @@ select count(*) as failures from dbt_internal_test`
 	if iAll < 0 || iMain < 0 || iInternal < 0 {
 		t.Fatalf("a CTE went missing:\n%s", got)
 	}
-	if !(iAll < iMain && iMain < iInternal) {
+	if iAll >= iMain || iMain >= iInternal {
 		t.Fatalf("order wrong (want all_values < test_main_sql < dbt_internal_test):\n%s", got)
 	}
 	// And no nesting remains: exactly one WITH keyword survives.

--- a/internal/warehouse/delta_test.go
+++ b/internal/warehouse/delta_test.go
@@ -54,7 +54,7 @@ func seedLakehouse(t *testing.T) (*store.Store, string, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	ws := &store.Workspace{DisplayName: "w"}
 	if err := st.CreateWorkspace(ws, store.Principal{ID: "u", Type: "User"}); err != nil {
 		t.Fatal(err)

--- a/internal/warehouse/reflect_test.go
+++ b/internal/warehouse/reflect_test.go
@@ -136,7 +136,7 @@ func TestReflect(t *testing.T) {
 // TestReflectListError: a store error listing Tables/ surfaces, not panics.
 func TestReflectListError(t *testing.T) {
 	st, _, itemID := seedLakehouse(t)
-	st.Close() // a closed store makes ListOneLakePaths fail
+	_ = st.Close() // a closed store makes ListOneLakePaths fail
 	db := testsupport.OpenMSSQL(t)
 	if _, err := Reflect(context.Background(), db, st, itemID); err == nil {
 		t.Fatal("expected an error from the closed store")

--- a/internal/warehouse/write_test.go
+++ b/internal/warehouse/write_test.go
@@ -14,7 +14,7 @@ func writeStore(t *testing.T) *store.Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { st.Close() })
+	t.Cleanup(func() { _ = st.Close() })
 	return st
 }
 


### PR DESCRIPTION
201 findings against current `main`, the last of the seven Go repos in the family. 71 files, all verified.

## The Livy proxy off the deprecated Director

`SA1019`: `httputil.ReverseProxy.Director` is deprecated as of Go 1.26, which this module now requires. This one is **not** the same migration I did in `databricks-emulator`, and the difference matters:

- There, the code **replaced** the default Director to avoid path joining, so `SetURL` was wrong.
- Here, the code **wraps** the default Director specifically to keep it: the handler sets `r.URL.Path` to the Livy-native suffix (`/sessions`, `/batches`) and relies on the proxy prepending the backend base. So `SetURL` is exactly right.

Two traps carried over from that migration:
- `ReverseProxy` appends `X-Forwarded-For` for a `Director` and **not** for a `Rewrite`, so `SetXForwarded()` is called explicitly rather than silently dropping a header.
- `NewSingleHostReverseProxy` installs a `Director`, and having both is refused **at request time**, so the proxy is constructed directly.

## ST1005: exempted, not rewritten

26 findings, and every one opens with the noun it is reporting on: `Airflow`, `Direct Lake`, `Filter`, `Spark`, `Window`. ST1005 exempts error strings beginning with a proper noun; staticcheck cannot tell these are product and operator names. `direct Lake table %q` would be wrong rather than merely ugly.

The exclusion **matches the source line, not the path**, so it names which nouns are exempt and an ordinary capitalised error in the same file is still reported. Two multi-line `fmt.Errorf(` calls opening with `Fabric Warehouse restriction` carry a site `//nolint` instead, because the reported position is the `Errorf(` line and the string is on the next one.

This is the correction I also had to make in `azure-apim-emulator#122`, where I initially lowercased 25 strings that opened with C# member names. Same rule, and getting it right depends entirely on what the string starts with and where it ends up.

## Four dead symbols and four dead writes

`unused` found `mustHost` (defined and unused in two different packages), `platformPart`, and `(*gatedWriter).status`. Removed, along with the imports that orphaned.

`ineffassign` found two dead writes in `depsReady` that the explicit `return true, false` below already overrides. The names (`satisfied`, `ready`) made this look like a dependency-scheduling bug; it is not, and the comment now says where the returns are actually set.

## Deferred, and labelled

`parser.ParseDir` is deprecated for Go 1.25. The replacement changes how `TestEveryRegistrationIsReachableFromRegister` discovers the package, and that test is what keeps registration reachability **derived rather than declared**. It gets its own change, not a rewrite inside a lint sweep.

## The rest

128 `errcheck`, including 27 `go f(...)` launches wrapped as `go func() { _ = f(...) }()`, plus `QF1001` x3, `QF1002` x2, `QF1012` x3, `QF1003`, `QF1008`, `S1005`, `S1030`.

## Coordination

Five sessions have active worktrees here. I checked overlap before starting: only the two KQL branches touch any of my 71 files, at 2 and 3 files respectively.

Verified: lint clean, `gofmt` clean, `go vet` clean, `go build` clean, `go test ./...` passes across 27 packages.