### PR TITLE
docs: draw the favicon, do not spell it

### DIFF
--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,6 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <!-- The same mark the landing page carries inline (site/index.html). Starlight
-       defaults its <link rel="icon"> to /favicon.svg and does NOT check that the
-       file exists, so without this every published doc page 404s its icon. -->
-  <text y=".9em" font-size="90">◱</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Fabric Emulator">
+  <!-- The same ◱ the landing page carries as an inline data: URI, and the same
+       accent (#1a6b52), so the two surfaces read as one site in a tab strip.
+       Drawn as paths rather than a <text>◱</text> glyph: a glyph renders only
+       where the font has it, and a favicon is exactly where that degrades
+       silently to a blank square. Reasoning from data-agent-service 9c280e5,
+       which fixed the same thing. -->
+  <rect width="100" height="100" rx="18" fill="#1a6b52"/>
+  <rect x="22" y="22" width="56" height="56" rx="4" fill="none" stroke="#fff" stroke-width="8"/><rect x="26" y="50" width="24" height="24" fill="#fff"/>
 </svg>


### PR DESCRIPTION
`website/public/favicon.svg` was a `<text>` glyph. A glyph renders only where the font carries the character, and a favicon is exactly where that degrades silently to a blank square, so it is drawn as paths now, on the landing page's own accent.

I shipped the glyph version earlier today when fixing the 404 (every page of all eight family sites was requesting a favicon that did not exist). I matched the landing page's inline data: URI, which was consistent but inherited its font dependency. A peer fixing the same bug in data-agent-service chose paths and said why, in the file:

> Drawn as paths rather than a `<text>◈</text>` glyph: a glyph renders only where the font has it, and a favicon is exactly where that silently degrades to a blank square.

That is the better call, so this adopts it.

### Checked

Parsed as XML rather than grepped: the document is well-formed and contains no `<text>` node, only `rect`/`path`/`circle`/`g`. Rendered at 76px and 16px beside the glyph it replaces, so the mark is recognisably the same shape and still legible at tab size. One full `make docs-build` run as a smoke test, which also re-resolves every absolute reference in every built page.

### Not changed

The landing page still carries an inline glyph data: URI. It has the same font dependency, but I did not ship it and it is one page rather than every docs page. Say the word and it can point at this file instead.