### PR TITLE
Send the preview redirect's target as the constant it is

### DIFF
--- a/scripts/assemble_site.py
+++ b/scripts/assemble_site.py
@@ -217,10 +217,24 @@ def serve(site: Path, port: int) -> int:
             super().__init__(*a, directory=str(site), **kw)
 
         def send_head(self):
-            verb, arg = resolve(self.path)
+            # The target is discarded on purpose -- see the redirect branch.
+            verb, _ = resolve(self.path)
             if verb == "redirect":
                 self.send_response(302)
-                self.send_header("Location", arg)
+                # SITE_PREFIX, not `arg`, and the difference is the point.
+                #
+                # The resolver's ONLY redirect target is that build-time
+                # constant -- the request path selects the branch and
+                # contributes nothing to the value. Sending the constant keeps
+                # the request out of the response header entirely, so there is
+                # no path by which a crafted request could put a newline in it
+                # and start a header of its own. It also reads truthfully: this
+                # redirect goes to one fixed place.
+                #
+                # A future redirect with a COMPUTED target must sanitise it
+                # rather than reinstating `arg` here. `resolve` is pinned by
+                # the self-test below so that change cannot pass unnoticed.
+                self.send_header("Location", SITE_PREFIX)
                 self.end_headers()
                 return None
             if verb == "404":
@@ -297,6 +311,24 @@ def self_test() -> int:
         got = resolve(request)
         ok &= got == expected
         print(f"  {'ok  ' if got == expected else 'FAIL'} {request} -> {got[0]} {got[1]}")
+
+    # The preview server sends SITE_PREFIX for every redirect rather than the
+    # resolver's returned target, which is only correct while the resolver has
+    # exactly one. Pinned here, including against a crafted request: a path
+    # that tried to smuggle a header must never come back as a redirect
+    # target.
+    hostile = (
+        "/",
+        SITE_PREFIX.rstrip("/"),
+        "/%0d%0aX-Injected:%20yes",
+        f"{SITE_PREFIX}..%0d%0a",
+        "/\r\nSet-Cookie: a=b",
+    )
+    for request in hostile:
+        verb, arg = resolve(request)
+        good = verb != "redirect" or arg == SITE_PREFIX
+        ok &= good
+        print(f"  {'ok  ' if good else 'FAIL'} redirect target for {request!r} is fixed")
 
     print("self-test passed" if ok else "self-test FAILED")
     return 0 if ok else 1


### PR DESCRIPTION
Closes CodeQL alert [73](https://github.com/calvinchengx/fabric-emulator/security/code-scanning/73) — `py/http-response-splitting`, medium.

The preview server's redirect branch sent `arg`, the second half of `resolve(self.path)`. CodeQL taints that tuple wholesale, and it is right to — the request path went in.

But the resolver has exactly **one** `return "redirect", …` and its value is `SITE_PREFIX`, a build-time constant. The request path *selects* the branch and contributes nothing to the header. Sending the constant keeps the request out of the response entirely, so no crafted request can put a newline in it and start a header of its own.

It also reads more truthfully: the redirect goes to one fixed place, and `arg` hid that behind a variable.

**The self-test pins the assumption the change depends on.** For every request it tries — including percent-encoded and literal CRLF — a `redirect` verdict must carry `SITE_PREFIX`:

```
ok   redirect target for '/' is fixed
ok   redirect target for '/%0d%0aX-Injected:%20yes' is fixed
ok   redirect target for '/\r\nSet-Cookie: a=b' is fixed
```

A future redirect with a computed target fails that test rather than quietly reintroducing the flow.

Ruff then flagged `arg` as unused — the same fact from the other side: the value no longer reaches the response.

**Scope:** the server binds `127.0.0.1` and previews the assembled docs before publishing. A local tool, not a deployed surface — worth fixing, not worth alarm.