### PR TITLE
A way back from the docs to the landing page.

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -27,6 +27,10 @@ export default defineConfig({
     starlight({
       title: 'Fabric Emulator',
       components: {
+        // A back-link to the landing page beside the site title. The
+        // component explains why it cannot live in the header icon row
+        // or the sidebar, and computes its href from the configured base.
+        SiteTitle: './src/components/SiteTitle.astro',
         Head: './src/components/Head.astro',
         // Top nav: the parity version picker, rendered beside the search box.
         // Search occupies the header's un-gated middle slot, so the picker stays

--- a/website/src/components/SiteTitle.astro
+++ b/website/src/components/SiteTitle.astro
@@ -1,0 +1,69 @@
+---
+// A back-link to this project's landing page, beside the site title.
+//
+// WHY IT EXISTS. The landing page links into the docs; nothing linked back, so
+// a reader who followed one of those links had the browser's Back button and
+// nothing else. Measured across the family: eleven repositories publish a
+// Starlight site and nine of them had no way back at all.
+//
+// WHY BESIDE THE TITLE. Not in the header's icon row, which is
+// `sl-hidden md:sl-flex` -- anything there vanishes on a narrow viewport, which
+// is exactly where a reader is most likely to be lost. The title renders at
+// every width, so a sibling of the title does too. Not in the sidebar either:
+// among a list of document titles, one more link reads as one more document.
+//
+// WHY THE HREF IS COMPUTED. `import.meta.env.BASE_URL` is the base Astro was
+// configured with, so this file is identical in every repository and cannot
+// drift from the site it belongs to. Two shapes exist in this family and both
+// resolve correctly:
+//
+//   base /repo/docs/  ->  /repo/          the landing page took the root
+//   base /repo/       ->  /repo/          docs sit at the root beside it
+//
+import Default from '@astrojs/starlight/components/SiteTitle.astro';
+
+const base = import.meta.env.BASE_URL;
+const home = base.replace(/docs\/?$/, '') || '/';
+---
+
+<div class="title-row">
+  <a class="site-home" href={home} aria-label="Back to the project home page">
+    <span aria-hidden="true">&larr;</span><span class="label">Home</span>
+  </a>
+  <Default><slot /></Default>
+</div>
+
+<style>
+  .title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 0;
+  }
+  .site-home {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    flex-shrink: 0;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 999px;
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+    line-height: 1.4;
+    text-decoration: none;
+  }
+  .site-home:hover {
+    background: var(--sl-color-gray-6);
+    border-color: var(--sl-color-accent);
+    color: var(--sl-color-accent-high);
+  }
+  /* On the narrowest screens the arrow alone carries it, so the site title
+     keeps the room it needs. */
+  @media (max-width: 30rem) {
+    .site-home .label {
+      display: none;
+    }
+  }
+</style>


### PR DESCRIPTION
The landing page links into the docs; nothing linked back. A reader who followed one of those links had the browser's Back button and nothing else.

This is `data-agent-service`'s `SiteTitle.astro`, already landed in `emulators`, `snowflake-emulator` and `azure-apim-emulator`.

## Where it goes, and why not elsewhere

Beside the site title, rendered at every width. **Not** in the header's icon row, which is `sl-hidden md:sl-flex`, so anything there vanishes on a narrow viewport, which is exactly where a reader is most likely to be lost. **Not** in the sidebar: among a list of document titles, one more link reads as one more document.

## The href is computed, not written

`import.meta.env.BASE_URL` is the base Astro was configured with, so this file is **byte-identical in every repository** and cannot drift from the site it belongs to. It resolves correctly for both shapes the family has used:

| configured base | resolves to |
|---|---|
| `/repo/docs/` | `/repo/` |
| `/repo/` | `/repo/` |

That mattered while this family was mid-migration to `/docs/`; it means this change is unaffected by whether a repo has moved yet.

## Verification

Built, and the **rendered HTML** counted rather than the source.

**100 Starlight pages, every one carrying the link, all pointing at `/fabric-emulator/`.**

**Pages without the link: 5 redirect stubs, plus `src/pages/index.astro`, a custom Astro page rather than a Starlight one. It is the file another session is editing right now, so I left it alone; it means /fabric-emulator/docs/ itself still has no way back.**