### PR TITLE
Pull OpenMetadata from the family's registry, not the vendor's.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -400,6 +400,20 @@ services:
   # ---- Governance (optional): OpenMetadata, profile-gated -------------------
   # Mirrors OpenMetadata's own quickstart compose (docker-compose-postgres.yml
   # @ 1.13.2), profile-gated so `docker compose up` never starts or pulls it.
+  #
+  # THE IMAGES COME FROM GHCR, not from docker.getcollate.io (G44). That vendor
+  # registry is backed by neither Docker Hub nor GHCR, four repositories pull it
+  # on nightly crons, and on 2026-08-22 it took two of them down: a TLS
+  # handshake timeout, then `connection reset by peer` on a rerun nineteen
+  # minutes later, which is more than the bounded retry in
+  # e2e/governance/stack.py absorbs.
+  #
+  # `calvinchengx/emulators` copies the manifest INDEX with
+  # `buildx imagetools create` and records the digest GHCR serves; both mirrors
+  # carry linux/amd64 and linux/arm64 and their index digests are identical to
+  # upstream's. The version below is still the vendored one, and
+  # test_the_pinned_schema_matches_the_version_docker_compose_runs still holds
+  # all three pins to it.
   # The OM env schema defaults every connection var; we set only the hosts.
   # Heavier than the emulators: the search backend alone wants ~1 GB heap.
   #
@@ -412,7 +426,7 @@ services:
   # ELv2/SSPL even though the source regained an AGPL option in 8.16.
   om-postgresql:
     profiles: [governance]
-    image: docker.getcollate.io/openmetadata/postgresql:1.13.2
+    image: ghcr.io/calvinchengx/openmetadata-postgresql:1.13.2
     command: "--work_mem=10MB"
     environment:
       POSTGRES_USER: postgres
@@ -448,7 +462,7 @@ services:
 
   om-migrate:
     profiles: [governance]
-    image: docker.getcollate.io/openmetadata/server:1.13.2
+    image: ghcr.io/calvinchengx/openmetadata-server:1.13.2
     command: "./bootstrap/openmetadata-ops.sh migrate"
     environment:
       DB_HOST: om-postgresql
@@ -472,7 +486,7 @@ services:
 
   openmetadata:
     profiles: [governance]
-    image: docker.getcollate.io/openmetadata/server:1.13.2
+    image: ghcr.io/calvinchengx/openmetadata-server:1.13.2
     ports:
       - "8585:8585" # UI + API (seeded basic-auth admin)
     environment:

--- a/e2e/governance/stack.py
+++ b/e2e/governance/stack.py
@@ -5,11 +5,18 @@
 Both bring up the same family + OpenMetadata, and each carried its own copy of
 *how* — which is exactly how one of them ended up without the pull retry.
 
-OpenMetadata ships from docker.getcollate.io, a third-party registry with no
-mirror, so a reset connection or a TLS handshake timeout mid-pull reds an
-otherwise-green run. `run.py` learned that and grew a bounded retry; `sso.py`
-held the same twenty lines minus the retry, and failed on precisely that pull.
-Two copies of a boot sequence is one copy that will not get the next fix.
+OpenMetadata used to ship here straight from docker.getcollate.io, a vendor
+registry backed by neither Docker Hub nor GHCR, so a reset connection or a TLS
+handshake timeout mid-pull reds an otherwise-green run. `run.py` learned that
+and grew a bounded retry; `sso.py` held the same twenty lines minus the retry,
+and failed on precisely that pull. Two copies of a boot sequence is one copy
+that will not get the next fix.
+
+THERE IS A MIRROR NOW (G44) and the retry stays anyway. docker-compose.yml
+pulls both images from ghcr.io/calvinchengx, which removes the single-vendor
+dependency; it does not make GHCR incapable of a hiccup, and the retry costs
+nothing on a healthy pull. What changed is that a failure here is now the
+family's own registry rather than somebody else's.
 
 Sibling module rather than a package: every e2e suite here is a directory of
 scripts run as `python e2e/<suite>/run.py`, and this follows that.

--- a/python/tests/test_govern_column_schema.py
+++ b/python/tests/test_govern_column_schema.py
@@ -197,9 +197,45 @@ def test_the_pinned_schema_matches_the_version_docker_compose_runs():
     vendored = m.group(1)
 
     compose = (ROOT / "docker-compose.yml").read_text()
-    pins = set(re.findall(r"docker\.getcollate\.io/openmetadata/[a-z]+:([0-9.]+)", compose))
+    # REGISTRY-AGNOSTIC, because the registry moved once already (G44: the
+    # images are mirrored into GHCR, where the repository is `openmetadata-server`
+    # rather than `openmetadata/server`). A pattern naming one host stops
+    # matching when the host changes and this test then depends entirely on the
+    # `assert pins` below to notice -- which it would, but as "no pins found"
+    # rather than as the version mismatch it is here to catch.
+    pins = set(re.findall(
+        r"image:\s*\S*openmetadata[-/](?:server|postgresql):([0-9.]+)", compose))
     assert pins, "no OpenMetadata image pins found in docker-compose.yml"
     assert pins == {vendored}, (
         f"vendored schema is {vendored} but docker-compose.yml pins {sorted(pins)} — "
         "re-vendor with scripts/vendor_openmetadata_schema.py or revert the image bump"
     )
+
+
+def test_the_catalog_images_come_from_a_registry_this_family_keeps_up():
+    """G44. OpenMetadata shipped straight from docker.getcollate.io, and on
+    2026-08-22 that registry failed two platform nightlies within an hour: a
+    TLS handshake timeout, then `connection reset by peer` on a rerun nineteen
+    minutes later. Neither Docker Hub nor GHCR backs it, and four repositories
+    pull it on crons, so it fails unattended and reads as a broken governance
+    step rather than as somebody else's outage.
+
+    The images are mirrored into ghcr.io/calvinchengx by
+    `calvinchengx/emulators`, which copies the manifest index with
+    `buildx imagetools create` and records the digest the registry serves.
+
+    THE TEST ABOVE WILL NOT CATCH A REVERT. Its pin regex is deliberately
+    registry-agnostic so a future move does not silently stop matching --
+    measured: pointing all three images back at the vendor leaves it green.
+    Which registry is a separate claim and needs its own assertion.
+    """
+    compose = (ROOT / "docker-compose.yml").read_text()
+    images = [ln.strip() for ln in compose.splitlines()
+              if ln.strip().startswith("image:") and "openmetadata" in ln]
+    assert len(images) == 3, (
+        f"expected three OpenMetadata image pins, found {len(images)} -- if the "
+        f"governance stack changed shape, this test needs to know")
+    for line in images:
+        assert "ghcr.io/calvinchengx/openmetadata-" in line, (
+            f"{line} does not come from the family's registry; see G44 and "
+            f"calvinchengx/emulators mirrors.json")


### PR DESCRIPTION
G44, the last of four consumers. Siblings: [snowflake-platform-tasks#21](https://github.com/calvinchengx/snowflake-platform-tasks/pull/21), [databricks-platform-jobs#25](https://github.com/calvinchengx/databricks-platform-jobs/pull/25), [fabric-platform-notebook-pipelines#39](https://github.com/calvinchengx/fabric-platform-notebook-pipelines/pull/39). The mirror is [emulators#7](https://github.com/calvinchengx/emulators/pull/7) and [#9](https://github.com/calvinchengx/emulators/pull/9).

`docker.getcollate.io` is backed by neither Docker Hub nor GHCR. This morning it failed two platform nightlies within an hour, a TLS handshake timeout and then `connection reset by peer` on a rerun nineteen minutes later, which is more than the bounded retry in `e2e/governance/stack.py` absorbs.

Both images now come from `ghcr.io/calvinchengx`, copied index-and-all with `buildx imagetools create`. The mirrors carry `linux/amd64` and `linux/arm64`, and their index digests are **identical to upstream's**.

## The pin test was passing on the wrong thing

`test_the_pinned_schema_matches_the_version_docker_compose_runs` found its pins with a regex naming `docker.getcollate.io`. Left alone it would have matched nothing after this change and fallen through to its own `assert pins` guard, reporting "no OpenMetadata image pins found" rather than the version mismatch it exists to catch. Its pattern is now registry-agnostic.

**That fix creates a hole, and it is measured, not assumed.** With a registry-agnostic pattern, pointing all three images back at the vendor leaves that test **green**. Which registry is a separate claim, so `test_the_catalog_images_come_from_a_registry_this_family_keeps_up` asserts it, and also asserts there are exactly three pins so a change in the stack's shape cannot quietly reduce what is checked.

## The retry stays, and its docstring stops lying

`e2e/governance/stack.py` said OpenMetadata ships from a registry "with no mirror". That is now false, and a stale claim sitting beside the truth gets read as current. The comment records what changed; the retry itself stays, because a mirror removes the single-vendor dependency and does not make GHCR incapable of a hiccup.

## Verification

| mutation | result |
|---|---|
| one pin left at 1.13.1 | version test red |
| all three reverted to the vendor registry | version test **green**, registry test red |
| the images removed entirely | version test red |
| one image reverted to the vendor | registry test red |

`pytest python/tests/test_govern_column_schema.py` passes (14), ruff clean on both touched Python files.