### PR TITLE
ci: ruff wants an explicit strict= on zip

### DIFF
--- a/scripts/build_landing_data.py
+++ b/scripts/build_landing_data.py
@@ -145,7 +145,7 @@ def engine_matrix() -> dict:
         if not columns or len(cells) - 1 != len(columns):
             continue
         probes += 1
-        for name, cell in zip(columns, cells[1:]):
+        for name, cell in zip(columns, cells[1:], strict=True):
             passes[name] = passes.get(name, 0) + (1 if cell.startswith("✅") else 0)
     if not probes:
         raise SystemExit(


### PR DESCRIPTION
#368 landed with `ruff check` failing on main:

```
scripts/build_landing_data.py:148
    for name, cell in zip(columns, cells[1:]):
help: Add explicit value for parameter `strict=`
```

`strict=True` rather than `False`. The row's width is already checked two lines above (`len(cells) - 1 != len(columns)` skips the row), so strict can never fire as the code stands. Saying `True` states that invariant instead of leaving silent truncation as the behaviour if that check is ever relaxed, which is the failure mode the rule exists to catch.

`ruff check .` passes. The guard itself still refuses to run without `site-stats.json`, which is the Astro build's output, so its ordering requirement is intact.

My subagent wrote that script and I merged #368 without running the linter over it. The docs lane means a `scripts/` change correctly runs the full suite, which is how this surfaced.