### PR TITLE
ci: extend the docs lane to codeql and make-targets

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,35 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # The same docs lane ci.yml carries. Nothing in this workflow reads the docs,
+  # so every job is gated; see scripts/docs_only_change.py for what counts.
+  changes:
+    name: Is this change documentation only?
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 scripts/docs_only_change.py --self-test
+      - id: classify
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if ! git rev-parse -q --verify "$BASE^{commit}" >/dev/null; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "base '$BASE' is not a commit here; running everything"
+            exit 0
+          fi
+          git diff --name-status "$BASE...$HEAD_SHA" | python3 scripts/docs_only_change.py
+
   analyze:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     # This repo requires an explicit timeout on every job (see

--- a/.github/workflows/make-targets.yml
+++ b/.github/workflows/make-targets.yml
@@ -54,7 +54,35 @@ permissions:
   contents: read
 
 jobs:
+  # The same docs lane ci.yml carries. Nothing in this workflow reads the docs,
+  # so every job is gated; see scripts/docs_only_change.py for what counts.
+  changes:
+    name: Is this change documentation only?
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 scripts/docs_only_change.py --self-test
+      - id: classify
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if ! git rev-parse -q --verify "$BASE^{commit}" >/dev/null; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "base '$BASE' is not a commit here; running everything"
+            exit 0
+          fi
+          git diff --name-status "$BASE...$HEAD_SHA" | python3 scripts/docs_only_change.py
+
   make-targets:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     name: make targets (${{ matrix.os }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
`ci.yml` has had the docs lane since #364. `codeql.yml` and `make-targets.yml` did not, so a prose-only change still ran CodeQL's analysis and the full make-targets matrix.

This reuses `scripts/docs_only_change.py` exactly as `ci.yml` does. Neither workflow has a job that reads the docs, so every job is gated.

## Context

I have been putting this lane into the rest of the emulator family, and it is this repo's design that is being copied, not the other way round. I started with workflow-level `paths:` filters and had to abandon them: a path filter stops the workflow starting, which takes the docs-reading jobs down with it. This repo's `ci.yml` already said why, and it is the sentence I ended up quoting into five other PRs:

> `witnesses` is deliberately NOT gated: it is the job that reads the docs (parity claims and their witnesses, the sidebar, intra-doc links, the conformance matrix), so it must run on a docs change and on a code change alike. The lane removes the jobs that cannot see the change, not the ones that check it.

Two properties of the classifier that `paths` cannot express, and that I only appreciated after trying:

- **A deleted or renamed page disqualifies the cheap lane**, because `examples_readme_test.go` reads `examples/README.md` and fails on a link to a page that no longer exists. `paths` matches paths, not statuses.
- **Every unknown answers `false`** — empty diff, null-sha `before`, unresolvable range.

The `--self-test` beside the real classification is the part I would have left out and been wrong to.

`security.yml` is untouched here as everywhere: a README with a real token pasted into an example is docs by path and a credential by content.