### PR TITLE
Dispatch to every Fabric platform, by its real name, or fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
   # The wheels the standalone acceptance repo installs: the fixture generators
   # and `fabric-target`.
   #
-  # `contoso-fabric-platform` runs this medallion against the RELEASED image, and
+  # `fabric-platform-notebook-pipelines` runs this medallion against the RELEASED image, and
   # its assertions must be the same numbers the in-tree examples assert. One
   # generator, published, is what makes that guarantee structural rather than
   # hopeful — two copies differing by a single RNG draw would each pass their
@@ -267,7 +267,7 @@ jobs:
   # expired is silence, which is why the acceptance workflow also runs on a
   # daily schedule — see its own comment.
   dispatch:
-    name: Tell contoso-fabric-platform to verify this release
+    name: Tell every Fabric platform to verify this release
     needs: [fixtures, image, compute-images]
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -276,19 +276,55 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ACCEPTANCE_DISPATCH_TOKEN }}
         run: |
+          # ALL THREE FABRIC PLATFORMS, not just the one this job grew up with.
+          # Each pins FABRIC_EMULATOR_VERSION and each has an acceptance
+          # workflow listening for this event. Telling one of three meant the
+          # other two adopted releases nobody had verified against them, and
+          # their pins moved when somebody remembered.
+          targets="fabric-platform-notebook-pipelines fabric-platform-airflow3 fabric-platform-airflow-builtin"
           if [ -z "$GH_TOKEN" ]; then
             echo "::error::ACCEPTANCE_DISPATCH_TOKEN is not set — the release " \
                  "shipped but nothing downstream was told. Add a PAT with " \
-                 "'contents: write' on calvinchengx/contoso-fabric-platform."
+                 "'contents: write' on every fabric-platform-* repository."
             exit 1
           fi
+          # THE NAME MUST BE THE REPOSITORY'S OWN, not one GitHub redirects for
+          # us. This job addressed `contoso-fabric-platform` for releases after
+          # that repository was renamed, and every one of them succeeded: the API
+          # follows a rename silently, so nothing here could tell. A redirect
+          # that works is still a name we did not update, and the day the old one
+          # is reused by something else this dispatch reaches the wrong repo.
+          for name in $targets; do
+            target="calvinchengx/$name"
+            actual=$(gh api "repos/$target" -q .full_name)
+            if [ "$actual" != "$target" ]; then
+              echo "::error::$target now resolves to $actual. The dispatch is " \
+                   "riding a GitHub redirect: update the name here rather than " \
+                   "relying on it."
+              exit 1
+            fi
+          done
           # The version travels WITH the event. Without it the downstream repo
           # would verify whatever its own versions.env pins — quite possibly
           # the previous release — and report success for a release nobody
           # tested.
           version="${GITHUB_REF_NAME#v}"
-          gh api repos/calvinchengx/contoso-fabric-platform/dispatches \
-            -f event_type=fabric-emulator-release \
-            -F "client_payload[version]=$version" \
-            -F "client_payload[tag]=${GITHUB_REF_NAME}"
-          echo "dispatched fabric-emulator-release for $version"
+          # EVERY target is told, and a failure on one does not silently spare
+          # the others: the loop records failures and exits non-zero at the end,
+          # so a release cannot report success having reached two of three.
+          failed=""
+          for name in $targets; do
+            if gh api "repos/calvinchengx/$name/dispatches" \
+                 -f event_type=fabric-emulator-release \
+                 -F "client_payload[version]=$version" \
+                 -F "client_payload[tag]=${GITHUB_REF_NAME}"; then
+              echo "dispatched fabric-emulator-release $version to $name"
+            else
+              echo "::error::could not dispatch to $name"
+              failed="$failed $name"
+            fi
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::not dispatched:$failed"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Concretely, that also unlocks:
   (`202` → poll `/v1/operations/{id}`). The emulator's clock control makes an LRO
   complete instantly or pins it in `Running` — impossible against real Fabric.
 
-See [`contoso-fabric-platform`](https://github.com/calvinchengx/contoso-fabric-platform)
+See [`fabric-platform-notebook-pipelines`](https://github.com/calvinchengx/fabric-platform-notebook-pipelines)
 for what this looks like end to end: four real vendor sources, a full medallion,
 a semantic model serving Power BI, all catalogued in OpenMetadata, running
 against a published release of this emulator.

--- a/examples/README.md
+++ b/examples/README.md
@@ -182,7 +182,7 @@ The controllable clock, fault injection, schedules, event triggers, and
 put-if-absent (`If-None-Match` — the Delta concurrency primitive).
 
 The fullest demonstration of those is not in this repository at all. The
-[contoso-fabric-platform](https://github.com/calvinchengx/contoso-fabric-platform)
+[fabric-platform-notebook-pipelines](https://github.com/calvinchengx/fabric-platform-notebook-pipelines)
 consumer drives the clock, creates schedules and Reflex triggers, and implements
 the `FABRIC_TARGET` toggle. The emulator's own examples show a data platform; a
 downstream consumer shows the emulator's fidelity. That is the wrong way round.


### PR DESCRIPTION
Two defects in one job, both silent.

## It addressed a renamed repository

`contoso-fabric-platform` became `fabric-platform-notebook-pipelines`, and **every release since has succeeded**, because the API follows a rename silently. A redirect that works is still a name nobody updated, and the day the old one is reused by something else this dispatch reaches the wrong repository.

The job now resolves each target and compares `full_name` to what it asked for. Both cases run against the live API rather than being argued:

```
asked: calvinchengx/fabric-platform-notebook-pipelines
got:   calvinchengx/fabric-platform-notebook-pipelines   -> passes

asked: calvinchengx/contoso-fabric-platform
got:   calvinchengx/fabric-platform-notebook-pipelines   -> fails the job
```

## It told one platform out of three

`fabric-platform-airflow3` and `fabric-platform-airflow-builtin` pin `FABRIC_EMULATOR_VERSION` too and were never told, so their pins moved when somebody remembered and they adopted releases nobody had verified against them. Both now have an acceptance workflow listening for this event:

- calvinchengx/fabric-platform-airflow3#7
- calvinchengx/fabric-platform-airflow-builtin#3

The second needed a `set_release.py` before it could point at a dispatched version at all.

**A failure on one target does not spare the others.** The loop records failures and exits non-zero at the end, so a release cannot report success having reached two of three. All three names were dry-run against the live API and resolve to themselves.

## Left alone

**Release notes.** `v0.26.0` says "the consumer repository is now `contoso-fabric-platform`", which was true when it shipped. Editing a release note to match today falsifies the record. Live prose in `README.md` and `examples/README.md` is updated.