### PR TITLE
The front page says "unreleased" to readers of a repo with 33 releases

### DIFF
--- a/website/scripts/parity-versions.mjs
+++ b/website/scripts/parity-versions.mjs
@@ -175,7 +175,13 @@ export function collectParity(repo) {
   const liveMd = liveName ? readFileSync(join(docsDir, liveName), 'utf8') : '';
   const liveSlug = liveName ? liveName.replace(/\.md$/, '') : null;
   points.push({ label: version, released: isRelease(version), latest: true, md: liveMd });
-  return { version, liveSlug, points, firstTag: tags[0] ?? null };
+  // latestRelease is the newest v* tag, INDEPENDENT of what this build sits
+  // on. `version` describes the build; this describes the project. A docs
+  // site built from main has a `latest-<sha>` version and still belongs to a
+  // project with releases, and conflating the two made the front page announce
+  // `unreleased` to a reader of a repository with thirty-one of them.
+  return { version, liveSlug, points, firstTag: tags[0] ?? null,
+           latestRelease: tags[tags.length - 1] ?? null };
 }
 
 // The live map's tally, for the landing page. Counted from the same parse the

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -210,7 +210,8 @@ writeFileSync(join(DATA, 'parity-versions.json'), JSON.stringify(parityManifest(
 // after the figure was 120 — a number in prose has no idea a row was added,
 // and the page most likely to be read is the least likely to be re-read. A
 // figure this file cannot compute does not go on the page.
-const stats = { version: PARITY.version, parity: parityStats(PARITY), docs: names.length };
+const stats = { version: PARITY.version, latestRelease: PARITY.latestRelease,
+                parity: parityStats(PARITY), docs: names.length };
 // Witness kinds are not equal evidence and the page says so, so they are
 // counted separately: `ci:` is a CI job driving a real third-party client,
 // which is the strongest kind this repo recognises.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -15,10 +15,32 @@ const base = import.meta.env.BASE_URL;
 const repo = 'https://github.com/calvinchengx/fabric-emulator';
 const p = stats.parity;
 const w = stats.witnesses ?? {};
-// A release build stamps `v0.33.0`; between releases it is `latest-<sha>`, and
-// the pill says so rather than implying a release nobody cut.
+// A release build stamps `v0.33.0`; between releases it is `latest-<sha>`.
+//
+// TWO DIFFERENT FACTS, and the pill used to collapse them. `version` describes
+// THIS BUILD; `latestRelease` describes the PROJECT. When the docs are built
+// from main -- which is almost always, because they publish on push -- the
+// first is `latest-<sha>` and the pill read `unreleased`. To anyone landing on
+// the front page that says "nobody has cut a release of this", of a repository
+// with a long tag history. The build being unreleased and the project being
+// unreleased are not the same claim.
+//
+// So the pill leads with the release when there is one, and says plainly that
+// the docs run ahead of it. Only a project with no tags at all says nothing.
 const released = /^v\d+\.\d+\.\d+$/.test(stats.version);
-const releaseUrl = released ? `${repo}/releases/tag/${stats.version}` : `${repo}/releases`;
+const latestRelease = stats.latestRelease ?? null;
+const onLatest = released && stats.version === latestRelease;
+const pillVersion = released ? stats.version : latestRelease;
+const releaseUrl = pillVersion ? `${repo}/releases/tag/${pillVersion}` : `${repo}/releases`;
+// What the trailing clause says, in order of what the reader most needs:
+//   on the tag        -> what you get
+//   ahead of the tag  -> the release, and that these docs are newer
+//   no tags at all    -> the honest "unreleased"
+const pillNote = onLatest || released
+  ? 'one binary, one compose file'
+  : latestRelease
+    ? `latest release \u00b7 docs built from ${stats.version}`
+    : `building on ${stats.version}`;
 const num = (n) => (typeof n === 'number' ? n.toLocaleString('en') : '—');
 ---
 <!doctype html>
@@ -156,8 +178,8 @@ footer a{text-decoration:none}
   <div class="wrap">
     <p class="eyebrow">Fabric Emulator</p>
     <a class="release-pill" href={releaseUrl}>
-      <span>{released ? stats.version : 'unreleased'}</span>
-      {released ? 'one binary, one compose file' : `building on ${stats.version}`} &rarr;
+      <span>{pillVersion ?? 'unreleased'}</span>
+      {pillNote} &rarr;
     </a>
     <h1>Run your Fabric work on a laptop. Then prove it behaves.</h1>
     <p>A local <b>Microsoft Fabric</b>: the control plane, OneLake, and engines that genuinely


### PR DESCRIPTION
The hero pill read **`unreleased`** on a repository with 33 tags.

It collapsed two different facts. `version` describes **this build**; whether the project has releases is a separate question — and the pill answered the second with the first. Since the docs publish on push, the version is almost always `latest-<sha>` rather than a tag, so the pill almost always said `unreleased`. To someone landing on the front page, that reads as *nobody has cut a release of this software*.

`latestRelease` is now collected alongside `version`, and the pill leads with it:

```
v0.33.0 · latest release · docs built from latest-8d99271
```

It also links to that release rather than the generic releases index — one fewer click to the thing it names.

**The version string is unchanged and was never the problem.** `latest-<sha>` is the honest description of a build between tags, and the reasoning for preferring it over `git describe`'s `v0.2.0-2-gb1e3520` (which reads like a release nobody cut) still stands.

Four states, all checked:

| build | pill |
| --- | --- |
| on the newest tag | `v0.33.0` — one binary, one compose file |
| on an older tag | `v0.30.0` — one binary, one compose file |
| ahead of a tag | `v0.33.0` — latest release · docs built from `latest-8d99271` |
| no tags at all | `unreleased` — building on `latest-abc1234` |

The last row is why the word stays in the code: for a project with no releases it is the truth.
