### PR TITLE
Escape the Blob dialect's error document too

### DIFF
--- a/internal/onelake/blob.go
+++ b/internal/onelake/blob.go
@@ -136,16 +136,40 @@ func (b *blockStage) commit(key string, ids []string) ([]byte, bool) {
 	return out, true
 }
 
+// blobError is the Blob dialect's error document. A struct rather than a
+// format string, so encoding/xml does the escaping.
+type blobError struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    string   `xml:"Code"`
+	Message string   `xml:"Message"`
+}
+
 func writeBlobErr(w http.ResponseWriter, status int, code, msg string) {
 	w.Header().Set("x-ms-error-code", code)
 	w.Header().Set("Content-Type", "application/xml")
+	noSniff(w)
 	w.WriteHeader(status)
-	fmt.Fprintf(w, `<?xml version="1.0" encoding="utf-8"?><Error><Code>%s</Code><Message>%s</Message></Error>`, code, msg)
+	// ENCODED, NOT FORMATTED. This was an `fmt.Fprintf` with two bare `%s`,
+	// and `msg` is frequently the caller's own path -- `ContainerNotFound`
+	// passes "No item matches <seg>" straight through. Markup in a path
+	// therefore arrived in the document verbatim, and unescaped markup does
+	// not merely risk being rendered: it makes the XML malformed, which is
+	// exactly when a browser stops parsing it as XML and starts guessing.
+	//
+	// The sibling DFS dialect had the same shape and was fixed first; this one
+	// was missed because the search stopped at onelake.go. The listing a few
+	// hundred lines below was always safe -- it went through xml.Encoder.
+	fmt.Fprint(w, xml.Header)
+	_ = xml.NewEncoder(w).Encode(blobError{Code: code, Message: msg})
 }
 
 // ServeBlob handles the Blob dialect. Paths arrive workspace-first (the
 // /onelake account prefix, when present, is stripped by the router).
 func (s *Service) ServeBlob(w http.ResponseWriter, r *http.Request) {
+	// Before anything else, as in ServeHTTP: this dialect serves stored bytes
+	// and error documents quoting the caller's path, and neither should be
+	// re-sniffed into HTML.
+	noSniff(w)
 	// Same env-gated tracing as the DFS surface (ServeHTTP): the Blob dialect
 	// is what delta-rs speaks, so a Delta commit is only visible here.
 	if os.Getenv("ONELAKE_TRACE") != "" {

--- a/internal/onelake/blob_test.go
+++ b/internal/onelake/blob_test.go
@@ -990,3 +990,43 @@ func TestListBlobsOmitsDirectories(t *testing.T) {
 		t.Errorf("blobs = %v; want only the real file", blobs)
 	}
 }
+
+// The Blob dialect quotes the caller's path back too -- ContainerNotFound
+// passes "No item matches <seg>" straight through -- and it used to do so with
+// a bare %s into an XML document.
+//
+// Unescaped markup does not merely risk being rendered: it makes the XML
+// malformed, which is exactly when a browser stops parsing it as XML and
+// starts guessing. The DFS dialect was fixed first; this one was missed
+// because the search stopped at onelake.go.
+func TestBlobErrorEscapesMarkupFromTheCallersPath(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeBlobErr(rec, http.StatusNotFound, "ContainerNotFound",
+		`No item matches <script>alert(1)</script> & "friends".`)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Fatalf("raw markup survived into the document: %s", body)
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Fatalf("expected escaped markup: %s", body)
+	}
+
+	// Still well-formed, and still the message that went in.
+	var got struct {
+		Code    string `xml:"Code"`
+		Message string `xml:"Message"`
+	}
+	if err := xml.Unmarshal([]byte(strings.TrimPrefix(body, xml.Header)), &got); err != nil {
+		t.Fatalf("document is not well-formed XML: %v\n%s", err, body)
+	}
+	if !strings.Contains(got.Message, "<script>") {
+		t.Fatalf("decoding did not recover the original message: %q", got.Message)
+	}
+	if got.Code != "ContainerNotFound" {
+		t.Fatalf("code lost: %q", got.Code)
+	}
+	if h := rec.Header().Get("X-Content-Type-Options"); h != "nosniff" {
+		t.Fatalf("X-Content-Type-Options=%q", h)
+	}
+}


### PR DESCRIPTION
Follow-up to #355, which fixed the DFS dialect for CodeQL alert 71 and **missed this one** — the search stopped at `onelake.go`, and `blob.go` is the same package with the same shape:

```go
fmt.Fprintf(w, `...<Code>%s</Code><Message>%s</Message>...`, code, msg)
```

It is fed the same value: `ContainerNotFound` passes the `dfsError` message straight through, and that message is `"No item matches " + seg` — the caller's own path.

Unescaped markup here is **worse** than in the JSON case. It does not merely risk being rendered: it makes the document malformed, and a malformed XML response is exactly when a browser stops parsing as XML and starts guessing.

Now a struct through `encoding/xml`, plus `nosniff` at the top of `ServeBlob` for the same reason `ServeHTTP` has it — this dialect serves stored bytes as well as error documents. The blob listing was always safe; it already went through `xml.Encoder`.

Test run against the reverted implementation to confirm it discriminates.

**Note on alert 71:** it may not close even with this. Its sink is `traceWriter.Write`, a generic wrapper CodeQL cannot see content types through, and that wrapper is only installed when `ONELAKE_TRACE` is set. If it survives, the honest resolution is a documented dismissal — every body write in the package now carries a non-HTML content type and `nosniff` — rather than further guessing. Both fixes are real improvements regardless.