### PR TITLE
Encode DFS errors as JSON, and refuse MIME sniffing

### DIFF
--- a/internal/onelake/onelake.go
+++ b/internal/onelake/onelake.go
@@ -63,8 +63,44 @@ type dfsError struct {
 func writeDFSErr(w http.ResponseWriter, e dfsError) {
 	w.Header().Set("x-ms-error-code", e.code)
 	w.Header().Set("Content-Type", "application/json")
+	noSniff(w)
 	w.WriteHeader(e.status)
-	fmt.Fprintf(w, `{"error":{"code":%q,"message":%q}}`, e.code, e.msg)
+	// encoding/json, NOT `%q`. These messages quote the caller's own path back
+	// at them -- "No item matches <seg>" -- so the value is attacker-chosen,
+	// and Go's %q is GO quoting, not JSON:
+	//
+	//   * it leaves < > & intact, so the body carries markup verbatim and a
+	//     browser that sniffs past the Content-Type renders it. That is the
+	//     reflected-XSS report this closes.
+	//   * it emits \x00 for a control byte, which is not valid JSON at all, so
+	//     a path with one produced a body no client could parse.
+	//
+	// json.Marshal escapes <, > and & to \u003c, \u003e and \u0026 by default
+	// and encodes control bytes as \u0000, which fixes both at once.
+	body, err := json.Marshal(map[string]any{
+		"error": map[string]string{"code": e.code, "message": e.msg},
+	})
+	if err != nil {
+		// A map of strings cannot fail to marshal, but saying so beats an
+		// empty body if it ever does.
+		body = []byte(`{"error":{"code":"InternalError","message":"error could not be encoded"}}`)
+	}
+	_, _ = w.Write(body)
+}
+
+// noSniff stops a browser second-guessing the Content-Type.
+//
+// EVERY response, not just the error bodies. This service hands back two kinds
+// of attacker-influenced bytes: error messages quoting the caller's path, and
+// the stored file content of `serveContent`, which is whatever somebody
+// uploaded. Both already carry a Content-Type that is not HTML --
+// `application/json` and `application/octet-stream` -- and without this header
+// that is a request, not an instruction: a browser may sniff the body and
+// render markup anyway, which turns an upload into stored XSS on this origin.
+//
+// Real ADLS Gen2 sends it, so this is parity rather than local hardening.
+func noSniff(w http.ResponseWriter) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
 // permHeaders sets OneLake's canned permission response headers.
@@ -93,6 +129,7 @@ func pathHeaders(w http.ResponseWriter, p *store.OneLakePath, st *store.Store) {
 // downloads and requires a 206 + Content-Range in reply).
 func serveContent(w http.ResponseWriter, r *http.Request, content []byte) {
 	w.Header().Set("Content-Type", "application/octet-stream")
+	noSniff(w)
 	w.Header().Set("Accept-Ranges", "bytes")
 	rng := r.Header.Get("Range")
 	if rng == "" {
@@ -407,6 +444,10 @@ func (s *Service) renameSource(wsID, itemID, src string) (string, *dfsError) {
 
 // ServeHTTP implements the DFS endpoint.
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// BEFORE ANYTHING ELSE, so every path out of this handler carries it --
+	// including the ones that write a body without going through writeDFSErr
+	// or serveContent, and the ones added later.
+	noSniff(w)
 	// Env-gated request tracing (diagnostics only; off in prod). Read per
 	// request so it can be toggled without a restart (and in tests).
 	if os.Getenv("ONELAKE_TRACE") != "" {

--- a/internal/onelake/onelake_test.go
+++ b/internal/onelake/onelake_test.go
@@ -789,3 +789,81 @@ func TestAWriteAtTheCeilingStillLandsWhole(t *testing.T) {
 		t.Fatalf("stored %d bytes of %d", got.Body.Len(), n)
 	}
 }
+
+// The error message quotes the caller's own path back at them, so markup in a
+// path must not survive into the body as markup.
+//
+// CodeQL reported this as reflected XSS (go/reflected-xss, alert 71). The old
+// body was built with `%q`, which is GO quoting: it leaves < > and & intact,
+// so a browser that sniffed past `application/json` rendered them.
+func TestDFSErrorEscapesMarkupFromTheCallersPath(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeDFSErr(rec, dfsError{"PathNotFound", http.StatusNotFound,
+		`No item matches <script>alert(1)</script> & "friends".`})
+
+	body := rec.Body.String()
+	for _, raw := range []string{"<script>", "</script>", "<", ">"} {
+		if strings.Contains(body, raw) {
+			t.Fatalf("raw %q survived into the body: %s", raw, body)
+		}
+	}
+	// The escaped forms encoding/json produces, which is what makes the body
+	// inert even if a browser sniffs past the Content-Type.
+	for _, esc := range []string{`\u003c`, `\u003e`, `\u0026`} {
+		if !strings.Contains(body, esc) {
+			t.Fatalf("expected %s in the escaped body: %s", esc, body)
+		}
+	}
+
+	// And it must still be JSON a client can parse -- the point of the change
+	// was correctness as much as safety.
+	var got struct {
+		Error struct{ Code, Message string } `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body is not valid JSON: %v\n%s", err, body)
+	}
+	if !strings.Contains(got.Error.Message, "<script>") {
+		t.Fatalf("decoding did not recover the original message: %q", got.Error.Message)
+	}
+	if got.Error.Code != "PathNotFound" {
+		t.Fatalf("code lost: %q", got.Error.Code)
+	}
+}
+
+// `%q` emitted \x00 for a control byte, which is not valid JSON. A path can
+// contain one, so the body it produced was unparseable.
+func TestDFSErrorEncodesControlBytesAsValidJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeDFSErr(rec, dfsError{"PathNotFound", http.StatusNotFound, "bad\x00path\x1f"})
+	if strings.Contains(rec.Body.String(), `\x`) {
+		t.Fatalf("Go-style escape in a JSON body: %s", rec.Body.String())
+	}
+	var any map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &any); err != nil {
+		t.Fatalf("control bytes produced invalid JSON: %v\n%s", err, rec.Body.String())
+	}
+}
+
+// A Content-Type that is not HTML is a request, not an instruction, unless
+// nosniff says otherwise -- and this service serves whatever was uploaded.
+func TestEveryResponseRefusesMIMESniffing(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		writeDFSErr(rec, dfsError{"PathNotFound", http.StatusNotFound, "nope"})
+		if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Fatalf("X-Content-Type-Options=%q", got)
+		}
+	})
+	t.Run("stored content", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		serveContent(rec, httptest.NewRequest(http.MethodGet, "/f", nil),
+			[]byte("<html><script>alert(1)</script></html>"))
+		if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Fatalf("uploaded HTML served without nosniff: %q", got)
+		}
+		if got := rec.Header().Get("Content-Type"); got != "application/octet-stream" {
+			t.Fatalf("stored content served as %q", got)
+		}
+	})
+}


### PR DESCRIPTION
Closes CodeQL alert [71](https://github.com/calvinchengx/fabric-emulator/security/code-scanning/71) - `go/reflected-xss`, high.

## What was wrong

The DFS error body was built with `fmt.Fprintf(w, ..., %q)`, and these messages quote the caller's own path back at them:

```go
"No item matches " + seg + " (use name.ItemType or GUIDs)."
```

`%q` is **Go** quoting, not JSON, and it is wrong in two separate ways:

- it leaves `<`, `>` and `&` intact, so markup travels verbatim in the body. With `application/json` and no `nosniff`, a browser may sniff past the declared type and render it - the reported vulnerability.
- it emits a Go-style hex escape for a control byte, which is **not valid JSON**. A path containing one produced a body no client could parse. A plain bug that happened to share the line.

`json.Marshal` fixes both - the `\u00xx` forms for `<` `>` `&` by default, and `\u0000` for control bytes.

## nosniff on every response, not just errors

This service returns two kinds of attacker-influenced bytes, and the second is the more serious: `serveContent` hands back **whatever was uploaded**. Both already declared a non-HTML Content-Type (`application/json`, `application/octet-stream`), but without the header that is a request rather than an instruction - an uploaded HTML file becomes stored XSS on this origin.

Set at the top of `ServeHTTP`, so paths that write a body without going through either helper - and paths added later - carry it too. Real ADLS Gen2 sends it, so this is parity rather than local hardening.

## Tests

Three, and the first two were run against the reverted implementation to confirm they discriminate rather than merely pass:

- markup from a path does not survive into the body as markup, and the body still decodes to the original message
- control bytes produce valid JSON
- both error and stored-content responses carry `nosniff`

`gofmt`, `go vet` and the full suite are clean.
