### PR TITLE
fix: a failure message must not raise while reporting the failure

### DIFF
--- a/python/tests/test_build_landing_data.py
+++ b/python/tests/test_build_landing_data.py
@@ -114,10 +114,45 @@ def sources(tmp_path, monkeypatch):
         if write_stats:
             site_stats.write_text(json.dumps(stats), encoding="utf-8")
         monkeypatch.setattr(c, "SITE_STATS", site_stats)
-        # Only used to shorten paths in messages; tmp_path is under it now.
-        monkeypatch.setattr(c, "ROOT", tmp_path)
+        # ROOT is deliberately left alone. tmp_path is outside the repo, so
+        # every failure message these provoke names a path ROOT does not
+        # contain, which is the case `shown()` exists to survive.
 
     return build
+
+
+# --- rendering a path inside a failure message -----------------------------
+
+def test_a_path_inside_the_repo_is_shortened():
+    assert c.shown(c.ROOT / "docs" / "witnesses.json") == "docs/witnesses.json"
+
+
+def test_a_path_outside_the_repo_is_shown_whole(tmp_path):
+    # `Path.relative_to` raises for anything outside ROOT, and every caller is
+    # inside a failure message. Without the fallback the branch whose job is to
+    # explain a problem replaces the explanation with a pathlib traceback.
+    outside = tmp_path / "witnesses.json"
+    assert c.shown(outside) == outside.as_posix()
+
+
+def test_a_message_reads_the_same_on_every_platform(monkeypatch):
+    # This suite runs on three operating systems, and `str()` on a Windows path
+    # renders backslashes, so one failure would read two ways depending on the
+    # runner. Driven with pure Windows paths so the case is exercised wherever
+    # this happens to run, rather than only on the platform that has the bug.
+    root = pathlib.PureWindowsPath(r"D:\a\fabric-emulator\fabric-emulator")
+    monkeypatch.setattr(c, "ROOT", root)
+    assert c.shown(root / "docs" / "witnesses.json") == "docs/witnesses.json"
+    assert c.shown(pathlib.PureWindowsPath(r"C:\elsewhere\x.json")) == "C:/elsewhere/x.json"
+
+
+def test_a_failure_message_survives_a_path_outside_the_repo(sources, tmp_path):
+    # The same thing through a real error branch: what a reader gets is the
+    # diagnosis, not a ValueError raised from inside the reporting.
+    sources(witnesses={"_gated": {}})
+    with pytest.raises(SystemExit) as excinfo:
+        c.real_tenant_claims()
+    assert (tmp_path / "witnesses.json").as_posix() in str(excinfo.value)
 
 
 # --- the check half: every case is a page it must refuse -------------------
@@ -208,6 +243,17 @@ def test_engine_matrix_counts_a_pass_per_column(sources):
     assert matrix["probes"] == 3
     assert matrix["columns"] == ["Sail", "Sail (emulator)", "JVM overlay"]
     assert matrix["passes"] == {"Sail": 1, "Sail (emulator)": 2, "JVM overlay": 3}
+
+
+def test_engine_matrix_skips_a_row_that_does_not_match_the_header(sources):
+    """The width guard is load-bearing, not defensive tidiness.
+
+    `zip(columns, cells[1:], strict=True)` below RAISES on a row with the wrong
+    number of cells, so without the guard one malformed line in a generated
+    matrix takes down the docs deploy with a ValueError instead of publishing.
+    """
+    sources(engine=ENGINE_MD + "| ragged | ✅ |\n")
+    assert c.engine_matrix()["probes"] == 3
 
 
 def test_engine_matrix_refuses_a_matrix_it_could_not_parse(sources):

--- a/scripts/build_landing_data.py
+++ b/scripts/build_landing_data.py
@@ -90,6 +90,29 @@ REQUIRED_STATS = (
 REAL_TENANT = "real-fabric"
 
 
+def shown(path: pathlib.PurePath) -> str:
+    """A path as a reader wants to see it: relative to the repo when it is inside it.
+
+    Every caller is inside a failure message, and `Path.relative_to` RAISES for
+    a path outside ROOT. So the branch whose whole job is to explain a problem
+    replaced the explanation with a ValueError from pathlib. Invisible in
+    production, where these are module constants under ROOT, and that is
+    exactly why nothing had ever executed one of them: the tests moved ROOT to
+    sit above their fixtures, which is the workaround this removes.
+
+    `as_posix()` rather than `str()`, as the sibling checkers already do: on
+    Windows `str()` renders `docs\\witnesses.json`, so one failure would read
+    two ways across the three platforms this suite runs on.
+
+    `PurePath`, not `Path`: nothing here touches the filesystem, and the wider
+    type is what lets the Windows rendering be tested from any platform.
+    """
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
 def read(path: pathlib.Path) -> str:
     """UTF-8 explicitly. The matrices' glyphs are what is being matched, and a
     locale-dependent read turns them into mojibake that matches nothing while
@@ -119,7 +142,7 @@ def real_tenant_claims() -> int:
     data = json.loads(read(WITNESSES))
     claims = {k: v for k, v in data.items() if k != "_gated"}
     if not claims:
-        raise SystemExit(f"FAIL: no claims parsed from {WITNESSES.relative_to(ROOT)}")
+        raise SystemExit(f"FAIL: no claims parsed from {shown(WITNESSES)}")
     return sum(
         1
         for claim in claims.values()
@@ -149,7 +172,7 @@ def engine_matrix() -> dict:
             passes[name] = passes.get(name, 0) + (1 if cell.startswith("✅") else 0)
     if not probes:
         raise SystemExit(
-            f"FAIL: no probes parsed from {ENGINE_MATRIX.relative_to(ROOT)} -- the "
+            f"FAIL: no probes parsed from {shown(ENGINE_MATRIX)} -- the "
             "matrix is not empty, so this is a parsing failure, and the page "
             "would show a dash while looking fine."
         )
@@ -177,7 +200,7 @@ def conformance() -> dict:
                 proven += 1
     if not contracts:
         raise SystemExit(
-            f"FAIL: no contracts parsed from {CONFORMANCE.relative_to(ROOT)}"
+            f"FAIL: no contracts parsed from {shown(CONFORMANCE)}"
         )
     return {"contracts": contracts, "proven": proven, "applicable": applicable}
 
@@ -186,7 +209,7 @@ def site_stats() -> dict:
     """The docs build's own tally, read rather than recomputed."""
     if not SITE_STATS.exists():
         raise SystemExit(
-            f"FAIL: {SITE_STATS.relative_to(ROOT)} does not exist. It is written by "
+            f"FAIL: {shown(SITE_STATS)} does not exist. It is written by "
             "the Astro build (`pnpm --filter fabric-emulator-docs build`), which "
             "must run before this script."
         )
@@ -196,7 +219,7 @@ def site_stats() -> dict:
         for key in path:
             if not isinstance(node, dict) or key not in node:
                 raise SystemExit(
-                    f"FAIL: {SITE_STATS.relative_to(ROOT)} no longer carries "
+                    f"FAIL: {shown(SITE_STATS)} no longer carries "
                     f"{'.'.join(path)}, which the landing page reads. Something in "
                     "website/scripts/sync-docs.mjs stopped counting it."
                 )


### PR DESCRIPTION
Rebased onto #374 and cut down to what that PR does not do. Everything else this branch carried (the permissions invariant test, the coverage for both scripts) landed there first, so it is gone from here.

## The defect

`build_landing_data.py` renders every failure message with `.relative_to(ROOT)`, which **raises** for a path outside the repo. Every caller is inside an error branch, so the branch whose whole job is to explain a problem replaced the explanation with a `ValueError` from pathlib.

It has never fired in production, where these are module constants under `ROOT`. It has also never been exercised, and #374's fixture says why:

```python
# Only used to shorten paths in messages; tmp_path is under it now.
monkeypatch.setattr(c, "ROOT", tmp_path)
```

Moving `ROOT` above the fixtures is the workaround for exactly this. With it removed, 11 of #374's own tests fail against the unfixed script, which is the measure of how much was being papered over.

## The fix

`shown()`, with two deliberate choices beyond the fallback:

- **`as_posix()`, not `str()`.** The three sibling checkers already do this. On Windows `str()` renders `docs\witnesses.json`, so one failure would read two ways across the three platforms this suite runs on. I know because I wrote `str()` first and only Windows CI caught it.
- **`PurePath`, not `Path`.** Nothing in it touches the filesystem, and the wider type is what lets the Windows rendering be driven from any platform, rather than needing a Windows runner to see a regression.

## Also: one uncovered guard

`engine_matrix` skips a row whose width disagrees with the header. That line was uncovered, and it is load-bearing rather than defensive: `zip(columns, cells[1:], strict=True)` **raises**, so without it one malformed line in a generated matrix takes down the docs deploy instead of publishing. Removing the guard now fails a test.

## Verification

```
1216 passed, 1 skipped     coverage 93.76%    build_landing_data.py 99.21%
ruff: All checks passed!   ty: All checks passed!
```

Three controls, each run with `__pycache__` cleared between steps:

| mutation | result |
|---|---|
| fallback removed | 11 tests fail |
| `as_posix()` back to `str()` | 1 test fails, on macOS |
| width guard removed | 1 test fails |