### PR TITLE
chore: reference the agent and sail by their current image names

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,7 +24,7 @@ services:
     # image + build: `docker compose pull` fetches the published sidecar (so a
     # pinned SAIL_VERSION is reproducible), while `docker compose build` still
     # works from source for local development. Defaults to latest, like the rest.
-    image: ghcr.io/calvinchengx/fabric-emulator-sail:${SAIL_VERSION:-latest}
+    image: ghcr.io/calvinchengx/emulator-sail:${SAIL_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/sail/Dockerfile
@@ -58,7 +58,7 @@ services:
       retries: 20
 
   spark-agent:
-    image: ghcr.io/calvinchengx/fabric-emulator-spark-agent:${SPARK_AGENT_VERSION:-latest}
+    image: ghcr.io/calvinchengx/emulator-spark-agent:${SPARK_AGENT_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/spark-agent/Dockerfile

--- a/e2e/fab-driven/run.py
+++ b/e2e/fab-driven/run.py
@@ -34,8 +34,8 @@ TAG = "ci"
 # separate version knobs cannot drift apart in CI.
 IMAGES = [
     ("ghcr.io/calvinchengx/fabric-emulator", "Dockerfile"),
-    ("ghcr.io/calvinchengx/fabric-emulator-sail", "docker/sail/Dockerfile"),
-    ("ghcr.io/calvinchengx/fabric-emulator-spark-agent", "docker/spark-agent/Dockerfile"),
+    ("ghcr.io/calvinchengx/emulator-sail", "docker/sail/Dockerfile"),
+    ("ghcr.io/calvinchengx/emulator-spark-agent", "docker/spark-agent/Dockerfile"),
 ]
 
 ENV = {

--- a/examples/fab-driven/docker-compose.yml
+++ b/examples/fab-driven/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           - "onelake.dfs.fabric.microsoft.com"
 
   sail:
-    image: ghcr.io/calvinchengx/fabric-emulator-sail:${SAIL_VERSION:?see .env}
+    image: ghcr.io/calvinchengx/emulator-sail:${SAIL_VERSION:?see .env}
     depends_on:
       fabric-emulator: { condition: service_healthy }
     environment:
@@ -79,7 +79,7 @@ services:
       SAIL_SPARK__SESSION_TIMEOUT_SECS: "3600"
 
   spark-agent:
-    image: ghcr.io/calvinchengx/fabric-emulator-spark-agent:${SPARK_AGENT_VERSION:?see .env}
+    image: ghcr.io/calvinchengx/emulator-spark-agent:${SPARK_AGENT_VERSION:?see .env}
     depends_on:
       sail: { condition: service_started }
     environment:

--- a/python/spark_agent/README.md
+++ b/python/spark_agent/README.md
@@ -7,7 +7,7 @@ the code.
 ## Why it lives here and not in `e2e/`
 
 It used to live in `e2e/livy/`, and that was a packaging bug rather than a
-filing preference. `ghcr.io/calvinchengx/fabric-emulator-spark-agent` is built
+filing preference. `ghcr.io/calvinchengx/emulator-spark-agent` is built
 from `docker/spark-agent/Dockerfile`, which copies `python/` — so anything
 under `e2e/` was never in the published image. Every compose file in this
 repository bind-mounted the source tree over the top, which meant the gap was


### PR DESCRIPTION
`emulator-spark-agent` and `emulator-sail` have been the names since v0.26.0, which introduced them and kept `fabric-emulator-*` as published aliases. This repo was still asking for the aliases in four places, including its own `docker-compose.override.yml` — so the inconsistency the consumers inherit starts here.

Both names resolve to the same digest, verified:

```
emulator-spark-agent         sha256:8983695ef6516fd1a7965335b830a3b69b98c773dfbc1fd3c8122faa76cdd348
fabric-emulator-spark-agent  sha256:8983695ef6516fd1a7965335b830a3b69b98c773dfbc1fd3c8122faa76cdd348
emulator-sail                sha256:f52fee559e27f0a89e0beccfeb90d9bd2cf6809fd284632d0ab9cf1433d53c62
fabric-emulator-sail         sha256:f52fee559e27f0a89e0beccfeb90d9bd2cf6809fd284632d0ab9cf1433d53c62
```

so this is a naming change with no behavioural one.

**Changed** — `docker-compose.override.yml`, `examples/fab-driven/docker-compose.yml`, `e2e/fab-driven/run.py` (its build/tag targets, kept in step with the compose beside it), and the live sentence in `python/spark_agent/README.md`.

**Deliberately not changed** — anything where the old name is a statement about the past, because rewriting those makes the record wrong rather than consistent:

- `docs/release-notes/v0.26.0.md`, which is where the rename was announced and promises "nothing that pins `fabric-emulator-sail` … needs to change"
- `docs/release-notes/v0.28.0.md` and `release.yml`'s comment, both recording a measured incident against `fabric-emulator-spark-agent:0.27.0`
- the `0.14.0` reproduction in `spark_agent/README.md` and `test_spark_agent_packaging.py` — at 0.14.0 the neutral name did not exist yet
- `scripts/check_image_digests.py`, whose comment explains a lookbehind that has to tell the two names apart — still true and still load-bearing

The `fabric-emulator-*` tags stay published, so external pins keep working.

Part of a family-wide sweep; consumer repos follow.