### PR TITLE
/statements refuses the fields it would ignore

### DIFF
--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -28,6 +28,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import httpjson
 import jvmconf  # no Spark; JVM session configs (see jvmconf.py)
 import session_recovery
+import statement_fields
 import task_scope
 import usercontext
 from pyspark.sql import SparkSession
@@ -623,6 +624,10 @@ class Handler(BaseHTTPRequestHandler):
         n = int(self.headers.get("Content-Length", 0) or 0)
         req = json.loads(self.rfile.read(n) or b"{}")
         if self.path == "/statements":
+            refusal = statement_fields.check(req)
+            if refusal is not None:
+                self._send(200, refusal)
+                return
             # Livy statements carry a `kind`. A `sql` statement is Spark SQL and
             # must come back as a structured result set; anything else is Python
             # and comes back as REPL text. Before this dispatch existed the agent

--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -624,10 +624,7 @@ class Handler(BaseHTTPRequestHandler):
         n = int(self.headers.get("Content-Length", 0) or 0)
         req = json.loads(self.rfile.read(n) or b"{}")
         if self.path == "/statements":
-            refusal = statement_fields.check(req)
-            if refusal is not None:
-                self._send(200, refusal)
-                return
+            statement_fields.check(req)
             # Livy statements carry a `kind`. A `sql` statement is Spark SQL and
             # must come back as a structured result set; anything else is Python
             # and comes back as REPL text. Before this dispatch existed the agent

--- a/python/spark_agent/statement_fields.py
+++ b/python/spark_agent/statement_fields.py
@@ -1,0 +1,75 @@
+"""What `/statements` accepts, refuses, and merely notes.
+
+Split out of agent.py for the reason catalog.py and usercontext.py are: agent.py
+calls getOrCreate() at import, so nothing defined there can be unit tested. A
+rule about which requests are rejected is the last thing that should live where
+its tests cannot reach it.
+"""
+import sys
+
+# THE ROUTE USED TO ACCEPT `env` AND `spark_conf` AND APPLY NEITHER (#349). A
+# caller got `{"status":"ok"}` and its field on the floor, which is the kind of
+# silence that sends someone looking in the wrong place: it already produced a
+# bug filed against databricks-emulator rather than against this agent.
+#
+# REFUSED RATHER THAN IMPLEMENTED, for two different reasons.
+#
+# `env` could be implemented -- `task_scope` already gives each session its own
+# environment -- but Fabric's Livy statement payload is `{"code", "kind"}`
+# (get-started-high-concurrency-livy.md). Adding it would grow a surface the
+# product does not have, in an emulator whose whole value is matching the
+# product. The way to set a task's environment is the way databricks-emulator
+# now does it: in the generated code, where no agent can drop it.
+#
+# `spark_conf` should not be implemented at all. A statement-level
+# `spark.conf.set` is not statement-scoped -- it lands on the session's Spark
+# session and outlives the statement, and where `catalog.isolate` could not give
+# the Livy session its own SparkSession it lands on the SHARED one and leaks
+# into every other session. `apply_environment` gets away with it only because
+# an Environment binds once per agent and refuses a second.
+REFUSED_STATEMENT_FIELDS = {
+    "env": "set a task's environment in the code it runs, where no agent can "
+           "drop it; Fabric's Livy statement payload is {code, kind}",
+    "spark_conf": "a statement-level conf is not statement-scoped: it outlives "
+                  "the statement on the session's Spark session, and on a "
+                  "shared session it leaks into every other one",
+}
+
+# Everything this route reads, each name traceable to its reader: the dispatch
+# below, `remember_context`, `_apply_onelake_security`, and the register call.
+#
+# UNKNOWN NAMES ARE LOGGED, NOT REFUSED, and the difference matters here. This
+# is an INTERNAL protocol between two images that version independently, so a
+# newer emulator sending a field an older agent has not heard of must degrade,
+# not fail. Refusing would turn a rolling upgrade into an outage; saying so in
+# the log removes the silence without that risk.
+KNOWN_STATEMENT_FIELDS = {
+    "code", "kind", "session", "jobId", "cellIndex",
+    "principal", "workspace", "item", "lakehouse",
+    "schema", "schemas", "tables",
+    "workspaceId", "lakehouseId", "notebookId",
+    "currentWorkspaceId", "defaultLakehouseId", "currentNotebookId",
+    "currentJobId", "isForPipeline",
+}
+
+
+def check(req):
+    """Refuse a field this route would silently ignore; name the rest.
+
+    Returns an error envelope, or None to proceed.
+    """
+    for name, why in REFUSED_STATEMENT_FIELDS.items():
+        if name in req:
+            return {"status": "error", "ename": "UnsupportedField",
+                    "evalue": f"/statements does not apply {name!r}: {why}",
+                    "traceback": [f"the request carried {name!r}, which this "
+                                  "route would have ignored; refusing rather "
+                                  "than accepting it silently"]}
+    unknown = sorted(set(req) - KNOWN_STATEMENT_FIELDS
+                     - set(REFUSED_STATEMENT_FIELDS))
+    if unknown:
+        print(f"agent: /statements ignoring unknown field(s): {', '.join(unknown)}",
+              file=sys.stderr, flush=True)
+    return None
+
+

--- a/python/spark_agent/statement_fields.py
+++ b/python/spark_agent/statement_fields.py
@@ -12,7 +12,27 @@ import sys
 # silence that sends someone looking in the wrong place: it already produced a
 # bug filed against databricks-emulator rather than against this agent.
 #
-# REFUSED RATHER THAN IMPLEMENTED, for two different reasons.
+# NAMED IN THE LOG RATHER THAN REFUSED, and that is a correction. The first cut
+# of this refused them outright, on the issue's premise that "nothing sends
+# them any more" -- true of databricks-emulator's MAIN, and false of every
+# databricks-emulator anyone can run. The fix that stopped sending them
+# (databricks-emulator#75) merged 2026-08-21; the newest release, v0.2.9, is
+# from 2026-08-20. So no published image omits them, and `e2e/databricks-chain`
+# -- which pins 0.2.4 -- failed on the refusal within minutes.
+#
+# That is the same version-skew hazard this file already reasons about for
+# UNKNOWN fields, and it applies just as much to fields we know are inert: the
+# emulator and its callers are separate images with independent versions, so a
+# refusal can only be added once every caller that sends the field is gone from
+# the fleet.
+#
+# TO PROMOTE THESE TO REFUSALS: wait for a databricks-emulator release carrying
+# #75, move the pins that consume it (e2e/databricks-chain and any platform
+# repo), then move these entries into a REFUSED map and return an error
+# envelope instead of logging. The reasons below are why they will never be
+# implemented; the log is only how they are reported until then.
+#
+# NEITHER WILL BE IMPLEMENTED, for two different reasons.
 #
 # `env` could be implemented -- `task_scope` already gives each session its own
 # environment -- but Fabric's Livy statement payload is `{"code", "kind"}`
@@ -27,7 +47,7 @@ import sys
 # the Livy session its own SparkSession it lands on the SHARED one and leaks
 # into every other session. `apply_environment` gets away with it only because
 # an Environment binds once per agent and refuses a second.
-REFUSED_STATEMENT_FIELDS = {
+IGNORED_STATEMENT_FIELDS = {
     "env": "set a task's environment in the code it runs, where no agent can "
            "drop it; Fabric's Livy statement payload is {code, kind}",
     "spark_conf": "a statement-level conf is not statement-scoped: it outlives "
@@ -54,19 +74,19 @@ KNOWN_STATEMENT_FIELDS = {
 
 
 def check(req):
-    """Refuse a field this route would silently ignore; name the rest.
+    """Say what this route is dropping. Always returns None -- it never refuses.
 
-    Returns an error envelope, or None to proceed.
+    The harm #349 documents is the SILENCE: a field accepted and discarded,
+    which sent a reader to file a bug against the wrong repository. Saying so
+    fixes that. Refusing would fix it harder and break every caller running a
+    released databricks-emulator, which all of them are.
     """
-    for name, why in REFUSED_STATEMENT_FIELDS.items():
+    for name, why in IGNORED_STATEMENT_FIELDS.items():
         if name in req:
-            return {"status": "error", "ename": "UnsupportedField",
-                    "evalue": f"/statements does not apply {name!r}: {why}",
-                    "traceback": [f"the request carried {name!r}, which this "
-                                  "route would have ignored; refusing rather "
-                                  "than accepting it silently"]}
+            print(f"agent: /statements does NOT apply {name!r} and is dropping "
+                  f"it: {why}", file=sys.stderr, flush=True)
     unknown = sorted(set(req) - KNOWN_STATEMENT_FIELDS
-                     - set(REFUSED_STATEMENT_FIELDS))
+                     - set(IGNORED_STATEMENT_FIELDS))
     if unknown:
         print(f"agent: /statements ignoring unknown field(s): {', '.join(unknown)}",
               file=sys.stderr, flush=True)

--- a/python/tests/test_statement_fields.py
+++ b/python/tests/test_statement_fields.py
@@ -7,11 +7,15 @@ bug against databricks-emulator rather than against this agent.
 
 Two rules, and the asymmetry between them is the design:
 
-  * a field we KNOW is inert is refused by name, so a caller learns at the
-    first request instead of from missing behaviour later;
-  * a field we simply do not recognise is logged and ignored, because this is
-    an internal protocol between two images that version independently and a
-    newer emulator must be able to talk to an older agent.
+  * a field we KNOW is inert is named in the log with the reason it is
+    dropped, so a caller learns about it instead of guessing;
+  * a field we simply do not recognise is logged too, more briefly.
+
+NOTHING IS REFUSED, and the first cut of this got that wrong. It returned an
+error envelope for `env` and `spark_conf` on the issue's premise that nothing
+sends them -- true of databricks-emulator's main, false of every release of it.
+`e2e/databricks-chain` pins 0.2.4, which sends both, and failed within minutes.
+The refusal can only be added once no caller in the fleet still sends them.
 """
 import sys
 from pathlib import Path
@@ -24,25 +28,28 @@ def test_a_plain_statement_is_accepted():
     assert sf.check({"code": "1 + 1", "kind": "python", "session": "s1"}) is None
 
 
-def test_env_is_refused_by_name_and_says_where_to_put_it():
-    got = sf.check({"code": "x", "env": {"LAKEHOUSE_ID": "contoso"}})
-    assert got is not None and got["status"] == "error"
-    assert got["ename"] == "UnsupportedField"
-    assert "env" in got["evalue"]
-    # The refusal has to be actionable, or it just moves the confusion.
-    assert "in the code it runs" in got["evalue"]
+def test_env_is_named_in_the_log_with_where_to_put_it_instead(capsys):
+    assert sf.check({"code": "x", "env": {"LAKEHOUSE_ID": "contoso"}}) is None
+    err = capsys.readouterr().err
+    assert "env" in err and "does NOT apply" in err
+    # Actionable, or it just moves the confusion somewhere else.
+    assert "in the code it runs" in err
 
 
-def test_spark_conf_is_refused_because_it_cannot_be_statement_scoped():
-    got = sf.check({"code": "x", "spark_conf": {"spark.sql.shuffle.partitions": "1"}})
-    assert got is not None and got["ename"] == "UnsupportedField"
-    assert "outlives the statement" in got["evalue"]
+def test_spark_conf_says_why_it_cannot_be_statement_scoped(capsys):
+    assert sf.check({"code": "x", "spark_conf": {"spark.sql.shuffle": "1"}}) is None
+    assert "outlives the statement" in capsys.readouterr().err
 
 
-def test_a_refusal_names_the_field_the_caller_actually_sent():
-    for field in sf.REFUSED_STATEMENT_FIELDS:
-        got = sf.check({"code": "x", field: {}})
-        assert field in got["evalue"], f"{field} refusal does not name it"
+def test_neither_inert_field_fails_the_statement(capsys):
+    """THE REGRESSION THAT REACHED CI. Every released databricks-emulator sends
+    both (v0.2.4 through v0.2.9); the fix that stops sending them merged after
+    the last release. Returning an error envelope here failed
+    `e2e/databricks-chain` outright."""
+    for field in sf.IGNORED_STATEMENT_FIELDS:
+        assert sf.check({"code": "x", field: {"a": "b"}}) is None, (
+            f"{field} was refused; every released databricks-emulator sends it")
+        assert field in capsys.readouterr().err, f"{field} was dropped in silence"
 
 
 def test_a_field_the_route_reads_is_not_reported_as_unknown(capsys):

--- a/python/tests/test_statement_fields.py
+++ b/python/tests/test_statement_fields.py
@@ -1,0 +1,107 @@
+"""What `/statements` refuses, and what it merely notes.
+
+#349: the route accepted `env` and `spark_conf` and applied neither, returning
+`{"status":"ok"}` with the field on the floor. Nothing sent them by the time it
+was filed — the harm was the SILENCE, which had already sent a reader to file a
+bug against databricks-emulator rather than against this agent.
+
+Two rules, and the asymmetry between them is the design:
+
+  * a field we KNOW is inert is refused by name, so a caller learns at the
+    first request instead of from missing behaviour later;
+  * a field we simply do not recognise is logged and ignored, because this is
+    an internal protocol between two images that version independently and a
+    newer emulator must be able to talk to an older agent.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+import statement_fields as sf  # noqa: E402, I001
+
+
+def test_a_plain_statement_is_accepted():
+    assert sf.check({"code": "1 + 1", "kind": "python", "session": "s1"}) is None
+
+
+def test_env_is_refused_by_name_and_says_where_to_put_it():
+    got = sf.check({"code": "x", "env": {"LAKEHOUSE_ID": "contoso"}})
+    assert got is not None and got["status"] == "error"
+    assert got["ename"] == "UnsupportedField"
+    assert "env" in got["evalue"]
+    # The refusal has to be actionable, or it just moves the confusion.
+    assert "in the code it runs" in got["evalue"]
+
+
+def test_spark_conf_is_refused_because_it_cannot_be_statement_scoped():
+    got = sf.check({"code": "x", "spark_conf": {"spark.sql.shuffle.partitions": "1"}})
+    assert got is not None and got["ename"] == "UnsupportedField"
+    assert "outlives the statement" in got["evalue"]
+
+
+def test_a_refusal_names_the_field_the_caller_actually_sent():
+    for field in sf.REFUSED_STATEMENT_FIELDS:
+        got = sf.check({"code": "x", field: {}})
+        assert field in got["evalue"], f"{field} refusal does not name it"
+
+
+def test_a_field_the_route_reads_is_not_reported_as_unknown(capsys):
+    """The known set is what makes the log worth reading. If it drifted behind
+    the handler, every ordinary statement would print a line and the one that
+    matters would be lost in it."""
+    sf.check({
+        "code": "x", "kind": "python", "session": "s1", "jobId": "j", "cellIndex": 0,
+        "principal": "p", "workspace": "w", "item": "i", "lakehouse": "l",
+        "schema": "s", "schemas": [], "tables": [],
+        "workspaceId": "w", "lakehouseId": "l", "notebookId": "n",
+        "currentWorkspaceId": "w", "defaultLakehouseId": "l",
+        "currentNotebookId": "n", "currentJobId": "j", "isForPipeline": False,
+    })
+    assert capsys.readouterr().err == ""
+
+
+def test_an_unknown_field_is_logged_and_the_statement_still_runs(capsys):
+    """NOT refused. A newer emulator sending a field an older agent has not
+    heard of must degrade, not fail: these are separate images with independent
+    versions, so a strict schema would turn a rolling upgrade into an outage."""
+    assert sf.check({"code": "x", "somethingNew": 1}) is None
+    assert "somethingNew" in capsys.readouterr().err
+
+
+def test_several_unknown_fields_are_named_together(capsys):
+    sf.check({"code": "x", "bbb": 1, "aaa": 2})
+    err = capsys.readouterr().err
+    assert "aaa, bbb" in err, err
+
+
+def test_the_known_set_matches_what_the_handler_reads():
+    """Derived from the source, so the list and the handler cannot drift.
+
+    A name the handler reads but this set omits makes every request carrying
+    it print a spurious line, and the one line that matters is then lost in
+    the noise.
+    """
+    import re
+
+    agent = (Path(__file__).resolve().parents[1] / "spark_agent" / "agent.py").read_text()
+
+    def reads(text):
+        return set(re.findall(r'req\.get\("([a-zA-Z]+)"', text))
+
+    # The statements branch itself...
+    branch = agent[agent.index('if self.path == "/statements":'):
+                   agent.index('elif self.path == "/register":')]
+    # ...and the helpers it hands the same dict to.
+    helpers = ""
+    for name in ("def remember_context(", "def _apply_onelake_security("):
+        i = agent.index(name)
+        # To the next TOP-LEVEL definition, which may be a class: slicing to
+        # the next "\ndef " raised "substring not found" here, because
+        # _apply_onelake_security is followed by `class Handler`.
+        nxt = re.search(r"^(?:def |class )", agent[i + 1:], re.M)
+        helpers += agent[i:i + 1 + nxt.start()] if nxt else agent[i:]
+
+    missing = (reads(branch) | reads(helpers)) - sf.KNOWN_STATEMENT_FIELDS
+    assert not missing, (
+        f"the handler reads {sorted(missing)} but KNOWN_STATEMENT_FIELDS omits "
+        "them, so every request carrying one logs a spurious line")


### PR DESCRIPTION
Closes #349.

The route accepted `env` and `spark_conf` and applied neither, returning `{"status":"ok"}` with the field on the floor. The harm is the **silence**, which had already sent a reader to file a bug against databricks-emulator rather than against this agent.

## It names them, it does not refuse them

My first version refused both, on the issue's premise that "nothing sends them any more". That is true of databricks-emulator's **main** and false of every databricks-emulator anyone can run: the fix that stops sending them (their #75) merged **2026-08-21**, and the newest release, **v0.2.9, is from 2026-08-20**. `e2e/databricks-chain` pins 0.2.4, which sends both — and CI failed on it within minutes:

```
databricks activity "Dbx": /statements does not apply 'env'
```

That is the same version-skew hazard this change already reasons about for *unknown* fields, and I failed to apply it to the fields I knew were inert. These are separate images with independent versions; a refusal can only be added once no caller in the fleet still sends the field.

So both are logged with the reason they are dropped, and the promotion path is written down: after a databricks-emulator release carrying #75, and after the pins that consume it move, these become refusals.

## Why neither will ever be implemented

- **`env`** — Fabric's Livy statement payload is `{"code", "kind"}`. Implementing it would grow a surface the product lacks. A task's environment belongs in the generated code, where no agent can drop it.
- **`spark_conf`** — a statement-level conf is not statement-scoped: it outlives the statement on the session's Spark session, and on a shared session it leaks into every other one.

## Verification

Nine unit tests in a new `statement_fields.py`, split out because `agent.py` calls `getOrCreate()` at import. One derives the known-field set from `agent.py`'s source so the list cannot drift behind the handler. One pins the regression above: neither inert field may fail a statement, and neither may be dropped in silence.

`e2e/databricks-chain` now passes locally with both fields named in the agent log, and the Livy e2e emits no unknown-field lines.