### PR TITLE
docs: lead with Docker, and stop claiming there are no releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ identities), so it could equally point at a real Entra tenant.
 
 | Command | You get |
 |---|---|
-| `docker compose up` | both emulators **plus real engines** — a Spark agent and a SQL Server sidecar, via the auto-loaded [override](docker-compose.override.yml). Livy sessions, notebook cells and the T-SQL/TDS warehouse run for real |
-| `docker compose -f docker-compose.yml up` | the lite, contract-only pair — honest `501`s on the engine surfaces |
+| `docker compose up` | seven services — the emulators **plus real engines**: [Sail](docs/20-lakesail-engine.md) behind the Livy statement agent, and a SQL Server sidecar, via the auto-loaded [override](docker-compose.override.yml). Livy sessions, notebook cells and the T-SQL/TDS warehouse run for real |
+| `docker compose -f docker-compose.yml up` | the lite, contract-only four — honest `501`s on the engine surfaces. Naming the base file is what makes Compose skip the override |
 | `--profile rti` | Microsoft's own KQL engine behind Eventhouse / KQL Database ([docs/25](docs/25-rti-kusto.md)) |
 | `--profile eventstream` | Apache Kafka KRaft behind Eventstream items — needs `-f docker-compose.eventstream.yml` ([docs/51](docs/51-eventstream-kafka.md)). Custom HTTP produce, Lakehouse Delta dest, Reflex job dest. Works on Sail (default) and the JVM overlay |
 | `FABRIC_DAX_URL` | Optional pump in front of `msmdsrv` on a machine you own — not a compose profile ([docs/52](docs/52-msmdsrv-hosts.md)) |
@@ -222,16 +222,17 @@ identities), so it could equally point at a real Entra tenant.
 | `-f docker-compose.spark-jvm.yml` | **swaps** Sail for JVM Spark, buying the RDD API, structured streaming, `OPTIMIZE`/`VACUUM` and Java/Scala UDFs at the cost of image size ([docs/20](docs/20-lakesail-engine.md)) |
 
 Profiles pull nothing unless asked for — but **`make up` asks for `governance`
-on your behalf**, so it starts 12 services rather than 6. `make up PROFILE=`
-gives the lean stack.
+and `airflow` on your behalf**, so it starts 15 services rather than 7.
+`make up PROFILE=` gives the lean stack. (Counts are what `docker compose
+config --services` resolves, not an estimate.)
 
 **How much machine you need.** Give the container runtime **8 GB** for the
-default six, **13 GB** with governance and Airflow, **2 GB** for the lite pair,
-**17 GB** for everything at once. Four cores is ample; six to eight if you run
+default seven, **13 GB** with governance and Airflow, **2 GB** for the
+contract-only four, **17 GB** for everything at once. Four cores is ample; six to eight if you run
 PySpark or warehouse queries.
 
 Those numbers are for *working*, and idle is nowhere near them — a freshly booted
-lite stack is 65 MB, and the whole default six is about 1 GB. The spread is the
+lite stack is 65 MB, and the whole default set about 1 GB. The spread is the
 work, not the container count: Sail costs 36 MB to start and ~1.9 GB to run
 PySpark through. So starting an engine you do not drive is nearly free, and
 [the per-service measurements](docs/27-running-modes.md#what-it-costs-to-run)
@@ -239,11 +240,27 @@ are what to size against.
 
 ## Getting started on Linux, macOS or Windows
 
-The workflow is the same on all three — only the prerequisites differ:
+**Docker is how you run this.** Clone the repo and bring the stack up — the
+compose files *are* the wiring, so the clone is the install:
+
+```bash
+git clone https://github.com/calvinchengx/fabric-emulator
+cd fabric-emulator
+docker compose up
+```
+
+That is seven services with **Sail already attached** — the auto-loaded
+[override](docker-compose.override.yml) gives you a real Spark engine and the
+T-SQL warehouse without a flag. A container runtime with Compose v2 is the
+entire prerequisite list. Then open <https://localhost:9443>.
+
+The `make` targets wrap exactly those commands; they are a convenience, not a
+second way to run things. The workflow is the same on all three platforms —
+only the prerequisites differ:
 
 ```bash
 make doctor   # toolchain, docker context, memory, ports — run this first
-make up       # 12 services incl. OpenMetadata + Airflow; `make up PROFILE=` for the lean 6
+make up       # 15 services incl. OpenMetadata + Airflow; `make up PROFILE=` for the lean 7
 make status   # "stack OK" is the real verdict; `make up` only means containers exist
 ```
 
@@ -264,8 +281,9 @@ make restart  # clean, then up
 make test     # go build, vet and unit tests
 ```
 
-Install the prerequisites once (a container runtime with Compose v2, plus GNU
-Make; Python 3 is optional and only used by `make spark` / `make seed`):
+Install the prerequisites once. Only the container runtime is required —
+GNU Make buys you the targets above, and Python 3 is optional (`make spark`,
+`make seed`):
 
 ```bash
 # Linux

--- a/docs/02-installation.md
+++ b/docs/02-installation.md
@@ -1,44 +1,119 @@
 # 02 — Installation
 
-One static Go binary (pure Go — no CGO, no runtime dependencies), CI-tested on
-Linux, macOS, and Windows.
+**Run this with Docker.** One command brings up the emulated stack wired
+together — the Fabric control plane, a real OneLake data plane, the Entra
+issuer it trusts, a real Spark engine, and the T-SQL warehouse — with the
+issuer alignment already done. That is the supported path and the one every
+example in these docs assumes.
 
-> **Release channels activate at the first tagged release.** Homebrew, winget,
-> the GHCR image, and the archive downloads below publish automatically from
-> `v*` tags; until the first tag lands, install from source (`go install`
-> works today).
+The standalone binary is a real install (see [below](#the-binary-on-its-own)),
+but it is the *emulator process alone*: no engine, no warehouse sidecar, and
+you supply an issuer yourself. Reach for it when you want the CLI or you are
+embedding the control plane in something else — not when you want Fabric.
 
-## macOS — Homebrew
+## Docker Compose — the whole stack
 
 ```bash
-brew install calvinchengx/tap/fabric-emulator
+git clone https://github.com/calvinchengx/fabric-emulator
+cd fabric-emulator
+docker compose up
 ```
 
-## Windows — winget
+The clone is the point: the compose files *are* the wiring, so this is not a
+step you can skip by pulling an image.
 
-> **winget deliberately lags the latest tag.** Homebrew and GHCR publish on
-> every `v*` tag; winget does not. Microsoft's moderation takes days, tags here
-> land several times a day, and a queue of superseded manifest PRs spends
-> moderator attention on versions nobody will install. So the manifest is
-> submitted for chosen releases only — the current one is
-> [PR #410794](https://github.com/microsoft/winget-pkgs/pull/410794), and the
-> command works once it merges. For the newest build, use Homebrew, the GHCR
-> image, `go install`, or the archives below.
+**Sail is already the default engine.** `docker-compose.override.yml` is
+auto-loaded by Compose whenever you do not name files with `-f`, and it attaches
+[LakeSail's Sail](20-lakesail-engine.md) — a Rust Spark-Connect server, no JVM
+anywhere — behind the Livy statement agent, plus a SQL Server sidecar for the
+T-SQL/TDS surface. No extra flag buys you real compute; you already have it
+([14-real-compute.md](14-real-compute.md) is the full account).
+
+Seven services, and what each one publishes:
+
+| Service | Port | What it is |
+|---|---|---|
+| `fabric-emulator` | `9443`, `1433` | control plane, OneLake, and the warehouse TDS surface |
+| `entra-emulator` | `8443` | the issuer whose tokens everything above trusts |
+| `keyvault-emulator` | `8444` | secrets, for pipelines that resolve them |
+| `arm-emulator` | `8445` | the ARM surface behind workspace provisioning |
+| `sail` | `50051` | Spark Connect — PySpark clients can attach directly at `sc://localhost:50051` |
+| `spark-agent` | — | the statement executor the emulator drives for Livy sessions and notebook cells |
+| `sqlserver` | — | the warehouse engine; reached through `fabric-emulator:1433`, not directly |
+
+Then open <https://localhost:9443> and go on to the
+[quickstart](01-quickstart.md).
+
+### Running less, or more
+
+```bash
+# Contract-only: four services, no engines, honest 501s on the Spark and SQL
+# surfaces. Naming the base file explicitly is what makes Compose skip the
+# override -- that is the opt-out mechanism, not a flag.
+docker compose -f docker-compose.yml up
+```
+
+Profiles pull nothing unless asked for. `--profile governance` adds
+OpenMetadata over the same state your pipelines write ([22](22-openmetadata.md));
+`--profile airflow` adds a real Airflow scheduler; `--profile rti` attaches
+Microsoft's own KQL engine ([25](25-rti-kusto.md)); `--profile eventstream`
+plus `-f docker-compose.eventstream.yml` attaches Apache Kafka
+([51](51-eventstream-kafka.md)). `-f docker-compose.spark-jvm.yml` **swaps**
+Sail for JVM Spark, buying the RDD API, structured streaming and JVM UDFs at
+the cost of image size ([20](20-lakesail-engine.md)).
+
+The `make` targets are a convenience wrapper over exactly these commands, not a
+second way to run things — `make up` is `docker compose` with `governance` and
+`airflow` already asked for, which is 15 services rather than 7. Make is
+optional; Docker is not.
+
+```bash
+make help     # every target with a one-line description
+make doctor   # toolchain, docker context, memory, ports
+make status   # "stack OK" is the real verdict -- `up` only means containers exist
+```
+
+### What it costs to run
+
+Give the container runtime **8 GB** for the default seven, **13 GB** with
+governance and Airflow, **2 GB** for the contract-only four, **17 GB** for
+everything at once. Four cores is ample; six to eight if you drive PySpark or
+warehouse queries.
+
+Idle is nowhere near those numbers — a freshly booted contract-only stack is
+65 MB and the default set about 1 GB. The spread is the *work*, not the
+container count: Sail costs 36 MB to start and ~1.9 GB to push PySpark through,
+so an engine you do not drive is nearly free.
+[Per-service measurements](27-running-modes.md#what-it-costs-to-run).
+
+### Prerequisites
+
+A container runtime with Compose v2. That is the whole list for
+`docker compose up`; the `make` targets add GNU Make, and Python 3 is optional
+(`make spark`, `make seed`).
+
+```bash
+# Linux
+curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker "$USER" && newgrp docker
+```
+
+```bash
+# macOS -- Docker Desktop and OrbStack work too
+brew install colima docker docker-compose && colima start --memory 8
+```
 
 ```powershell
-winget install calvinchengx.fabric-emulator
+# Windows -- Git supplies sh.exe and friends; ezwinports supplies make
+winget install Git.Git; winget install ezwinports.make
 ```
 
-## Any platform — go install
+Details that bite per platform — the `docker` group on Linux, the VM memory cap
+and Apple-silicon sidecar constraints on macOS, `sh.exe` and GNU Make on
+Windows — are in [26-platform-setup.md](26-platform-setup.md). `make doctor`
+checks the result on any of them and names what is missing rather than letting
+it surface later as a broken recipe.
 
-```bash
-go install github.com/calvinchengx/fabric-emulator/cmd/fabric-emulator@latest
-```
-
-Needs Go ≥ 1.25. Pure Go all the way down (`modernc.org/sqlite`), so this
-cross-compiles and installs anywhere Go runs.
-
-## Docker
+## One container, without the stack
 
 ```bash
 docker run --rm -p 9443:9443 \
@@ -47,60 +122,36 @@ docker run --rm -p 9443:9443 \
   ghcr.io/calvinchengx/fabric-emulator:latest
 ```
 
-Distroless, multi-arch (amd64/arm64), with a built-in `HEALTHCHECK` (the
-binary probes its own `/health` — no shell in the image). State lives in
-`/data`; mount it to persist.
+Distroless, multi-arch (amd64/arm64), with a built-in `HEALTHCHECK` — the
+binary probes its own `/health`, since there is no shell in the image. State
+lives in `/data`; mount it to persist.
 
-## docker-compose — the emulator family, with real engines by default
+This is the emulator **on its own**: it still needs an issuer to trust, which
+is what the `FABRIC_ENTRA_ISSUER` above points at, and it has no Spark engine
+and no warehouse sidecar. The Spark and SQL surfaces answer `501`.
 
-```bash
-docker compose up
-```
+## The binary on its own
 
-This starts the **whole family** wired together (issuer alignment included):
-entra-emulator (`:8443`), azure-keyvault-emulator (`:8444`), and
-fabric-emulator (`:9443`) — **plus real compute attached by default**: a Spark
-statement-executor agent (native Livy sessions, notebook cell execution) and a
-SQL Server sidecar (the T-SQL/TDS warehouse surface — Warehouse, Lakehouse SQL
-endpoint, Fabric SQL Database). `docker-compose.override.yml` — auto-loaded
-alongside [`docker-compose.yml`](../docker-compose.yml), no flag needed — adds
-those sidecars and their env vars; see [14-real-compute.md](14-real-compute.md).
-`--profile rti` attaches Microsoft's KQL engine; `--profile eventstream`
-plus `-f docker-compose.eventstream.yml` attaches Apache Kafka (Lakehouse
-and Reflex destinations included). An optional `msmdsrv` DAX oracle is
-`FABRIC_DAX_URL` on a machine you own, not a compose profile
-([52](52-msmdsrv-hosts.md)).
-
-To run the same stack explicitly on **LakeSail's Sail** (the default Rust
-Spark-Connect engine, with no JVM; see
-[20-lakesail-engine.md](20-lakesail-engine.md)):
+For the CLI, or to embed the control plane. Same caveats as the single
+container: no engines, and you supply an issuer.
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.compute.yml up
+# macOS / Linux
+brew install calvinchengx/tap/fabric-emulator
 ```
-
-Opt out to the lite, contract-only pair (no heavy sidecars, honest 501s on the
-Spark/SQL surfaces) by naming the base file explicitly, which makes Compose skip
-the override:
 
 ```bash
-docker compose -f docker-compose.yml up
+# Anywhere Go runs -- needs Go >= 1.25
+go install github.com/calvinchengx/fabric-emulator/cmd/fabric-emulator@latest
 ```
 
-This is the recommended way to run the full stack — see the
-[quickstart](01-quickstart.md).
+Pure Go all the way down (`modernc.org/sqlite`) — no CGO and no runtime
+dependencies, so it cross-compiles anywhere and is CI-tested on Linux, macOS
+and Windows.
 
-Prerequisites differ per platform — the Docker group on Linux, the VM memory
-cap and Apple-silicon sidecar constraints on macOS, `sh.exe` and GNU Make on
-Windows. [26-platform-setup.md](26-platform-setup.md) covers all three, and
-`make doctor` verifies the result on any of them.
-
-## Release archives
-
-Tagged releases carry `tar.gz`/`zip` archives per OS/arch plus
-`checksums.txt`: <https://github.com/calvinchengx/fabric-emulator/releases>.
-
-## From source
+Tagged releases also carry `tar.gz`/`zip` archives per OS/arch plus
+`checksums.txt`:
+<https://github.com/calvinchengx/fabric-emulator/releases>. Or build it:
 
 ```bash
 git clone https://github.com/calvinchengx/fabric-emulator
@@ -108,13 +159,20 @@ cd fabric-emulator
 go build ./cmd/fabric-emulator
 ```
 
-## Verify
+> **winget is not available yet.** Manifests have been
+> [submitted](https://github.com/microsoft/winget-pkgs/pulls?q=calvinchengx.fabric-emulator)
+> but none has landed, so `winget install calvinchengx.fabric-emulator` does not
+> work today — the moderation queue moves in days and tags here land several
+> times a day. On Windows, use Docker, `go install`, or the archives.
+
+### Verify
 
 ```bash
 fabric-emulator version      # stamped by the release pipeline; "dev" from source
 fabric-emulator healthcheck  # exit 0 when a local instance is healthy
 ```
 
-The server needs one thing to start: an issuer to trust
+The server needs exactly one thing to start: an issuer to trust
 (`FABRIC_ENTRA_ISSUER` or `-entra-issuer`) — see
-[configuration](04-configuration.md).
+[configuration](04-configuration.md). Compose sets it for you, which is most of
+why it is the recommended path.


### PR DESCRIPTION
**Docker first.** `docker compose up` is the only path that gives you *Fabric* rather than the emulator process on its own, so [02-installation](docs/02-installation.md) now opens with it and the binary installs move below with an explicit note about what they don't include (no engine, no warehouse, bring your own issuer).

### Three things that were wrong

| Claim | Reality |
|---|---|
| "Release channels activate at the first tagged release… until the first tag lands, install from source" | **42 tags**, latest `v0.33.0` |
| winget [PR #410794](https://github.com/microsoft/winget-pkgs/pull/410794) is "the current one" and the command "works once it merges" | That PR is **closed**, and was for `0.10.0`. **No manifest has ever landed** — `winget install` does not work today, which the page now says outright |
| Sail is what you get by adding `-f docker-compose.compute.yml` | `docker-compose.override.yml` is **auto-loaded** and already attaches Sail. `compute.yml` is the explicit restatement for when `-f` disables the auto-load — not the way to get an engine |

### Counts, measured

From `docker compose config --services`, not estimated:

| | README said | Actual |
|---|---|---|
| `make up` | 12 | **15** |
| default | 6 | **7** |
| contract-only | "pair" | **4** |

`make up` also asks for `airflow` as well as `governance`. Make is now framed as a wrapper over compose rather than the way in — a container runtime with Compose v2 is the entire prerequisite list for `docker compose up`.

`check_docs_links`, `check_docs_sidebar` and `check_arch_services` all pass.