### PR TITLE
Credit dbt-fabricspark, and reconcile the ecosystem table with the manifest

### DIFF
--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -577,7 +577,8 @@
       "go:TestHCLivyE2E",
       "go:TestHCSessionPacking",
       "go:TestHCRBACAndScope",
-      "ci:spark-a2"
+      "ci:spark-a2",
+      "ci:dbt-fabricspark"
     ]
   },
   "lookup-activity-onelake-csv-json-parquet-delta": {
@@ -885,7 +886,8 @@
     "section": "Data Engineering (`data-engineering/`)",
     "claim": "Spark session / statement / batch via the **Livy API**",
     "witnesses": [
-      "ci:livy-native"
+      "ci:livy-native",
+      "ci:dbt-fabricspark"
     ]
   },
   "sql-analytics-endpoint-semantics-over-lakehouse-delta": {

--- a/python/tests/test_check_witnesses.py
+++ b/python/tests/test_check_witnesses.py
@@ -16,9 +16,12 @@ The valuable seams are the three the checker gets wrong most cheaply:
     one-level check missed a helper fronting another helper.
 """
 import importlib.util
+import json
 import sys
 import textwrap
 from pathlib import Path
+
+import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -210,3 +213,153 @@ def test_the_actual_repo_passes_strict():
     cw.CI = REPO / ".github" / "workflows" / "ci.yml"
     sys.argv = ["check_witnesses.py", "--strict"]
     assert cw.main() == 0
+
+
+# --- the ecosystem-conformance table -----------------------------------------
+#
+# That section is SKIPPED by the claim scanner, correctly: its rows are clients,
+# not capabilities. Which left its 🟢 marks governed by nothing, and two real
+# client suites sitting outside the manifest — `dbt-fabricspark`, which runs in
+# five CI jobs and was cited by no claim, and `vscode-extension`. The tests
+# below drive the reconciliation from the failing side, because a checker over
+# a table that currently satisfies it passes whether or not it works.
+
+@pytest.fixture(autouse=True)
+def _restore_module_globals():
+    """Every test here rebinds module-level paths and maps on `cw`.
+
+    Autouse and module-wide on purpose: without it the last test to run leaves
+    its tmp_path bound to cw.PARITY, and whichever test is appended next reads
+    a directory that pytest has deleted. Nothing had bitten yet, which is the
+    only reason it was safe to leave.
+    """
+    saved = {name: getattr(cw, name)
+             for name in ("PARITY", "MANIFEST", "ROOT", "CI", "JOB_FOR", "UNCREDITED")
+             if hasattr(cw, name)}
+    yield
+    for name, value in saved.items():
+        setattr(cw, name, value)
+
+
+ECO_DOC = textwrap.dedent("""\
+    # Parity
+
+    ## Platform
+
+    | Fabric feature | Notes | Status |
+    |---|---|---|
+    | Workspaces CRUD | crud | 🟢 Real |
+
+    ## Ecosystem conformance: real OSS/vendor clients as witnesses
+
+    | Real client (pinned) | Surface exercised | Status |
+    |---|---|---|
+    | `some-client` | Control plane | 🟢 `e2e/some-client` — debug→run |
+    | `go-mssqldb` | TDS | 🟢 `internal/server`, `internal/tds` |
+    | `not-yet` | Nothing | 🔴 planned |
+
+    Prose underneath mentioning `e2e/type-map`, which is a probe, not a row.
+    """)
+
+
+def eco(tmp_path, manifest, text=ECO_DOC, job_for=None, uncredited=None):
+    p = tmp_path / "parity.md"
+    p.write_text(text, encoding="utf-8")
+    cw.PARITY = p
+    cw.JOB_FOR = {} if job_for is None else job_for
+    cw.UNCREDITED = {} if uncredited is None else uncredited
+    return cw.ecosystem_gaps(manifest)
+
+
+def cited(*jobs):
+    return {"a-claim": {"witnesses": [f"ci:{j}" for j in jobs]}}
+
+
+def test_a_credited_client_row_is_clean(tmp_path):
+    assert eco(tmp_path, cited("some-client")) == []
+
+
+def test_a_client_row_nothing_cites_is_reported(tmp_path):
+    """The live case. Deleting that CI job would turn nothing red."""
+    problems = eco(tmp_path, cited("something-else"))
+    assert len(problems) == 1
+    assert "e2e/some-client" in problems[0]
+    assert "ci:some-client" in problems[0]
+
+
+def test_a_row_naming_no_e2e_suite_is_not_checked(tmp_path):
+    """`go-mssqldb` is witnessed from internal/, and that is legitimate."""
+    assert all("mssqldb" not in p for p in eco(tmp_path, cited("some-client")))
+
+
+def test_an_unsupported_row_is_not_required_to_have_a_witness(tmp_path):
+    assert all("not-yet" not in p for p in eco(tmp_path, cited("some-client")))
+
+
+def test_prose_below_the_table_is_not_read_as_a_row(tmp_path):
+    """Reading the whole section reported `e2e/type-map` — a probe another
+    suite invokes — as an uncredited witness. A false alarm gets a gate
+    switched off, so the parser takes rows, not section text."""
+    assert all("type-map" not in p for p in eco(tmp_path, cited("some-client")))
+
+
+def test_a_suite_whose_job_is_named_differently_resolves_through_job_for(tmp_path):
+    assert eco(tmp_path, cited("client-job"),
+               job_for={"some-client": "client-job"}) == []
+
+
+def test_a_stale_job_for_entry_is_reported(tmp_path):
+    """A mapping to a job that witnesses nothing: renamed again, or wrong all
+    along. Either way it is a declaration nothing checks, which is the shape of
+    the original bug."""
+    problems = eco(tmp_path, cited("some-client"),
+                   job_for={"some-client": "gone-away"})
+    assert any("JOB_FOR" in p and "gone-away" in p for p in problems)
+
+
+def test_an_exempt_suite_is_not_required_to_be_credited(tmp_path):
+    assert eco(tmp_path, cited("nothing"),
+               uncredited={"some-client": "no graded row covers it"}) == []
+
+
+def test_an_exemption_that_is_now_credited_is_reported(tmp_path):
+    """Exemptions describe the present or they describe the past."""
+    problems = eco(tmp_path, cited("some-client"),
+                   uncredited={"some-client": "stale reason"})
+    assert any("UNCREDITED" in p for p in problems)
+
+
+def test_a_map_without_the_section_is_not_forced_to_have_one(tmp_path):
+    """A synthetic map in a unit test has no ecosystem table, and requiring one
+    is how #367 broke four tests: an invariant its own fixtures could not
+    satisfy. That THIS repo's map carries the section is asserted against the
+    repo, below, where it can be true."""
+    text = ECO_DOC.split("## Ecosystem")[0]
+    assert eco(tmp_path, cited("some-client"), text=text) == []
+
+
+def test_a_table_with_no_suite_at_all_is_an_error_not_a_pass(tmp_path):
+    """Vacuous success is the failure mode this whole file exists for."""
+    text = ECO_DOC.replace("🟢 `e2e/some-client` — debug→run", "🟢 somewhere")
+    with pytest.raises(cw.Unreadable, match=r"vacuous"):
+        eco(tmp_path, cited("some-client"), text=text)
+
+
+def test_the_committed_map_still_has_a_readable_ecosystem_table():
+    """The control the generic tests cannot give: all of them build their own
+    table, so every one would pass with the real section renamed away and the
+    reconciliation quietly disabled."""
+    cw.PARITY = REPO / "docs" / "parity.md"
+    suites = cw.ecosystem_suites()
+    assert len(suites) > 10, suites
+    assert "dbt-fabricspark" in suites
+
+
+def test_the_committed_map_credits_dbt_fabricspark(tmp_path):
+    """The regression this was opened for: Microsoft's Spark adapter drives the
+    Livy high-concurrency surface and was credited to no claim, while the two
+    `ci:dbt-fabric` citations sat on the warehouse rows."""
+    manifest = json.loads((REPO / "docs" / "witnesses.json").read_text(encoding="utf-8"))
+    cites = {w for entry in manifest.values() if isinstance(entry, dict)
+             for w in entry.get("witnesses", [])}
+    assert "ci:dbt-fabricspark" in cites

--- a/scripts/check_witnesses.py
+++ b/scripts/check_witnesses.py
@@ -87,6 +87,42 @@ if hasattr(sys.stdout, "reconfigure"):
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PARITY = ROOT / "docs" / "parity.md"
 MANIFEST = ROOT / "docs" / "witnesses.json"
+
+# The ecosystem-conformance section is SKIPPED by the claim scanner below, and
+# correctly: its rows are clients, not capabilities. But that left its 🟢 marks
+# governed by nothing. A client row could say 🟢 while no claim credited the
+# suite behind it, and the whole point of a third-party witness is that it
+# backs a claim -- delete that CI job and nothing would go red.
+#
+# Found by review, twice over: `e2e/dbt-fabricspark` runs in five CI jobs,
+# is named in that table, and was cited by no claim, while `ci:dbt-fabric`
+# was cited twice. The surface it drives -- Livy High-Concurrency -- rested on
+# three of our own Go tests plus a Spark Connect suite that speaks a different
+# protocol. The strongest available evidence was sitting outside the manifest.
+ECOSYSTEM_SECTION = "Ecosystem conformance: real OSS/vendor clients as witnesses"
+
+# Suites named in that table that deliberately credit no claim. Each needs a
+# REASON, because "not credited" and "credited to nothing yet" look identical.
+# Suites whose CI job is named differently from the directory. Small, explicit
+# and self-policing (a mapping to a job that witnesses nothing is reported),
+# because deriving it from ci.yml went wrong in a way worth recording: the
+# medallion jobs invoke their suites through an `examples/` matrix, not an
+# `e2e/` path, so a reachability scan attributed `e2e/medallion` to whichever
+# unrelated job happened to mention it.
+JOB_FOR = {
+    "spark": "spark-a2",
+    "livy": "livy-native",
+    "eventstream": "eventstream-sail",
+}
+
+UNCREDITED = {
+    "vscode-extension": (
+        "exercises the shared-backend/MWC authoring routes through "
+        "api.powerbi.com, which no row in the graded sections covers. Not a "
+        "missing citation: a missing claim. See issue #385 (the map states no "
+        "denominator) -- the fix is a graded row, and then a citation here."
+    ),
+}
 CI = ROOT / ".github" / "workflows" / "ci.yml"
 
 # Sections that do not make capability claims: the legend, the conformance
@@ -99,6 +135,10 @@ SKIP_SECTIONS = {
     "Emulator-only (no Fabric equivalent — these exist for testing)",
     "Why the boundary sits where it does",
 }
+
+
+class Unreadable(Exception):
+    """The parity map no longer has the shape this checker reads."""
 
 
 def key_for(feature: str) -> str:
@@ -278,6 +318,78 @@ def stale_declarations(declared, gated_used, credited, gated_tests, tests,
     return out
 
 
+def ecosystem_suites() -> list[str]:
+    """The e2e suite named by each ROW of the ecosystem-conformance table.
+
+    Rows, not the section text: the prose underneath mentions `e2e/type-map`,
+    which is a probe another suite invokes rather than a client row of its own.
+    Reading the whole section reported it as an uncredited witness, which is
+    the sort of false alarm that gets a gate switched off.
+    """
+    text = PARITY.read_text(encoding="utf-8")
+    if "## " + ECOSYSTEM_SECTION not in text:
+        # No section, nothing to reconcile. NOT an error here: a synthetic map
+        # in a unit test has no ecosystem table and should not be forced to
+        # grow one — that is how #367 broke four tests, by adding an invariant
+        # its own fixtures could not satisfy. The requirement that THIS repo's
+        # map carries the section belongs to the real-repo test, where it can
+        # actually be true, and where a rename fails loudly.
+        return []
+    section = text.split("## " + ECOSYSTEM_SECTION, 1)[1].split("\n## ", 1)[0]
+    suites = []
+    for line in section.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 3 or "🟢" not in cells[-1]:
+            continue
+        suites += re.findall(r"e2e/([a-z0-9][a-z0-9-]*)", cells[-1])
+    if not suites:
+        raise Unreadable(
+            "the ecosystem-conformance table names no e2e suite in any 🟢 row. The "
+            "row format must have changed, and this check is now vacuous.")
+    return sorted(set(suites))
+
+
+def ecosystem_gaps(manifest: dict) -> list[str]:
+    """Every real-client suite in the ecosystem table must back a claim.
+
+    Plus the two declaration maps police themselves: an alias that resolves to
+    nothing, or an exemption for a suite that IS credited now, is stale and
+    says so. A declaration nothing checks is how the original gap survived.
+    """
+    cited = {w[3:] for entry in manifest.values()
+             if isinstance(entry, dict)
+             for w in entry.get("witnesses", []) or [] if w.startswith("ci:")}
+    suites = ecosystem_suites()
+    if not suites:
+        return []  # no table here; see ecosystem_suites for why that is allowed
+    problems = []
+    for suite in suites:
+        job = JOB_FOR.get(suite, suite)
+        if suite in UNCREDITED:
+            if job in cited:
+                problems.append(
+                    f"e2e/{suite} is listed in UNCREDITED but ci:{job} now witnesses a "
+                    "claim. Drop the exemption; it is describing the past.")
+            continue
+        if job not in cited:
+            problems.append(
+                f"e2e/{suite} is a 🟢 client row but no claim cites ci:{job}. Delete "
+                "that CI job and nothing would go red — credit it on the rows it "
+                "drives, or add it to UNCREDITED with the reason.")
+    # Staleness of the two maps, checked only once a table was actually read:
+    # against a synthetic map that names none of these suites, every entry
+    # would look stale and the checker would fail four unrelated tests.
+    for suite, job in sorted(JOB_FOR.items()):
+        if job in cited or suite in UNCREDITED or suite not in suites:
+            continue
+        problems.append(
+            f"JOB_FOR maps e2e/{suite} to ci:{job}, which witnesses nothing. Either "
+            "the job was renamed again, or the mapping was always wrong.")
+    return problems
+
+
 def main() -> int:
     strict = "--strict" in sys.argv
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8")) if MANIFEST.exists() else {}
@@ -401,6 +513,15 @@ def main() -> int:
         for witness, covered in heavy[:5]:
             print(f"  {witness}: {len(covered)} claims")
 
+    try:
+        eco = ecosystem_gaps(manifest)
+    except Unreadable as exc:
+        eco = [str(exc)]
+    if eco:
+        print("\nEcosystem-conformance suites that back no claim:")
+        for problem in eco:
+            print(f"  {problem}")
+
     if missing:
         print("\nClaims with no manifest entry:")
         for section, feature, key in missing[:20]:
@@ -428,6 +549,11 @@ def main() -> int:
         failed = True
     if strict and unproven:
         print("\nFAIL: a claim needs at least one witness that runs unconditionally.")
+        failed = True
+    if strict and eco:
+        print("\nFAIL: a client named in the ecosystem-conformance table must be the")
+        print("witness for something. That table is the only place several real-client")
+        print("suites are recorded, and nothing reconciled it against the manifest.")
         failed = True
     return 1 if failed else 0
 


### PR DESCRIPTION
Found while answering "why isn't `dbt-fabricspark` used as a witness when `dbt-fabric` is?". It **is** used: its own CI job runs `debug → seed → run → test` over Livy High-Concurrency on Sail, and five jobs exercise it in total. What it was not is a **witness**.

```
docs/witnesses.json:  ci:dbt-fabric        2 citations
                      ci:dbt-fabricspark   0 citations
```

Two consequences:

1. **It was invisible to the gate that exists to protect it.** `check_witnesses.py` exists to catch "a test being renamed or deleted out from under the claim that depended on it". Delete that job and no claim would lose a witness; `--strict` stayed green.
2. **The claim it should back was carried by weaker evidence.** *Livy High-Concurrency (5-REPL) sessions* cited `go:TestHCLivyE2E`, `go:TestHCSessionPacking`, `go:TestHCRBACAndScope` and `ci:spark-a2`. Three are our own tests; `spark-a2` is a real PySpark client but speaks Spark Connect, not the Livy session protocol. The only released third-party client that drives HC end to end was the one not named.

`ci:dbt-fabricspark` now witnesses that row and *Spark session / statement / batch via the Livy API*.

## Why nothing caught it

The ecosystem-conformance table is in `SKIP_SECTIONS`, correctly: its rows are clients, not capabilities. That left its 🟢 marks governed by nothing at all, and it is the only place several real-client suites are recorded. A second hand-maintained list of witnesses that nothing reconciles against the manifest is the pattern this repo has removed elsewhere (`gen_event_kinds.py --check`, the `.PHONY`-derived target list).

`check_witnesses.py` now reconciles them: every 🟢 client row naming an `e2e/` suite must be cited as `ci:<job>` by some claim, or be listed in `UNCREDITED` with a reason. Both declaration maps police themselves, since a declaration nothing checks is exactly how this survived:

- `JOB_FOR` (3 entries, for suites whose CI job is named differently: `spark`→`spark-a2`, `livy`→`livy-native`, `eventstream`→`eventstream-sail`) reports any entry pointing at a job that witnesses nothing.
- `UNCREDITED` reports any entry whose suite **is** credited now, so an exemption cannot outlive its reason.

It found a second one: **`e2e/vscode-extension`** has a CI job and a 🟢 row and witnesses nothing. That is not a missing citation but a missing *claim* — it exercises the shared-backend/MWC authoring routes through `api.powerbi.com`, which no graded row covers. Exempted with that reason, cross-referencing #385.

## Two things I got wrong first, both recorded in comments

- **Deriving suite→job from ci.yml.** The medallion jobs invoke their suites through an `examples/` matrix, not an `e2e/` path, so a reachability scan attributed `e2e/medallion` to whichever unrelated job happened to mention it, and reported `e2e/type-map` as uncredited on the strength of it. Replaced with the three explicit, self-policing entries above.
- **Reading the whole section instead of its rows.** The prose underneath mentions `e2e/type-map`, a probe another suite invokes rather than a client row. A false alarm is how a gate gets switched off.

Also: a missing section returns no problems rather than raising, so a synthetic map in a unit test is not forced to grow an ecosystem table. That is #367's mistake (an invariant its own fixtures could not satisfy, four tests broken) and I nearly repeated it: the first version failed four `test_check_witnesses_verdicts` tests. The requirement that *this* repo's map carries a readable table is asserted against the repo instead, where it can be true.

13 new tests, each driven from the failing side. 1520 passed, coverage 93.86%.