### PR TITLE
A statement's stdout is its own, not the interpreter's

### DIFF
--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -22,7 +22,7 @@ import json
 import os
 import sys
 import traceback
-from contextlib import contextmanager, redirect_stdout
+from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import httpjson
@@ -466,7 +466,13 @@ def run_code(code, g):
     if tree.body and isinstance(tree.body[-1], ast.Expr):
         last_expr = ast.Expression(tree.body.pop().value)
     try:
-        with redirect_stdout(out):
+        # NOT redirect_stdout. That assigns `sys.stdout`, one attribute on one
+        # module per interpreter, and this server runs statements concurrently:
+        # measured (#346), one task's response carried another's output and two
+        # came back empty. `task_scope.capturing` binds the buffer in a
+        # ContextVar instead, so each statement resolves its own and neither
+        # restores over the other.
+        with task_scope.capturing(out):
             if tree.body:
                 exec(compile(tree, "<statement>", "exec"), g)
             result = eval(compile(last_expr, "<statement>", "eval"), g) if last_expr is not None else None

--- a/python/spark_agent/task_scope.py
+++ b/python/spark_agent/task_scope.py
@@ -67,6 +67,17 @@ from contextvars import ContextVar
 # subscripted ContextVar.
 _bound = ContextVar("spark_agent_task_scope", default=None)
 
+# The buffer the RUNNING STATEMENT's prints go to.
+#
+# ITS OWN ContextVar, not a field on the session scope, and the difference is
+# not cosmetic. A scope is per SESSION and lives as long as the session does; a
+# capture buffer is per STATEMENT. Two statements of the same session can be in
+# flight at once -- the agent is a ThreadingHTTPServer and nothing serialises
+# them per session -- and hanging the buffer off the shared scope would put both
+# of their output in one place, which is the bug being fixed with a smaller
+# blast radius.
+_capture = ContextVar("spark_agent_stdout", default=None)
+
 # A scoped `del os.environ[k]` must hide a PROCESS variable from this session
 # without unsetting it for the agent. Storing a tombstone keeps the delete
 # private; actually deleting it would be the same class of bug this module
@@ -198,6 +209,87 @@ def bind(scope):
 
 def unbind(token):
     _bound.reset(token)
+
+
+class _SessionStdout:
+    """The single object in `sys.__dict__["stdout"]`, routed per statement.
+
+    NOT A PROPERTY ON `_AgentSys`, which is what `argv` uses and what the issue
+    proposed. Measured: it does not work.
+
+        print("x")            -> the REAL stdout   (property bypassed)
+        sys.stdout.write("x") -> the capture       (property honoured)
+
+    `print` reaches stdout through `PySys_GetObject`, which reads the sys
+    module's DICT directly; a property lives on the module's TYPE and is never
+    consulted. `sys.argv` is safe because user code reads it as an attribute,
+    and `print` is the overwhelmingly common way a statement produces output --
+    so the property approach would have captured almost nothing while looking
+    correct in a `sys.stdout.write` test.
+
+    So the dict entry stays ONE stable object and the routing happens inside
+    it. Nothing is saved or restored, which is the property this module exists
+    to preserve: a concurrent statement resolves its own buffer through the
+    ContextVar and neither can restore over the other.
+    """
+
+    def __init__(self, wrapped):
+        # The stream to use when no statement is capturing: the agent's own
+        # log. Held rather than looked up, because looking it up would find
+        # this proxy.
+        self._wrapped = wrapped
+
+    def _target(self):
+        captured = _capture.get()
+        return self._wrapped if captured is None else captured
+
+    def write(self, text):
+        return self._target().write(text)
+
+    def writelines(self, lines):
+        return self._target().writelines(lines)
+
+    def flush(self):
+        return self._target().flush()
+
+    def __getattr__(self, name):
+        # `encoding`, `fileno`, `isatty`, everything else a caller may reach
+        # for. Delegated to whichever stream is live, so a captured statement
+        # sees the buffer's answers -- including `fileno()` raising, exactly as
+        # it did under redirect_stdout.
+        return getattr(self._target(), name)
+
+
+def _ensure_proxy():
+    """Put the proxy in the sys module dict, over whatever is there now.
+
+    Idempotent, and re-applied on every capture rather than once at install:
+    pytest and other harnesses assign `sys.stdout` after import, which replaces
+    the dict entry outright. Re-checking here costs one isinstance and means a
+    capture cannot silently stop working because something else swapped the
+    stream first.
+    """
+    current = sys.__dict__.get("stdout")
+    if not isinstance(current, _SessionStdout):
+        sys.__dict__["stdout"] = _SessionStdout(current)
+
+
+@contextmanager
+def capturing(buffer):
+    """Send this statement's prints to `buffer` for the duration.
+
+    Replaces `redirect_stdout` at the one call site that captures a statement's
+    output. Nothing is saved or restored: the buffer is bound in a ContextVar
+    and read by the proxy sitting in `sys.__dict__["stdout"]`, so a concurrent
+    statement in another thread resolves its own and neither can restore over
+    the other.
+    """
+    _ensure_proxy()
+    token = _capture.set(buffer)
+    try:
+        yield buffer
+    finally:
+        _capture.reset(token)
 
 
 @contextmanager

--- a/python/tests/test_spark_agent_task_scope.py
+++ b/python/tests/test_spark_agent_task_scope.py
@@ -20,6 +20,7 @@ rest of the suite. That is safe by construction: with no scope bound both
 attributes fall through to the real process values, which the
 `unbound_*` tests below assert directly rather than assume.
 """
+import io
 import os
 import subprocess
 import sys
@@ -282,3 +283,102 @@ def test_cell_identity_survives_an_overlapping_statement():
     assert got["a"] == "job-a"
     assert got["b"] == "job-b"
     assert "FABRIC_JOB_ID" not in os.environ
+
+
+# --- stdout -------------------------------------------------------------------
+#
+# #346: `sys.stdout` is the same class of shared module state as `argv`, and it
+# was captured with `contextlib.redirect_stdout` — the save/restore discipline
+# this module's docstring rules out. Measured with three concurrent tasks: one
+# response carried ANOTHER task's output and two carried nothing.
+#
+# Same barrier as the argv tests, and for the same reason: the interleaving is
+# an input, not a sample. Both statements are inside their capture before
+# either prints, which is the order that breaks. A stress loop would pass on a
+# broken tree most of the time.
+
+def test_concurrent_statements_each_capture_their_own_output():
+    def task(word):
+        def body(sync):
+            buffer = io.StringIO()
+            with task_scope.capturing(buffer):
+                sync()  # the other statement is now inside its capture too
+                print(word)
+                sync()  # ...and has printed, before either reads
+            return buffer.getvalue()
+        return body
+
+    got = run_concurrently({"a": task("alpha"), "b": task("beta")})
+    assert got["a"] == "alpha\n", f"a's response carried {got['a']!r}"
+    assert got["b"] == "beta\n", f"b's response carried {got['b']!r}"
+
+
+def test_a_statement_that_reimports_sys_still_captures_its_own_output():
+    """`import sys; sys.stdout.write(...)` walks past any rebound local name,
+    the same way the argv test's re-import does."""
+    def task(word):
+        def body(sync):
+            buffer = io.StringIO()
+            with task_scope.capturing(buffer):
+                sync()
+                import sys as reimported
+
+                reimported.stdout.write(word)
+                sync()
+            return buffer.getvalue()
+        return body
+
+    got = run_concurrently({"a": task("alpha"), "b": task("beta")})
+    assert got == {"a": "alpha", "b": "beta"}
+
+
+def test_output_outside_a_capture_goes_to_the_real_stdout(capsys):
+    """The agent's own logging must not vanish into whichever statement happens
+    to be running, and must not raise when none is."""
+    print("agent: a line of its own")
+    assert "agent: a line of its own" in capsys.readouterr().out
+
+
+def test_a_capture_ends_when_the_statement_does():
+    buffer = io.StringIO()
+    with task_scope.capturing(buffer):
+        print("inside")
+    assert buffer.getvalue() == "inside\n"
+    # And the next print does not land in a buffer nobody is reading.
+    assert task_scope._capture.get() is None
+
+
+def test_print_is_captured_not_only_sys_stdout_write():
+    """THE CASE A PROPERTY WOULD HAVE MISSED, which is why the proxy exists.
+
+    `print` reaches stdout through `PySys_GetObject` — a read of the sys module
+    DICT — so a property on the module's type is never consulted. Measured
+    while building this: with the property approach, `sys.stdout.write` was
+    captured and `print` went straight to the real stream. Since `print` is how
+    a statement almost always produces output, that version would have captured
+    almost nothing while passing a `sys.stdout.write` test.
+    """
+    buffer = io.StringIO()
+    with task_scope.capturing(buffer):
+        print("printed")
+        sys.stdout.write("written\n")
+    assert buffer.getvalue() == "printed\nwritten\n"
+
+
+def test_a_harness_that_swaps_stdout_does_not_disable_capturing():
+    """pytest assigns `sys.stdout` after import, replacing the dict entry. The
+    proxy is re-applied per capture so that cannot silently switch capturing
+    off — which is how this would rot in the one environment that tests it."""
+    replacement = io.StringIO()
+    saved = sys.__dict__["stdout"]
+    try:
+        sys.__dict__["stdout"] = replacement  # the harness swaps it
+        buffer = io.StringIO()
+        with task_scope.capturing(buffer):
+            print("still captured")
+        assert buffer.getvalue() == "still captured\n"
+        # ...and output outside a capture reaches what the harness installed.
+        print("to the harness")
+        assert "to the harness" in replacement.getvalue()
+    finally:
+        sys.__dict__["stdout"] = saved


### PR DESCRIPTION
Closes #346.

`redirect_stdout` assigns `sys.stdout` — one attribute on one module per interpreter — and the agent is a `ThreadingHTTPServer`, so statements genuinely overlap. Measured in the issue: of three concurrent tasks that each printed, **one response carried another task's output and two carried nothing.** The writes were correct; only the attribution was wrong, which is the failure hardest to notice.

`task_scope`'s own docstring already rejects this pattern for `argv` and `environ`: *"It is a stack discipline and these do not stack."* `redirect_stdout` **is** save/restore.

## The suggested fix does not work, and only measurement showed it

The issue proposed a property on the `_AgentSys` ModuleType subclass, mirroring `argv`. Built it, and it captures almost nothing:

```
print("x")            -> the REAL stdout   (property bypassed)
sys.stdout.write("x") -> the capture       (property honoured)
```

`print` reaches stdout through `PySys_GetObject`, a read of the sys module **dict**; a property lives on the module's **type** and is never consulted. `argv` is safe because user code reads it as an attribute. Since `print` is how a statement almost always produces output, that version would have passed a `sys.stdout.write` test while capturing nothing real.

## What landed instead

One stable proxy object in `sys.__dict__["stdout"]`, routing each write to the running statement's buffer through a `ContextVar`, falling through to the agent's log when nothing is capturing. Nothing is saved or restored, so no statement can restore over another.

Two details worth their lines:
- **The buffer is its own ContextVar, not a field on the session scope.** A scope is per session; a capture is per statement, and two statements of one session can overlap.
- **The proxy is re-applied per capture.** pytest and similar harnesses assign `sys.stdout` after import, replacing the dict entry — re-checking means a capture cannot silently stop working in the one environment that tests it.

## Tests

Barrier-released concurrency, matching the existing `argv` tests: the interleaving is an input, not a sample. Plus the `print`-vs-`write` case that killed the first design, and a harness-swap case. Three mutations checked — routing every write to the real stream, installing the proxy once instead of per capture, and sharing one buffer — each fails five tests.

Verified end to end: the Livy e2e still returns `even rows: 500` from a batch statement's `print`.