### PR TITLE
fix: give codeql.yml a permissions floor, and make the next one impossible to forget

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,19 @@ on:
   schedule:
     - cron: '31 7 * * 1' # weekly, Monday 07:31 UTC (parity with Default setup)
 
+# THE FLOOR FOR EVERY JOB HERE, as every other workflow in this repo declares.
+# `analyze` carried its own block and `changes` carried none, so `changes` ran
+# with whatever the repository default grants -- which CodeQL's own `actions`
+# pack flagged on this very file (actions/missing-workflow-permissions). A job
+# that checks out the tree and diffs it needs to read contents and nothing else.
+#
+# Workflow-level rather than a second job-level block, so a job added tomorrow
+# inherits the floor instead of silently getting the default. `analyze` keeps
+# its own block: a job-level `permissions` replaces this wholesale, and it needs
+# security-events: write to upload SARIF.
+permissions:
+  contents: read
+
 # Superseding a PR run is free money. Superseding a main run is not: a cancelled
 # CodeQL job still uploads its SARIF, flagged `unsuccessful execution` with zero
 # results, and that errored analysis becomes the newest one for its category —

--- a/scripts/check_workflow_concurrency.py
+++ b/scripts/check_workflow_concurrency.py
@@ -43,6 +43,17 @@ to `gh pr checks`. The timeouts were added to all 47 jobs in one pass; nothing
 stopped the 48th from arriving without one, which is the same
 maintained-by-attention coupling this file already exists to remove.
 
+THIRD INVARIANT: EVERY WORKFLOW DECLARES A TOP-LEVEL `permissions:` BLOCK.
+Without one a job gets whatever the repository default grants, which is a
+write-scoped token for a job that only reads. CodeQL's `actions` pack found the
+one file that lacked it -- codeql.yml, whose `analyze` job carried its own block
+while its `changes` job carried none and therefore inherited the default. Every
+other workflow already declared one, which is precisely the shape the paragraph
+above describes: an invariant established in one pass, with nothing to stop the
+next arrival from missing it. Top-level rather than per-job, so a job added
+tomorrow inherits a floor instead of the default; a job needing more still
+overrides it, as `analyze` does for `security-events: write`.
+
 Usage:
     check_workflow_concurrency.py     exit non-zero describing any divergence
 """
@@ -53,6 +64,11 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github" / "workflows"
 COUPLED = ("ci.yml", "make-targets.yml")
+
+# A top-level `permissions:` block. Anchored at column 0 for the same reason the
+# concurrency pattern is: a job-level block is indented, and matching one would
+# report a floor that does not exist.
+_PERMISSIONS = re.compile(r"^permissions:\s*$", re.MULTILINE)
 
 # A top-level `concurrency:` block and its two keys. Anchored at column 0 so a
 # job-level concurrency block (indented) is never mistaken for the workflow's.
@@ -191,6 +207,15 @@ def main():
     except ConcurrencyUnreadable as exc:
         problems.append(str(exc))
 
+    # A workflow with no floor hands every job in it the repository default.
+    unscoped = [path.name for path in sorted(WORKFLOWS.glob("*.yml"))
+                if not _PERMISSIONS.search(path.read_text(encoding="utf-8"))]
+    if unscoped:
+        problems.append(
+            f"{len(unscoped)} workflow(s) declare no top-level `permissions:`, so every "
+            f"job in them takes the repository default rather than a floor:\n    "
+            + "\n    ".join(unscoped))
+
     if problems:
         print("check_workflow_concurrency: " + "\n\n".join(problems))
         print(f"\n{a} and {b} together are what \"main is green\" means; a verdict from "
@@ -201,7 +226,8 @@ def main():
                 for p in sorted(WORKFLOWS.glob("*.yml")))
     print(f"check_workflow_concurrency: {a} and {b} agree "
           f"(group {expr_a}, cancel-in-progress {cancel_a}); "
-          f"all {total} jobs declare timeout-minutes")
+          f"all {total} jobs declare timeout-minutes; "
+          f"all {len(list(WORKFLOWS.glob('*.yml')))} workflows declare top-level permissions")
     return 0
 
 


### PR DESCRIPTION
Closes CodeQL alert [#72](https://github.com/calvinchengx/fabric-emulator/security/code-scanning/72) (`actions/missing-workflow-permissions`), which landed on `codeql.yml` itself.

**The finding.** `analyze` carried its own `permissions` block; `changes` carried none, so it ran with whatever the repository default grants. It checks out the tree and diffs it — `contents: read` and nothing else.

**Top-level, not a second job-level block.** Every other workflow here already declares one that way, and a floor is inherited by a job added tomorrow where a per-job block is not. `analyze` keeps its own: a job-level `permissions` replaces the workflow's wholesale, and it needs `security-events: write` to upload SARIF.

**The second half is the point.** `check_workflow_concurrency.py`'s docstring already argues this case for timeouts — *"The timeouts were added to all 47 jobs in one pass; nothing stopped the 48th from arriving without one, which is the same maintained-by-attention coupling this file exists to remove."* Permissions were in exactly that state: present on ten workflows out of eleven, held there by attention, and the gap found by a scanner rather than by the repo. It is now a third invariant in the same script, reported in the same success line.

```
check_workflow_concurrency: ci.yml and make-targets.yml agree (…); all 89 jobs
declare timeout-minutes; all 11 workflows declare top-level permissions
```

**Checked in both directions**, not on the exit code alone — with the block removed it fails naming the file:

```
1 workflow(s) declare no top-level `permissions:`, so every job in them takes
the repository default rather than a floor:
    codeql.yml
```

Only `analyze`'s effective permissions matter for CodeQL itself, and they are unchanged (verified by parsing the YAML: `security-events: write, packages: read, actions: read, contents: read`).