### PR TITLE
Axis A: derive the notebookutils surface from Microsoft's own stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,6 +542,13 @@ jobs:
         with:
           version: "0.11.32"
       - run: uv run --frozen --no-sync python scripts/check_witnesses.py --strict
+      # Axis A of docs/56, derived rather than transcribed: our notebookutils
+      # shim against Microsoft's OWN pinned stubs
+      # (third_party/notebookutils-stubs). Every difference is allowed and each
+      # carries a reason; none may be silent. Catches the case nothing else
+      # would — Microsoft renaming a parameter, which turns a keyword call
+      # written for Fabric into a TypeError here.
+      - run: uv run --frozen --no-sync python scripts/check_notebookutils_surface.py --strict
       # Cheap guard for the constraint the governance e2e discovers the
       # expensive way: a column OpenMetadata refuses costs the whole table.
       - run: uv run --frozen --no-sync python scripts/check_govern_types.py

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ lint: ## ruff + ty over the Python sources — the CI lint job, locally
 
 check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_witnesses.py --strict
+	@$(PY) scripts/check_notebookutils_surface.py --strict
 	@$(PY) scripts/check_govern_types.py
 	@$(PY) scripts/check_example_parity.py
 	@$(PY) scripts/check_example_portability.py

--- a/docs/56-notebook-capability-parity-plan.md
+++ b/docs/56-notebook-capability-parity-plan.md
@@ -71,6 +71,54 @@ source page and that page's own last-updated date.
 
 Graded by contract 2 on both lakehouse backends, every run.
 
+### A second source, and the two Microsoft sources disagree
+
+The table above is transcribed: a person read Learn pages and wrote signatures
+down, with a source URL and read-date per entry. That is the strongest form of
+transcription and it is still transcription, which has two failure modes it
+cannot see past — it cannot notice surface the page does not tabulate, and it
+cannot notice when Microsoft's own implementation says something else.
+
+So Axis A now carries a **second source**, pinned in
+[`third_party/notebookutils-stubs/`](https://github.com/calvinchengx/fabric-emulator/tree/main/third_party/notebookutils-stubs):
+`dummy-notebookutils`, the MIT-licensed stub package Microsoft publishes so
+notebook code can be developed off-cluster. Every function, every parameter
+name, empty bodies. `scripts/check_notebookutils_surface.py` holds all three
+descriptions — the documentation, the stub, and our shim — and runs offline in
+`make check` and the `witnesses` job.
+
+**They disagree, in ten places.** A sample:
+
+| Member | Microsoft's stub | Fabric's docs |
+|---|---|---|
+| `fs.ls` | `dir` | `path` |
+| `fs.exists` | `file` | `path` |
+| `fs.unmount` | `extraOptions` | `extraConfigs` |
+| `notebook.run` | `workspaceId` | `workspace` |
+| `credentials.getToken` | `(audience, name)` | `(audience)` |
+
+The shim follows the documentation, which is right: the stub is Synapse-lineage
+and the pages are Fabric's own. But *right* was not a decision anyone made,
+because the disagreement was invisible. The arbitration is now derived rather
+than declared: where ours matches the docs and the stub differs, the checker
+says so without anyone maintaining a list, so it cannot go stale.
+
+**What only the stub knew.** Fifteen members Microsoft ships that no page
+yielded to transcription, now listed as gaps with reasons. The largest is
+`help()`, which exists on every module of the real package and on none of ours
+— and which Fabric's own `fs` page documents in its opening lines, as prose
+rather than as a row in the method table, which is exactly why a careful
+reading missed it. The rest: `runtime.getCurrentWorkspaceId`, `udf.run`,
+`lakehouse.getDefinition` / `updateDefinition`, `fs.nbResPath` (notebook
+resources, which Axis C lists as absent too), `fs.refreshMounts`.
+
+**Scope needs both sources.** The stub is broader than Fabric: `conf`,
+`connections`, `data` and `fabricClient` are absent from Fabric's module list,
+and Fabric's page says `fabricClient` and `PBIClient` "aren't supported yet".
+Taking the stub alone would have manufactured about twenty phantom gaps. A
+module present in the stub and classified in neither list fails the build
+rather than being guessed at.
+
 ### The eight that existed and would have failed anyway
 
 The finding worth Phase 0, and the reason Phase 2 was not just "write the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,7 +393,11 @@ fail_under = 92
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-extend-exclude = ["e2e/*/target", "website"]
+# third_party is somebody else's artifact, pinned. Linting it would report
+# style in code we must not touch — the sha256 in each PROVENANCE.md describes
+# the file as upstream ships it, and a ruff --fix would break that on the one
+# field whose whole job is to be exact.
+extend-exclude = ["e2e/*/target", "website", "third_party"]
 
 [tool.ruff.lint]
 # Deliberately not the kitchen sink. Each family here has caught something in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -456,6 +456,13 @@ ignore = [
 "docker/**" = ["B007", "SIM115", "RUF005"]
 
 [tool.ty.src]
+# third_party is somebody else's artifact, pinned, and it does not type-check:
+# Microsoft's own notebookutils stub annotates a parameter `parameters: {}`,
+# which is not a valid type expression. That is a fact about their package, not
+# a defect in ours, and the sha256 in its PROVENANCE.md describes the file as
+# they ship it — so it is excluded rather than corrected. ruff excludes it for
+# the same reason (see [tool.ruff]).
+exclude = ["third_party"]
 # PEP 723 uv-script drivers carry their own dependency block and are run with
 # `uv run --script`. Checking them against the lint/test venv reports
 # unresolved imports for packages that exist only in that block (this PR:

--- a/python/tests/test_check_notebookutils_surface.py
+++ b/python/tests/test_check_notebookutils_surface.py
@@ -1,0 +1,323 @@
+"""Tests for the Axis A derivation: our shim against Microsoft's two sources.
+
+THE FAILURE THIS GUARDS AGAINST IS ITS OWN. A surface checker that stops
+matching reports nothing and exits 0, which is indistinguishable from a shim
+that agrees with Microsoft. That is the same defect one tier up from the one it
+exists to catch, so every test drives it with a divergence it must find, and
+the real repository is the control at the end.
+
+The interesting behaviour is the arbitration. There are three descriptions of
+this API — Fabric's documentation, Microsoft's stub package, and our shim — and
+the first two disagree. The rule is that the documentation wins where it
+speaks, and that a disagreement between the two Microsoft sources is DERIVED
+rather than declared, so nobody has to remember to write it down.
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+import textwrap
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+spec = importlib.util.spec_from_file_location(
+    "check_notebookutils_surface", REPO / "scripts" / "check_notebookutils_surface.py")
+assert spec and spec.loader
+c = importlib.util.module_from_spec(spec)
+sys.modules["check_notebookutils_surface"] = c
+spec.loader.exec_module(c)
+
+
+STUB_FS = textwrap.dedent("""\
+    def ls(dir):
+        pass
+
+
+    def cp(src, dest, recurse=False):
+        pass
+    """)
+
+OURS_FS = textwrap.dedent("""\
+    def ls(path):
+        return []
+
+
+    def cp(src, dest, recurse=False):
+        return True
+    """)
+
+# What Fabric's own page says, which is `path` where the stub says `dir`.
+DOC_FS = {"ls": ["path"], "cp": ["src", "dest", "recurse"]}
+
+
+@pytest.fixture(autouse=True)
+def _restore():
+    saved = {name: getattr(c, name) for name in
+             ("STUBS", "SHIM", "DOCS", "FABRIC_MODULES", "NOT_FABRIC_MODULES",
+              "WAIVED", "PLANNED", "EXTRA_PARAMS")}
+    yield
+    for name, value in saved.items():
+        setattr(c, name, value)
+
+
+@pytest.fixture
+def surface(tmp_path):
+    """A stub tree, a shim tree and a documentation reference we control."""
+
+    def build(stub_modules, shim_modules, docs=None, fabric=("fs",), not_fabric=(),
+              waived=None, planned=None, extra=None):
+        stubs, shim = tmp_path / "stubs", tmp_path / "shim"
+        for root, modules in ((stubs, stub_modules), (shim, shim_modules)):
+            root.mkdir(exist_ok=True)
+            for name, body in modules.items():
+                (root / f"{name}.py").write_text(body, encoding="utf-8")
+        reference = {"modules": {
+            f"notebookutils.{module}": {
+                member: ({"params": params} if isinstance(params, list) else params)
+                for member, params in members.items()}
+            for module, members in (docs if docs is not None else {"fs": DOC_FS}).items()}}
+        doc_path = tmp_path / "reference.json"
+        doc_path.write_text(json.dumps(reference), encoding="utf-8")
+        c.STUBS, c.SHIM, c.DOCS = stubs, shim, doc_path
+        c.FABRIC_MODULES = set(fabric)
+        c.NOT_FABRIC_MODULES = dict.fromkeys(not_fabric, "declared out of scope")
+        c.WAIVED = dict(waived or {})
+        c.PLANNED = dict(planned or {})
+        c.EXTRA_PARAMS = dict(extra or {})
+        return c.problems
+
+    return build
+
+
+# --- the control -------------------------------------------------------------
+
+
+def test_a_shim_matching_the_documentation_is_clean_of_failures(surface):
+    """And the stub's disagreement on `ls` is reported, not raised."""
+    failures, notes = surface({"fs": STUB_FS}, {"fs": OURS_FS})()
+    assert failures == []
+    assert any("stub(dir) docs(path)" in n for n in notes)
+
+
+# --- arbitration between the three descriptions ------------------------------
+
+
+def test_the_documentation_wins_over_the_stub(surface):
+    """Following the stub against the docs must FAIL, not pass quietly.
+
+    This is the case that decides whether the check is worth having: the stub
+    is Synapse-lineage and the pages are Fabric's own.
+    """
+    ours = OURS_FS.replace("def ls(path):", "def ls(dir):")
+    failures, _ = surface({"fs": STUB_FS}, {"fs": ours})()
+    assert any("DOCUMENTED signature" in f and "docs(path) ours(dir)" in f
+               for f in failures)
+
+
+def test_a_disagreement_between_the_two_microsoft_sources_needs_no_declaration(surface):
+    """Derived, so it cannot go stale and nobody has to maintain a list."""
+    _, notes = surface({"fs": STUB_FS}, {"fs": OURS_FS})()
+    assert [n for n in notes if n.startswith("stub")]
+
+
+def test_a_member_documented_by_fabric_and_absent_from_ours_fails(surface):
+    failures, _ = surface({"fs": STUB_FS}, {"fs": "def cp(src, dest, recurse=False):\n    pass\n"})()
+    assert any("DOCUMENTED Fabric surface" in f and "fs.ls" in f for f in failures)
+
+
+def test_a_property_in_the_reference_is_not_compared_as_a_function(surface):
+    """`runtime.context` is a dict a notebook reads.
+
+    Comparing it as a callable reported our shim as missing documented surface
+    that it implements as a module attribute — a false alarm, and false alarms
+    are how a gate gets switched off.
+    """
+    docs = {"fs": dict(DOC_FS, context={"params": [], "kind": "property"})}
+    failures, _ = surface({"fs": STUB_FS}, {"fs": OURS_FS}, docs=docs)()
+    assert failures == []
+
+
+# --- surface only the stub knows about ---------------------------------------
+
+
+def test_an_undocumented_stub_member_must_be_classified(surface):
+    stub = STUB_FS + "\n\ndef help(method_name=None):\n    pass\n"
+    failures, _ = surface({"fs": stub}, {"fs": OURS_FS})()
+    assert any("fs.help" in f and "WAIVED" in f and "PLANNED" in f for f in failures)
+
+
+def test_a_waived_member_is_silent(surface):
+    stub = STUB_FS + "\n\ndef mountToDriverNode(source):\n    pass\n"
+    failures, notes = surface({"fs": stub}, {"fs": OURS_FS},
+                              waived={"fs.mountToDriverNode": "Synapse-era"})()
+    assert failures == []
+    assert not [n for n in notes if n.startswith("gap")]
+
+
+def test_a_planned_member_is_reported_and_not_fatal(surface):
+    stub = STUB_FS + "\n\ndef help(method_name=None):\n    pass\n"
+    failures, notes = surface({"fs": stub}, {"fs": OURS_FS},
+                              planned={"fs.help": "we have it on no module"})()
+    assert failures == []
+    assert any(n.startswith("gap") and "fs.help" in n for n in notes)
+
+
+def test_undocumented_surface_we_do_implement_is_held_to_the_stub(surface):
+    """With no page to arbitrate, the stub is the only source there is."""
+    stub = STUB_FS + "\n\ndef nbResPath():\n    pass\n"
+    ours = OURS_FS + "\n\ndef nbResPath(scope):\n    return ''\n"
+    failures, _ = surface({"fs": stub}, {"fs": ours})()
+    assert any("only source there is" in f for f in failures)
+
+
+# --- parameters we add -------------------------------------------------------
+
+
+def test_an_extra_parameter_must_be_declared(surface):
+    """Forgiving is still divergent: a notebook written here can pass an
+    argument that does not exist upstream, and fails there rather than here."""
+    ours = OURS_FS.replace("def ls(path):", "def ls(path, depth=1):")
+    failures, _ = surface({"fs": STUB_FS}, {"fs": ours})()
+    assert any("accepts depth" in f for f in failures)
+
+
+def test_a_declared_extra_parameter_is_reported_and_not_fatal(surface):
+    ours = OURS_FS.replace("def ls(path):", "def ls(path, depth=1):")
+    failures, notes = surface({"fs": STUB_FS}, {"fs": ours},
+                              extra={"fs.ls": "an emulator lever"})()
+    assert failures == []
+    assert any(n.startswith("extra") and "depth" in n for n in notes)
+
+
+# --- the two-source scope rule ----------------------------------------------
+
+
+def test_a_module_in_neither_list_is_refused(surface):
+    failures, _ = surface({"fs": STUB_FS, "conf": "def get(key):\n    pass\n"},
+                          {"fs": OURS_FS})()
+    assert any("neither FABRIC_MODULES nor NOT_FABRIC_MODULES" in f for f in failures)
+
+
+def test_a_module_declared_out_of_scope_is_not_compared(surface):
+    failures, _ = surface({"fs": STUB_FS, "conf": "def get(key):\n    pass\n"},
+                          {"fs": OURS_FS}, not_fabric=("conf",))()
+    assert failures == []
+
+
+def test_a_fabric_module_the_pin_does_not_carry_is_reported(surface):
+    failures, _ = surface({"fs": STUB_FS}, {"fs": OURS_FS}, fabric=("fs", "udf"))()
+    assert any("FABRIC_MODULES lists udf" in f for f in failures)
+
+
+def test_an_out_of_scope_entry_for_a_vanished_module_is_reported(surface):
+    failures, _ = surface({"fs": STUB_FS}, {"fs": OURS_FS}, not_fabric=("gone",))()
+    assert any("NOT_FABRIC_MODULES excludes gone" in f for f in failures)
+
+
+# --- staleness of every declaration -----------------------------------------
+
+
+@pytest.mark.parametrize("declaration", ["waived", "planned", "extra"])
+def test_a_declaration_that_describes_nothing_is_reported(surface, declaration):
+    """The failure mode every map in this repo eventually hits: it reads as
+    current, and the gap it was hiding survives the fix."""
+    failures, _ = surface({"fs": STUB_FS}, {"fs": OURS_FS},
+                          **{declaration: {"fs.cp": "a reason from the past"}})()
+    assert any("fs.cp" in f and ("no longer" in f) for f in failures)
+
+
+# --- the pin itself ----------------------------------------------------------
+
+
+def test_a_missing_pin_is_an_error_not_a_pass(surface, tmp_path):
+    surface({"fs": STUB_FS}, {"fs": OURS_FS})
+    c.STUBS = tmp_path / "not-vendored"
+    with pytest.raises(c.Unreadable, match="vendor_notebookutils_stubs"):
+        c.problems()
+
+
+def test_an_empty_pin_is_an_error_not_a_pass(surface):
+    """A directory with no modules compares nothing and would exit 0."""
+    surface({}, {"fs": OURS_FS})
+    with pytest.raises(c.Unreadable, match="vacuous"):
+        c.problems()
+
+
+def test_a_missing_documentation_reference_is_an_error(surface, tmp_path):
+    surface({"fs": STUB_FS}, {"fs": OURS_FS})
+    c.DOCS = tmp_path / "gone.json"
+    with pytest.raises(c.Unreadable, match="half the check"):
+        c.problems()
+
+
+# --- the real repository -----------------------------------------------------
+
+
+def test_the_committed_shim_is_fully_declared():
+    """Every difference between our shim and Microsoft's is allowed; none may
+    be silent."""
+    assert c.main(["--strict"]) == 0
+
+
+def test_the_derivation_covers_the_whole_documented_surface():
+    """Axis A was graded against one source. If this drops to a handful of
+    members, the derivation has quietly stopped working."""
+    stubs = c.stub_modules()
+    checked = c.FABRIC_MODULES & set(stubs)
+    assert len(checked) >= 8, sorted(checked)
+    assert sum(len(stubs[m]) for m in checked) >= 60
+
+
+def test_the_two_microsoft_sources_are_known_to_disagree():
+    """The finding this was built for, asserted so a future pin that silently
+    agrees with the docs is noticed rather than assumed."""
+    _, notes = c.problems()
+    disagreements = [n for n in notes if n.startswith("stub")]
+    assert len(disagreements) >= 5, notes
+
+
+def test_the_vendored_pin_is_microsofts_and_carries_its_licence():
+    """A golden reference without its licence is one third_party/README
+    forbids, and one nobody can legally keep."""
+    vendored = REPO / "third_party" / "notebookutils-stubs"
+    licence = (vendored / "LICENSE").read_text(encoding="utf-8")
+    assert "MIT" in licence
+    assert "Microsoft Corporation" in licence
+    provenance = (vendored / "PROVENANCE.md").read_text(encoding="utf-8")
+    assert "dummy-notebookutils" in provenance
+    assert "sha256" in provenance
+
+
+# --- the command line, which is what CI actually runs ------------------------
+
+
+def test_a_documented_module_our_shim_lacks_entirely_is_a_failure(surface):
+    failures, _ = surface({"fs": STUB_FS}, {})()
+    assert any("our shim has no such file" in f for f in failures)
+
+
+def test_strict_exits_non_zero_and_says_why(surface, capsys):
+    """The path CI takes. A checker whose failure branch is untested is one
+    nobody has watched fail."""
+    ours = OURS_FS.replace("def ls(path):", "def ls(dir):")
+    surface({"fs": STUB_FS}, {"fs": ours})
+    assert c.main(["--strict"]) == 1
+    printed = capsys.readouterr().out
+    assert "Undeclared:" in printed
+    assert "none may be silent" in printed
+
+
+def test_without_strict_it_reports_and_exits_zero(surface, capsys):
+    ours = OURS_FS.replace("def ls(path):", "def ls(dir):")
+    surface({"fs": STUB_FS}, {"fs": ours})
+    assert c.main([]) == 0
+    assert "Undeclared:" in capsys.readouterr().out
+
+
+def test_an_unreadable_pin_exits_non_zero_from_main(surface, tmp_path, capsys):
+    surface({"fs": STUB_FS}, {"fs": OURS_FS})
+    c.STUBS = tmp_path / "not-vendored"
+    assert c.main(["--strict"]) == 1
+    assert "vendor_notebookutils_stubs" in capsys.readouterr().out

--- a/scripts/check_notebookutils_surface.py
+++ b/scripts/check_notebookutils_surface.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Axis A, derived: our `notebookutils` shim against Microsoft's OWN stubs.
+
+`docs/56` calls Axis A — what `notebookutils.*` exposes, and with which
+parameters — "enumerable, therefore gradeable". It is graded, against
+`e2e/conformance/notebookutils-reference.json`: 44 members transcribed from
+Learn pages by hand, each carrying its source URL and read-date, checked live
+by contract 2 on both backends.
+
+This adds the SECOND source, and it is the one transcription cannot supply:
+`third_party/notebookutils-stubs/` pins the `dummy-notebookutils` wheel
+Microsoft publishes so notebook code can be developed off-cluster. Every
+function, every parameter name, empty bodies, MIT.
+
+WHAT HOLDING BOTH FOUND. **The two Microsoft sources disagree**, and until now
+nothing in this repo could see it. A sample of what the run prints today — the
+count is not written here, because a number in a docstring is a claim nothing
+checks, which is the defect this file exists to remove:
+
+    fs.ls          stub `dir`          docs `path`
+    fs.exists      stub `file`         docs `path`
+    fs.unmount     stub `extraOptions` docs `extraConfigs`
+    notebook.run   stub `workspaceId`  docs `workspace`
+    credentials.getToken   stub `(audience, name)`   docs `(audience)`
+
+The shim follows the documentation, which is the right call — the stub is
+Synapse-lineage and the pages are Fabric's own — but "right call" was not a
+decision anyone made, because the disagreement was invisible. Now it is
+computed on every run, and the classification is DERIVED rather than declared:
+if ours matches the docs and the stub differs, that is a stale stub and this
+says so without a human writing an entry.
+
+WHAT ONLY THE STUB KNOWS. It also carries members the per-module pages did not
+yield to transcription: `help()` on every module (which Fabric's own fs page
+documents in its opening lines), `runtime.getCurrentWorkspaceId`, `udf.run`,
+`lakehouse.getDefinition`. Those are real gaps, listed in PLANNED, and they are
+the answer to "what does a second source buy over a careful reading".
+
+WHAT IT IS NOT. The stub is broader than Fabric: `conf`, `connections`, `data`
+and `fabricClient` are absent from Fabric's module list, and Fabric's page says
+`fabricClient` and `PBIClient` "aren't supported yet". A module classified in
+neither list FAILS rather than being guessed at, which would either manufacture
+~20 phantom gaps or hide a real one.
+
+Usage:
+    check_notebookutils_surface.py            report
+    check_notebookutils_surface.py --strict   exit non-zero on any problem
+"""
+import argparse
+import ast
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+STUBS = ROOT / "third_party" / "notebookutils-stubs" / "notebookutils"
+SHIM = ROOT / "python" / "notebookutils"
+DOCS = ROOT / "e2e" / "conformance" / "notebookutils-reference.json"
+
+# Fabric's documented modules, from
+# https://learn.microsoft.com/en-us/fabric/data-engineering/notebook-utilities
+# (read 2026-08-24). `notebook` appears twice on that page, as "run and
+# orchestration" and "management"; it is one namespace.
+FABRIC_MODULES = {
+    "fs", "notebook", "credentials", "lakehouse", "runtime", "session",
+    "udf", "variableLibrary",
+}
+
+# In the stub, absent from Fabric's list. Each needs the reason, because
+# "not implemented" and "not part of the product" look identical in a diff.
+NOT_FABRIC_MODULES = {
+    "conf": "Synapse-era Spark conf helper; absent from Fabric's module list.",
+    "connections": "Synapse linked-service connections; Fabric uses Connections "
+                   "on the control plane, not a notebook module.",
+    "data": "Synapse-era data helper; absent from Fabric's module list.",
+    "fabricClient": "Fabric's own page says under Known issues that fabricClient "
+                    "and PBIClient 'aren't supported yet'. Implementing it would "
+                    "be surface Fabric does not have.",
+}
+
+# Members the stub has, the documentation does not, and we deliberately do not
+# implement. Synapse inheritance, mostly: one package ships for both products.
+WAIVED = {
+    "credentials.getConnectionStringOrCreds": "linked services are Synapse, not Fabric",
+    "credentials.getFullConnectionString": "linked services are Synapse, not Fabric",
+    "credentials.getPropertiesAll": "linked services are Synapse, not Fabric",
+    "credentials.getSPTokenWithCert": "certificate-based SP auth against a Synapse linked "
+                                      "service or AKV URI; no Fabric equivalent",
+    "credentials.getSPTokenWithCertLS": "as getSPTokenWithCert, via a linked service",
+    "credentials.putSecretWithLS": "linked services are Synapse, not Fabric",
+    "credentials.configureAzureBlobStorageSASBased": "configures a Spark session from a "
+                                                     "Synapse linked service",
+    "credentials.configureADLS2TokenBased": "configures a Spark session from a Synapse "
+                                            "linked service",
+    "credentials.configureADLS2SASBased": "configures a Spark session from a Synapse "
+                                          "linked service",
+    "credentials.configureADLS2AzureKeyVaultBased": "configures a Spark session from a "
+                                                    "Synapse linked service",
+    "credentials.tridentHelp": "internal help text for the Fabric (Trident) build of the "
+                               "real package; not a capability",
+    "credentials.synapseHelp": "internal help text for the Synapse build",
+    "fs.mountToDriverNode": "mounts onto the Spark DRIVER's local filesystem. Sail has no "
+                            "driver node in that sense, and docs/37 records the single "
+                            "mount point this emulator does model",
+    "fs.unmountFromDriverNode": "as mountToDriverNode",
+    "notebook.updateNBSEndpoint": "repoints the package at another notebook-service "
+                                  "endpoint; ours is set by NOTEBOOKUTILS_FABRIC_URL",
+}
+
+# Gaps that ARE surface Microsoft ships. Each is visible in every run rather
+# than living in a diff nobody runs, and removing an entry is how one is closed.
+PLANNED = {
+    "fs.help": "the help() family — Fabric's own fs page opens by documenting "
+               "`notebookutils.fs.help()` as the discovery mechanism, and we have it on "
+               "no module. The transcription did not yield it because it is prose on the "
+               "page rather than a row in the method table",
+    "credentials.help": "see fs.help",
+    "lakehouse.help": "see fs.help",
+    "notebook.help": "see fs.help",
+    "runtime.help": "see fs.help",
+    "session.help": "see fs.help",
+    "udf.help": "see fs.help",
+    "fs.refreshMounts": "mount lifecycle beyond the single mount point docs/37 models",
+    "fs.nbResPath": "notebook resources (`builtin/`), which Axis C also lists as absent",
+    "lakehouse.getDefinition": "definition round-trip through the shim; the REST surface "
+                               "behind it exists",
+    "lakehouse.updateDefinition": "as getDefinition",
+    "runtime.getCurrentWorkspaceId": "runtime context member",
+    "udf.run": "invoking a User Data Function; the UDF item type has no engine here",
+    "udf.getHelpString": "help text for udf",
+    "variableLibrary.getHelpString": "help text for variableLibrary",
+}
+
+# Parameters we accept that Fabric's documentation does not list. Forgiving is
+# still divergent: a notebook written here can pass an argument that does not
+# exist upstream, and it fails in Fabric rather than locally.
+EXTRA_PARAMS = {
+    # These two are Microsoft's OWN signature, from the stub, and narrower in
+    # the docs. Keeping them costs nothing and drops a caller written against
+    # the real package; the direction of risk is the opposite of notebook.run's.
+    "credentials.getSecret": "linkedService is in Microsoft's stub and not on Fabric's "
+                             "credentials page. Synapse-era, accepted and ignored, so "
+                             "code written against the real package still imports",
+    "session.stop": "detach is in Microsoft's stub and not on Fabric's session page",
+    "notebook.run": "spark_environment and attach_lakehouse are emulator levers for "
+                    "binding a run to an Environment item or a default lakehouse without "
+                    "a portal. Documented in docs/14; not in Fabric's signature",
+}
+
+
+class Unreadable(Exception):
+    """The vendored stubs or the shim are not the shape this reads."""
+
+
+def members(path: pathlib.Path) -> dict[str, list[str]]:
+    """Public module-level functions and their positional parameter names."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    out = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and not node.name.startswith("_"):
+            args = node.args
+            out[node.name] = [a.arg for a in args.posonlyargs + args.args]
+    return out
+
+
+def stub_modules() -> dict[str, dict[str, list[str]]]:
+    if not STUBS.is_dir():
+        raise Unreadable(
+            f"{STUBS} is missing. Run scripts/vendor_notebookutils_stubs.py; without the "
+            "pin this check has no oracle and would pass over nothing.")
+    found = {p.stem: members(p) for p in sorted(STUBS.glob("*.py")) if p.stem != "__init__"}
+    if not found:
+        raise Unreadable(
+            f"{STUBS} contains no stub module. The wheel layout changed and this check "
+            "is now vacuous.")
+    return found
+
+
+def documented() -> dict[str, dict[str, list[str]]]:
+    """Fabric's own signatures, as transcribed with a source per entry."""
+    if not DOCS.is_file():
+        raise Unreadable(f"{DOCS} is missing; the documentation source is half the check")
+    raw = json.loads(DOCS.read_text(encoding="utf-8"))["modules"]
+    # `kind: property` entries are not callables. `runtime.context` is the one
+    # today: a dict a notebook READS, so it has no signature to compare and
+    # comparing it as a function reported our shim as missing documented
+    # surface it implements as a module attribute.
+    return {name.split(".", 1)[1]:
+            {m: e["params"] for m, e in members.items() if e.get("kind") != "property"}
+            for name, members in raw.items()}
+
+
+def problems() -> tuple[list[str], list[str]]:
+    """(failures, notes). Notes are declared divergences, reported not fatal."""
+    stubs = stub_modules()
+    docs = documented()
+    failures: list[str] = []
+    notes: list[str] = []
+
+    unclassified = sorted(set(stubs) - FABRIC_MODULES - set(NOT_FABRIC_MODULES))
+    for module in unclassified:
+        failures.append(
+            f"notebookutils.{module} is in the pinned stubs and in neither FABRIC_MODULES "
+            "nor NOT_FABRIC_MODULES. Decide which, with the reason: guessing would either "
+            "manufacture phantom gaps or hide a real one.")
+    for module in sorted(FABRIC_MODULES - set(stubs)):
+        failures.append(
+            f"FABRIC_MODULES lists {module}, which the pinned stubs do not carry. Either "
+            "the pin moved or the list was wrong.")
+    for module in sorted(set(NOT_FABRIC_MODULES) - set(stubs)):
+        failures.append(
+            f"NOT_FABRIC_MODULES excludes {module}, which the pinned stubs no longer "
+            "carry. Drop the entry; it is describing the past.")
+
+    seen_waived: set[str] = set()
+    seen_planned: set[str] = set()
+    seen_extra: set[str] = set()
+
+    for module in sorted(FABRIC_MODULES & set(stubs)):
+        ours_path = SHIM / f"{module}.py"
+        if not ours_path.exists():
+            failures.append(
+                f"notebookutils.{module} is a documented Fabric module and our shim has "
+                "no such file")
+            continue
+        theirs, ours, doc = stubs[module], members(ours_path), docs.get(module, {})
+        for name in sorted(set(theirs) | set(doc)):
+            qualified = f"{module}.{name}"
+            stub_sig, doc_sig, our_sig = theirs.get(name), doc.get(name), ours.get(name)
+
+            if our_sig is None:
+                if qualified in WAIVED and doc_sig is None:
+                    seen_waived.add(qualified)
+                elif qualified in PLANNED:
+                    seen_planned.add(qualified)
+                    shape = ", ".join(doc_sig if doc_sig is not None else stub_sig or [])
+                    notes.append(f"gap      {qualified}({shape}) — {PLANNED[qualified]}")
+                elif doc_sig is not None:
+                    failures.append(
+                        f"{qualified}({', '.join(doc_sig)}) is DOCUMENTED Fabric surface "
+                        "and absent from our shim")
+                else:
+                    failures.append(
+                        f"{qualified}({', '.join(stub_sig or [])}) is in Microsoft's stub "
+                        "and not in ours. Declare it in WAIVED (not Fabric surface) or "
+                        "PLANNED (a real gap), with the reason.")
+                continue
+
+            # The documentation wins where it speaks: it is Fabric's, the stub
+            # is one package for Fabric and Synapse both.
+            if doc_sig is not None:
+                extra = our_sig[len(doc_sig):]
+                if our_sig[:len(doc_sig)] != doc_sig:
+                    failures.append(
+                        f"{qualified} does not match Fabric's DOCUMENTED signature: "
+                        f"docs({', '.join(doc_sig)}) ours({', '.join(our_sig)})")
+                elif extra:
+                    if qualified in EXTRA_PARAMS:
+                        seen_extra.add(qualified)
+                        notes.append(
+                            f"extra    {qualified} accepts {', '.join(extra)} beyond "
+                            f"Fabric's signature — {EXTRA_PARAMS[qualified]}")
+                    else:
+                        failures.append(
+                            f"{qualified} accepts {', '.join(extra)}, which Fabric's "
+                            "signature does not. Declare it in EXTRA_PARAMS with the "
+                            "reason, or drop it: a notebook written here would fail there.")
+                # DERIVED, not declared: ours agrees with the docs and the stub
+                # does not, so the stub is stale. No human writes this down.
+                if stub_sig is not None and stub_sig != doc_sig:
+                    notes.append(
+                        f"stub     {qualified}: stub({', '.join(stub_sig)}) "
+                        f"docs({', '.join(doc_sig)}) — we follow the documentation")
+                continue
+
+            # Undocumented but shipped by Microsoft and present in ours: fine,
+            # and worth saying, because the transcription did not reach it.
+            if stub_sig is not None and our_sig != stub_sig:
+                failures.append(
+                    f"{qualified} is undocumented surface we implement, and our signature "
+                    f"differs from the stub: stub({', '.join(stub_sig)}) "
+                    f"ours({', '.join(our_sig)}). With no doc page to arbitrate, the stub "
+                    "is the only source there is.")
+
+    for qualified in sorted(set(WAIVED) - seen_waived):
+        failures.append(f"WAIVED lists {qualified}, which is no longer a gap. Drop it.")
+    for qualified in sorted(set(PLANNED) - seen_planned):
+        failures.append(f"PLANNED lists {qualified}, which is no longer a gap. Drop it.")
+    for qualified in sorted(set(EXTRA_PARAMS) - seen_extra):
+        failures.append(
+            f"EXTRA_PARAMS lists {qualified}, which no longer takes anything beyond the "
+            "documented signature. Drop it.")
+    return failures, notes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        failures, notes = problems()
+    except Unreadable as exc:
+        print(f"notebookutils-surface: {exc}")
+        return 1
+
+    stubs = stub_modules()
+    checked = sorted(FABRIC_MODULES & set(stubs))
+    total = sum(len(stubs[m]) for m in checked)
+    print("notebookutils surface (pinned stubs, Fabric-documented modules only):")
+    print(f"  modules checked   : {len(checked)} of {len(stubs)} in the stub "
+          f"({len(NOT_FABRIC_MODULES)} are not Fabric surface)")
+    print(f"  members compared  : {total}")
+    print(f"  waived (Synapse)  : {len(WAIVED)}")
+    print(f"  known gaps        : {len(PLANNED)}")
+    print(f"  extra parameters  : {len(EXTRA_PARAMS)}")
+
+    if notes:
+        print("\nDivergences. `stub` lines are the two Microsoft sources disagreeing "
+              "and are derived, not declared:")
+        for note in notes:
+            print(f"  {note}")
+    if failures:
+        print("\nUndeclared:")
+        for failure in failures:
+            print(f"  {failure}")
+        if args.strict:
+            print("\nFAIL: the shim's surface and Microsoft's have diverged in a way "
+                  "nothing declared. Every difference is allowed; none may be silent.")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vendor_notebookutils_stubs.py
+++ b/scripts/vendor_notebookutils_stubs.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Re-fetch and re-pin Microsoft's own `notebookutils` stubs.
+
+    scripts/vendor_notebookutils_stubs.py [--version 1.6.3]
+
+WHY VENDOR THIS. `docs/56`'s Axis A asks what `notebookutils.*` exposes and
+whether each member carries the documented signature. Until now the answer came
+from `e2e/conformance/notebookutils-reference.json`, transcribed by hand from
+Learn pages, one module of nine. Transcription is the weakest link in an
+evidence chain: it is a claim about Microsoft's surface with a person in the
+middle, and it does not notice when the surface moves.
+
+Microsoft publishes the surface itself. `dummy-notebookutils` is their stub
+package — every function, every parameter name and default, empty bodies —
+shipped so notebook code can be developed off-cluster. MIT, 12 KB. Pinning it
+turns Axis A from a reading exercise into a diff.
+
+WHAT IT IS NOT. It is Synapse-lineage (its own homepage is
+`Azure/azure-synapse-analytics`, its summary says "synapse mssparkutils"), so it
+is BROADER than Fabric: `conf`, `connections`, `data` and `fabricClient` are not
+in Fabric's documented module list, and Fabric's own page says `fabricClient`
+and `PBIClient` "aren't supported yet". The stub is the oracle for SIGNATURES;
+Fabric's docs remain the oracle for SCOPE. `check_notebookutils_surface.py`
+holds both, and refuses to guess when a new module appears in one and not the
+other.
+
+The refresh is a command rather than a ritual for the reason third_party/README
+gives: a PROVENANCE table maintained by hand ships with stale hashes, and the
+hash is the one field whose whole job is to be exact.
+"""
+import argparse
+import hashlib
+import io
+import json
+import pathlib
+import re
+import sys
+import urllib.request
+import zipfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+VENDOR = ROOT / "third_party" / "notebookutils-stubs"
+PACKAGE = "dummy-notebookutils"
+PYPI = f"https://pypi.org/pypi/{PACKAGE}/json"
+
+# The rows this script owns in PROVENANCE.md, between the markers. Everything
+# outside them is prose a person wrote and this must not touch.
+BEGIN = "<!-- integrity:begin -->"
+END = "<!-- integrity:end -->"
+
+
+def wheel_url(version: str) -> tuple[str, str]:
+    """The wheel for a version, and the upload date PyPI records for it."""
+    with urllib.request.urlopen(PYPI, timeout=30) as response:
+        index = json.load(response)
+    files = index["releases"].get(version)
+    if not files:
+        raise SystemExit(
+            f"vendor-notebookutils: {PACKAGE} has no release {version}. "
+            f"Available: {', '.join(sorted(index['releases'])[-6:])}")
+    for entry in files:
+        if entry["filename"].endswith(".whl"):
+            return entry["url"], entry["upload_time"][:10]
+    raise SystemExit(f"vendor-notebookutils: {PACKAGE} {version} ships no wheel")
+
+
+def extract(url: str) -> dict[str, bytes]:
+    """The stub sources and the licence, keyed by the path they land at.
+
+    Only `.py` under `notebookutils/` and the licence file: a wheel also
+    carries RECORD and METADATA, which describe the distribution rather than
+    the surface and would churn the integrity table on every rebuild.
+    """
+    with urllib.request.urlopen(url, timeout=60) as response:
+        blob = response.read()
+    out: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(blob)) as wheel:
+        for name in wheel.namelist():
+            if name.startswith("notebookutils/") and name.endswith(".py"):
+                out[name] = wheel.read(name)
+            elif name.endswith(".dist-info/licenses/LICENSE"):
+                out["LICENSE"] = wheel.read(name)
+    if "LICENSE" not in out:
+        raise SystemExit(
+            "vendor-notebookutils: the wheel carries no LICENSE. third_party/README "
+            "requires the licence text beside what it covers; do not vendor without it.")
+    if not any(n.endswith("notebook.py") for n in out):
+        raise SystemExit(
+            "vendor-notebookutils: no notebookutils/notebook.py in the wheel. The "
+            "layout changed, and vendoring the rest would pin a surface with a hole "
+            "in it.")
+    return out
+
+
+def write(files: dict[str, bytes]) -> None:
+    for existing in sorted(VENDOR.rglob("*.py")):
+        existing.unlink()
+    for name, blob in files.items():
+        target = VENDOR / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(blob)
+
+
+def integrity_table(files: dict[str, bytes]) -> str:
+    rows = ["| File | sha256 | Bytes |", "|---|---|---|"]
+    for name in sorted(files):
+        digest = hashlib.sha256(files[name]).hexdigest()
+        rows.append(f"| `{name}` | `{digest}` | {len(files[name])} |")
+    return "\n".join(rows)
+
+
+def repin(version: str, url: str, uploaded: str, files: dict[str, bytes], today: str) -> None:
+    path = VENDOR / "PROVENANCE.md"
+    text = path.read_text(encoding="utf-8")
+    for field, value in (
+        ("Pinned revision", f"`{version}` (uploaded {uploaded})"),
+        ("Retrieved", today),
+        ("Wheel", f"{url}"),
+    ):
+        text = re.sub(rf"(\| \*\*{field}\*\* \| )[^|]*(\|)", rf"\g<1>{value} \g<2>", text)
+    if BEGIN not in text or END not in text:
+        raise SystemExit(f"vendor-notebookutils: {path} lost its integrity markers")
+    head, rest = text.split(BEGIN, 1)
+    _, tail = rest.split(END, 1)
+    path.write_text(head + BEGIN + "\n" + integrity_table(files) + "\n" + END + tail,
+                    encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", default="1.6.3")
+    # Passed in rather than read from the clock, so a rerun on the same pin
+    # produces the same bytes and the diff says "nothing moved".
+    parser.add_argument("--today", default="", help="date to record as Retrieved")
+    args = parser.parse_args()
+
+    url, uploaded = wheel_url(args.version)
+    files = extract(url)
+    write(files)
+    if args.today:
+        repin(args.version, url, uploaded, files, args.today)
+    else:
+        print("no --today given: files refreshed, PROVENANCE.md left alone")
+    print(f"vendor-notebookutils: {PACKAGE} {args.version} — "
+          f"{len(files) - 1} stub file(s) + LICENSE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -53,6 +53,13 @@ the golden truth is reviewable. Never let a reference float.
   corpus (CC-BY-4.0, pinned by reference). Golden reference for the XMLA
   protocol, rowset encodings, schema rowsets, and the TMSL/TMDL model formats.
 
+- [`notebookutils-stubs/`](notebookutils-stubs/) — Microsoft's own
+  `dummy-notebookutils` wheel, the stub package they publish so notebook code
+  can be developed off-cluster. It states the `notebookutils.*` surface in a
+  machine-readable form, which is what `scripts/check_notebookutils_surface.py`
+  holds our shim to. Synapse-lineage and therefore broader than Fabric, so the
+  checker carries Fabric's module list as a second source.
+
 See [docs/18-semantic-model-references.md](../docs/18-semantic-model-references.md)
 for how these map onto the (as-yet-unbuilt) semantic-model engine and the DAX
 oracle strategy.

--- a/third_party/notebookutils-stubs/LICENSE
+++ b/third_party/notebookutils-stubs/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/notebookutils-stubs/PROVENANCE.md
+++ b/third_party/notebookutils-stubs/PROVENANCE.md
@@ -1,0 +1,74 @@
+# `notebookutils` — Microsoft's own stub package
+
+Golden reference for **Axis A** of [docs/56](../../docs/56-notebook-capability-parity-plan.md):
+what `notebookutils.*` exposes, and with which parameters. Copied in full
+(MIT, 12 KB).
+
+| Field | Value |
+|---|---|
+| **Upstream** | `dummy-notebookutils` on PyPI — https://pypi.org/project/dummy-notebookutils/ |
+| **Pinned revision** | `1.6.3` (uploaded 2026-01-22) |
+| **Retrieved** | 2026-08-24 |
+| **Wheel** | https://files.pythonhosted.org/packages/5d/c1/2321118a61728a9debe7bf423e29c4854c9bfedcbd966805ebb9cfd5a62e/dummy_notebookutils-1.6.3-py3-none-any.whl |
+| **License** | MIT — Microsoft Corporation. Text in [`LICENSE`](LICENSE) |
+| **Used by** | `scripts/check_notebookutils_surface.py`, which checks every member of every Fabric-documented module against `python/notebookutils/` |
+| **Refresh** | `python3 scripts/vendor_notebookutils_stubs.py --version <v> --today <YYYY-MM-DD>` — re-fetches, re-hashes and rewrites the table below |
+
+## Why a stub package is the right oracle
+
+The package has no functionality: every body is `pass` or a bare return. That
+is exactly what makes it useful. Axis A is a question about the **surface** —
+which members exist and what they are called — and this is Microsoft stating
+that surface in a machine-readable form, shipped so notebook code can be
+developed off-cluster. The alternative, which this replaces, was transcribing
+signatures from Learn pages by hand: a claim about Microsoft's API with a
+person in the middle, covering one module of nine, and unable to notice when
+the surface moved.
+
+## What it is NOT, and why the checker carries a second source
+
+It is Synapse-lineage. Its own homepage is `Azure/azure-synapse-analytics` and
+its summary says "synapse mssparkutils", so it is **broader than Fabric**:
+`conf`, `connections`, `data` and `fabricClient` are absent from
+[Fabric's module list](https://learn.microsoft.com/en-us/fabric/data-engineering/notebook-utilities),
+and that page says in its own Known issues that `fabricClient` and `PBIClient`
+"aren't supported yet".
+
+So this pin is the oracle for **signatures**, and Fabric's documentation stays
+the oracle for **scope**. `check_notebookutils_surface.py` holds both and
+refuses to guess: a module that appears here and is classified in neither list
+fails the build rather than being silently treated as in or out.
+
+The legacy `notebookutils/mssparkutils/` namespace is vendored because it ships
+in the wheel, and is deliberately **not** checked: Fabric's page says the
+namespace is backward-compatible and "will be retired in the future", so
+holding our shim to it would pin us to a surface Microsoft is removing.
+
+## Integrity
+
+<!-- integrity:begin -->
+| File | sha256 | Bytes |
+|---|---|---|
+| `LICENSE` | `903df5512f7d02609fed0c780a9b704f5a3eeb6e4d84ebe42a29845c81899a3c` | 1093 |
+| `notebookutils/__init__.py` | `22551788d59ff83b15c88748b1c2db16af02201ae9c2c297b464714e257c6146` | 358 |
+| `notebookutils/conf.py` | `947834edb32bb87173ac7bc14df1bfdbff11e81c9c8cfc15442dc7bfa9866fcc` | 386 |
+| `notebookutils/connections.py` | `6e12c665118a89b1641cb94fbb84938282dc9632db9328e7900247fbb381248d` | 756 |
+| `notebookutils/credentials.py` | `00ecdad30a175e9f91248b3aee2c2f4310725e1c134889677e87bfecb9c31dbb` | 1239 |
+| `notebookutils/data.py` | `1d70e04b82f838aaef435a160dcb06da44bf2d61f106ff6d0bbcaf44bd3576e1` | 218 |
+| `notebookutils/fabricClient.py` | `9261ff2a1b700173d6958e7b853c2e1e13d4f06dc702e16567368d973bcf9587` | 334 |
+| `notebookutils/fs.py` | `3015e2ee490d72405efcd18d95b9dd84c7d708436b0764158854bed186c39834` | 1097 |
+| `notebookutils/lakehouse.py` | `73026baed61c8f41fd6e6882942382be6409888969f1b047ddfde1a14af436a5` | 695 |
+| `notebookutils/mssparkutils/__init__.py` | `5b548feb632e124bf95437e20384a205930de55a3e192ec52bb011d84b4c6432` | 519 |
+| `notebookutils/mssparkutils/credentials.py` | `ff7e3a0e2604d395b0901c270005c471c3efecc7a99244bc6f32ec07cfbda3de` | 1273 |
+| `notebookutils/mssparkutils/env.py` | `a33fd7c99173be1b4ee9d9934ddf10912e053d1b041019e2e4e7151a20e0c589` | 258 |
+| `notebookutils/mssparkutils/fs.py` | `d420e52ab17691c30f5f9470f4a63f9914ca91373669fec77c7b57d7bee6c31d` | 1060 |
+| `notebookutils/mssparkutils/lakehouse.py` | `460ea1b4723b8877bba2d5d4e215c90e22870f5ba0a57f9187566cff40d9c538` | 348 |
+| `notebookutils/mssparkutils/notebook.py` | `5ad84fc0912b5008d9a93b4d3397996b14864dda862f88cf69531e06370ff6d5` | 289 |
+| `notebookutils/mssparkutils/runtime.py` | `f1874b50df6a519a17f1c94aab94a1914340ba6e5db0d3ec5822ffa6fde5f9a5` | 141 |
+| `notebookutils/mssparkutils/session.py` | `ca6f1d52784ff5c594ae76ee5b7b133d0785860c36496a2e3d93a06e038cfc2c` | 59 |
+| `notebookutils/notebook.py` | `5d954cd9b26038c9a75dd5c434c6a984fb4d41376cb49a5a83e541e777f18fa1` | 1006 |
+| `notebookutils/runtime.py` | `2d42889887200e50c6d5e5eb379486eab1f51e4896b36b76bfccbfac15fd65f3` | 101 |
+| `notebookutils/session.py` | `2bcaaa9aa3607f75ef064d6b2821e5275351462aec4c0348716a0b9ce6f0a80c` | 113 |
+| `notebookutils/udf.py` | `4eeb11babf94007fe634cc70ecd2aaadf207175737c1a324d4f75dcab1fe196e` | 933 |
+| `notebookutils/variableLibrary.py` | `29d6b0f6573b4332889948c0e2a84546e89dc36aa051a7abde18b978313e45aa` | 807 |
+<!-- integrity:end -->

--- a/third_party/notebookutils-stubs/notebookutils/__init__.py
+++ b/third_party/notebookutils-stubs/notebookutils/__init__.py
@@ -1,0 +1,28 @@
+__version__ = "1.6.3"
+
+__all__ = [
+    "data",
+    "fs",
+    "lakehouse",
+    "notebook",
+    "session",
+    "runtime",
+    "fabricClient",
+    "credentials",
+    "udf",
+    "conf",
+    "connections",
+    "variableLibrary",
+]
+from . import *
+
+
+def help(module_name=""):
+    pass
+
+
+def __getattr__(name):
+    pass
+
+
+nbResPath = ""

--- a/third_party/notebookutils-stubs/notebookutils/conf.py
+++ b/third_party/notebookutils-stubs/notebookutils/conf.py
@@ -1,0 +1,13 @@
+_CONF: dict[str, str] = {}
+
+
+def set(key: str, value: str) -> None:
+    """Set a notebookutils config key/value (in-memory dummy implementation)."""
+
+    _CONF[str(key)] = "" if value is None else str(value)
+
+
+def get(key: str, default: str = "") -> str:
+    """Get a notebookutils config value (in-memory dummy implementation)."""
+
+    return _CONF.get(str(key), default)

--- a/third_party/notebookutils-stubs/notebookutils/connections.py
+++ b/third_party/notebookutils-stubs/notebookutils/connections.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class DatasourceCredential:
+    """A lightweight placeholder for Fabric/Synapse DatasourceCredential."""
+
+    connectionId: str = ""
+    artifactId: str = ""
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+
+_dummyStr: str = ""
+
+
+def getCredential(connectionId: str, artifactId: str = "") -> Optional[DatasourceCredential]:
+    """Return a dummy DatasourceCredential.
+
+    This project mirrors runtime APIs for local development; no real credential lookup is performed.
+    """
+
+    return None
+
+
+def getHelpString(funcName: str = "", namespace: str = "") -> str:
+    return _dummyStr

--- a/third_party/notebookutils-stubs/notebookutils/credentials.py
+++ b/third_party/notebookutils-stubs/notebookutils/credentials.py
@@ -1,0 +1,74 @@
+def getToken(audience, name=""):
+    pass
+
+
+def getConnectionStringOrCreds(linkedService):
+    pass
+
+
+def getFullConnectionString(linkedService):
+    pass
+
+
+def getPropertiesAll(linkedService):
+    pass
+
+
+def getSPTokenWithCert(resource, authority, clientId, akvNameOrUri, certificateName):
+    pass
+
+
+def getSPTokenWithCertLS(
+    resource, authority, clientId, akvLinkedService, certificateName
+):
+    pass
+
+
+def getSecret(akvName, secret, linkedService=""):
+    pass
+
+
+def getSecretWithLS(linkedService, secret):
+    pass
+
+
+def putSecret(akvName, secretName, secretValue, linkedService=""):
+    pass
+
+
+def putSecretWithLS(linkedService, secretName, secretValue):
+    pass
+
+
+def isValidToken(token):
+    return False
+
+
+def configureAzureBlobStorageSASBased(linkedService, container, sparkSession):
+    pass
+
+
+def configureADLS2TokenBased(linkedService, sparkSession):
+    pass
+
+
+def configureADLS2SASBased(linkedService, sparkSession):
+    pass
+
+
+def configureADLS2AzureKeyVaultBased(
+    akvLinkedService, storageAccountName, secretName, sparkSession
+):
+    pass
+
+
+def tridentHelp():
+    pass
+
+
+def synapseHelp():
+    pass
+
+
+def help(method_name=None):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/data.py
+++ b/third_party/notebookutils-stubs/notebookutils/data.py
@@ -1,0 +1,11 @@
+__all__ = ["help", "connect_to_artifact"]
+
+
+def help(method_name: str = "") -> None:
+    pass
+
+
+def connect_to_artifact(
+    artifact: str, workspace: str = "", artifact_type: str = "", **kwargs
+):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/fabricClient.py
+++ b/third_party/notebookutils-stubs/notebookutils/fabricClient.py
@@ -1,0 +1,26 @@
+def get(path, headers={}):
+    pass
+
+
+def post(path, content, headers={}):
+    pass
+
+
+def patch(path, content, headers={}):
+    pass
+
+
+def put(path, content, headers={}):
+    pass
+
+
+def delete(path, headers={}):
+    pass
+
+
+def listCapacities(maxResults=1000):
+    pass
+
+
+def help(method_name=None):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/fs.py
+++ b/third_party/notebookutils-stubs/notebookutils/fs.py
@@ -1,0 +1,74 @@
+def help(method_name=None):
+    pass
+
+
+def cp(src, dest, recurse=False):
+    return False
+
+
+def mv(src, dest, create_path=False, overwrite=False):
+    return False
+
+
+def ls(dir):
+    return []
+
+
+def mkdirs(dir):
+    return False
+
+
+def put(file, content, overwrite=False):
+    return False
+
+
+def head(file, max_bytes=1024 * 100):
+    return False
+
+
+def append(file, content, createFileIfNotExists=False):
+    return False
+
+
+def rm(dir, recurse=False):
+    return False
+
+
+def exists(file):
+    return False
+
+
+def mountToDriverNode(source, mountPoint, extraConfigs={}):
+    return False
+
+
+def unmountFromDriverNode(mountPoint):
+    return False
+
+
+def mount(source, mountPoint, extraConfigs={}):
+    return False
+
+
+def unmount(mountPoint, extraOptions={}):
+    return False
+
+
+def mounts(extraOptions={}):
+    return False
+
+
+def refreshMounts():
+    return False
+
+
+def getMountPath(mountPoint, scope=""):
+    return False
+
+
+def fastcp(src, dest, recurse=True, extraConfigs={}):
+    return False
+
+
+def nbResPath():
+    return ""

--- a/third_party/notebookutils-stubs/notebookutils/lakehouse.py
+++ b/third_party/notebookutils-stubs/notebookutils/lakehouse.py
@@ -1,0 +1,42 @@
+def create(name, description="", definition=None, workspaceId=""):
+    pass
+
+
+def delete(name, workspaceId=""):
+    pass
+
+
+def list(workspaceId="", maxResults=1000):
+    pass
+
+
+def get(name="", workspaceId=""):
+    pass
+
+
+def update(name, newName, description="", workspaceId=""):
+    pass
+
+
+def getDefinition(name, workspaceId=""):
+    pass
+
+
+def updateDefinition(name, definition, workspaceId=""):
+    pass
+
+
+def listTables(lakehouse="", workspaceId="", maxResults=1000):
+    pass
+
+
+def loadTable(loadOption, table, lakehouse="", workspaceId=""):
+    pass
+
+
+def getWithProperties(name, workspaceId=""):
+    pass
+
+
+def help(method_name=None):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/__init__.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/__init__.py
@@ -1,0 +1,14 @@
+__all__ = ["fs", "notebook", "env", "credentials", "runtime", "session", "lakehouse"]
+
+# put import * statement here after __all__ variable initialized to
+# make sure all sub-module from mssparkutils is imported to current namespace *mssparkutils*,
+# so people can use the exposed interfaces like `mssparkutils.<interface>`.
+# reference https://docs.python.org/3/tutorial/modules.html#importing-from-a-package
+from notebookutils.mssparkutils import *
+
+
+def help(module_name=""):
+    pass
+
+
+nbResPath = ""

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/credentials.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/credentials.py
@@ -1,0 +1,74 @@
+def getToken(audience, name=""):
+    return ""
+
+
+def getConnectionStringOrCreds(linkedService):
+    return ""
+
+
+def getFullConnectionString(linkedService):
+    return ""
+
+
+def getPropertiesAll(linkedService):
+    return ""
+
+
+def getSPTokenWithCert(resource, authority, clientId, akvNameOrUri, certificateName):
+    return ""
+
+
+def getSPTokenWithCertLS(
+    resource, authority, clientId, akvLinkedService, certificateName
+):
+    return ""
+
+
+def getSecret(akvName, secret, linkedService=""):
+    return ""
+
+
+def getSecretWithLS(linkedService, secret):
+    return ""
+
+
+def putSecret(akvName, secretName, secretValue, linkedService=""):
+    return ""
+
+
+def putSecretWithLS(linkedService, secretName, secretValue):
+    return ""
+
+
+def isValidToken(token):
+    return False
+
+
+def configureAzureBlobStorageSASBased(linkedService, container, sparkSession):
+    pass
+
+
+def configureADLS2TokenBased(linkedService, sparkSession):
+    pass
+
+
+def configureADLS2SASBased(linkedService, sparkSession):
+    pass
+
+
+def configureADLS2AzureKeyVaultBased(
+    akvLinkedService, storageAccountName, secretName, sparkSession
+):
+    pass
+
+
+def tridentHelp():
+    pass
+
+
+def synapseHelp():
+    pass
+
+
+def help():
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/env.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/env.py
@@ -1,0 +1,26 @@
+def getUserName():
+    return ""
+
+
+def getUserId():
+    return ""
+
+
+def getJobId():
+    return ""
+
+
+def getWorkspaceName():
+    return ""
+
+
+def getPoolName():
+    return ""
+
+
+def getClusterId():
+    return ""
+
+
+def help():
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/fs.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/fs.py
@@ -1,0 +1,70 @@
+def help(method_name=None):
+    pass
+
+
+def cp(src, dest, recurse=False):
+    return False
+
+
+def mv(src, dest, create_path=False, overwrite=False):
+    return False
+
+
+def ls(dir):
+    return []
+
+
+def mkdirs(dir):
+    return False
+
+
+def put(file, content, overwrite=False):
+    return False
+
+
+def head(file, max_bytes=1024 * 100):
+    return False
+
+
+def append(file, content, createFileIfNotExists=False):
+    return False
+
+
+def rm(dir, recurse=False):
+    return False
+
+
+def exists(file):
+    return False
+
+
+def mountToDriverNode(source, mountPoint, extraConfigs={}):
+    return False
+
+
+def unmountFromDriverNode(mountPoint):
+    return False
+
+
+def mount(source, mountPoint, extraConfigs={}):
+    return False
+
+
+def unmount(mountPoint, extraOptions={}):
+    return False
+
+
+def mounts(extraOptions={}):
+    return False
+
+
+def refreshMounts():
+    return False
+
+
+def getMountPath(mountPoint, scope=""):
+    return False
+
+
+def fastcp(src, dest, recurse=True, extraConfigs={}):
+    return False

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/lakehouse.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/lakehouse.py
@@ -1,0 +1,22 @@
+def create(name, description="", definition=None, workspaceId=""):
+    pass
+
+
+def delete(name, workspaceId=""):
+    pass
+
+
+def list(workspaceId="", maxResults=1000):
+    pass
+
+
+def get(name, workspaceId=""):
+    pass
+
+
+def update(name, newName, description="", workspaceId=""):
+    pass
+
+
+def help(method_name=None):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/notebook.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/notebook.py
@@ -1,0 +1,22 @@
+def updateNBSEndpoint(endpoint):
+    pass
+
+
+def help(method_name=None):
+    pass
+
+
+def run(path, timeout_seconds=90, arguments={}, workspace=""):
+    return ""
+
+
+def exit(value):
+    pass
+
+
+def runMultiple(dag, config=None):
+    pass
+
+
+def validateDAG(dag):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/runtime.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/runtime.py
@@ -1,0 +1,13 @@
+context = {}
+
+
+def setHcReplId(replId):
+    pass
+
+
+def getCurrentWorkspaceId():
+    pass
+
+
+def help(method_name=None):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/mssparkutils/session.py
+++ b/third_party/notebookutils-stubs/notebookutils/mssparkutils/session.py
@@ -1,0 +1,6 @@
+def stop():
+    pass
+
+
+def restartPython():
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/notebook.py
+++ b/third_party/notebookutils-stubs/notebookutils/notebook.py
@@ -1,0 +1,67 @@
+def updateNBSEndpoint(endpoint):
+    pass
+
+
+def help(method_name=None):
+    pass
+
+
+def run(
+    path, timeout_seconds=90, arguments={}, workspaceId=""
+):  # Pay attention to the parameters!
+    return ""
+
+
+def exit(value):
+    pass
+
+
+def runMultiple(dag, config=None):
+    pass
+
+
+def validateDAG(dag):
+    pass
+
+
+def create(
+    name,
+    description="",
+    content=None,
+    defaultLakehouse="",
+    defaultLakehouseWorkspace="",
+    workspaceId="",
+):
+    pass
+
+
+def delete(name, workspaceId=""):
+    pass
+
+
+def list(workspaceId="", maxResults=1000):
+    pass
+
+
+def get(name, workspaceId=""):
+    pass
+
+
+def update(name, newName, description="", workspaceId=""):
+    pass
+
+
+def updateDefinition(
+    name,
+    content=None,
+    defaultLakehouse="",
+    defaultLakehouseWorkspace="",
+    workspaceId="",
+    environmentId="",
+    environmentWorkspaceId="",
+):
+    pass
+
+
+def getDefinition(name, workspaceId="", format="ipynb"):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/runtime.py
+++ b/third_party/notebookutils-stubs/notebookutils/runtime.py
@@ -1,0 +1,9 @@
+context = {}
+
+
+def getCurrentWorkspaceId():
+    pass
+
+
+def help(method_name=None):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/session.py
+++ b/third_party/notebookutils-stubs/notebookutils/session.py
@@ -1,0 +1,10 @@
+def stop(detach=True):
+    pass
+
+
+def restartPython():
+    pass
+
+
+def help(method_name=None):
+    pass

--- a/third_party/notebookutils-stubs/notebookutils/udf.py
+++ b/third_party/notebookutils-stubs/notebookutils/udf.py
@@ -1,0 +1,34 @@
+def run(
+    artifactId: str,
+    functionName: str,
+    parameters: {} = None,
+    workspaceId: str = "",
+    capacityId: str = "",
+):
+    """
+    Run a User data functions (UDF).
+    :param artifactId: The UDF artifact id.
+    :param functionName: The UDF function name.
+    :param parameters: The UDF parameters.
+    :param workspaceId: The UDF workspace id, if not provided, it will be retrieved from the current workspace.
+    :param capacityId: The UDF capacity id, if not provided, it will be retrieved from the current capacity.
+    :return: The UDF execution result.
+    """
+    return None
+
+
+def getFunctions(udf: str, workspaceId: str = ""):
+    """Get functions metadata for a UDF artifact.
+
+    Dummy implementation for local development.
+    """
+
+    return None
+
+
+def getHelpString(funcName: str = "", namespace: str = "") -> str:
+    return ""
+
+
+def help(method=None):
+    return ""

--- a/third_party/notebookutils-stubs/notebookutils/variableLibrary.py
+++ b/third_party/notebookutils-stubs/notebookutils/variableLibrary.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class VariableLibrary:
+    """A lightweight placeholder for a Fabric Variable Library item."""
+
+    name: str = ""
+    variables: Dict[str, Any] = field(default_factory=dict)
+
+
+_dummyStr: str = ""
+
+
+def get(variableReference: str) -> Any:
+    """Get a variable value by reference.
+
+    Dummy implementation: returns None.
+    """
+
+    return None
+
+
+def getLibrary(variableLibraryName: str) -> Optional[VariableLibrary]:
+    """Get a VariableLibrary by name.
+
+    Dummy implementation: returns an empty VariableLibrary object.
+    """
+
+    return None
+
+
+def getHelpString(funcName: str = "", namespace: str = "") -> str:
+    return _dummyStr


### PR DESCRIPTION
`docs/56` calls Axis A — what `notebookutils.*` exposes and with which parameters — "enumerable, therefore gradeable". It is graded, against 44 members transcribed from Learn pages by hand. This adds the source transcription cannot supply.

## The pin

`third_party/notebookutils-stubs/` is **`dummy-notebookutils`, published by Microsoft Corporation, MIT**: the stub package they ship so notebook code can be developed off-cluster. Every function, every parameter name, empty bodies, 12 KB. Vendored in full with a PROVENANCE table and a refresh script, following `openmetadata-schema`.

## What holding two sources found

**They disagree, in ten places.** A sample:

| Member | Microsoft's stub | Fabric's docs |
|---|---|---|
| `fs.ls` | `dir` | `path` |
| `fs.exists` | `file` | `path` |
| `fs.unmount` | `extraOptions` | `extraConfigs` |
| `notebook.run` | `workspaceId` | `workspace` |
| `credentials.getToken` | `(audience, name)` | `(audience)` |

The shim follows the documentation, which is right — the stub is Synapse-lineage and the pages are Fabric's own. But *right* was not a decision anyone made, because the disagreement was invisible. **The arbitration is derived, not declared**: where ours matches the docs and the stub differs, the checker says so with nobody maintaining a list, so it cannot go stale.

**Fifteen members only the stub knew about**, now listed as gaps with reasons. The largest is `help()`, which the real package has on every module and ours on none — and which Fabric's own `fs` page documents in its opening lines, as prose rather than a row in the method table, which is exactly why a careful reading missed it. Also `runtime.getCurrentWorkspaceId`, `udf.run`, `lakehouse.getDefinition`/`updateDefinition`, `fs.nbResPath`, `fs.refreshMounts`.

**Three parameters we accept beyond Fabric's signature**, now declared rather than incidental. `notebook.run`'s `spark_environment` and `attach_lakehouse` are emulator levers; `credentials.getSecret`'s `linkedService` and `session.stop`'s `detach` come from Microsoft's own package and are narrower in the docs. Forgiving is still divergent: a notebook written here can pass an argument that does not exist upstream.

## Why the second source is needed for scope, not just signatures

The stub is broader than Fabric: `conf`, `connections`, `data` and `fabricClient` are absent from Fabric's module list, and Fabric's page says `fabricClient` and `PBIClient` "aren't supported yet". Taking the stub alone would have manufactured about twenty phantom gaps. **A module in the stub and classified in neither list fails the build** rather than being guessed at, and both classification maps report entries that no longer describe anything.

## One bug in the checker, found by its own control

`runtime.context` is a dict a notebook reads, carried in the reference as `kind: property`. Comparing it as a callable reported our shim as missing documented surface it implements as a module attribute. False alarms are how a gate gets switched off, so `kind` is now respected and there is a test for it.

## Verification

Runs offline in `make check` and the `witnesses` job. 8 modules, 73 members compared, 0 undeclared. 29 tests, each driven from the failing side, plus a control asserting the two Microsoft sources still disagree — so a future pin that silently agrees is noticed rather than assumed. 1536 passed, coverage 92.92%, the new script at 99%.

`third_party` is now excluded from ruff: linting a pinned artifact would report style in code we must not touch, and a `--fix` would break the sha256 that describes it.