### PR TITLE
pyarrow off the vulnerable range: floor to 23.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ test = [
     # gap the moment the Connect wraps landed. Same pins as the `delta-rs`
     # group; pandas is what `read_change_feed` materialises through.
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
     "pandas>=2,<3",
     "pyjks>=20,<22",
     # 49.0.0 is the first release that closes the three open wheel and
@@ -52,7 +52,7 @@ lint = [
 ]
 adls-sdk = [
     "azure-storage-blob>=12.24,<13",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
 ]
 # The third-party witness for the Purview Data Map row. pyapacheatlas speaks
 # Apache Atlas v2, which is what the Data Map IS — so this is a real client
@@ -73,12 +73,12 @@ mcp = [
 ]
 delta-rs = [
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
 ]
 duckdb = [
     "deltalake>=0.23,<2",
     "duckdb>=1.1,<2",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
 ]
 s3 = [
     "boto3>=1.35,<2",
@@ -97,7 +97,7 @@ fabric-target = [
 ]
 governance = [
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
     "requests>=2.32,<3",
     # govern_ingest reads the ODCS contracts, so a cataloged table carries the
     # meaning a human wrote rather than only the shape the emulator can infer.
@@ -108,7 +108,7 @@ governance = [
 # own Copy executor rather than by an engine.
 demo = [
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
     "requests>=2.32,<3",
 ]
 great-expectations = [
@@ -169,7 +169,7 @@ sail-delta = [
     { include-group = "spark-client" },
     "deltalake>=0.23,<2",
     "pandas>=2,<3",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
     "requests>=2.32,<3",
     # OSS format("kafka") on Sail: the agent consumes and createDataFrames
     # Kafka-schema rows into the engine. JVM keeps spark-sql-kafka.
@@ -216,7 +216,7 @@ jupyter = [
     "jupyterlab>=4.2,<5",
     { include-group = "spark-client" },
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
     "requests>=2.32,<3",
 ]
 spark-connect = [
@@ -243,7 +243,7 @@ dbt-fabricspark = ["dbt-fabricspark>=1.13"]
 dbt-duckdb = [
     "dbt-duckdb>=1.9,<2",
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
 ]
 # FLOOR AT 3.15, not 3.1. `>=3.1` let a "bump the python group" PR RESOLVE
 # DOWNWARDS on this runtime: main locked one mlflow 3.15.1, and the update
@@ -264,7 +264,7 @@ data-science-loop = [
     "dbt-duckdb>=1.9,<2",
     "deltalake>=0.23,<2",
     "mlflow>=3.15,<4",  # see the `mlflow` group above for why the floor is 3.15
-    "pyarrow>=18,<26",
+    "pyarrow>=23.0.1,<26",
     { include-group = "spark-client" },
 ]
 # NOTE: examples/ deliberately do NOT appear here. Each example owns its

--- a/uv.lock
+++ b/uv.lock
@@ -998,8 +998,7 @@ wheels = [
 
 [package.optional-dependencies]
 pyarrow = [
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (python_full_version < '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (python_full_version >= '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
 ]
 
 [[package]]
@@ -1388,15 +1387,13 @@ source = { virtual = "." }
 [package.dev-dependencies]
 adls-sdk = [
     { name = "azure-storage-blob" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
 ]
 data-science-loop = [
     { name = "dbt-duckdb" },
     { name = "deltalake" },
     { name = "mlflow" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "pyspark-client" },
 ]
 databricks-sdk = [
@@ -1406,8 +1403,7 @@ databricks-sdk = [
 dbt-duckdb = [
     { name = "dbt-duckdb" },
     { name = "deltalake" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
 ]
 dbt-fabric = [
     { name = "dbt-fabric" },
@@ -1417,20 +1413,17 @@ dbt-fabricspark = [
 ]
 delta-rs = [
     { name = "deltalake" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
 ]
 demo = [
     { name = "deltalake" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "requests" },
 ]
 duckdb = [
     { name = "deltalake" },
     { name = "duckdb" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
 ]
 fabric-cicd = [
     { name = "fabric-cicd" },
@@ -1445,8 +1438,7 @@ fabric-target = [
 ]
 governance = [
     { name = "deltalake" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "requests" },
 ]
@@ -1457,8 +1449,7 @@ great-expectations = [
 jupyter = [
     { name = "deltalake" },
     { name = "jupyterlab" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "pyspark-client" },
     { name = "requests" },
 ]
@@ -1493,8 +1484,7 @@ sail-delta = [
     { name = "gssapi" },
     { name = "kafka-python" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "pyjks" },
     { name = "pyspark-client" },
     { name = "requests" },
@@ -1506,8 +1496,7 @@ spark-agent-dbt = [
     { name = "gssapi" },
     { name = "kafka-python" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (python_full_version < '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabricspark' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (python_full_version >= '3.14' and extra != 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "pyjks" },
     { name = "pysail" },
     { name = "pyspark-client" },
@@ -1531,8 +1520,7 @@ test = [
     { name = "fabric-target" },
     { name = "jsonschema" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "pyjks" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1545,13 +1533,13 @@ test = [
 [package.metadata.requires-dev]
 adls-sdk = [
     { name = "azure-storage-blob", specifier = ">=12.24,<13" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
 ]
 data-science-loop = [
     { name = "dbt-duckdb", specifier = ">=1.9,<2" },
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "mlflow", specifier = ">=3.15,<4" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyspark-client", specifier = "==4.2.0" },
 ]
 databricks-sdk = [
@@ -1561,23 +1549,23 @@ databricks-sdk = [
 dbt-duckdb = [
     { name = "dbt-duckdb", specifier = ">=1.9,<2" },
     { name = "deltalake", specifier = ">=0.23,<2" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
 ]
 dbt-fabric = [{ name = "dbt-fabric", specifier = ">=1.11" }]
 dbt-fabricspark = [{ name = "dbt-fabricspark", specifier = ">=1.13" }]
 delta-rs = [
     { name = "deltalake", specifier = ">=0.23,<2" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
 ]
 demo = [
     { name = "deltalake", specifier = ">=0.23,<2" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 duckdb = [
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "duckdb", specifier = ">=1.1,<2" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
 ]
 fabric-cicd = [{ name = "fabric-cicd", specifier = ">=1.3" }]
 fabric-cli = [{ name = "ms-fabric-cli", specifier = ">=1.2" }]
@@ -1588,7 +1576,7 @@ fabric-target = [
 ]
 governance = [
     { name = "deltalake", specifier = ">=0.23,<2" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
@@ -1599,7 +1587,7 @@ great-expectations = [
 jupyter = [
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "jupyterlab", specifier = ">=4.2,<5" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyspark-client", specifier = "==4.2.0" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
@@ -1629,7 +1617,7 @@ sail-delta = [
     { name = "gssapi", specifier = ">=1.8,<2" },
     { name = "kafka-python", specifier = ">=2.0.2,<4" },
     { name = "pandas", specifier = ">=2,<3" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyjks", specifier = ">=20,<22" },
     { name = "pyspark-client", specifier = "==4.2.0" },
     { name = "requests", specifier = ">=2.32,<3" },
@@ -1641,7 +1629,7 @@ spark-agent-dbt = [
     { name = "gssapi", specifier = ">=1.8,<2" },
     { name = "kafka-python", specifier = ">=2.0.2,<4" },
     { name = "pandas", specifier = ">=2,<3" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyjks", specifier = ">=20,<22" },
     { name = "pysail", specifier = "==0.7.0" },
     { name = "pyspark-client", specifier = "==4.2.0" },
@@ -1663,7 +1651,7 @@ test = [
     { name = "fabric-target", editable = "python/fabric-target" },
     { name = "jsonschema", specifier = ">=4.21,<5" },
     { name = "pandas", specifier = ">=2,<3" },
-    { name = "pyarrow", specifier = ">=18,<26" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyjks", specifier = ">=20,<22" },
     { name = "pytest", specifier = ">=8.3,<10" },
     { name = "pytest-cov", specifier = ">=5,<8" },
@@ -3132,8 +3120,7 @@ dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "skops" },
@@ -4121,50 +4108,8 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "21.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'linux'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/ea068b8f00905c06329a3dfcd40d0fcc2b7d0f2e355bdb25b65e0a0e4cd4/pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc", size = 1133487, upload-time = "2025-07-18T00:57:31.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/d4/d4f817b21aacc30195cf6a46ba041dd1be827efa4a623cc8bf39a1c2a0c0/pyarrow-21.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:3a302f0e0963db37e0a24a70c56cf91a4faa0bca51c23812279ca2e23481fccd", size = 31160305, upload-time = "2025-07-18T00:55:35.373Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9c/dcd38ce6e4b4d9a19e1d36914cb8e2b1da4e6003dd075474c4cfcdfe0601/pyarrow-21.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:b6b27cf01e243871390474a211a7922bfbe3bda21e39bc9160daf0da3fe48876", size = 32684264, upload-time = "2025-07-18T00:55:39.303Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/74/2a2d9f8d7a59b639523454bec12dba35ae3d0a07d8ab529dc0809f74b23c/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e72a8ec6b868e258a2cd2672d91f2860ad532d590ce94cdf7d5e7ec674ccf03d", size = 41108099, upload-time = "2025-07-18T00:55:42.889Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/90/2660332eeb31303c13b653ea566a9918484b6e4d6b9d2d46879a33ab0622/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b7ae0bbdc8c6674259b25bef5d2a1d6af5d39d7200c819cf99e07f7dfef1c51e", size = 42829529, upload-time = "2025-07-18T00:55:47.069Z" },
-    { url = "https://files.pythonhosted.org/packages/33/27/1a93a25c92717f6aa0fca06eb4700860577d016cd3ae51aad0e0488ac899/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:58c30a1729f82d201627c173d91bd431db88ea74dcaa3885855bc6203e433b82", size = 43367883, upload-time = "2025-07-18T00:55:53.069Z" },
-    { url = "https://files.pythonhosted.org/packages/05/d9/4d09d919f35d599bc05c6950095e358c3e15148ead26292dfca1fb659b0c/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:072116f65604b822a7f22945a7a6e581cfa28e3454fdcc6939d4ff6090126623", size = 45133802, upload-time = "2025-07-18T00:55:57.714Z" },
-    { url = "https://files.pythonhosted.org/packages/71/30/f3795b6e192c3ab881325ffe172e526499eb3780e306a15103a2764916a2/pyarrow-21.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf56ec8b0a5c8c9d7021d6fd754e688104f9ebebf1bf4449613c9531f5346a18", size = 26203175, upload-time = "2025-07-18T00:56:01.364Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ca/c7eaa8e62db8fb37ce942b1ea0c6d7abfe3786ca193957afa25e71b81b66/pyarrow-21.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e99310a4ebd4479bcd1964dff9e14af33746300cb014aa4a3781738ac63baf4a", size = 31154306, upload-time = "2025-07-18T00:56:04.42Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/e8/e87d9e3b2489302b3a1aea709aaca4b781c5252fcb812a17ab6275a9a484/pyarrow-21.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:d2fe8e7f3ce329a71b7ddd7498b3cfac0eeb200c2789bd840234f0dc271a8efe", size = 32680622, upload-time = "2025-07-18T00:56:07.505Z" },
-    { url = "https://files.pythonhosted.org/packages/84/52/79095d73a742aa0aba370c7942b1b655f598069489ab387fe47261a849e1/pyarrow-21.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f522e5709379d72fb3da7785aa489ff0bb87448a9dc5a75f45763a795a089ebd", size = 41104094, upload-time = "2025-07-18T00:56:10.994Z" },
-    { url = "https://files.pythonhosted.org/packages/89/4b/7782438b551dbb0468892a276b8c789b8bbdb25ea5c5eb27faadd753e037/pyarrow-21.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:69cbbdf0631396e9925e048cfa5bce4e8c3d3b41562bbd70c685a8eb53a91e61", size = 42825576, upload-time = "2025-07-18T00:56:15.569Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/62/0f29de6e0a1e33518dec92c65be0351d32d7ca351e51ec5f4f837a9aab91/pyarrow-21.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:731c7022587006b755d0bdb27626a1a3bb004bb56b11fb30d98b6c1b4718579d", size = 43368342, upload-time = "2025-07-18T00:56:19.531Z" },
-    { url = "https://files.pythonhosted.org/packages/90/c7/0fa1f3f29cf75f339768cc698c8ad4ddd2481c1742e9741459911c9ac477/pyarrow-21.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc56bc708f2d8ac71bd1dcb927e458c93cec10b98eb4120206a4091db7b67b99", size = 45131218, upload-time = "2025-07-18T00:56:23.347Z" },
-    { url = "https://files.pythonhosted.org/packages/01/63/581f2076465e67b23bc5a37d4a2abff8362d389d29d8105832e82c9c811c/pyarrow-21.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:186aa00bca62139f75b7de8420f745f2af12941595bbbfa7ed3870ff63e25636", size = 26087551, upload-time = "2025-07-18T00:56:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ab/357d0d9648bb8241ee7348e564f2479d206ebe6e1c47ac5027c2e31ecd39/pyarrow-21.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:a7a102574faa3f421141a64c10216e078df467ab9576684d5cd696952546e2da", size = 31290064, upload-time = "2025-07-18T00:56:30.214Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/8a/5685d62a990e4cac2043fc76b4661bf38d06efed55cf45a334b455bd2759/pyarrow-21.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:1e005378c4a2c6db3ada3ad4c217b381f6c886f0a80d6a316fe586b90f77efd7", size = 32727837, upload-time = "2025-07-18T00:56:33.935Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/de/c0828ee09525c2bafefd3e736a248ebe764d07d0fd762d4f0929dbc516c9/pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:65f8e85f79031449ec8706b74504a316805217b35b6099155dd7e227eef0d4b6", size = 41014158, upload-time = "2025-07-18T00:56:37.528Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/26/a2865c420c50b7a3748320b614f3484bfcde8347b2639b2b903b21ce6a72/pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:3a81486adc665c7eb1a2bde0224cfca6ceaba344a82a971ef059678417880eb8", size = 42667885, upload-time = "2025-07-18T00:56:41.483Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/f9/4ee798dc902533159250fb4321267730bc0a107d8c6889e07c3add4fe3a5/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fc0d2f88b81dcf3ccf9a6ae17f89183762c8a94a5bdcfa09e05cfe413acf0503", size = 43276625, upload-time = "2025-07-18T00:56:48.002Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/da/e02544d6997037a4b0d22d8e5f66bc9315c3671371a8b18c79ade1cefe14/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6299449adf89df38537837487a4f8d3bd91ec94354fdd2a7d30bc11c48ef6e79", size = 44951890, upload-time = "2025-07-18T00:56:52.568Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/4e/519c1bc1876625fe6b71e9a28287c43ec2f20f73c658b9ae1d485c0c206e/pyarrow-21.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:222c39e2c70113543982c6b34f3077962b44fca38c0bd9e68bb6781534425c10", size = 26371006, upload-time = "2025-07-18T00:56:56.379Z" },
-]
-
-[[package]]
-name = "pyarrow"
 version = "25.0.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'linux'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/e2/9ab15b88cbfac28e16419ce5439ec29234c5172cb8259301b4ba639bdec0/pyarrow-25.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:df961f2e7ae9cf496459259d798652c70625f6c080650d6952f8c04053c58ee9", size = 35861559, upload-time = "2026-08-10T12:38:02.567Z" },
@@ -4586,8 +4531,7 @@ dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
-    { name = "pyarrow", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'group-22-fabric-emulator-python-databricks-sdk' and extra == 'group-22-fabric-emulator-python-spark-agent-dbt') or (extra == 'group-22-fabric-emulator-python-dbt-fabric' and extra == 'group-22-fabric-emulator-python-dbt-fabricspark')" },
+    { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "zstandard" },
 ]


### PR DESCRIPTION
Closes Dependabot **#55** — [GHSA-rgxp-2hwp-jwgg](https://github.com/advisories/GHSA-rgxp-2hwp-jwgg), high: *use-after-free when reading an IPC file with pre-buffering*. Vulnerable range `>= 15.0.0, < 23.0.1`.

### The lock held two pyarrow entries

That is why this was not obvious from a glance at the lockfile:

| version | serves | vulnerable |
|---|---|---|
| `25.0.1` | `python_full_version >= '3.14'` | no |
| `21.0.0` | everything below 3.14 | **yes** |

**Everything below 3.14 is what this stack actually runs** — the sail image is `python:3.12-slim`. I first read the lock from a stale working tree, saw only `25.0.1`, and the alert looked spurious; `main` had both. Reading the file from `main` rather than the checkout is what caught it.

### Nothing required the old one

No dependency caps pyarrow — the project's own `>=18,<26` was the only bound. `requires-python` is `>=3.12`, and both 23.0.1 and 25.0.1 support `>=3.10`, so the 21.0.0 fork was a resolution artefact rather than a constraint.

Raising the floor to the patched version collapses the forks: `Updated pyarrow v21.0.0, v25.0.1 -> v25.0.1`, and the only version line the lock loses is `21.0.0`.

`uv lock --check` passes and `make check` is green.