### PR TITLE
Contract 8: a refusal the service makes must be made here

### DIFF
--- a/docs/24-parity-completion.md
+++ b/docs/24-parity-completion.md
@@ -57,14 +57,22 @@ for real; today its `conformance` job is `skipped` in every run, because
 `AZURE_CLIENT_ID` and `FABRIC_TEST_WORKSPACE` are unset (`AZURE_TENANT_ID` is
 set, and OIDC needs no client secret).
 
-**Convertible today — one row, and it is the interesting one.** Class B strict
-mode (`-tsql-strict`) looks emulator-only because the *toggle* is ours. What the
-toggle produces is a **refusal over TDS**, and `ci:warehouse-tds` already drives
-that surface with a real client. This is exactly the shape of `FABRIC_FORCE_LRO`,
-which was own-only for the same mistaken reason until a real client's poll loop
-was pointed at it: separate "the engine is internal" from "the contract is
-internal". The oracle for *which* constructs Fabric rejects stays the reference
-(docs/29), the same as it is today.
+**Converted, and it was the interesting one.** Class B strict mode
+(`-tsql-strict`) looked emulator-only because the *toggle* is ours. What the
+toggle produces is a **refusal over TDS**, and a real client either receives it
+or does not: `TestWarehouseStrictModeRefusesClassBOverRealTDS` now drives it
+with go-mssqldb in the `warehouse-tds` job, and the claim left this list. Same
+shape as `FABRIC_FORCE_LRO`, which was own-only for the same mistaken reason
+until a real client's poll loop was pointed at it — separate "the engine is
+internal" from "the contract is internal". The oracle for *which* constructs
+Fabric rejects stays the reference (docs/29).
+
+That same test is now also the **warehouse leg of contract 8**
+([38](38-framework-conformance.md#8-a-refusal-the-service-makes-must-be-made-here)),
+which was written afterwards and independently arrived at its shape: a refusal
+naming the documented feature, plus the permitted form of the same statement
+succeeding, because a build that refused everything would pass the refusal
+assertions. It was wired rather than copied.
 
 ## Tier 1 — Control plane only (no engine, no research risk)
 
@@ -79,9 +87,9 @@ Pure CRUD + RBAC in patterns the repo has executed a dozen times.
 | ~~Sensitivity labels~~ ✅ | bulkSetLabels/bulkRemoveLabels + documented label-change audit events. 🟢 (taxonomy is emulator-provided: Purview is not attachable) | M |
 | Dataflow Gen2 **management** completeness | Finish the non-engine surface; execution stays 501 | S |
 | **Runtime divergences** (Environment items, Files mount, `input_file_name()` in SQL, inline pipeline jobs) | Four analogs the code states rather than hides. Environments and the Files mount (write-back + per-statement refresh + refuse a second lakehouse) are done; `input_file_name()` in SQL remains. Pipelines are the last job type that does not use the repo's own async pattern. Scoped in [37-runtime-fidelity-gaps.md](37-runtime-fidelity-gaps.md) | XS–M remaining |
-| **Framework conformance kit** | The runtime contracts a Fabric framework depends on and the REST reference does not describe: the context fallback chain, signature introspection, the runtime version floor, write-landing verification, concurrent session isolation, rewrite fall-through, credential lifetime. Every defect in this class was found by driving a real product while the parity map, the witness system and four medallion examples stayed green. Notebooks, assertions and one CI job — no engine work. Scoped in [38-framework-conformance.md](38-framework-conformance.md) | M |
+| **Framework conformance kit** | The runtime contracts a Fabric framework depends on and the REST reference does not describe: the context fallback chain, signature introspection, the runtime version floor, write-landing verification, concurrent session isolation, rewrite fall-through, credential lifetime, and **refusal fidelity** — the emulator must not be more permissive than Fabric, which is the only one of the eight whose failure mode is a green. Every defect in this class was found by driving a real product while the parity map, the witness system and four medallion examples stayed green. Notebooks, assertions and one CI job — no engine work. Scoped in [38-framework-conformance.md](38-framework-conformance.md) | M |
 | ~~Capacity **job queueing** and throttling~~ ✅ | Per-capacity concurrent-job ceiling (default 999). Manual submits against a full capacity are `430 CapacityNotAvailable` with `Retry-After`; scheduled and event-triggered jobs enter `Queued` and are admitted FIFO on the same clock/list levers that fire schedules. Same-item jobs are not serialised. [36-capacity-job-queueing.md](36-capacity-job-queueing.md) | M |
-| **`runMultiple` full parity** (exit values, per-cell timeout, lakehouse inheritance, concurrency, retry) | The DAG semantics are real; what's missing includes two wrong answers shipping today — `exitVal` hardcoded `""`, and `timeoutPerCellInSeconds` applied as a whole-notebook deadline. Also a latent agent bug: catalog state is process-wide across concurrent Livy sessions. Scoped in [39-run-multiple-parity-plan.md](39-run-multiple-parity-plan.md) | S–M each |
+| ~~**`runMultiple` full parity**~~ ✅ | **Both wrong answers this row was written for are fixed, and this entry said otherwise for months** — which is its own small lesson about a planning doc nothing checks. `exitVal` carries the child's real exit value, and `timeoutPerCellInSeconds` is multiplied by the notebook's real cell count where that count is readable, falling back to a whole-notebook ceiling on a tenant (`…/notebookRun` 404s there). Concurrency, retry and the failure contract are graded rows in [parity.md](parity.md). What is NOT closed is the differential half: `runmultiple-failure-contract` and `runmultiple-retry-and-timeouts` are two of the three claims still waiting on the tenant oracle. Scoped in [39-run-multiple-parity-plan.md](39-run-multiple-parity-plan.md) | — |
 
 ## Tier 2 — Attach a real engine that exists
 

--- a/docs/38-framework-conformance.md
+++ b/docs/38-framework-conformance.md
@@ -585,15 +585,68 @@ assumed from the fact that the behaviour is covered.
 
 ---
 
+### 8. A refusal the service makes must be made here
+
+`notebookutils.fs.rm(path)` on a directory **deleted the entire subtree**.
+OneLake's DELETE ignored `?recursive=` completely, so a bare `rm` that ADLS
+Gen2 answers `409 DirectoryNotEmpty` succeeded here and took the tree with it.
+It shipped in v0.33.0.
+
+This document already states the rule, one level up, under
+[What must NOT be done](#what-must-not-be-done):
+
+> Being more permissive than the thing being emulated is the one direction that
+> actively misleads: it passes here and fails there.
+
+It says that about **signature parameters**, and `check_notebookutils_surface.py`
+grades those — three divergences are recorded in `EXTRA_PARAMS` with reasons.
+Nothing applied it to **behaviour**, and nothing graded it. `fs.rm` is that rule
+violated one level down, with a worse failure direction than the sentence
+describes: here it did not merely pass, it succeeded and destroyed data.
+
+**The generalisation.** Where the service refuses, the emulator refuses, with
+the documented code. This is the only contract in this document whose failure
+mode is a *green* — every other one catches a wrong answer, and a wrong answer
+is at least visible. Over-permissiveness is invisible locally by construction:
+the local run is the one that passes, and the tenant is where you find out.
+
+**A refusal alone is not the assertion, and this is the part worth getting
+right.** An operation that is simply broken refuses everything, including what
+Fabric permits — an `fs.rm` raising on every path would satisfy a probe that
+only checked the refusal, while being more wrong than the over-permissiveness
+it was written to catch. So every case carries a **control**: the same
+operation in the form the service *permits* must succeed. `rm` without
+`recurse` is refused **and** `rm` with `recurse=True` deletes. The control is
+the same device contract 7 uses for the read before the wait, for the same
+reason — a probe with no baseline grades a surface that never worked.
+
+**The code is graded, not just the refusal.** `DirectoryNotEmpty` and a bare
+500 are both "it did not delete"; only one of them tells a caller to pass
+`recurse`. A client branches on the code, so the code is the contract.
+
+**A case the session never attempted fails.** A probe whose case list can
+silently shrink grades whatever survived and reports green for it.
+
+**The ceiling, stated rather than implied.** Like the other seven, this
+contract's expectations come from Microsoft's documentation, so it says
+*conforms to the published contract* and never *matches Fabric*. Where the
+docs are silent about a refusal, this cannot invent one — and the differential
+leg ([#384](https://github.com/calvinchengx/fabric-emulator/issues/384)) is
+still the only oracle that could.
+
+---
+
 ## The conformance kit
 
-**Status: built; contracts 4 and 1 are live.** The harness, the committed
-matrix, and the offline checker are in tree. Sail, JVM, and warehouse each
-write through the emulator path and an out-of-band reader confirms the
-artifact. Items 3 and 5–7 are still individually tractable. The reason
-they existed for months is that nothing exercised them, and that is the
-gap worth closing first — a new framework will find a new one next week
-otherwise. Contract 1 found two on its first run, and contract 2 a third.
+**Status: built; contracts 1–7 are live, and 8 is the newest row.** The
+harness, the committed matrix, and the offline checker are in tree. Sail,
+JVM, and warehouse each write through the emulator path and an out-of-band
+reader confirms the artifact. The reason these contracts went unproven for
+months is that nothing exercised them, and each one added has found
+something: contract 1 found two defects on its first run, and contract 2 a
+third. **Contract 8 was added last and for the opposite reason** — not
+because a probe found a wrong answer, but because a *green* hid one, and
+`fs.rm` deleted a user's directory tree for a release before anybody looked.
 
 **Contracts share a run but must not share a failure.** Contract 1 rides the
 same notebook as contract 4, which costs nothing and describes one session
@@ -627,6 +680,7 @@ correctly when probed.
 | 5 | Concurrent isolation | N sessions live at once, each reporting its own identity: notebook children each see their own context; TDS sessions each answer with their own warehouse and principal |
 | 6 | Fall-through | A statement the rewrite grammar does not recognise reaches the engine unmodified — proven by a second engine that *can* plan it, or, where there is only one, by the engine echoing the bytes back |
 | 7 | Credential lifetime | A run that outlives the token lifetime keeps working, on a surface that still refuses an expired credential |
+| 8 | Refusal fidelity | An operation the service refuses is refused here with the documented code — and the *permitted* form of the same operation succeeds, so a broken operation cannot pass by refusing everything |
 
 ### Every contract proves real execution, on a real backend
 
@@ -660,6 +714,7 @@ inventing anything.
 | 5 | Concurrent isolation | required | required | required |
 | 6 | Rewrite fall-through | required | control | required |
 | 7 | Credential lifetime | required | required | required |
+| 8 | Refusal fidelity | required | required | required |
 
 <!-- APPLICABILITY:END -->
 

--- a/docs/conformance-matrix.md
+++ b/docs/conformance-matrix.md
@@ -28,3 +28,4 @@ wrote. A ✅ is that out-of-band reader, never the writer's own catalog.
 | 5 | Concurrent isolation | ✅ | ✅ | ✅ |
 | 6 | Rewrite fall-through | ✅ | ✅ | ✅ |
 | 7 | Credential lifetime | ✅ | ✅ | ✅ |
+| 8 | Refusal fidelity | ✅ | ✅ | ✅ |

--- a/docs/witnesses.json
+++ b/docs/witnesses.json
@@ -1305,7 +1305,7 @@
   },
   "framework-conformance-runtime-contracts": {
     "section": "Runtime contracts (`docs/38`)",
-    "claim": "Framework conformance kit — write landing first",
+    "claim": "Framework conformance kit — eight runtime contracts, graded per backend",
     "witnesses": [
       "ci:conformance-sail",
       "ci:conformance-jvm",

--- a/e2e/conformance/live.py
+++ b/e2e/conformance/live.py
@@ -41,6 +41,8 @@ from probes import (  # noqa: E402
     CredentialClaim,
     FallThroughClaim,
     IsolationClaim,
+    RefusalCase,
+    RefusalClaim,
     RuntimeClaim,
     SignatureClaim,
     WriteClaim,
@@ -49,6 +51,7 @@ from probes import (  # noqa: E402
     credential_lifetime,
     fall_through,
     record,
+    refusal_fidelity,
     runtime_floor,
     signature_shape,
     write_landing,
@@ -85,6 +88,9 @@ TABLE_DIR = "lake.Lakehouse/Tables/events"
 # out-of-band reader is then a single DFS GET with no Parquet parser, and the
 # file is what a Fabric notebook can write with one documented call.
 FINDINGS_PATH = "lake.Lakehouse/Files/conformance/context.json"
+# Contract 8 works under its own directory so a refusal case that leaves a
+# file behind cannot disturb what another contract reads.
+REFUSALS_DIR = "lake.Lakehouse/Files/conformance/refusals"
 # Contract 5's children write one file each, keyed by the marker they were
 # given, so a child that wrote another child's file is visible as a mismatch
 # rather than as an overwrite nobody can see.
@@ -486,6 +492,93 @@ try:
         _run_err = f"{type(_exc).__name__}: {_exc}"
     _findings["run_magic"] = {"ok": _run_ok, "error": _run_err}
 
+    # Contract 8. Two operations the service refuses, each attempted in the
+    # form real Fabric REJECTS and again in the form it PERMITS.
+    #
+    # THE PERMITTED FORM IS HALF THE CASE, and skipping it is how this probe
+    # would grade a broken filesystem green: an `fs.rm` that raised on every
+    # path refuses the non-recursive form too. The control is the same device
+    # contract 7 uses for the read before the wait.
+    #
+    # NOT loadTable, which also refuses by name: it refuses in EVERY form,
+    # because it is unimplemented. There is no permitted form to be the
+    # control, so it is an honest 501 rather than a refusal this contract can
+    # grade -- and the rule caught that before the case was written.
+    #
+    # THE CODE, NOT THE MESSAGE. `fs.rm` raises OSError, and so does half the
+    # standard library -- grading the class alone would accept a connection
+    # reset as a correct refusal. `rm`'s own docstring says the errno is the
+    # contract ("the mapping here is exact -- this is what `os.rmdir` raises
+    # for the identical situation"), so the errno NAME is what gets reported.
+    import errno as _errno
+
+    def _refuse(fn):
+        try:
+            fn()
+            return False, ""
+        except OSError as exc:
+            name = _errno.errorcode.get(getattr(exc, "errno", None), "")
+            return True, f"{type(exc).__name__}/{name}".rstrip("/")
+        except Exception as exc:  # noqa: BLE001
+            return True, type(exc).__name__
+
+    _ref = {}
+    _base = "abfss://__WS__@onelake.dfs.fabric.microsoft.com/__REFUSALS__"
+    try:
+        # TWO IDENTICAL TREES, not one used twice. If the bare `rm` wrongly
+        # SUCCEEDS, a control pointed at the same path has nothing left to
+        # delete and fails for a reason that has nothing to do with recurse --
+        # so the run would report a broken fixture instead of the data loss.
+        _nbu.fs.put(_base + "/tree/leaf.txt", "leaf", True)
+        _nbu.fs.put(_base + "/tree-control/leaf.txt", "leaf", True)
+        # rm on a non-empty directory: ADLS Gen2 answers 409 DirectoryNotEmpty,
+        # so a bare rm is SAFE on Fabric. Here it deleted the subtree for a
+        # release (v0.33.0), which is why this contract exists.
+        _rm_refused, _rm_code = _refuse(lambda: _nbu.fs.rm(_base + "/tree"))
+        _rm_ctl_ok, _rm_ctl_err = _try(
+            lambda: _nbu.fs.rm(_base + "/tree-control", True))
+        _ref["rm-non-empty-without-recurse"] = {
+            "refused": _rm_refused, "code": _rm_code,
+            # `recurse=True` must really have removed it -- a call that
+            # returned True while leaving the tree in place would be the
+            # writer confirming its own write.
+            "control_ok": (bool(_rm_ctl_ok)
+                           and not _nbu.fs.exists(_base + "/tree-control")),
+            "control_error": _rm_ctl_err,
+        }
+        # Two sources for the same reason as the two trees above: a clobber
+        # that wrongly succeeds consumes the source, and the control would
+        # then fail because there was nothing to move.
+        _nbu.fs.put(_base + "/src.txt", "src", True)
+        _nbu.fs.put(_base + "/src-control.txt", "src", True)
+        _nbu.fs.put(_base + "/dst.txt", "dst", True)
+        _nbu.fs.put(_base + "/dst-control.txt", "dst", True)
+        _mv_refused, _mv_code = _refuse(
+            lambda: _nbu.fs.mv(_base + "/src.txt", _base + "/dst.txt"))
+        _mv_ctl_ok, _mv_ctl_err = _try(
+            lambda: _nbu.fs.mv(_base + "/src-control.txt",
+                               _base + "/dst-control.txt", True, True))
+        _ref["mv-onto-existing-without-overwrite"] = {
+            "refused": _mv_refused, "code": _mv_code,
+            # The overwrite really happened: the destination now holds the
+            # SOURCE bytes, and the source is gone.
+            "control_ok": (bool(_mv_ctl_ok)
+                           and _nbu.fs.head(_base + "/dst-control.txt") == "src"
+                           and not _nbu.fs.exists(_base + "/src-control.txt")),
+            "control_error": _mv_ctl_err,
+        }
+        # Seed the fixtures for the WIRE case the harness runs. The operation
+        # under test there is the DELETE, and that is what stays out of band;
+        # creating the tree here uses the one writer this session has already
+        # proven works, instead of a second one in the harness that can fail
+        # for its own reasons and report the result as a product defect.
+        _nbu.fs.put(_base + "/wire/leaf.txt", "leaf", True)
+        _nbu.fs.put(_base + "/wire-control/leaf.txt", "leaf", True)
+        _findings["refusals"] = _ref
+    except Exception as _exc:  # noqa: BLE001
+        _findings["refusals"] = {
+            "setup_error": f"{type(_exc).__name__}: {_exc}"}
+
     _findings["runtime"] = {
         "declared": _os.environ.get("FABRIC_RUNTIME", ""),
         "python": ".".join(str(n) for n in _sys.version_info[:3]),
@@ -517,6 +610,7 @@ _run_magic_seen = None
 _runtime_seen = None
 _fall_seen = None
 _cred_seen = None
+_refusals_seen = None
 
 
 def log(msg: str) -> None:
@@ -625,6 +719,7 @@ def writer() -> WriteClaim:
             "payload": base64.b64encode(
                 (NOTEBOOK_BODY.replace("__WS__", ws)
                  .replace("__FINDINGS__", FINDINGS_PATH)
+                 .replace("__REFUSALS__", REFUSALS_DIR)
                  .replace("__MODULES__", json.dumps(sorted(REFERENCE_MODULES)))
                  + meta).encode()).decode()}]}},
         token=fabric_token())
@@ -734,9 +829,10 @@ def session_context() -> ContextClaim:
     global _sigs_seen, _runtime_seen
     _sigs_seen = found.get("module_signatures")
     _runtime_seen = found.get("runtime")
-    global _fall_seen, _cred_seen
+    global _fall_seen, _cred_seen, _refusals_seen
     _fall_seen = found.get("fall_through")
     _cred_seen = found.get("credential")
+    _refusals_seen = found.get("refusals")
     log(f"context findings: { {k: v for k, v in found.items() if k != 'module_signatures'} }")
     global _run_magic_seen
     _run_magic_seen = found.get("run_magic")
@@ -1089,6 +1185,102 @@ def session_credential() -> CredentialClaim:
     )
 
 
+# The documented refusals contract 8 grades on a lakehouse. Each key names the
+# error a caller must be able to branch on -- the ADLS Gen2 code on the wire,
+# and the exception type on the shim, because a notebook author catches
+# filesystem exceptions and `fs.rm`'s own docstring says the mapping to
+# `os.rmdir`'s errno is the point.
+REFUSAL_EXPECTATIONS = {
+    "rm-non-empty-without-recurse": "OSError/ENOTEMPTY",
+    "mv-onto-existing-without-overwrite": "FileExistsError",
+    "dfs-delete-non-empty-directory": "409 DirectoryNotEmpty",
+}
+
+
+def _dfs_delete_case() -> RefusalCase:
+    """The wire half, run by the HARNESS rather than by the notebook.
+
+    The shim's two cases above prove `notebookutils` refuses. This proves the
+    thing underneath it does -- and the defect that produced this contract was
+    exactly there: OneLake's DELETE ignored `?recursive=` completely, so the
+    shim was faithfully reporting a success that should never have been
+    available to it. A probe that only asked the shim would have passed on the
+    day the tree was deleted, because the shim did nothing wrong.
+
+    Out of band by construction: this process never ran inside the session. The
+    FIXTURE is seeded by the notebook, deliberately -- what has to be out of
+    band is the operation under test, and a second writer here would be one
+    more thing that can fail and be reported as a product defect.
+    """
+    name = "dfs-delete-non-empty-directory"
+    root = f"http://{ACCT}/{_ws}/{urllib.parse.quote(REFUSALS_DIR)}"
+    token = storage_token()
+    # The Host header is what selects the DFS data plane -- the emulator is
+    # host-routed like real Fabric, and without it this reaches the control
+    # plane's catch-all instead. Omitting it cost a run: the bare 404 that
+    # came back carried NO `x-ms-error-code`, which is the tell that no OneLake
+    # handler ever saw the request. The contract's own control rule is what
+    # surfaced it, rather than the harness bug being reported as a product one.
+    hdrs = {"Host": DFS_HOST}
+    code = ""
+    try:
+        req("DELETE", f"{root}/wire", token=token, headers=hdrs)
+        refused = False
+    except urllib.error.HTTPError as exc:
+        refused = True
+        # `x-ms-error-code` is where ADLS Gen2 puts it, and where a client
+        # reads it. str(HTTPError) is "HTTP Error 409: Conflict" and names no
+        # code at all, so grading that would accept any 409 the emulator ever
+        # returns for any reason.
+        code = f"{exc.status} {exc.headers.get('x-ms-error-code', '')}".strip()
+    except Exception as exc:  # noqa: BLE001
+        refused = True
+        code = f"not an HTTP response: {type(exc).__name__}: {exc}"
+    control_ok, control_error = False, ""
+    try:
+        req("DELETE", f"{root}/wire-control?recursive=true", token=token,
+            headers=hdrs)
+        control_ok = True
+    except urllib.error.HTTPError as exc:
+        # THE CODE FIRST, then the path. A red truncated to its URL prefix says
+        # only "something about this path", which is where the first run of
+        # this probe left a reader.
+        control_error = (f"{exc.status} "
+                         f"{exc.headers.get('x-ms-error-code', '')} on "
+                         f"DELETE {REFUSALS_DIR}/wire-control?recursive=true")
+    except Exception as exc:  # noqa: BLE001
+        control_error = (f"{type(exc).__name__}: {exc} on "
+                         f"DELETE {REFUSALS_DIR}/wire-control?recursive=true")
+    return RefusalCase(name=name, refused=refused, code=code,
+                       control_ok=control_ok, control_error=control_error)
+
+
+def session_refusals() -> RefusalClaim:
+    """Contract 8 reads the same artifact contracts 1-3, 6 and 7 already fetched,
+    and adds the one case the notebook cannot make -- the raw DFS DELETE."""
+    if _refusals_seen is None:
+        return RefusalClaim(
+            ok=False,
+            error="no refusal results in the findings artifact — the session "
+                  "did not get as far as attempting the operations")
+    if _refusals_seen.get("setup_error"):
+        return RefusalClaim(
+            ok=False,
+            error=("the refusal fixtures could not be created "
+                   f"({_refusals_seen['setup_error'][:160]}), so neither the "
+                   "refused form nor the permitted one says anything"))
+    cases = [
+        RefusalCase(name=name,
+                    refused=bool(rec.get("refused")),
+                    code=rec.get("code", ""),
+                    control_ok=bool(rec.get("control_ok")),
+                    control_error=rec.get("control_error", ""))
+        for name, rec in sorted(_refusals_seen.items())
+    ]
+    cases.append(_dfs_delete_case())
+    return RefusalClaim(ok=True, cases=tuple(cases))
+
+
 def main() -> int:
     backend = os.environ.get("BACKEND", "")
     if backend not in ("sail", "jvm"):
@@ -1123,10 +1315,13 @@ def main() -> int:
     # and the doc is the authority on which is which.
     fall = fall_through(session=session_fall_through, backend=backend,
                         control=(6, backend) in CONTROL)
+    refusals = refusal_fidelity(session=session_refusals,
+                                expected=REFUSAL_EXPECTATIONS, backend=backend)
     rows = record(backend,
                   live={1: ctx, 2: sig, 3: floor, 4: result, 5: iso, 6: fall,
                         7: credential_lifetime(session=session_credential,
-                                               backend=backend)})
+                                               backend=backend),
+                        8: refusals})
     out = DIR / "out"
     out.mkdir(parents=True, exist_ok=True)
     path = out / f"{backend}.json"
@@ -1136,6 +1331,7 @@ def main() -> int:
     log(f"wrote {path} contract 3={floor.status} {floor.error}".rstrip())
     log(f"wrote {path} contract 5={iso.status} {iso.error}".rstrip())
     log(f"wrote {path} contract 6={fall.status} {fall.error}".rstrip())
+    log(f"wrote {path} contract 8={refusals.status} {refusals.error}".rstrip())
     seven = next(r for r in rows if r["id"] == "7")
     log(f"wrote {path} contract 7={seven['status']} {seven.get('error', '')}".rstrip())
     log(f"wrote {path} contract 4={result.status} {result.error}".rstrip())

--- a/e2e/conformance/out/jvm.json
+++ b/e2e/conformance/out/jvm.json
@@ -54,5 +54,13 @@
     "status": "pass",
     "error": "",
     "pointer": ""
+  },
+  {
+    "id": "8",
+    "contract": "Refusal fidelity",
+    "backend": "jvm",
+    "status": "pass",
+    "error": "",
+    "pointer": ""
   }
 ]

--- a/e2e/conformance/out/sail.json
+++ b/e2e/conformance/out/sail.json
@@ -54,5 +54,13 @@
     "status": "pass",
     "error": "",
     "pointer": ""
+  },
+  {
+    "id": "8",
+    "contract": "Refusal fidelity",
+    "backend": "sail",
+    "status": "pass",
+    "error": "",
+    "pointer": ""
   }
 ]

--- a/e2e/conformance/out/warehouse.json
+++ b/e2e/conformance/out/warehouse.json
@@ -54,5 +54,13 @@
     "status": "pass",
     "error": "",
     "pointer": ""
+  },
+  {
+    "id": "8",
+    "contract": "Refusal fidelity",
+    "backend": "warehouse",
+    "status": "pass",
+    "error": "",
+    "pointer": ""
   }
 ]

--- a/e2e/conformance/probes.py
+++ b/e2e/conformance/probes.py
@@ -47,6 +47,8 @@ CONTRACTS: tuple[tuple[int, str, str], ...] = (
      "38-framework-conformance.md#6-engine-gaps-need-a-bounded-rewrite-escape-hatch-with-a-stated-contract"),
     (7, "Credential lifetime",
      "38-framework-conformance.md#7-credentials-must-outlive-the-run"),
+    (8, "Refusal fidelity",
+     "38-framework-conformance.md#8-a-refusal-the-service-makes-must-be-made-here"),
 )
 
 # Mirrors the APPLICABILITY table. Duplicated here so a probe run does not
@@ -69,6 +71,7 @@ GAP_REASON = {
     5: "no live fan-out recorded — isolation is a property of concurrent sessions",
     6: "no live statements recorded — fall-through is a property of a running engine",
     7: "no live run recorded — outliving a token needs a session that outlived one",
+    8: "no live run recorded — a refusal is a property of an operation attempted",
 }
 
 
@@ -694,6 +697,125 @@ def credential_lifetime(
                    "is checking expiry at all"),
             pointer=pointer)
     return Result(id="7", contract=title, backend=backend, status="pass")
+
+
+@dataclass(frozen=True)
+class RefusalCase:
+    """One operation the service refuses, and the permitted form of the same one.
+
+    `refused` / `code` describe what happened when the operation was attempted
+    in the form real Fabric rejects. `control_ok` describes the SAME operation
+    in the form real Fabric permits.
+
+    THE CONTROL IS NOT OPTIONAL, and it is the whole reason this dataclass has
+    four fields instead of two. "The operation was refused" and "the operation
+    is broken" produce the identical green on a probe that only checks the
+    refusal — and a broken operation refuses everything, including what Fabric
+    allows. `fs.rm` that raises on every path would pass a refusal-only test
+    while being far more wrong than the over-permissiveness it was written to
+    catch.
+    """
+
+    name: str
+    refused: bool = False
+    code: str = ""
+    error: str = ""
+    control_ok: bool = False
+    control_error: str = ""
+
+
+@dataclass(frozen=True)
+class RefusalClaim:
+    """What one session reported after attempting every refusal case."""
+
+    ok: bool
+    cases: tuple[RefusalCase, ...] = ()
+    error: str = ""
+
+
+def refusal_fidelity(
+    *,
+    session: Callable[[], RefusalClaim],
+    expected: dict[str, str],
+    backend: str,
+) -> Result:
+    """Contract 8: a refusal the service makes must be made here, with its code.
+
+    `expected` maps a case name to the error code real Fabric answers with —
+    `409 DirectoryNotEmpty`, `NotebookLakehouseMismatch`. It comes from
+    Microsoft's documentation, which is this contract's ceiling and is stated
+    as one in docs/38: it says *conforms to the published contract*, never
+    *matches Fabric*.
+
+    THE FAILURE DIRECTION THIS EXISTS FOR IS THE PERMISSIVE ONE. Every other
+    contract here catches the emulator answering wrongly and loudly. This one
+    catches it answering *successfully* where the service would have stopped
+    you — which is invisible locally by construction, because the local run is
+    the one that passes. `notebookutils.fs.rm` deleted whole directory trees
+    for a release under exactly that shape: ADLS Gen2 answers
+    `409 DirectoryNotEmpty`, so a bare `rm` is safe on Fabric and destructive
+    here.
+
+    A CASE THE SESSION NEVER REPORTED IS A FAILURE, not an omission. A probe
+    whose case list can silently shrink grades whatever survived, and reports
+    green for it — the vacuity hole that makes a suite an ornament.
+
+    THE CODE IS GRADED, NOT JUST THE REFUSAL. A client branches on the code:
+    `DirectoryNotEmpty` and a bare 500 are both "it did not delete", and only
+    one of them tells a caller to pass `recurse`.
+    """
+    title = CONTRACTS[7][1]
+    pointer = CONTRACTS[7][2]
+    if not expected:
+        raise ValueError(
+            "refusal_fidelity needs at least one expected case; an empty "
+            "expectation set passes for any session, including one that "
+            "attempted nothing")
+    claim = session()
+    if not claim.ok:
+        return Result(id="8", contract=title, backend=backend, status="fail",
+                      error=claim.error or "the session attempted no operations",
+                      pointer=pointer)
+
+    seen = {case.name: case for case in claim.cases}
+    problems: list[str] = []
+    for name in sorted(expected):
+        case = seen.get(name)
+        if case is None:
+            problems.append(
+                f"{name}: not reported — the session did not attempt it, so "
+                f"nothing here says whether the refusal is made")
+            continue
+        # ORDER MATTERS, and getting it backwards is how this probe would have
+        # reported the defect it exists for as a broken fixture. When the
+        # operation was ALLOWED, that is the finding — the control may well
+        # have failed too, as a CONSEQUENCE (an `rm` that already deleted the
+        # tree leaves the recursive form nothing to delete), and leading with
+        # that reads as "your harness is wrong" rather than "the emulator
+        # destroyed the directory".
+        if not case.refused:
+            problems.append(
+                f"{name}: ALLOWED — real Fabric answers {expected[name]}, so "
+                f"this passes here and fails there")
+            continue
+        if not case.control_ok:
+            problems.append(
+                f"{name}: the PERMITTED form of the same operation failed "
+                f"({case.control_error[:200] or 'no reason given'}) — a broken "
+                f"operation refuses everything, so its refusal proves nothing")
+            continue
+        if expected[name] not in case.code:
+            problems.append(
+                f"{name}: refused with {case.code or 'no code'!r}, not the "
+                f"documented {expected[name]!r} — a client branches on the code")
+    extra = sorted(set(seen) - set(expected))
+    if extra:
+        problems.append(
+            f"reported case(s) with no documented expectation: {', '.join(extra)}")
+    if problems:
+        return Result(id="8", contract=title, backend=backend, status="fail",
+                      error="; ".join(problems), pointer=pointer)
+    return Result(id="8", contract=title, backend=backend, status="pass")
 
 
 def record(backend: str, live: dict[int, Result] | None = None) -> list[dict]:

--- a/e2e/conformance/run.py
+++ b/e2e/conformance/run.py
@@ -158,6 +158,15 @@ WAREHOUSE_TESTS: dict[int, str] = {
     5: "TestConformanceConcurrentIsolation",
     6: "TestConformanceFallThrough",
     7: "TestConformanceCredentialLifetime",
+    # Contract 8 reuses a test written before the contract existed, rather than
+    # adding a near-copy beside it. It already has the shape docs/38 §8
+    # requires and says so in its own comments: a refusal a real client
+    # receives over real TDS, naming the documented feature; the same statement
+    # succeeding with the toggle OFF; and a Class A statement succeeding with
+    # it ON, because "a version that refused everything would pass the refusal
+    # assertions". Wiring it is what makes that a graded cell instead of a test
+    # nobody counted.
+    8: "TestWarehouseStrictModeRefusesClassBOverRealTDS",
 }
 
 

--- a/python/tests/test_check_conformance.py
+++ b/python/tests/test_check_conformance.py
@@ -91,11 +91,15 @@ def test_the_actual_repo_passes_strict():
 
 
 def test_the_actual_repo_defines_every_contract_it_promises():
-    """Seven contracts, and none of them n/a everywhere."""
+    """Eight contracts, and none of them n/a everywhere."""
     cc.DOC = REPO / "docs" / "38-framework-conformance.md"
     table, errors = cc.load_applicability()
     assert errors == []
-    assert len(table) == 7
+    assert len(table) == 8
+    # Contract 8 is required everywhere: the refusals differ per surface —
+    # OneLake's on the lakehouse, Class B strict on the warehouse — but no
+    # surface is without one, so n/a would be a decision rather than a fact.
+    assert set(table[8].values()) == {"required"}
     assert set(table[4]) == {"sail", "jvm", "warehouse"}
     # Contract 6 is the one the JVM column exists to make provable.
     assert table[6]["jvm"] == "control"

--- a/python/tests/test_conformance_kit.py
+++ b/python/tests/test_conformance_kit.py
@@ -834,7 +834,8 @@ def test_all_passing_reports_no_failure():
     live, failed = run.warehouse_results(verdicts, 0)
     assert failed is False
     assert {n: r.status for n, r in live.items()} == {4: "pass", 5: "pass",
-                                                     6: "pass", 7: "pass"}
+                                                     6: "pass", 7: "pass",
+                                                     8: "pass"}
     assert all(r.error == "" for r in live.values())
 
 
@@ -843,3 +844,124 @@ def test_every_warehouse_test_maps_to_an_applicable_contract():
     mapping one to it would record a pass the applicability table forbids."""
     for num in run.WAREHOUSE_TESTS:
         assert (num, "warehouse") not in probes.NOT_APPLICABLE
+
+
+# --- contract 8: refusal fidelity ---------------------------------------------
+#
+# The direction this contract exists for is the PERMISSIVE one, so the test
+# that matters most is the one where the emulator succeeded.
+
+_RM = "rm-non-empty-without-recurse"
+_MV = "mv-onto-existing-without-overwrite"
+_EXPECTED = {_RM: "DirectoryNotEmpty", _MV: "AlreadyExists"}
+
+
+def _refusals(*cases):
+    return lambda: probes.RefusalClaim(ok=True, cases=tuple(cases))
+
+
+def _refused_case(name, code):
+    return probes.RefusalCase(name=name, refused=True, code=code, control_ok=True)
+
+
+def test_refusal_fidelity_passes_when_every_case_is_refused_with_its_code():
+    result = probes.refusal_fidelity(
+        session=_refusals(_refused_case(_RM, "409 DirectoryNotEmpty"),
+                       _refused_case(_MV, "AlreadyExists")),
+        expected=_EXPECTED, backend="sail")
+    assert result.status == "pass", result.error
+
+
+def test_an_operation_the_emulator_ALLOWED_is_the_failure_this_contract_exists_for():
+    """`fs.rm` deleting a directory tree, in the shape that shipped."""
+    result = probes.refusal_fidelity(
+        session=_refusals(probes.RefusalCase(name=_RM, refused=False, control_ok=True),
+                       _refused_case(_MV, "AlreadyExists")),
+        expected=_EXPECTED, backend="sail")
+    assert result.status == "fail"
+    assert "ALLOWED" in result.error
+    assert "passes here and fails there" in result.error
+
+
+def test_a_refusal_with_the_wrong_code_fails_because_a_client_branches_on_it():
+    result = probes.refusal_fidelity(
+        session=_refusals(_refused_case(_RM, "500 InternalError"),
+                       _refused_case(_MV, "AlreadyExists")),
+        expected=_EXPECTED, backend="sail")
+    assert result.status == "fail"
+    assert "not the documented" in result.error
+
+
+def test_a_broken_operation_cannot_pass_by_refusing_everything():
+    """The control half. An `fs.rm` that raises on every path refuses the
+    non-recursive form too, and a refusal-only probe would call that green."""
+    result = probes.refusal_fidelity(
+        session=_refusals(probes.RefusalCase(name=_RM, refused=True,
+                                          code="409 DirectoryNotEmpty",
+                                          control_ok=False,
+                                          control_error="recurse=True also raised"),
+                       _refused_case(_MV, "AlreadyExists")),
+        expected=_EXPECTED, backend="sail")
+    assert result.status == "fail"
+    assert "PERMITTED form" in result.error
+    assert "refuses everything" in result.error
+
+
+def test_a_case_the_session_never_attempted_is_a_failure_not_an_omission():
+    result = probes.refusal_fidelity(
+        session=_refusals(_refused_case(_MV, "AlreadyExists")),
+        expected=_EXPECTED, backend="sail")
+    assert result.status == "fail"
+    assert "not reported" in result.error
+
+
+def test_a_case_with_no_documented_expectation_is_reported_rather_than_graded():
+    result = probes.refusal_fidelity(
+        session=_refusals(_refused_case(_RM, "409 DirectoryNotEmpty"),
+                       _refused_case(_MV, "AlreadyExists"),
+                       _refused_case("invented", "Whatever")),
+        expected=_EXPECTED, backend="sail")
+    assert result.status == "fail"
+    assert "no documented expectation" in result.error
+
+
+def test_a_session_that_ran_nothing_fails_with_its_own_reason():
+    result = probes.refusal_fidelity(
+        session=lambda: probes.RefusalClaim(ok=False, error="no lakehouse bound"),
+        expected=_EXPECTED, backend="jvm")
+    assert result.status == "fail"
+    assert "no lakehouse bound" in result.error
+
+
+def test_an_empty_expectation_set_is_refused_rather_than_passing_vacuously():
+    with pytest.raises(ValueError, match="attempted nothing"):
+        probes.refusal_fidelity(session=_refusals(), expected={}, backend="sail")
+
+
+def test_contract_8_is_required_on_every_backend():
+    """n/a would make it unprovable; the refusals differ per surface but each
+    surface has some."""
+    for backend in probes.BACKENDS:
+        assert (8, backend) not in probes.NOT_APPLICABLE
+        rows = {r["id"]: r for r in probes.record(backend)}
+        assert rows["8"]["status"] == "gap"
+        assert rows["8"]["pointer"]
+
+
+def test_an_allowed_operation_is_reported_as_allowed_even_when_its_control_also_failed():
+    """The ordering rule, and the reason it is a rule.
+
+    An `fs.rm` that wrongly deletes the tree leaves the recursive control
+    nothing to delete, so BOTH halves come back bad. Leading with the control
+    would report the data-loss defect as a broken fixture — which is how the
+    probe written to catch it would have hidden it.
+    """
+    result = probes.refusal_fidelity(
+        session=_refusals(
+            probes.RefusalCase(name=_RM, refused=False, control_ok=False,
+                               control_error="404: the tree is already gone"),
+            _refused_case(_MV, "AlreadyExists")),
+        expected=_EXPECTED, backend="sail")
+    assert result.status == "fail"
+    assert "ALLOWED" in result.error
+    assert "404" not in result.error


### PR DESCRIPTION
Closes #399.

`docs/38` already stated the rule — *"Being more permissive than the thing being emulated is the one direction that actively misleads: it passes here and fails there"* — about **signature parameters**, which `check_notebookutils_surface.py` grades (three divergences recorded in `EXTRA_PARAMS`). Nothing applied it to **behaviour**, and `notebookutils.fs.rm` deleted whole directory trees for a release because of it.

Contract 8 makes over-permissiveness a measured class. It is the only one of the eight whose failure mode is a **green**: every other contract catches a wrong answer, which is at least visible; this one catches the emulator *succeeding* where the service would have stopped you — invisible locally by construction, because the local run is the one that passes.

### Measured, not asserted

| # | Contract | sail | jvm | warehouse |
|---|---|---|---|---|
| 8 | Refusal fidelity | ✅ | ✅ | ✅ |

All 21 cells recorded from live runs — sail and jvm through RunNotebook, warehouse through the TDS relay against a real SQL Server. Contract 8 went red twice for reasons I had to fix before it went green.

### A refusal alone is not the assertion

An operation that is simply broken refuses everything, *including what Fabric permits* — an `fs.rm` raising on every path would satisfy a refusal-only probe while being worse than the over-permissiveness it was written to catch. So every case carries a **control**: the same operation in the form the service PERMITS must succeed. Same device contract 7 uses for the read before the wait.

That rule earned its keep three times before this landed:

- **It rejected `lakehouse.loadTable` as a case.** It refuses by name in every form because it is unimplemented — no permitted form exists to be the control, so it is an honest 501 rather than a refusal this contract can grade.
- **It caught a fixture that could not have worked.** The first version pointed the control at the path the refused call had just been asked to delete, so a wrongly-successful `rm` would have reported the data loss as a broken harness. Two identical trees now, and the probe reports `ALLOWED` before it reports a failed control, for the same reason.
- **It caught my own harness bug rather than blaming the product.** The wire-level DELETE reached the control plane's catch-all because it omitted the `Host: onelake.dfs…` header the other DFS readers set. The tell was a 404 carrying **no `x-ms-error-code`** — no OneLake handler ever saw it.

### The cases

Three per lakehouse backend, spanning shim and wire:

| case | expected |
|---|---|
| `fs.rm` on a non-empty directory | `OSError/ENOTEMPTY` |
| `fs.mv` onto an existing destination | `FileExistsError` |
| raw DFS DELETE, run by the harness out of band | `409 DirectoryNotEmpty` |

The wire case is the layer the original defect lived in: OneLake's DELETE ignored `?recursive=` entirely, so the shim was faithfully reporting a success that should never have been available to it. A probe that only asked the shim would have passed on the day the tree was deleted.

The **warehouse leg wires an existing test rather than copying it**. `TestWarehouseStrictModeRefusesClassBOverRealTDS` predates this contract and independently arrived at its shape — a refusal a real client receives over real TDS naming the documented feature, the same statement succeeding with the toggle off, and a Class A statement succeeding with it on, *"because a version that refused everything would pass the refusal assertions"*.

### Two stale rows in docs/24, corrected on the way

That doc is what a maintainer reads to decide where to start, and it was pointing at finished work:

- the two `runMultiple` wrong answers it lists as *"shipping today"* are fixed
- the `-tsql-strict` row it calls *"convertible today"* was converted

### The ceiling, stated rather than implied

Like the other seven, this contract's expectations come from Microsoft's documentation, so it says *conforms to the published contract* and never *matches Fabric*. Where the docs are silent about a refusal, it cannot invent one — #384 is still the only oracle that could.
