### PR TITLE
One docs home, not two

### DIFF
--- a/python/tests/test_check_docs_links.py
+++ b/python/tests/test_check_docs_links.py
@@ -25,7 +25,7 @@ def site(tmp_path, monkeypatch):
     """A docs tree, an astro config and a sync-docs.mjs we control."""
 
     def build(docs=(), slugs=(), doc_re=r"^(\d{2}-.*|parity)\.md$", readme=None,
-              parity_versions=False, sync_body=None, synthesized="overview"):
+              parity_versions=False, sync_body=None):
         docs_dir = tmp_path / "docs"
         docs_dir.mkdir(exist_ok=True)
         for name, *body in [(d,) if isinstance(d, str) else d for d in docs]:
@@ -33,11 +33,9 @@ def site(tmp_path, monkeypatch):
         config = tmp_path / "astro.config.mjs"
         config.write_text("sidebar: [\n" + "\n".join(f"  {{ slug: '{s}' }}," for s in slugs) + "\n]\n")
         sync = tmp_path / "sync-docs.mjs"
-        # The fixture must model BOTH things the checker derives from the
-        # generator: the published-set regex and the pages it synthesizes.
+        # The one thing the checker still derives from the generator: the
+        # published-set regex. It no longer synthesizes any page by name.
         default_body = f"const DOC_RE = /{doc_re}/;\n"
-        if synthesized:
-            default_body += f"writeFileSync(join(OUT, '{synthesized}.md'), frontmatter + body);\n"
         sync.write_text(sync_body if sync_body is not None else default_body)
         root = tmp_path / "root"
         root.mkdir(exist_ok=True)
@@ -83,26 +81,24 @@ def test_readme_link_into_docs_is_checked(site):
     assert any("README.md links to docs/99-nope.md" in p for p in c.problems())
 
 
-def test_a_synthesized_page_needs_no_sidebar_entry(site):
-    """And the exemption is the generator's, not this test's."""
-    site(docs=["overview.md", "01-quickstart.md"], slugs=["01-quickstart"],
-         doc_re=r"^(\d{2}-.*|parity|overview)\.md$", synthesized="overview")
-    assert c.problems() == []
+def test_a_sidebar_slug_with_no_page_is_reported(site):
+    """Nothing is exempt by name any more, and that is the point.
+
+    The checker used to skip any slug the generator synthesized, because the
+    docs overview had a sidebar entry and no file. The docs root absorbed that
+    page, so the exemption matched nothing -- and an exemption matching nothing
+    passes whatever a future sidebar lists.
+    """
+    site(docs=["01-quickstart.md"], slugs=["01-quickstart", "overview"])
+    problems = c.problems()
+    assert any("overview" in p and "no page" in p for p in problems), problems
 
 
-def test_a_sidebar_slug_for_a_synthesized_page_is_not_dangling(site):
-    """The live case: `overview` is first in the sidebar and has no docs file."""
-    site(docs=["01-quickstart.md"], slugs=["01-quickstart", "overview"], synthesized="overview")
-    assert c.problems() == []
-
-
-def test_a_generator_that_synthesizes_nothing_is_an_error(site):
-    """Empty would mean 'exempt nothing', which reads exactly like 'all fine'."""
-    site(docs=["01-quickstart.md"], slugs=["01-quickstart"],
-         sync_body=r"const DOC_RE = /^(\d{2}-.*)\.md$/;" + "\n")
-    with pytest.raises(SystemExit) as exc:
-        c.problems()
-    assert "synthesizes no page" in str(exc.value)
+def test_a_page_missing_from_the_sidebar_is_still_reported(site):
+    """The other direction, which the exemption also used to soften."""
+    site(docs=["01-quickstart.md", "02-installation.md"], slugs=["01-quickstart"])
+    problems = c.problems()
+    assert any("02-installation" in p for p in problems), problems
 
 
 def test_generated_parity_history_is_exempt_only_with_the_generator(site):

--- a/scripts/assemble_site.py
+++ b/scripts/assemble_site.py
@@ -54,7 +54,14 @@ BASE = "/fabric-emulator/docs/"
 # and now serves the landing page. It is deliberately absent from the oracle
 # below: it does not 404, it shows a different page, which is the point of the
 # change.
-ALIASES: dict[str, str] = {}
+# Old published routes with no doc behind them any more. The empty target
+# means the docs root.
+#
+# `overview` was the docs site's second home until the docs root absorbed it.
+# published-routes.txt records that the route was served, and the oracle below
+# fails the build if a published route would 404 — so it is redirected rather
+# than dropped.
+ALIASES: dict[str, str] = {"overview": ""}
 
 STUB = """<!doctype html>
 <html lang="en">

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -51,19 +51,20 @@ SIDEBAR_SLUG = re.compile(r"slug:\s*'([^']+)'")
 # checker then reported a page that was fine and exempted one that no longer
 # existed, both silently. Derived from the generator instead, so it cannot
 # disagree with what is actually written.
-_SYNTHESIZED = re.compile(r"writeFileSync\(join\(OUT, '([a-z0-9-]+)\.md'\)")
 
 
-def synthesized() -> set[str]:
-    if not SYNC_DOCS.exists():
-        raise SystemExit(f"docs-links: {SYNC_DOCS} not found; cannot derive the synthesized set")
-    found = set(_SYNTHESIZED.findall(SYNC_DOCS.read_text()))
-    if not found:
-        raise SystemExit(
-            f"docs-links: {SYNC_DOCS} synthesizes no page by literal name any more. If that is "
-            "deliberate, remove this derivation; do not leave it matching nothing."
-        )
-    return found
+# NO SYNTHESIZED SET ANY MORE, and its own error message asked for this:
+# "If that is deliberate, remove this derivation; do not leave it matching
+# nothing."
+#
+# sync-docs.mjs used to write one page with no file behind it -- the docs
+# overview -- so a sidebar entry for it had to be exempted from the
+# has-a-page check. The docs root absorbed that page, nothing is synthesized
+# by literal name, and an exemption matching nothing is worse than none: it
+# would pass whatever a future sidebar listed.
+#
+# A page generated in FAMILIES rather than by name is still covered, by the
+# parity-versions rule just below.
 
 # Routes the site GENERATES rather than reads from docs/. `parity-versions.mjs`
 # writes a `parity-history/` index, a `parity-history/changelog`, and one page
@@ -112,11 +113,8 @@ def problems() -> list[str]:
         return found
 
     slugs = set(SIDEBAR_SLUG.findall(CONFIG.read_text()))
-    exempt = synthesized()
     generated = PARITY_VERSIONS.exists()
     for slug in sorted(slugs):
-        if slug in exempt:
-            continue
         if generated and (slug == GENERATED_PREFIX or slug.startswith(GENERATED_PREFIX + "/")):
             continue
         if not (DOCS / f"{slug}.md").exists():
@@ -124,7 +122,7 @@ def problems() -> list[str]:
 
     published = [p for p in sorted(DOCS.glob("*.md")) if published_re.match(p.name)]
     for page in published:
-        if page.stem in exempt or page.stem in slugs:
+        if page.stem in slugs:
             continue
         found.append(f"{page.name} is not in the sidebar, so nothing on the site links to it")
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -17,6 +17,9 @@ export default defineConfig({
     // The parity map dropped its reading-order number (it's a living
     // reference, not a chapter) and now lives at /parity/.
     '/17-parity/': '/fabric-emulator/docs/parity/',
+    // The docs overview WAS this site's second home; the docs root is the
+    // overview now, so the old URL lands there rather than 404ing.
+    '/overview/': '/fabric-emulator/docs/',
   },
   // remarkMermaid turns ```mermaid fences into <pre class="mermaid"> before
   // Expressive Code sees them; src/components/Head.astro renders them client-side.
@@ -52,7 +55,6 @@ export default defineConfig({
         {
           label: 'Getting started',
           items: [
-            { slug: 'overview' },
             { slug: '01-quickstart' },
             { slug: '02-installation' },
             { slug: '26-platform-setup' },

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -116,80 +116,20 @@ function convert(name) {
   return frontmatter + body;
 }
 
-function writeOverview() {
-  // NO COUNTS HERE, deliberately. This page carried "113 supported capability
-  // claims" long after the number was 120: a figure hardcoded in a generator
-  // is a claim nothing checks, on the one page most likely to be read and
-  // least likely to be re-read. The parity map owns the number and is
-  // regenerated with it; this page owns the invitation to go and look.
-  const body = rewriteLinks(
-    `A local **Microsoft Fabric**: the control plane, OneLake, and engines that ` +
-      `genuinely run your code. Workspaces, items and their CI/CD definitions, ` +
-      `workspace RBAC, git integration, jobs and the 202/poll long-running-` +
-      `operation contract — validating Microsoft Entra bearer tokens against ` +
-      `[entra-emulator](https://calvinchengx.github.io/entra-emulator/) exactly ` +
-      `as real Fabric validates against Entra. The same pipeline runs unmodified ` +
-      `here and against a real tenant (\`FABRIC_TARGET\`).\n\n` +
-      `**It computes.** \`docker compose up\` attaches Sail and a SQL Server ` +
-      `sidecar: a notebook runs on Spark and writes Delta to OneLake, a warehouse ` +
-      `query executes over a real TDS connection, and KQL runs on Microsoft's own ` +
-      `Kusto engine. Microsoft's own tools drive it — \`fabric-cicd\`, the Fabric ` +
-      `CLI, \`dbt-fabric\`, the Terraform provider, the VS Code extension — with ` +
-      `no capacity and no cloud tenant.\n\n` +
-      `:::caution\n**Local development tool only** — intentionally insecure (no ` +
-      `real authorization boundary, self-signed TLS, seeded credentials). Run it ` +
-      `on \`localhost\` only.\n:::\n\n` +
-      `## The gap this is built around\n\n` +
-      `Testing Fabric work against Fabric means a tenant, a capacity and a `+
-      `cloud round trip for every iteration. A capacity is shared and always `+
-      `on, so a pull request cannot have one of its own, and a workspace is `+
-      `shared state, so one run's cleanup is another run's broken fixture. `+
-      `The usual outcome is that the Fabric-specific parts (the deployment `+
-      `pipeline, the OneLake writes, the notebook that only fails on real `+
-      `data) are the parts nobody tests until they break in someone else's `+
-      `run.\n\n` +
-      `This puts the whole tenant on a laptop: up in seconds, offline, torn `+
-      `down and recreated per test. What it cannot do is *assert* that it `+
-      `behaves like Fabric, which is why every supported claim below names `+
-      `the test that witnesses it, and the known differences are `+
-      `[written down](37-runtime-fidelity-gaps.md) rather than left to be `+
-      `discovered.\n\n` +
-      `## Start here\n\n` +
-      `- [Quickstart](01-quickstart.md) — compose up the family, mint a token, create a workspace, write to OneLake\n` +
-      `- [Installation](02-installation.md) — brew, winget, \`go install\`, Docker, compose\n` +
-      `- [Tutorial](28-tutorial-end-to-end.md) — a medallion pipeline end to end, bronze through gold\n` +
-      `- [Running modes](27-running-modes.md) — default stack, lite, JVM overlay, profiles, optional DAX oracle\n` +
-      `- [Architecture](03-architecture.md) — the emulator family, token acceptance, the LRO engine\n\n` +
-      `## What it runs\n\n` +
-      `- [Real compute](14-real-compute.md) — what actually executes, and what is still only a contract\n` +
-      `- [Notebooks and Spark](20-lakesail-engine.md) — Sail as the default engine, JVM Spark as an optional oracle\n` +
-      `- [Warehouse and T-SQL](16-warehouse-tds.md) — a real TDS endpoint over SQL Server, and its [T-SQL parity](29-tsql-parity.md)\n` +
-      `- [OneLake](08-onelake.md) — the ADLS and Blob surfaces, shortcuts, Delta, and [OneLake security](54-onelake-security.md)\n` +
-      `- [Control-plane API](07-control-plane-api.md) — every emulated endpoint, including Fabric Core MCP\n` +
-      `- [Real-Time Intelligence](25-rti-kusto.md) and [Eventstream](51-eventstream-kafka.md) — KQL eventhouses and a Kafka broker\n` +
-      `- [Deployment pipelines](23-deployment-pipelines.md) and [git integration](11-testing-with-fabric-cicd.md) — CI/CD against a local tenant\n\n` +
-      `## How the claims are checked\n\n` +
-      `Parity here is not self-assessed. Every supported capability names the ` +
-      `test that witnesses it, CI fails if one loses its witness, and the ` +
-      `strongest witnesses are third-party clients rather than our own tests.\n\n` +
-      `- [Parity map](parity.md) — every claim, graded, with the witness that holds it\n` +
-      `- [Ecosystem conformance](38-framework-conformance.md) — real vendor and OSS clients driving the emulator in CI\n` +
-      `- [Runtime fidelity gaps](37-runtime-fidelity-gaps.md) — where it still differs from Fabric, stated rather than discovered\n` +
-      `- [Testing](10-testing.md) — freeze the clock, inject faults, force LRO outcomes\n` +
-      `- [Parity history](parity-history.md) — how the map moved, release by release\n\n` +
-      `## Going further\n\n` +
-      `- [Configuration](04-configuration.md) and [TLS and hosts](05-tls-and-hosts.md)\n` +
-      `- [Real Fabric toggle](21-real-fabric-toggle.md) — point the same code at a real tenant\n` +
-      `- [OpenMetadata](22-openmetadata.md) — catalog the emulated estate\n` +
-      `- [Roadmap](13-roadmap.md) — phases P0–P3, R0–R5, S, and what landed after\n`,
-  );
-  // Synthesized here (no /docs source), so it has no "Edit this page"
-  // target. This is the docs OVERVIEW, at /overview/ and first in the
-  // sidebar; the site root is the landing page in src/pages/index.astro.
-  const frontmatter =
-    `---\ntitle: Overview\ndescription: A local Microsoft Fabric — control plane, OneLake, and engines that actually compute — validating real Entra tokens, with every supported claim tied to a named witness.\neditUrl: false\n---\n\n`;
-  writeFileSync(join(OUT, 'overview.md'), frontmatter + body);
-}
+// NO writeOverview() ANY MORE, and this note is here so its absence reads as a
+// decision rather than an omission.
+//
+// The docs site had two homes. `/docs/` is src/pages/index.astro and `/docs/
+// overview/` was synthesized here, and the two said the same thing in two
+// formats: 81 shared ten-word runs, a sidebar whose first entry sent a reader
+// straight from one to the other, and no single place to edit either. The
+// overview's own contribution was a curated index, so those links moved onto
+// the docs root rather than being deleted with it.
+//
+// `/overview/` still resolves — astro.config.mjs redirects it and
+// assemble_site.py keeps the site-root stub, because published-routes.txt
+// records that the route was once served and the assembler fails if a
+// published route would 404.
 
 rmSync(OUT, { recursive: true, force: true });
 mkdirSync(OUT, { recursive: true });
@@ -197,7 +137,6 @@ const names = readdirSync(DOCS_SRC).filter((n) => DOC_RE.test(n)).sort();
 for (const name of names) {
   writeFileSync(join(OUT, name), convert(name));
 }
-writeOverview();
 const info = writeParityHistory(OUT, PARITY, { convertBody });
 // The right-sidebar picker is an Astro component and can't shell out to git, so
 // hand it the same points as a build-time manifest.
@@ -248,7 +187,7 @@ try {
 writeFileSync(join(DATA, 'site-stats.json'), JSON.stringify(stats, null, 2) + '\n');
 
 console.log(
-  `sync-docs: wrote ${names.length} docs + overview to src/content/docs/ ` +
+  `sync-docs: wrote ${names.length} docs to src/content/docs/ ` +
     `(parity ${info.version}; ${info.snapshots.length} tagged snapshot(s); ` +
     `${stats.parity.real} real of ${stats.parity.total} rows)`,
 );

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -169,7 +169,7 @@ footer a{text-decoration:none}
       <a href="#checked">Evidence</a>
       <a href="#start">Run it</a>
       <a href={repo}>GitHub</a>
-      <a class="strong" href={`${base}overview/`}>Documentation &rarr;</a>
+      <a class="strong" href={`${base}01-quickstart/`}>Documentation &rarr;</a>
     </div>
   </div>
 </nav>
@@ -195,7 +195,7 @@ footer a{text-decoration:none}
       says which.</p>
     <div class="cta">
       <a class="btn primary" href={`${base}01-quickstart/`}>Quickstart</a>
-      <a class="btn ghost" href={`${base}overview/`}>Read the docs</a>
+      <a class="btn ghost" href={`${base}01-quickstart/`}>Read the docs</a>
       <a class="btn ghost" href={repo}>Source on GitHub</a>
       <a class="btn ghost" href={`${base}parity/`}>The parity map</a>
     </div>
@@ -251,7 +251,11 @@ footer a{text-decoration:none}
     <h2>How it fits together</h2>
     <p class="lede">One Go binary is the control plane and OneLake. The engines beside it are
       real, unmodified software: Sail for Spark, SQL Server for T-SQL, Microsoft's own Kusto
-      container for KQL, Apache Kafka for Eventstream. No client knows it is not Fabric.</p>
+      container for KQL, Apache Kafka for Eventstream. No client knows it is not Fabric.{' '}
+      <a href={`${base}03-architecture/`}>Architecture</a> takes the same picture apart — the
+      emulator family, how a token is accepted, and the long-running-operation engine — and{' '}
+      <a href={`${base}14-real-compute/`}>real compute</a> separates what genuinely executes from
+      what is still only a contract.</p>
     <figure>
       <svg viewBox="0 0 940 380" width="100%" role="img" aria-label="Architecture: Microsoft's own clients authenticate against entra-emulator, then call the fabric-emulator binary, which serves the control plane, OneLake and the Livy and TDS front doors, and dispatches work to Sail, SQL Server, Kusto and Kafka.">
         <rect class="bx" x="8" y="120" width="150" height="112" rx="10"/>
@@ -425,6 +429,10 @@ footer a{text-decoration:none}
         <a href={`${base}parity-history/`}>history</a> shows how every row moved release by
         release, and <a href={`${base}38-framework-conformance/`}>ecosystem conformance</a>{' '}
         lists the real clients driving it in CI.</p>
+      <p class="lede">To drive the checks yourself: <a href={`${base}10-testing/`}>testing</a>{' '}
+        freezes the clock, injects faults and forces LRO outcomes, and{' '}
+        <a href={`${base}11-testing-with-fabric-cicd/`}>testing with fabric-cicd</a> runs
+        Microsoft's own deployment tool against a local tenant.</p>
     </div>
   </div>
 </section>
@@ -467,7 +475,10 @@ go install {`github.com/calvinchengx/fabric-emulator/cmd/fabric-emulator@latest`
 docker pull ghcr.io/calvinchengx/fabric-emulator:latest</code></pre>
     <p class="lede" style="margin-top:24px">Every option, including the archives and the compose
       files, is in <a href={`${base}02-installation/`}>installation</a>. What each running mode
-      costs in memory and startup time is in <a href={`${base}27-running-modes/`}>running modes</a>.</p>
+      costs in memory and startup time is in <a href={`${base}27-running-modes/`}>running modes</a>.{' '}
+      <a href={`${base}04-configuration/`}>Configuration</a> lists every setting, and{' '}
+      <a href={`${base}05-tls-and-hosts/`}>TLS and hosts</a> covers the certificate and the
+      hostnames clients resolve.</p>
   </div>
 </section>
 
@@ -498,7 +509,7 @@ docker compose up          # or: make up, which adds OpenMetadata and Airflow</c
     <p>Third-party engines and clients are used as published and never modified. Where one has a
       bug, it is logged upstream and routed around rather than patched here, so what passes
       locally is what passes against the real thing.</p>
-    <p><a href={`${base}overview/`}>Documentation</a> ·
+    <p><a href={`${base}01-quickstart/`}>Documentation</a> ·
       <a href={`${base}parity/`}>Parity map</a> ·
       <a href={`${base}13-roadmap/`}>Roadmap</a> ·
       <a href="https://calvinchengx.github.io/entra-emulator/">entra-emulator</a> ·


### PR DESCRIPTION
The docs site had two homes: `/docs/` (`src/pages/index.astro`) and `/docs/overview/` (synthesized by `sync-docs.mjs`). They said the same thing in two formats — **81 shared ten-word runs**, a sidebar whose first entry sent a reader straight from one to the other, and no single place to edit either.

That duplication has a cost on the record: the version pill that read `unreleased` on a repo with 33 tags lived in one of them and not the other.

## The overview was not just duplicate prose

Its bulk was a curated index, and **six docs were reachable from it and from nowhere else** on the root:

`03-architecture` · `04-configuration` · `05-tls-and-hosts` · `10-testing` · `11-testing-with-fabric-cicd` · `14-real-compute`

Those links moved onto the docs root, into the sections they belong to, rather than being deleted with the page. The three links pointing *at* the overview now point at the quickstart — a "Documentation" link on the documentation home is dead weight.

## Old URLs still resolve, both ways in

- `astro.config.mjs` redirects `/overview/` → `/fabric-emulator/docs/`
- `assemble_site.py` keeps the site-root stub, because `published-routes.txt` records the route as once served and the assembler **fails the build** if a published route would 404

Both verified in the built output.

## Two guards retired, one of which asked for it

`check_docs_links` exempted any page the generator synthesized by name. Nothing is synthesized by name now, and its own error message already said:

> If that is deliberate, remove this derivation; do not leave it matching nothing.

An exemption matching nothing passes whatever a future sidebar lists. Three tests covered only that machinery; they are replaced by two pinning the stricter behaviour — a sidebar slug with no page **is** reported, and a page missing from the sidebar **is** reported.

## Verified, not inspected

- assembler oracle: **105 pre-move routes still resolving**
- both `/overview/` paths land on the docs root in `_site`
- all six carried links present in the built page
- `ruff`, `ty`, `docs-links`, and **1351 tests** clean

## Not in scope

`site/index.html` (1,912 words) and `index.astro` (1,981 words) are still two hero landing pages at `/fabric-emulator/` and `/fabric-emulator/docs/`. They share little copy but serve the same purpose, and the duplicated version-pill logic between them is the same class of problem. Worth deciding separately.
