### PR TITLE
third_party: vendor ADF's Pipeline.json, and check the compat names against it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,6 +578,11 @@ jobs:
       # until someone re-read the article. Twelve of them once fell to the success
       # stub for exactly that reason. Held to the vendored table instead.
       - run: uv run --frozen --no-sync python scripts/check_fabric_activity_types.py
+      # The ADF half of the same guard: the emulator accepts ADF's activity
+      # vocabulary as a compatibility surface, so an ADF type it does not
+      # recognise reaches the same success stub. Found SparkJob doing exactly
+      # that when it was written.
+      - run: uv run --frozen --no-sync python scripts/check_adf_activity_types.py
       # Starlight's sidebar is an explicit list — no autogenerate. A doc left
       # out still builds and still has a URL, but nothing links to it, so it is
       # published and unreachable. Same drift, same guard.

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_conformance.py --strict
 	@$(PY) scripts/check_arch_services.py
 	@$(PY) scripts/check_fabric_activity_types.py
+	@$(PY) scripts/check_adf_activity_types.py
 	@$(PY) scripts/check_docs_sidebar.py
 	@$(PY) scripts/check_workflow_concurrency.py
 	@$(PY) scripts/check_cron_workflow_freshness.py

--- a/internal/api/unrunnableactivities.go
+++ b/internal/api/unrunnableactivities.go
@@ -67,6 +67,14 @@ var unrunnableActivities = map[string]string{
 		"here — a mapper/reducer pair is not a command the caller wrote (that is the Custom " +
 		"activity), it is a MapReduce runtime the emulator would have to supply around it",
 
+	"SparkJob": "submits a Spark job definition held in a SYNAPSE workspace, named by a " +
+		"SparkJobDefinitionReference plus args. The emulator models no Synapse workspace, " +
+		"so there is no artifact to resolve that reference against. Fabric's own " +
+		"SparkJobDefinition activity IS implemented and is the modelled route — but it " +
+		"names a Fabric item by sparkJobDefinitionId + workspaceId" + ", so treating the two as one would mean resolving a " +
+		"Synapse artifact reference against Fabric items: a mapping nobody wrote, and the " +
+		"same objection that refuses a dbfs: path in the Databricks activity",
+
 	"DataLakeAnalyticsU-SQL": dataLakeAnalyticsCause,
 
 	"ExecuteSSISPackage": "runs an SSIS package on an Azure-SSIS integration runtime, named " +

--- a/internal/api/unrunnableactivities_test.go
+++ b/internal/api/unrunnableactivities_test.go
@@ -101,7 +101,15 @@ func TestTheStubStillAnswersForConnectorLeaves(t *testing.T) {
 }
 
 // TestUnrunnableRefusalsCoverTheDiff pins the SET, not just its members. The
-// list came from diffing ADF's discriminators against the dispatch; if someone
+// list came from diffing ADF's discriminators against the dispatch;
+//
+// NOTE, now that both halves of that diff are DERIVED rather than typed:
+// scripts/check_adf_activity_types.py and scripts/check_fabric_activity_types.py
+// walk the vendored schemas, so a name missing from the dispatch already fails a
+// check without this map. What this map still adds is the reverse direction with
+// a REASON attached — it forces a deliberate edit, and its comments record why
+// each entry is here and when two of them left. Worth revisiting whether that is
+// enough to keep it. if someone
 // later implements one of these for real they must remove it from the map, and
 // if someone adds a type string here it must be a real discriminator. The
 // names are asserted literally because a typo would silently un-refuse an
@@ -123,6 +131,13 @@ func TestUnrunnableRefusalsCoverTheDiff(t *testing.T) {
 		"Teams": true, "MicrosoftTeams": true, "Office365Email": true, "Email": true,
 
 		"PBISemanticModelRefresh": true,
+
+		// Synapse's spark-job activity. Found by the ADF half of the same
+		// method — scripts/check_adf_activity_types.py, which walks the
+		// VENDORED ADF schema rather than a list anyone typed. It was reaching
+		// the stub: the only ADF discriminator still unhandled when that
+		// checker was written.
+		"SparkJob": true,
 
 		// SparkJobDefinition and InvokeCopyJob WERE here, marked temporary
 		// because the emulator already ran both item types and only the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,6 +367,12 @@ omit = [
     # log — is NOT unwitnessed: scripts/check_capture_redaction.py asserts it in
     # `make check`, and python/tests/test_check_capture_redaction.py drives the
     # same cases plus the two mutations (a leaky redactor, an over-zealous one).
+    # Fetch-and-write with a truncation guard, and nothing else: the ADF
+    # schema is one file at one commit, so there is no parsing to get wrong —
+    # unlike vendor_fabric_activity_types.py, whose HTML extraction IS the
+    # load-bearing part and is now tested (test_vendor_fabric_activity_types.py)
+    # rather than exempted. Omitted for what it is, not for convenience.
+    "scripts/vendor_adf_pipeline_schema.py",
     "scripts/capture_definition_shape.py",
     # The conformance harness itself: it publishes notebooks, drives
     # RunNotebook and reads OneLake, so it cannot run without the compose

--- a/python/tests/test_check_adf_activity_types.py
+++ b/python/tests/test_check_adf_activity_types.py
@@ -97,3 +97,27 @@ def test_all_three_handling_routes_count(sandbox):
     assert "Copy" in handled            # dispatch
     assert "ForEach" in handled         # interpreter
     assert "HDInsightHive" in handled   # refused by name
+
+
+def test_a_missing_input_fails_rather_than_passing_vacuously(sandbox, capsys):
+    """If the schema is gone, the type set is empty and every check trivially
+    'passes'. The guard exists so an absent oracle is a failure, not a green."""
+    sandbox["SCHEMA"].unlink()
+    assert c.main() == 1
+    assert "missing" in capsys.readouterr().out
+
+
+def test_provenance_without_a_hash_fails(sandbox, capsys):
+    """third_party/README.md requires the sha256; a provenance file that has
+    lost it cannot be an integrity check."""
+    sandbox["PROVENANCE"].write_text("# no hash here\n", encoding="utf-8")
+    assert c.main() == 1
+    assert "records no sha256" in capsys.readouterr().out
+
+
+def test_non_dict_definitions_do_not_break_the_walk():
+    """Swagger allows non-object members; the walk must skip them rather than
+    raise, or a future schema shape takes the whole checker down."""
+    got = c.concrete_types({"definitions": {"ok": {"x-ms-discriminator-value": "Copy"},
+                                            "weird": "a string, not an object"}})
+    assert got == {"Copy": "ok"}

--- a/python/tests/test_check_adf_activity_types.py
+++ b/python/tests/test_check_adf_activity_types.py
@@ -1,0 +1,99 @@
+"""The ADF activity-type checker, driven by pytest as well as by `make check`.
+
+Same convention as its Fabric sibling: a checker that guards a list is worth
+nothing if it can itself drift, so the failure directions are asserted rather
+than reviewed.
+
+The property worth the most here is the DERIVED exclusion of abstract bases.
+`Container` and `Execution` are discriminators on base classes nothing authors;
+excluding them by a hand-written exemption would reintroduce, inside the fix,
+exactly the declared list the fix removes.
+"""
+import hashlib
+import json
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_adf_activity_types as c  # noqa: E402
+
+SCHEMA = c.SCHEMA.read_bytes()
+PROV = c.PROVENANCE.read_text(encoding="utf-8")
+REFUSALS = c.REFUSALS.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    files = {}
+    for attr, src in (("SCHEMA", SCHEMA), ("PROVENANCE", PROV.encode()),
+                      ("DISPATCH", c.DISPATCH.read_bytes()),
+                      ("INTERP", c.INTERP.read_bytes()),
+                      ("REFUSALS", REFUSALS.encode())):
+        p = tmp_path / attr.lower()
+        p.write_bytes(src)
+        monkeypatch.setattr(c, attr, p)
+        files[attr] = p
+    monkeypatch.setattr(c, "ROOT", tmp_path)
+    return files
+
+
+def repin(files, payload: bytes):
+    files["SCHEMA"].write_bytes(payload)
+    digest = hashlib.sha256(payload).hexdigest()
+    files["PROVENANCE"].write_text(
+        c.SHA.sub(f"`sha256:{digest}`", files["PROVENANCE"].read_text(encoding="utf-8")),
+        encoding="utf-8")
+
+
+def test_the_repo_as_it_stands_passes():
+    assert c.main() == 0
+
+
+def test_abstract_bases_are_excluded_by_derivation():
+    """Container and Execution carry discriminators but are base classes.
+    They must not appear as types to handle — and the exclusion must come from
+    the schema's own allOf graph, not from a list in this repo."""
+    types = c.concrete_types(json.loads(SCHEMA))
+    assert "Container" not in types and "Execution" not in types
+    # ...and the concrete ones ARE there, so the derivation is not just
+    # excluding everything.
+    assert {"Copy", "HDInsightHive", "SparkJob"} <= set(types)
+
+
+def test_an_unhandled_type_fails(sandbox, capsys):
+    """The defect: a type nothing handles reaches the dispatch default and is
+    reported Succeeded having run nothing."""
+    sandbox["REFUSALS"].write_text(REFUSALS.replace('\t"SparkJob":', '\t"SparkJobX":'),
+                                   encoding="utf-8")
+    assert c.main() == 1
+    out = capsys.readouterr().out
+    assert "SparkJob" in out and "Succeeded having run nothing" in out
+
+
+def test_a_tampered_schema_fails(sandbox, capsys):
+    sandbox["SCHEMA"].write_bytes(SCHEMA + b" ")
+    assert c.main() == 1
+    assert "does not match its own hash" in capsys.readouterr().out
+
+
+def test_a_schema_it_can_no_longer_read_fails(sandbox, capsys):
+    """A parse that silently finds three types would 'pass' while checking
+    almost nothing — the guard must notice it has stopped working."""
+    repin(sandbox, json.dumps({"definitions": {}}).encode())
+    assert c.main() == 1
+    assert "reading it wrong" in capsys.readouterr().out
+
+
+def test_all_three_handling_routes_count(sandbox):
+    """Dispatch case, interpreter case, and refusal map are equally valid
+    answers — the checker asserts a real outcome exists, not which one."""
+    handled = c.handled(c.DISPATCH.read_text(encoding="utf-8"),
+                        c.INTERP.read_text(encoding="utf-8"),
+                        REFUSALS)
+    assert "Copy" in handled            # dispatch
+    assert "ForEach" in handled         # interpreter
+    assert "HDInsightHive" in handled   # refused by name

--- a/python/tests/test_vendor_fabric_activity_types.py
+++ b/python/tests/test_vendor_fabric_activity_types.py
@@ -1,0 +1,95 @@
+"""The HTML extraction behind the vendored Fabric activity table.
+
+The checker holds the Go list to the vendored file, and the vendored file is
+whatever `extract()` pulled out of Microsoft's page. So `extract()` is the load-
+bearing part of that chain and it shipped with no test at all — a parse that
+quietly returns the wrong rows would vendor a table the checker then agrees
+with, and agreement with a bad oracle reads exactly like correctness.
+
+The network fetch is not tested and does not need to be: it is one urlopen. The
+parsing, and its two refusals, are.
+"""
+import json
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import vendor_fabric_activity_types as v  # noqa: E402
+
+
+def page(rows: str, heading: str | None = None) -> str:
+    h = heading or v.SECTION
+    return (f"<h3 id=x>{h}</h3>\n<table>\n<thead><tr><th>Name</th><th>Description</th></tr>"
+            f"</thead>\n<tbody>\n{rows}\n</tbody>\n</table>\n")
+
+
+def row(name: str, desc: str, link: bool = True) -> str:
+    cell = f'<a href="#x" data-linktype="self-bookmark">{name}</a>' if link else name
+    return f"<tr>\n<td>{cell}</td>\n<td>{desc}</td>\n</tr>"
+
+
+def enough(extra: str = "") -> str:
+    return "\n".join([row(f"Type{i}", f"does thing {i}") for i in range(25)]) + extra
+
+
+def test_it_reads_names_and_descriptions():
+    got = v.extract(page(enough()))
+    assert got["Type0"] == "does thing 0"
+    assert len(got) == 25
+
+
+def test_markup_and_entities_are_stripped():
+    """The name is a link and the description carries entities; the vendored
+    artifact must hold neither."""
+    got = v.extract(page(enough(row("Web&amp;Hook", "Calls a <em>webhook</em> &amp; waits"))))
+    assert "Web&Hook" in got
+    assert got["Web&Hook"] == "Calls a webhook & waits"
+
+
+def test_whitespace_in_a_description_is_collapsed():
+    got = v.extract(page(enough(row("Spaced", "one\n   two\t three"))))
+    assert got["Spaced"] == "one two three"
+
+
+def test_the_result_is_sorted():
+    """A stable order is what makes the sha256 pin meaningful — an unsorted dict
+    would re-hash on every fetch and every refresh would look like a change."""
+    got = v.extract(page(enough(row("Aaa", "first")) + row("Zzz", "last")))
+    assert list(got) == sorted(got)
+
+
+def test_a_missing_heading_refuses():
+    with pytest.raises(SystemExit, match="heading not found"):
+        v.extract(page(enough(), heading="SomeOtherSection"))
+
+
+def test_a_heading_with_no_table_refuses():
+    with pytest.raises(SystemExit, match="no table"):
+        v.extract(f"<h3>{v.SECTION}</h3><p>prose, no table</p>")
+
+
+def test_a_partial_parse_refuses_rather_than_vendoring_it():
+    """THE ONE THAT MATTERS. A parse that finds three rows would vendor a table
+    the checker then 'agrees' with, silently narrowing the guard to nothing."""
+    with pytest.raises(SystemExit, match="refusing to vendor a partial table"):
+        v.extract(page(row("Copy", "copies") + row("Wait", "waits")))
+
+
+def test_it_anchors_on_the_heading_not_the_first_table():
+    """The article carries several tables; position is not a contract."""
+    other = "<table><tbody>" + row("Decoy", "a table earlier on the page") + "</tbody></table>"
+    got = v.extract("<h2>Something else</h2>" + other + page(enough()))
+    assert "Decoy" not in got
+
+
+def test_render_is_deterministic_and_carries_its_source():
+    rows = v.extract(page(enough()))
+    a, b = v.render(rows), v.render(rows)
+    assert a == b, "the artifact must be byte-stable or its sha256 pin is noise"
+    doc = json.loads(a)
+    assert doc["source"] == v.URL and doc["section"] == v.SECTION
+    assert doc["types"] == rows

--- a/scripts/check_adf_activity_types.py
+++ b/scripts/check_adf_activity_types.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Every CONCRETE ADF activity type must be handled — never the success stub.
+
+The emulator accepts ADF's activity vocabulary beside Fabric's own, so an ADF
+type it does not recognise falls to the dispatch default and is reported
+`{"status": "Succeeded"}` having done nothing. That is the defect that hit
+twelve Fabric types; the ADF half was still guarded only by hand-written lists
+in Go, and a hand-written list is what nothing checks.
+
+"Handled" means one of three real outcomes, and the checker does not care which:
+
+  * a `case` in `internal/api/pipelines.go`'s dispatch — it runs, or fails on
+    its own properties;
+  * a `case` in `internal/pipeline/activities.go` — control flow, interpreted
+    before the executor sees it;
+  * a key in `unrunnableActivities` — refused by name, with a cause.
+
+ABSTRACT BASES ARE EXCLUDED BY DERIVATION, NOT BY EXEMPTION. `Container`
+(`ControlActivity`) and `Execution` (`ExecutionActivity`) carry discriminators
+but are base classes other definitions inherit from; they are not authorable.
+The checker finds them by walking `allOf` and asking which definitions are
+someone else's base — because an exemption list here would be the very thing
+this file exists to delete.
+"""
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+VENDOR = ROOT / "third_party" / "adf-pipeline-schema"
+SCHEMA = VENDOR / "Pipeline.json"
+PROVENANCE = VENDOR / "PROVENANCE.md"
+DISPATCH = ROOT / "internal" / "api" / "pipelines.go"
+INTERP = ROOT / "internal" / "pipeline" / "activities.go"
+REFUSALS = ROOT / "internal" / "api" / "unrunnableactivities.go"
+
+SHA = re.compile(r"`sha256:([0-9a-f]{64})`")
+CASE = re.compile(r'^\tcase ((?:"[A-Za-z0-9-]+"(?:, )?)+):', re.M)
+QUOTED = re.compile(r'"([A-Za-z0-9-]+)"')
+REFUSAL_KEY = re.compile(r'^\t"([A-Za-z0-9-]+)":', re.M)
+
+
+def concrete_types(schema: dict) -> dict[str, str]:
+    """Discriminator -> definition name, for definitions nothing inherits from."""
+    defs = schema["definitions"]
+    bases = set()
+    for v in defs.values():
+        for a in (v.get("allOf") or []) if isinstance(v, dict) else []:
+            ref = a.get("$ref", "")
+            if ref.startswith("#/definitions/"):
+                bases.add(ref.rsplit("/", 1)[-1])
+    out = {}
+    for name, v in defs.items():
+        if not isinstance(v, dict):
+            continue
+        disc = v.get("x-ms-discriminator-value")
+        if disc and name not in bases:
+            out[disc] = name
+    return out
+
+
+def handled(text_dispatch: str, text_interp: str, text_refusals: str) -> set[str]:
+    names: set[str] = set()
+    for m in CASE.finditer(text_dispatch):
+        names |= set(QUOTED.findall(m.group(1)))
+    names |= set(re.findall(r'case "([A-Za-z0-9-]+)"', text_interp))
+    names |= set(REFUSAL_KEY.findall(text_refusals))
+    return names
+
+
+def main() -> int:
+    for p in (SCHEMA, PROVENANCE, DISPATCH, INTERP, REFUSALS):
+        if not p.exists():
+            print(f"check_adf_activity_types: missing {p.relative_to(ROOT)}")
+            return 1
+
+    raw = SCHEMA.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    pinned = SHA.search(PROVENANCE.read_text(encoding="utf-8"))
+    if not pinned:
+        print("check_adf_activity_types: PROVENANCE.md records no sha256")
+        return 1
+    if pinned.group(1) != digest:
+        print("check_adf_activity_types: the vendored schema does not match its own hash.\n"
+              f"  PROVENANCE.md: sha256:{pinned.group(1)}\n"
+              f"  Pipeline.json: sha256:{digest}\n"
+              "Re-pin deliberately with scripts/vendor_adf_pipeline_schema.py and read the diff.")
+        return 1
+
+    types = concrete_types(json.loads(raw))
+    if len(types) < 30:
+        print(f"check_adf_activity_types: only {len(types)} concrete types found — "
+              "the schema's shape changed and this checker is reading it wrong, which "
+              "would silently narrow the guard")
+        return 1
+
+    known = handled(DISPATCH.read_text(encoding="utf-8"),
+                    INTERP.read_text(encoding="utf-8"),
+                    REFUSALS.read_text(encoding="utf-8"))
+    gap = sorted(t for t in types if t not in known)
+    if gap:
+        print("check_adf_activity_types: these ADF activity types are handled nowhere, so a "
+              "pipeline using one is told it Succeeded having run nothing:\n")
+        for t in gap:
+            print(f"  {t}   ({types[t]})")
+        print("\nEach needs a dispatch case, an interpreter case, or an entry in "
+              "unrunnableActivities with its cause.")
+        return 1
+
+    print(f"check_adf_activity_types: {len(types)} concrete ADF types, all handled "
+          f"(dispatch, interpreter, or refused by name)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vendor_adf_pipeline_schema.py
+++ b/scripts/vendor_adf_pipeline_schema.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Re-fetch and re-pin ADF/Synapse's `entityTypes/Pipeline.json`.
+
+    scripts/vendor_adf_pipeline_schema.py [--sha <commit>]
+
+WHY. The emulator accepts ADF's activity vocabulary as a COMPATIBILITY surface
+(`RunNotebook`, `AzureFunctionActivity`, `DatabricksSparkJar`, the HDInsight
+family, …) alongside Fabric's own. Fabric's list is vendored and checked
+(third_party/fabric-activity-types). ADF's was not: it lived in hand-written
+lists in Go, which is the shape that let twelve Fabric types reach the success
+stub before anyone noticed.
+
+Unlike the Fabric article, this one CAN be pinned properly — it is a file in a
+public git repo, so the pin is a commit SHA as third_party/README.md asks,
+not a content hash.
+"""
+import argparse
+import hashlib
+import pathlib
+import sys
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+VENDOR = ROOT / "third_party" / "adf-pipeline-schema"
+REPO = "Azure/azure-rest-api-specs"
+PATH = ("specification/synapse/data-plane/Microsoft.Synapse/preview/"
+        "2021-06-01-preview/entityTypes/Pipeline.json")
+DEFAULT_SHA = "e773d51070bcccd61bafc30ccfedb96b261a0754"
+
+
+def fetch(sha: str, path: str) -> bytes:
+    url = f"https://raw.githubusercontent.com/{REPO}/{sha}/{path}"
+    with urllib.request.urlopen(url, timeout=60) as r:
+        return r.read()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sha", default=DEFAULT_SHA, help="upstream commit to pin")
+    args = ap.parse_args()
+
+    schema = fetch(args.sha, PATH)
+    licence = fetch(args.sha, "LICENSE")
+    if len(schema) < 100_000:
+        raise SystemExit(f"schema is only {len(schema)} bytes — refusing to vendor a truncated fetch")
+
+    VENDOR.mkdir(parents=True, exist_ok=True)
+    (VENDOR / "Pipeline.json").write_bytes(schema)
+    (VENDOR / "LICENSE").write_bytes(licence)
+    digest = hashlib.sha256(schema).hexdigest()
+    (VENDOR / "PROVENANCE.md").write_text(f"""# ADF/Synapse `entityTypes/Pipeline.json` — copied in full
+
+The published schema for Data Factory / Synapse pipeline **activities**: the
+`x-ms-discriminator-value` of every activity type ADF defines. The emulator
+accepts this vocabulary as a compatibility surface beside Fabric's own
+(third_party/fabric-activity-types), so it is an oracle in exactly the same way
+and is now checked in exactly the same way.
+
+## Provenance
+
+- **Upstream:** https://github.com/{REPO}
+- **File:** `{PATH}`
+- **Pinned revision:** `{args.sha}`
+- **Integrity:** `sha256:{digest}`, {len(schema)} bytes (`Pipeline.json`)
+- **License:** MIT (`LICENSE`) — © Microsoft Corporation.
+- **Used by:** `scripts/check_adf_activity_types.py` (in `make check` and CI),
+  which asserts every CONCRETE ADF activity type is handled by the dispatch,
+  the pipeline interpreter, or the refusal map — never the success stub.
+
+## Concrete vs abstract, and why the checker derives it
+
+Three of the 41 discriminators are not authorable activity types: `Container`
+(`ControlActivity`) and `Execution` (`ExecutionActivity`) are **base classes**
+other definitions inherit from. The checker excludes them by DERIVING which
+definitions are `allOf` bases, rather than carrying an exemption list — an
+exemption list is the thing this whole exercise exists to remove.
+
+## Refresh
+
+    scripts/vendor_adf_pipeline_schema.py --sha <newer-commit>
+
+Bump deliberately, in its own commit, and diff the schema: a change here is a
+change to the golden truth the dispatch is measured against.
+""")
+    print(f"vendored Pipeline.json at {args.sha[:12]}, sha256:{digest[:12]}…, {len(schema)} bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -53,6 +53,14 @@ the golden truth is reviewable. Never let a reference float.
   corpus (CC-BY-4.0, pinned by reference). Golden reference for the XMLA
   protocol, rowset encodings, schema rowsets, and the TMSL/TMDL model formats.
 
+- [`adf-pipeline-schema/`](adf-pipeline-schema/) — ADF/Synapse's published
+  `entityTypes/Pipeline.json` (MIT, copied in full, pinned to a commit SHA).
+  Golden reference for the ADF activity vocabulary the emulator accepts beside
+  Fabric's own; `scripts/check_adf_activity_types.py` asserts every CONCRETE
+  discriminator in it is handled — dispatch, interpreter, or refused by name —
+  and never the success stub. Abstract base classes are excluded by walking the
+  schema's `allOf` graph, not by an exemption list.
+
 - [`fabric-activity-types/`](fabric-activity-types/) — Microsoft's own
   `DataPipelineActivityTypes` table, the list of data-pipeline activity
   discriminators Fabric documents. Pinned by **content hash rather than a

--- a/third_party/adf-pipeline-schema/LICENSE
+++ b/third_party/adf-pipeline-schema/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/adf-pipeline-schema/PROVENANCE.md
+++ b/third_party/adf-pipeline-schema/PROVENANCE.md
@@ -1,0 +1,33 @@
+# ADF/Synapse `entityTypes/Pipeline.json` — copied in full
+
+The published schema for Data Factory / Synapse pipeline **activities**: the
+`x-ms-discriminator-value` of every activity type ADF defines. The emulator
+accepts this vocabulary as a compatibility surface beside Fabric's own
+(third_party/fabric-activity-types), so it is an oracle in exactly the same way
+and is now checked in exactly the same way.
+
+## Provenance
+
+- **Upstream:** https://github.com/Azure/azure-rest-api-specs
+- **File:** `specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/entityTypes/Pipeline.json`
+- **Pinned revision:** `e773d51070bcccd61bafc30ccfedb96b261a0754`
+- **Integrity:** `sha256:d4d1b9cadf9b8f17ec3bef9b0eb7a8cfcfa0d6eb4ccd48a63bf11cd14a4ea951`, 270562 bytes (`Pipeline.json`)
+- **License:** MIT (`LICENSE`) — © Microsoft Corporation.
+- **Used by:** `scripts/check_adf_activity_types.py` (in `make check` and CI),
+  which asserts every CONCRETE ADF activity type is handled by the dispatch,
+  the pipeline interpreter, or the refusal map — never the success stub.
+
+## Concrete vs abstract, and why the checker derives it
+
+Three of the 41 discriminators are not authorable activity types: `Container`
+(`ControlActivity`) and `Execution` (`ExecutionActivity`) are **base classes**
+other definitions inherit from. The checker excludes them by DERIVING which
+definitions are `allOf` bases, rather than carrying an exemption list — an
+exemption list is the thing this whole exercise exists to remove.
+
+## Refresh
+
+    scripts/vendor_adf_pipeline_schema.py --sha <newer-commit>
+
+Bump deliberately, in its own commit, and diff the schema: a change here is a
+change to the golden truth the dispatch is measured against.

--- a/third_party/adf-pipeline-schema/Pipeline.json
+++ b/third_party/adf-pipeline-schema/Pipeline.json
@@ -1,0 +1,7465 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ArtifactsClient",
+    "version": "2021-06-01-preview"
+  },
+  "paths": {},
+  "definitions": {
+    "Pipeline": {
+      "description": "A workspace pipeline.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "The description of the pipeline.",
+          "type": "string"
+        },
+        "activities": {
+          "type": "array",
+          "description": "List of activities in pipeline.",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        },
+        "parameters": {
+          "$ref": "../artifacts.json#/definitions/ParameterDefinitionSpecification",
+          "description": "List of parameters for pipeline."
+        },
+        "variables": {
+          "$ref": "../artifacts.json#/definitions/VariableDefinitionSpecification",
+          "description": "List of variables for pipeline."
+        },
+        "concurrency": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The max number of concurrent runs for the pipeline."
+        },
+        "annotations": {
+          "description": "List of tags that can be used for describing the Pipeline.",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "runDimensions": {
+          "description": "Dimensions emitted by Pipeline.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "folder": {
+          "description": "The folder that this Pipeline is in. If not specified, Pipeline will appear at the root level.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name of the folder that this Pipeline is in.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "Activity": {
+      "discriminator": "type",
+      "description": "A pipeline activity.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Activity name.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of activity."
+        },
+        "description": {
+          "description": "Activity description.",
+          "type": "string"
+        },
+        "dependsOn": {
+          "type": "array",
+          "description": "Activity depends on condition.",
+          "items": {
+            "$ref": "#/definitions/ActivityDependency"
+          }
+        },
+        "userProperties": {
+          "type": "array",
+          "description": "Activity user properties.",
+          "items": {
+            "$ref": "#/definitions/UserProperty"
+          }
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "UserProperty": {
+      "description": "User property.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "User property name.",
+          "type": "string"
+        },
+        "value": {
+          "description": "User property value. Type: string (or Expression with resultType string).",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "ActivityDependency": {
+      "description": "Activity dependency information.",
+      "type": "object",
+      "properties": {
+        "activity": {
+          "description": "Activity name.",
+          "type": "string"
+        },
+        "dependencyConditions": {
+          "type": "array",
+          "description": "Match-Condition for the dependency.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Succeeded",
+              "Failed",
+              "Skipped",
+              "Completed"
+            ],
+            "x-ms-enum": {
+              "name": "DependencyCondition",
+              "modelAsString": true
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "activity",
+        "dependencyConditions"
+      ]
+    },
+    "ControlActivity": {
+      "x-ms-discriminator-value": "Container",
+      "type": "object",
+      "description": "Base class for all control activities like IfCondition, ForEach , Until.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Activity"
+        }
+      ],
+      "properties": {}
+    },
+    "ExecutionActivity": {
+      "x-ms-discriminator-value": "Execution",
+      "description": "Base class for all execution activities.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Activity"
+        }
+      ],
+      "properties": {
+        "linkedServiceName": {
+          "description": "Linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "policy": {
+          "$ref": "#/definitions/ActivityPolicy",
+          "description": "Activity policy."
+        }
+      }
+    },
+    "ActivityPolicy": {
+      "description": "Execution policy for an activity.",
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "type": "object",
+          "description": "Specifies the timeout for the activity to run. The default timeout is 7 days. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "retry": {
+          "type": "object",
+          "description": "Maximum ordinary retry attempts. Default is 0. Type: integer (or Expression with resultType integer), minimum: 0."
+        },
+        "retryIntervalInSeconds": {
+          "type": "integer",
+          "description": "Interval between each retry attempt (in seconds). The default is 30 sec.",
+          "minimum": 30,
+          "maximum": 86400
+        },
+        "secureInput": {
+          "type": "boolean",
+          "description": "When set to true, Input from activity is considered as secure and will not be logged to monitoring."
+        },
+        "secureOutput": {
+          "type": "boolean",
+          "description": "When set to true, Output from activity is considered as secure and will not be logged to monitoring."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      }
+    },
+    "StoreReadSettings": {
+      "description": "Connector read setting.",
+      "discriminator": "type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The read setting type."
+        },
+        "maxConcurrentConnections": {
+          "type": "object",
+          "description": "The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "AzureBlobStorageReadSettings": {
+      "description": "Azure blob read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "Azure blob wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "Azure blob wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "prefix": {
+          "type": "object",
+          "description": "The prefix filter for the Azure Blob name. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureBlobFSReadSettings": {
+      "description": "Azure blobFS read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "Azure blobFS wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "Azure blobFS wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureDataLakeStoreReadSettings": {
+      "description": "Azure data lake store read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "ADLS wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "ADLS wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "listAfter": {
+          "type": "object",
+          "description": "Lists files after the value (exclusive) based on file/folder names’ lexicographical order. Applies under the folderPath in data set, and filter files/sub-folders under the folderPath. Type: string (or Expression with resultType string)."
+        },
+        "listBefore": {
+          "type": "object",
+          "description": "Lists files before the value (inclusive) based on file/folder names’ lexicographical order. Applies under the folderPath in data set, and filter files/sub-folders under the folderPath. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AmazonS3ReadSettings": {
+      "description": "Azure data lake store read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "AmazonS3 wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "AmazonS3 wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "prefix": {
+          "type": "object",
+          "description": "The prefix filter for the S3 object name. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "FileServerReadSettings": {
+      "description": "File server read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "FileServer wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "FileServer wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "fileFilter": {
+          "type": "object",
+          "description": "Specify a filter to be used to select a subset of files in the folderPath rather than all files. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureFileStorageReadSettings": {
+      "description": "Azure File Storage read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "Azure File Storage wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "Azure File Storage wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "prefix": {
+          "type": "object",
+          "description": "The prefix filter for the Azure File name starting from root path. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SftpWriteSettings": {
+      "description": "Sftp write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreWriteSettings"
+        }
+      ],
+      "properties": {
+        "operationTimeout": {
+          "description": "Specifies the timeout for writing each chunk to SFTP server. Default value: 01:00:00 (one hour). Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "useTempFileRename": {
+          "description": "Upload to temporary file(s) and rename. Disable this option if your SFTP server doesn't support rename operation. Type: boolean (or Expression with resultType boolean).",
+          "type": "object"
+        }
+      }
+    },
+    "GoogleCloudStorageReadSettings": {
+      "description": "Google Cloud Storage read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "Google Cloud Storage wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "Google Cloud Storage wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "prefix": {
+          "type": "object",
+          "description": "The prefix filter for the Google Cloud Storage object name. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "FtpReadSettings": {
+      "description": "Ftp read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "Ftp wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "Ftp wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "useBinaryTransfer": {
+          "type": "boolean",
+          "description": "Specify whether to use binary transfer mode for FTP stores."
+        },
+        "disableChunking": {
+          "type": "object",
+          "description": "If true, disable parallel reading within each file. Default is false. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "SftpReadSettings": {
+      "description": "Sftp read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "Sftp wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "Sftp wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "disableChunking": {
+          "type": "object",
+          "description": "If true, disable parallel reading within each file. Default is false. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "HttpReadSettings": {
+      "description": "Sftp read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "requestMethod": {
+          "type": "object",
+          "description": "The HTTP method used to call the RESTful API. The default is GET. Type: string (or Expression with resultType string)."
+        },
+        "requestBody": {
+          "type": "object",
+          "description": "The HTTP request body to the RESTful API if requestMethod is POST. Type: string (or Expression with resultType string)."
+        },
+        "additionalHeaders": {
+          "type": "object",
+          "description": "The additional HTTP headers in the request to the RESTful API. Type: string (or Expression with resultType string)."
+        },
+        "requestTimeout": {
+          "type": "object",
+          "description": "Specifies the timeout for a HTTP client to get HTTP response from HTTP server."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "HdfsReadSettings": {
+      "description": "HDFS read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreReadSettings"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "wildcardFolderPath": {
+          "type": "object",
+          "description": "HDFS wildcardFolderPath. Type: string (or Expression with resultType string)."
+        },
+        "wildcardFileName": {
+          "type": "object",
+          "description": "HDFS wildcardFileName. Type: string (or Expression with resultType string)."
+        },
+        "fileListPath": {
+          "type": "object",
+          "description": "Point to a text file that lists each file (relative path to the path configured in the dataset) that you want to copy. Type: string (or Expression with resultType string)."
+        },
+        "enablePartitionDiscovery": {
+          "type": "boolean",
+          "description": "Indicates whether to enable partition discovery."
+        },
+        "partitionRootPath": {
+          "type": "object",
+          "description": "Specify the root path where partition discovery starts from. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeStart": {
+          "type": "object",
+          "description": "The start of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "modifiedDatetimeEnd": {
+          "type": "object",
+          "description": "The end of file's modified datetime. Type: string (or Expression with resultType string)."
+        },
+        "distcpSettings": {
+          "description": "Specifies Distcp-related settings.",
+          "$ref": "#/definitions/DistcpSettings"
+        },
+        "deleteFilesAfterCompletion": {
+          "type": "object",
+          "description": "Indicates whether the source files need to be deleted after copy completion. Default is false. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "StoreWriteSettings": {
+      "description": "Connector write settings.",
+      "discriminator": "type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The write setting type."
+        },
+        "maxConcurrentConnections": {
+          "type": "object",
+          "description": "The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer)."
+        },
+        "copyBehavior": {
+          "description": "The type of copy behavior for copy sink.",
+          "type": "object"
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "AzureBlobStorageWriteSettings": {
+      "description": "Azure blob write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreWriteSettings"
+        }
+      ],
+      "properties": {
+        "blockSizeInMB": {
+          "description": "Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).",
+          "type": "object"
+        }
+      }
+    },
+    "AzureBlobFSWriteSettings": {
+      "description": "Azure blobFS write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreWriteSettings"
+        }
+      ],
+      "properties": {
+        "blockSizeInMB": {
+          "description": "Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).",
+          "type": "object"
+        }
+      }
+    },
+    "AzureDataLakeStoreWriteSettings": {
+      "description": "Azure data lake store write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreWriteSettings"
+        }
+      ],
+      "properties": {
+        "expiryDateTime": {
+          "description": "Specifies the expiry time of the written files. The time is applied to the UTC time zone in the format of \"2018-12-01T05:00:00Z\". Default value is NULL. Type: integer (or Expression with resultType integer).",
+          "type": "object"
+        }
+      }
+    },
+    "FileServerWriteSettings": {
+      "description": "File server write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreWriteSettings"
+        }
+      ]
+    },
+    "AzureFileStorageWriteSettings": {
+      "description": "Azure File Storage write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StoreWriteSettings"
+        }
+      ]
+    },
+    "FormatReadSettings": {
+      "description": "Format read settings.",
+      "discriminator": "type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The read setting type."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "CompressionReadSettings": {
+      "description": "Compression read settings.",
+      "discriminator": "type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The Compression setting type."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ZipDeflateReadSettings": {
+      "description": "The ZipDeflate compression read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CompressionReadSettings"
+        }
+      ],
+      "properties": {
+        "preserveZipFileNameAsFolder": {
+          "description": "Preserve the zip file name as folder path. Type: boolean (or Expression with resultType boolean).",
+          "type": "object"
+        }
+      }
+    },
+    "TarReadSettings": {
+      "description": "The Tar compression read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CompressionReadSettings"
+        }
+      ],
+      "properties": {
+        "preserveCompressionFileNameAsFolder": {
+          "description": "Preserve the compression file name as folder path. Type: boolean (or Expression with resultType boolean).",
+          "type": "object"
+        }
+      }
+    },
+    "TarGZipReadSettings": {
+      "description": "The TarGZip compression read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CompressionReadSettings"
+        }
+      ],
+      "properties": {
+        "preserveCompressionFileNameAsFolder": {
+          "description": "Preserve the compression file name as folder path. Type: boolean (or Expression with resultType boolean).",
+          "type": "object"
+        }
+      }
+    },
+    "DelimitedTextReadSettings": {
+      "description": "Delimited text read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatReadSettings"
+        }
+      ],
+      "properties": {
+        "skipLineCount": {
+          "type": "object",
+          "description": "Indicates the number of non-empty rows to skip when reading data from input files. Type: integer (or Expression with resultType integer)."
+        },
+        "compressionProperties": {
+          "$ref": "#/definitions/CompressionReadSettings",
+          "description": "Compression settings."
+        }
+      }
+    },
+    "JsonReadSettings": {
+      "description": "Json read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatReadSettings"
+        }
+      ],
+      "properties": {
+        "compressionProperties": {
+          "$ref": "#/definitions/CompressionReadSettings",
+          "description": "Compression settings."
+        }
+      }
+    },
+    "XmlReadSettings": {
+      "description": "Xml read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatReadSettings"
+        }
+      ],
+      "properties": {
+        "compressionProperties": {
+          "$ref": "#/definitions/CompressionReadSettings",
+          "description": "Compression settings."
+        },
+        "validationMode": {
+          "type": "object",
+          "description": "Indicates what validation method is used when reading the xml files. Allowed values: 'none', 'xsd', or 'dtd'. Type: string (or Expression with resultType string)."
+        },
+        "detectDataType": {
+          "type": "object",
+          "description": "Indicates whether type detection is enabled when reading the xml files. Type: boolean (or Expression with resultType boolean)."
+        },
+        "namespaces": {
+          "type": "object",
+          "description": "Indicates whether namespace is enabled when reading the xml files. Type: boolean (or Expression with resultType boolean)."
+        },
+        "namespacePrefixes": {
+          "type": "object",
+          "description": "Namespace uri to prefix mappings to override the prefixes in column names when namespace is enabled, if no prefix is defined for a namespace uri, the prefix of xml element/attribute name in the xml data file will be used. Example: \"{\"http://www.example.com/xml\":\"prefix\"}\" Type: object (or Expression with resultType object)."
+        }
+      }
+    },
+    "BinaryReadSettings": {
+      "description": "Binary read settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatReadSettings"
+        }
+      ],
+      "properties": {
+        "compressionProperties": {
+          "$ref": "#/definitions/CompressionReadSettings",
+          "description": "Compression settings."
+        }
+      }
+    },
+    "FormatWriteSettings": {
+      "description": "Format write settings.",
+      "discriminator": "type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The write setting type."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "AvroWriteSettings": {
+      "description": "Avro write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatWriteSettings"
+        }
+      ],
+      "properties": {
+        "recordName": {
+          "type": "string",
+          "description": "Top level record name in write result, which is required in AVRO spec."
+        },
+        "recordNamespace": {
+          "type": "string",
+          "description": "Record namespace in the write result."
+        },
+        "maxRowsPerFile": {
+          "type": "object",
+          "description": "Limit the written file's row count to be smaller than or equal to the specified count. Type: integer (or Expression with resultType integer)."
+        },
+        "fileNamePrefix": {
+          "type": "object",
+          "description": "Specifies the file name pattern <fileNamePrefix>_<fileIndex>.<fileExtension> when copy from non-file based store without partitionOptions. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "OrcWriteSettings": {
+      "description": "Orc write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatWriteSettings"
+        }
+      ],
+      "properties": {
+        "maxRowsPerFile": {
+          "type": "object",
+          "description": "Limit the written file's row count to be smaller than or equal to the specified count. Type: integer (or Expression with resultType integer)."
+        },
+        "fileNamePrefix": {
+          "type": "object",
+          "description": "Specifies the file name pattern <fileNamePrefix>_<fileIndex>.<fileExtension> when copy from non-file based store without partitionOptions. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ParquetWriteSettings": {
+      "description": "Parquet write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatWriteSettings"
+        }
+      ],
+      "properties": {
+        "maxRowsPerFile": {
+          "type": "object",
+          "description": "Limit the written file's row count to be smaller than or equal to the specified count. Type: integer (or Expression with resultType integer)."
+        },
+        "fileNamePrefix": {
+          "type": "object",
+          "description": "Specifies the file name pattern <fileNamePrefix>_<fileIndex>.<fileExtension> when copy from non-file based store without partitionOptions. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "DelimitedTextWriteSettings": {
+      "description": "Delimited text write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatWriteSettings"
+        }
+      ],
+      "properties": {
+        "quoteAllText": {
+          "type": "object",
+          "description": "Indicates whether string values should always be enclosed with quotes. Type: boolean (or Expression with resultType boolean)."
+        },
+        "fileExtension": {
+          "type": "object",
+          "description": "The file extension used to create the files. Type: string (or Expression with resultType string)."
+        },
+        "maxRowsPerFile": {
+          "type": "object",
+          "description": "Limit the written file's row count to be smaller than or equal to the specified count. Type: integer (or Expression with resultType integer)."
+        },
+        "fileNamePrefix": {
+          "type": "object",
+          "description": "Specifies the file name pattern <fileNamePrefix>_<fileIndex>.<fileExtension> when copy from non-file based store without partitionOptions. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "fileExtension"
+      ]
+    },
+    "JsonWriteSettings": {
+      "description": "Json write settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FormatWriteSettings"
+        }
+      ],
+      "properties": {
+        "filePattern": {
+          "type": "object",
+          "description": "File pattern of JSON. This setting controls the way a collection of JSON objects will be treated. The default value is 'setOfObjects'. It is case-sensitive."
+        }
+      }
+    },
+    "JsonWriteFilePattern": {
+      "description": "All available filePatterns.",
+      "type": "string",
+      "enum": [
+        "setOfObjects",
+        "arrayOfObjects"
+      ],
+      "x-ms-enum": {
+        "name": "JsonWriteFilePattern",
+        "modelAsString": true
+      }
+    },
+    "AvroSource": {
+      "description": "A copy activity Avro source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "Avro store settings."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "ExcelSource": {
+      "description": "A copy activity excel source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "Excel store settings."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "ParquetSource": {
+      "description": "A copy activity Parquet source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "Parquet store settings."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "DelimitedTextSource": {
+      "description": "A copy activity DelimitedText source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "DelimitedText store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/DelimitedTextReadSettings",
+          "description": "DelimitedText format settings."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "JsonSource": {
+      "description": "A copy activity Json source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "Json store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/JsonReadSettings",
+          "description": "Json format settings."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "XmlSource": {
+      "description": "A copy activity Xml source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "Xml store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/XmlReadSettings",
+          "description": "Xml format settings."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "OrcSource": {
+      "description": "A copy activity ORC source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "ORC store settings."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "DelimitedTextSink": {
+      "description": "A copy activity DelimitedText sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreWriteSettings",
+          "description": "DelimitedText store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/DelimitedTextWriteSettings",
+          "description": "DelimitedText format settings."
+        }
+      }
+    },
+    "JsonSink": {
+      "description": "A copy activity Json sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreWriteSettings",
+          "description": "Json store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/JsonWriteSettings",
+          "description": "Json format settings."
+        }
+      }
+    },
+    "OrcSink": {
+      "description": "A copy activity ORC sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreWriteSettings",
+          "description": "ORC store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/OrcWriteSettings",
+          "description": "ORC format settings."
+        }
+      }
+    },
+    "CopyActivity": {
+      "x-ms-discriminator-value": "Copy",
+      "description": "Copy activity.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Copy activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/CopyActivityTypeProperties"
+        },
+        "inputs": {
+          "type": "array",
+          "description": "List of inputs for the activity.",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/DatasetReference"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "description": "List of outputs for the activity.",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/DatasetReference"
+          }
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "CopyActivityTypeProperties": {
+      "description": "Copy activity properties.",
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Copy activity source.",
+          "$ref": "#/definitions/CopySource"
+        },
+        "sink": {
+          "description": "Copy activity sink.",
+          "$ref": "#/definitions/CopySink"
+        },
+        "translator": {
+          "description": "Copy activity translator. If not specified, tabular translator is used.",
+          "type": "object"
+        },
+        "enableStaging": {
+          "type": "object",
+          "description": "Specifies whether to copy data via an interim staging. Default value is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "stagingSettings": {
+          "description": "Specifies interim staging settings when EnableStaging is true.",
+          "$ref": "#/definitions/StagingSettings"
+        },
+        "parallelCopies": {
+          "type": "object",
+          "description": "Maximum number of concurrent sessions opened on the source or sink to avoid overloading the data store. Type: integer (or Expression with resultType integer), minimum: 0."
+        },
+        "dataIntegrationUnits": {
+          "type": "object",
+          "description": "Maximum number of data integration units that can be used to perform this data movement. Type: integer (or Expression with resultType integer), minimum: 0."
+        },
+        "enableSkipIncompatibleRow": {
+          "type": "object",
+          "description": "Whether to skip incompatible row. Default value is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "redirectIncompatibleRowSettings": {
+          "description": "Redirect incompatible row settings when EnableSkipIncompatibleRow is true.",
+          "$ref": "#/definitions/RedirectIncompatibleRowSettings"
+        },
+        "logStorageSettings": {
+          "description": "(Deprecated. Please use LogSettings) Log storage settings customer need to provide when enabling session log.",
+          "$ref": "#/definitions/LogStorageSettings"
+        },
+        "logSettings": {
+          "description": "Log settings customer needs provide when enabling log.",
+          "$ref": "#/definitions/LogSettings"
+        },
+        "preserveRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          },
+          "description": "Preserve Rules."
+        },
+        "preserve": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          },
+          "description": "Preserve rules."
+        },
+        "validateDataConsistency": {
+          "type": "object",
+          "description": "Whether to enable Data Consistency validation. Type: boolean (or Expression with resultType boolean)."
+        },
+        "skipErrorFile": {
+          "description": "Specify the fault tolerance for data consistency.",
+          "$ref": "#/definitions/SkipErrorFile"
+        }
+      },
+      "required": [
+        "source",
+        "sink"
+      ]
+    },
+    "CopySource": {
+      "discriminator": "type",
+      "description": "A copy activity source.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Copy source type."
+        },
+        "sourceRetryCount": {
+          "type": "object",
+          "description": "Source retry count. Type: integer (or Expression with resultType integer)."
+        },
+        "sourceRetryWait": {
+          "type": "object",
+          "description": "Source retry wait. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "maxConcurrentConnections": {
+          "type": "object",
+          "description": "The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "BinarySource": {
+      "description": "A copy activity Binary source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "Binary store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/BinaryReadSettings",
+          "description": "Binary format settings."
+        }
+      }
+    },
+    "TabularSource": {
+      "description": "Copy activity sources of tabular type.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "AzureTableSource": {
+      "description": "A copy activity Azure Table source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "azureTableSourceQuery": {
+          "type": "object",
+          "description": "Azure Table source query. Type: string (or Expression with resultType string)."
+        },
+        "azureTableSourceIgnoreTableNotFound": {
+          "type": "object",
+          "description": "Azure Table source ignore table not found. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "BlobSource": {
+      "description": "A copy activity Azure Blob source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "treatEmptyAsNull": {
+          "type": "object",
+          "description": "Treat empty as null. Type: boolean (or Expression with resultType boolean)."
+        },
+        "skipHeaderLineCount": {
+          "type": "object",
+          "description": "Number of header lines to skip from each blob. Type: integer (or Expression with resultType integer)."
+        },
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "DocumentDbCollectionSource": {
+      "description": "A copy activity Document Database Collection source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Documents query. Type: string (or Expression with resultType string)."
+        },
+        "nestingSeparator": {
+          "type": "object",
+          "description": "Nested properties separator. Type: string (or Expression with resultType string)."
+        },
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "CosmosDbSqlApiSource": {
+      "description": "A copy activity Azure CosmosDB (SQL API) Collection source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "SQL API query. Type: string (or Expression with resultType string)."
+        },
+        "pageSize": {
+          "type": "object",
+          "description": "Page size of the result. Type: integer (or Expression with resultType integer)."
+        },
+        "preferredRegions": {
+          "type": "object",
+          "description": "Preferred regions. Type: array of strings (or Expression with resultType array of strings)."
+        },
+        "detectDatetime": {
+          "type": "object",
+          "description": "Whether detect primitive values as datetime values. Type: boolean (or Expression with resultType boolean)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "DynamicsSource": {
+      "description": "A copy activity Dynamics source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "FetchXML is a proprietary query language that is used in Microsoft Dynamics (online & on-premises). Type: string (or Expression with resultType string)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "DynamicsCrmSource": {
+      "description": "A copy activity Dynamics CRM source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "FetchXML is a proprietary query language that is used in Microsoft Dynamics CRM (online & on-premises). Type: string (or Expression with resultType string)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "CommonDataServiceForAppsSource": {
+      "description": "A copy activity Common Data Service for Apps source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "FetchXML is a proprietary query language that is used in Microsoft Common Data Service for Apps (online & on-premises). Type: string (or Expression with resultType string)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "RelationalSource": {
+      "description": "A copy activity source for various relational databases.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "InformixSource": {
+      "description": "A copy activity source for Informix.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "MicrosoftAccessSource": {
+      "description": "A copy activity source for Microsoft Access.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "Db2Source": {
+      "description": "A copy activity source for Db2 databases.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "OdbcSource": {
+      "description": "A copy activity source for ODBC databases.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "MySqlSource": {
+      "description": "A copy activity source for MySQL databases.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "PostgreSqlSource": {
+      "description": "A copy activity source for PostgreSQL databases.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SybaseSource": {
+      "description": "A copy activity source for Sybase databases.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SapBwSource": {
+      "description": "A copy activity source for SapBW server via MDX.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "MDX query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ODataSource": {
+      "description": "A copy activity source for OData source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "OData query. For example, \"$top=1\". Type: string (or Expression with resultType string)."
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data. Default value: 00:05:00. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "SalesforceSource": {
+      "description": "A copy activity Salesforce source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        },
+        "readBehavior": {
+          "description": "The read behavior for the operation. Default is Query.",
+          "type": "string",
+          "enum": [
+            "Query",
+            "QueryAll"
+          ],
+          "x-ms-enum": {
+            "name": "SalesforceSourceReadBehavior",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "SalesforceServiceCloudSource": {
+      "description": "A copy activity Salesforce Service Cloud source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        },
+        "readBehavior": {
+          "description": "The read behavior for the operation. Default is Query.",
+          "type": "string",
+          "enum": [
+            "Query",
+            "QueryAll"
+          ],
+          "x-ms-enum": {
+            "name": "SalesforceSourceReadBehavior",
+            "modelAsString": true
+          }
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "SapCloudForCustomerSource": {
+      "description": "A copy activity source for SAP Cloud for Customer source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "SAP Cloud for Customer OData query. For example, \"$top=1\". Type: string (or Expression with resultType string)."
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data. Default value: 00:05:00. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        }
+      }
+    },
+    "SapEccSource": {
+      "description": "A copy activity source for SAP ECC source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "SAP ECC OData query. For example, \"$top=1\". Type: string (or Expression with resultType string)."
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data. Default value: 00:05:00. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        }
+      }
+    },
+    "SapHanaSource": {
+      "description": "A copy activity source for SAP HANA source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "SAP HANA Sql query. Type: string (or Expression with resultType string)."
+        },
+        "packetSize": {
+          "type": "object",
+          "description": "The packet size of data read from SAP HANA. Type: integer(or Expression with resultType integer)."
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for SAP HANA read in parallel.",
+          "type": "string",
+          "enum": [
+            "None",
+            "PhysicalPartitionsOfTable",
+            "SapHanaDynamicRange"
+          ],
+          "x-ms-enum": {
+            "name": "SapHanaPartitionOption",
+            "modelAsString": true
+          }
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for SAP HANA source partitioning.",
+          "$ref": "#/definitions/SapHanaPartitionSettings"
+        }
+      }
+    },
+    "SapHanaPartitionSettings": {
+      "description": "The settings that will be leveraged for SAP HANA source partitioning.",
+      "type": "object",
+      "properties": {
+        "partitionColumnName": {
+          "type": "object",
+          "description": "The name of the column that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SapOpenHubSource": {
+      "description": "A copy activity source for SAP Business Warehouse Open Hub Destination source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "excludeLastRequest": {
+          "type": "object",
+          "description": "Whether to exclude the records of the last request. The default value is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "baseRequestId": {
+          "type": "object",
+          "description": "The ID of request for delta loading. Once it is set, only data with requestId larger than the value of this property will be retrieved. The default value is 0. Type: integer (or Expression with resultType integer )."
+        },
+        "customRfcReadTableFunctionModule": {
+          "type": "object",
+          "description": "Specifies the custom RFC function module that will be used to read data from SAP Table. Type: string (or Expression with resultType string)."
+        },
+        "sapDataColumnDelimiter": {
+          "type": "object",
+          "description": "The single character that will be used as delimiter passed to SAP RFC as well as splitting the output data retrieved. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SapTableSource": {
+      "description": "A copy activity source for SAP Table source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "rowCount": {
+          "type": "object",
+          "description": "The number of rows to be retrieved. Type: integer(or Expression with resultType integer)."
+        },
+        "rowSkips": {
+          "type": "object",
+          "description": "The number of rows that will be skipped. Type: integer (or Expression with resultType integer)."
+        },
+        "rfcTableFields": {
+          "type": "object",
+          "description": "The fields of the SAP table that will be retrieved. For example, column0, column1. Type: string (or Expression with resultType string)."
+        },
+        "rfcTableOptions": {
+          "type": "object",
+          "description": "The options for the filtering of the SAP Table. For example, COLUMN0 EQ SOME VALUE. Type: string (or Expression with resultType string)."
+        },
+        "batchSize": {
+          "type": "object",
+          "description": "Specifies the maximum number of rows that will be retrieved at a time when retrieving data from SAP Table. Type: integer (or Expression with resultType integer)."
+        },
+        "customRfcReadTableFunctionModule": {
+          "type": "object",
+          "description": "Specifies the custom RFC function module that will be used to read data from SAP Table. Type: string (or Expression with resultType string)."
+        },
+        "sapDataColumnDelimiter": {
+          "type": "object",
+          "description": "The single character that will be used as delimiter passed to SAP RFC as well as splitting the output data retrieved. Type: string (or Expression with resultType string)."
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for SAP table read in parallel.",
+          "type": "string",
+          "enum": [
+            "None",
+            "PartitionOnInt",
+            "PartitionOnCalendarYear",
+            "PartitionOnCalendarMonth",
+            "PartitionOnCalendarDate",
+            "PartitionOnTime"
+          ],
+          "x-ms-enum": {
+            "name": "SapTablePartitionOption",
+            "modelAsString": true
+          }
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for SAP table source partitioning.",
+          "$ref": "#/definitions/SapTablePartitionSettings"
+        }
+      }
+    },
+    "SapTablePartitionSettings": {
+      "description": "The settings that will be leveraged for SAP table source partitioning.",
+      "type": "object",
+      "properties": {
+        "partitionColumnName": {
+          "type": "object",
+          "description": "The name of the column that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionUpperBound": {
+          "type": "object",
+          "description": "The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionLowerBound": {
+          "type": "object",
+          "description": "The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "maxPartitionsNumber": {
+          "type": "object",
+          "description": "The maximum value of partitions the table will be split into. Type: integer (or Expression with resultType string)."
+        }
+      }
+    },
+    "RestSink": {
+      "description": "A copy activity Rest service Sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "requestMethod": {
+          "type": "object",
+          "description": "The HTTP method used to call the RESTful API. The default is POST. Type: string (or Expression with resultType string)."
+        },
+        "additionalHeaders": {
+          "type": "object",
+          "description": "The additional HTTP headers in the request to the RESTful API. Type: string (or Expression with resultType string)."
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data. Default value: 00:01:40. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "requestInterval": {
+          "type": "object",
+          "description": "The time to await before sending next request, in milliseconds "
+        },
+        "httpCompressionType": {
+          "type": "object",
+          "description": "Http Compression Type to Send data in compressed format with Optimal Compression Level, Default is None. And The Only Supported option is Gzip. "
+        }
+      }
+    },
+    "RestSource": {
+      "description": "A copy activity Rest service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "requestMethod": {
+          "type": "object",
+          "description": "The HTTP method used to call the RESTful API. The default is GET. Type: string (or Expression with resultType string)."
+        },
+        "requestBody": {
+          "type": "object",
+          "description": "The HTTP request body to the RESTful API if requestMethod is POST. Type: string (or Expression with resultType string)."
+        },
+        "additionalHeaders": {
+          "type": "object",
+          "description": "The additional HTTP headers in the request to the RESTful API. Type: string (or Expression with resultType string)."
+        },
+        "paginationRules": {
+          "type": "object",
+          "description": "The pagination rules to compose next page requests. Type: string (or Expression with resultType string)."
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data. Default value: 00:01:40. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "requestInterval": {
+          "type": "object",
+          "description": "The time to await before sending next page request. "
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "SqlSource": {
+      "description": "A copy activity SQL source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "sqlReaderQuery": {
+          "type": "object",
+          "description": "SQL reader query. Type: string (or Expression with resultType string)."
+        },
+        "sqlReaderStoredProcedureName": {
+          "type": "object",
+          "description": "Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "isolationLevel": {
+          "description": "Specifies the transaction locking behavior for the SQL source. Allowed values: ReadCommitted/ReadUncommitted/RepeatableRead/Serializable/Snapshot. The default value is ReadCommitted. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Sql read in parallel. Possible values include: \"None\", \"PhysicalPartitionsOfTable\", \"DynamicRange\".",
+          "type": "object"
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Sql source partitioning.",
+          "$ref": "#/definitions/SqlPartitionSettings"
+        }
+      }
+    },
+    "SqlServerSource": {
+      "description": "A copy activity SQL server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "sqlReaderQuery": {
+          "type": "object",
+          "description": "SQL reader query. Type: string (or Expression with resultType string)."
+        },
+        "sqlReaderStoredProcedureName": {
+          "type": "object",
+          "description": "Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "produceAdditionalTypes": {
+          "description": "Which additional types to produce.",
+          "type": "object"
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Sql read in parallel. Possible values include: \"None\", \"PhysicalPartitionsOfTable\", \"DynamicRange\".",
+          "type": "object"
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Sql source partitioning.",
+          "$ref": "#/definitions/SqlPartitionSettings"
+        }
+      }
+    },
+    "AmazonRdsForSqlServerSource": {
+      "description": "A copy activity Amazon RDS for SQL Server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "sqlReaderQuery": {
+          "type": "object",
+          "description": "SQL reader query. Type: string (or Expression with resultType string)."
+        },
+        "sqlReaderStoredProcedureName": {
+          "type": "object",
+          "description": "Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "produceAdditionalTypes": {
+          "description": "Which additional types to produce.",
+          "type": "object"
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Sql read in parallel. Possible values include: \"None\", \"PhysicalPartitionsOfTable\", \"DynamicRange\".",
+          "type": "object"
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Sql source partitioning.",
+          "$ref": "#/definitions/SqlPartitionSettings"
+        }
+      }
+    },
+    "AzureSqlSource": {
+      "description": "A copy activity Azure SQL source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "sqlReaderQuery": {
+          "type": "object",
+          "description": "SQL reader query. Type: string (or Expression with resultType string)."
+        },
+        "sqlReaderStoredProcedureName": {
+          "type": "object",
+          "description": "Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "produceAdditionalTypes": {
+          "description": "Which additional types to produce.",
+          "type": "object"
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Sql read in parallel. Possible values include: \"None\", \"PhysicalPartitionsOfTable\", \"DynamicRange\".",
+          "type": "object"
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Sql source partitioning.",
+          "$ref": "#/definitions/SqlPartitionSettings"
+        }
+      }
+    },
+    "SqlMISource": {
+      "description": "A copy activity Azure SQL Managed Instance source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "sqlReaderQuery": {
+          "type": "object",
+          "description": "SQL reader query. Type: string (or Expression with resultType string)."
+        },
+        "sqlReaderStoredProcedureName": {
+          "type": "object",
+          "description": "Name of the stored procedure for a Azure SQL Managed Instance source. This cannot be used at the same time as SqlReaderQuery. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "produceAdditionalTypes": {
+          "description": "Which additional types to produce.",
+          "type": "object"
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Sql read in parallel. Possible values include: \"None\", \"PhysicalPartitionsOfTable\", \"DynamicRange\".",
+          "type": "object"
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Sql source partitioning.",
+          "$ref": "#/definitions/SqlPartitionSettings"
+        }
+      }
+    },
+    "SqlDWSource": {
+      "description": "A copy activity SQL Data Warehouse source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "sqlReaderQuery": {
+          "type": "object",
+          "description": "SQL Data Warehouse reader query. Type: string (or Expression with resultType string)."
+        },
+        "sqlReaderStoredProcedureName": {
+          "type": "object",
+          "description": "Name of the stored procedure for a SQL Data Warehouse source. This cannot be used at the same time as SqlReaderQuery. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "type": "object",
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\". Type: object (or Expression with resultType object), itemType: StoredProcedureParameter."
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Sql read in parallel. Possible values include: \"None\", \"PhysicalPartitionsOfTable\", \"DynamicRange\".",
+          "type": "object"
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Sql source partitioning.",
+          "$ref": "#/definitions/SqlPartitionSettings"
+        }
+      }
+    },
+    "SqlPartitionSettings": {
+      "description": "The settings that will be leveraged for Sql source partitioning.",
+      "type": "object",
+      "properties": {
+        "partitionColumnName": {
+          "type": "object",
+          "description": "The name of the column in integer or datetime type that will be used for proceeding partitioning. If not specified, the primary key of the table is auto-detected and used as the partition column. Type: string (or Expression with resultType string)."
+        },
+        "partitionUpperBound": {
+          "type": "object",
+          "description": "The maximum value of the partition column for partition range splitting. This value is used to decide the partition stride, not for filtering the rows in table. All rows in the table or query result will be partitioned and copied. Type: string (or Expression with resultType string)."
+        },
+        "partitionLowerBound": {
+          "type": "object",
+          "description": "The minimum value of the partition column for partition range splitting. This value is used to decide the partition stride, not for filtering the rows in table. All rows in the table or query result will be partitioned and copied. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "FileSystemSource": {
+      "description": "A copy activity file system source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "HdfsSource": {
+      "description": "A copy activity HDFS source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "distcpSettings": {
+          "description": "Specifies Distcp-related settings.",
+          "$ref": "#/definitions/DistcpSettings"
+        }
+      }
+    },
+    "DistcpSettings": {
+      "description": "Distcp settings.",
+      "type": "object",
+      "properties": {
+        "resourceManagerEndpoint": {
+          "type": "object",
+          "description": "Specifies the Yarn ResourceManager endpoint. Type: string (or Expression with resultType string)."
+        },
+        "tempScriptPath": {
+          "type": "object",
+          "description": "Specifies an existing folder path which will be used to store temp Distcp command script. The script file is generated by ADF and will be removed after Copy job finished. Type: string (or Expression with resultType string)."
+        },
+        "distcpOptions": {
+          "type": "object",
+          "description": "Specifies the Distcp options. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "resourceManagerEndpoint",
+        "tempScriptPath"
+      ]
+    },
+    "AzureMySqlSource": {
+      "description": "A copy activity Azure MySQL source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureDataExplorerSource": {
+      "description": "A copy activity Azure Data Explorer (Kusto) source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Should be a Kusto Query Language (KQL) query. Type: string (or Expression with resultType string)."
+        },
+        "noTruncation": {
+          "type": "object",
+          "description": "The name of the Boolean option that controls whether truncation is applied to result-sets that go beyond a certain row-count limit."
+        },
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9])).."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "OracleSource": {
+      "description": "A copy activity Oracle source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "oracleReaderQuery": {
+          "type": "object",
+          "description": "Oracle reader query. Type: string (or Expression with resultType string)."
+        },
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Oracle read in parallel.",
+          "type": "string",
+          "enum": [
+            "None",
+            "PhysicalPartitionsOfTable",
+            "DynamicRange"
+          ],
+          "x-ms-enum": {
+            "name": "OraclePartitionOption",
+            "modelAsString": true
+          }
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Oracle source partitioning.",
+          "$ref": "#/definitions/OraclePartitionSettings"
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "OraclePartitionSettings": {
+      "description": "The settings that will be leveraged for Oracle source partitioning.",
+      "type": "object",
+      "properties": {
+        "partitionNames": {
+          "type": "object",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          },
+          "description": "Names of the physical partitions of Oracle table. "
+        },
+        "partitionColumnName": {
+          "type": "object",
+          "description": "The name of the column in integer type that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionUpperBound": {
+          "type": "object",
+          "description": "The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionLowerBound": {
+          "type": "object",
+          "description": "The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AmazonRdsForOracleSource": {
+      "description": "A copy activity AmazonRdsForOracle source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "oracleReaderQuery": {
+          "type": "object",
+          "description": "AmazonRdsForOracle reader query. Type: string (or Expression with resultType string)."
+        },
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "partitionOption": {
+          "type": "object",
+          "description": "The partition mechanism that will be used for AmazonRdsForOracle read in parallel. Type: string (or Expression with resultType string)."
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for AmazonRdsForOracle source partitioning.",
+          "$ref": "#/definitions/AmazonRdsForOraclePartitionSettings"
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "AmazonRdsForOraclePartitionOption": {
+      "type": "string",
+      "enum": [
+        "None",
+        "PhysicalPartitionsOfTable",
+        "DynamicRange"
+      ],
+      "x-ms-enum": {
+        "name": "AmazonRdsForOraclePartitionOption",
+        "modelAsString": true
+      }
+    },
+    "AmazonRdsForOraclePartitionSettings": {
+      "description": "The settings that will be leveraged for AmazonRdsForOracle source partitioning.",
+      "type": "object",
+      "properties": {
+        "partitionNames": {
+          "type": "object",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          },
+          "description": "Names of the physical partitions of AmazonRdsForOracle table. "
+        },
+        "partitionColumnName": {
+          "type": "object",
+          "description": "The name of the column in integer type that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionUpperBound": {
+          "type": "object",
+          "description": "The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionLowerBound": {
+          "type": "object",
+          "description": "The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "TeradataSource": {
+      "description": "A copy activity Teradata source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Teradata query. Type: string (or Expression with resultType string)."
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for teradata read in parallel.",
+          "type": "string",
+          "enum": [
+            "None",
+            "Hash",
+            "DynamicRange"
+          ],
+          "x-ms-enum": {
+            "name": "TeradataPartitionOption",
+            "modelAsString": true
+          }
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for teradata source partitioning.",
+          "$ref": "#/definitions/TeradataPartitionSettings"
+        }
+      }
+    },
+    "TeradataPartitionSettings": {
+      "description": "The settings that will be leveraged for teradata source partitioning.",
+      "type": "object",
+      "properties": {
+        "partitionColumnName": {
+          "type": "object",
+          "description": "The name of the column that will be used for proceeding range or hash partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionUpperBound": {
+          "type": "object",
+          "description": "The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionLowerBound": {
+          "type": "object",
+          "description": "The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "WebSource": {
+      "description": "A copy activity source for web page table.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "CassandraSource": {
+      "description": "A copy activity source for a Cassandra database.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Should be a SQL-92 query expression or Cassandra Query Language (CQL) command. Type: string (or Expression with resultType string)."
+        },
+        "consistencyLevel": {
+          "description": "The consistency level specifies how many Cassandra servers must respond to a read request before returning data to the client application. Cassandra checks the specified number of Cassandra servers for data to satisfy the read request. Must be one of cassandraSourceReadConsistencyLevels. The default value is 'ONE'. It is case-insensitive.",
+          "type": "string",
+          "enum": [
+            "ALL",
+            "EACH_QUORUM",
+            "QUORUM",
+            "LOCAL_QUORUM",
+            "ONE",
+            "TWO",
+            "THREE",
+            "LOCAL_ONE",
+            "SERIAL",
+            "LOCAL_SERIAL"
+          ],
+          "x-ms-enum": {
+            "name": "CassandraSourceReadConsistencyLevels",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "MongoDbSource": {
+      "description": "A copy activity source for a MongoDB database.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Should be a SQL-92 query expression. Type: string (or Expression with resultType string)."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "MongoDbAtlasSource": {
+      "description": "A copy activity source for a MongoDB Atlas database.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "filter": {
+          "type": "object",
+          "description": "Specifies selection filter using query operators. To return all documents in a collection, omit this parameter or pass an empty document ({}). Type: string (or Expression with resultType string)."
+        },
+        "cursorMethods": {
+          "description": "Cursor methods for Mongodb query",
+          "$ref": "#/definitions/MongoDbCursorMethodsProperties"
+        },
+        "batchSize": {
+          "type": "object",
+          "description": "Specifies the number of documents to return in each batch of the response from MongoDB Atlas instance. In most cases, modifying the batch size will not affect the user or the application. This property's main purpose is to avoid hit the limitation of response size. Type: integer (or Expression with resultType integer)."
+        },
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "MongoDbV2Source": {
+      "description": "A copy activity source for a MongoDB database.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "filter": {
+          "type": "object",
+          "description": "Specifies selection filter using query operators. To return all documents in a collection, omit this parameter or pass an empty document ({}). Type: string (or Expression with resultType string)."
+        },
+        "cursorMethods": {
+          "description": "Cursor methods for Mongodb query",
+          "$ref": "#/definitions/MongoDbCursorMethodsProperties"
+        },
+        "batchSize": {
+          "type": "object",
+          "description": "Specifies the number of documents to return in each batch of the response from MongoDB instance. In most cases, modifying the batch size will not affect the user or the application. This property's main purpose is to avoid hit the limitation of response size. Type: integer (or Expression with resultType integer)."
+        },
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "CosmosDbMongoDbApiSource": {
+      "description": "A copy activity source for a CosmosDB (MongoDB API) database.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "filter": {
+          "type": "object",
+          "description": "Specifies selection filter using query operators. To return all documents in a collection, omit this parameter or pass an empty document ({}). Type: string (or Expression with resultType string)."
+        },
+        "cursorMethods": {
+          "description": "Cursor methods for Mongodb query.",
+          "$ref": "#/definitions/MongoDbCursorMethodsProperties"
+        },
+        "batchSize": {
+          "type": "object",
+          "description": "Specifies the number of documents to return in each batch of the response from MongoDB instance. In most cases, modifying the batch size will not affect the user or the application. This property's main purpose is to avoid hit the limitation of response size. Type: integer (or Expression with resultType integer)."
+        },
+        "queryTimeout": {
+          "type": "object",
+          "description": "Query timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "additionalColumns": {
+          "type": "object",
+          "description": "Specifies the additional columns to be added to source data. Type: array of objects(AdditionalColumns) (or Expression with resultType array of objects)."
+        }
+      }
+    },
+    "MongoDbCursorMethodsProperties": {
+      "description": "Cursor methods for Mongodb query",
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "object",
+          "description": "Specifies the fields to return in the documents that match the query filter. To return all fields in the matching documents, omit this parameter. Type: string (or Expression with resultType string)."
+        },
+        "sort": {
+          "type": "object",
+          "description": "Specifies the order in which the query returns matching documents. Type: string (or Expression with resultType string). Type: string (or Expression with resultType string)."
+        },
+        "skip": {
+          "type": "object",
+          "description": "Specifies the how many documents skipped and where MongoDB begins returning results. This approach may be useful in implementing paginated results. Type: integer (or Expression with resultType integer)."
+        },
+        "limit": {
+          "type": "object",
+          "description": "Specifies the maximum number of documents the server returns. limit() is analogous to the LIMIT statement in a SQL database. Type: integer (or Expression with resultType integer)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      }
+    },
+    "Office365Source": {
+      "description": "A copy activity source for an Office 365 service.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "allowedGroups": {
+          "type": "object",
+          "description": "The groups containing all the users. Type: array of strings (or Expression with resultType array of strings)."
+        },
+        "userScopeFilterUri": {
+          "type": "object",
+          "description": "The user scope uri. Type: string (or Expression with resultType string)."
+        },
+        "dateFilterColumn": {
+          "type": "object",
+          "description": "The Column to apply the <paramref name=\"StartTime\"/> and <paramref name=\"EndTime\"/>. Type: string (or Expression with resultType string)."
+        },
+        "startTime": {
+          "type": "object",
+          "description": "Start time of the requested range for this dataset. Type: string (or Expression with resultType string)."
+        },
+        "endTime": {
+          "type": "object",
+          "description": "End time of the requested range for this dataset. Type: string (or Expression with resultType string)."
+        },
+        "outputColumns": {
+          "type": "object",
+          "description": "The columns to be read out from the Office 365 table. Type: array of objects (or Expression with resultType array of objects). Example: [ { \"name\": \"Id\" }, { \"name\": \"CreatedDateTime\" } ]"
+        }
+      }
+    },
+    "AzureDataLakeStoreSource": {
+      "description": "A copy activity Azure Data Lake source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "AzureBlobFSSource": {
+      "description": "A copy activity Azure BlobFS source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "treatEmptyAsNull": {
+          "type": "object",
+          "description": "Treat empty as null. Type: boolean (or Expression with resultType boolean)."
+        },
+        "skipHeaderLineCount": {
+          "type": "object",
+          "description": "Number of header lines to skip from each blob. Type: integer (or Expression with resultType integer)."
+        },
+        "recursive": {
+          "type": "object",
+          "description": "If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "HttpSource": {
+      "description": "A copy activity source for an HTTP file.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "Specifies the timeout for a HTTP client to get HTTP response from HTTP server. The default value is equivalent to System.Net.HttpWebRequest.Timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        }
+      }
+    },
+    "AmazonMWSSource": {
+      "description": "A copy activity Amazon Marketplace Web Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzurePostgreSqlSource": {
+      "description": "A copy activity Azure PostgreSQL source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzurePostgreSqlSink": {
+      "description": "A copy activity Azure PostgreSQL sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "A query to execute before starting the copy. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureMySqlSink": {
+      "description": "A copy activity Azure MySql sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "A query to execute before starting the copy. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ConcurSource": {
+      "description": "A copy activity Concur Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "CouchbaseSource": {
+      "description": "A copy activity Couchbase server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "DrillSource": {
+      "description": "A copy activity Drill server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "EloquaSource": {
+      "description": "A copy activity Eloqua server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "GoogleBigQuerySource": {
+      "description": "A copy activity Google BigQuery service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "GreenplumSource": {
+      "description": "A copy activity Greenplum Database source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "HBaseSource": {
+      "description": "A copy activity HBase server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "HiveSource": {
+      "description": "A copy activity Hive Server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "HubspotSource": {
+      "description": "A copy activity Hubspot Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ImpalaSource": {
+      "description": "A copy activity Impala server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "JiraSource": {
+      "description": "A copy activity Jira Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "MagentoSource": {
+      "description": "A copy activity Magento server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "MariaDBSource": {
+      "description": "A copy activity MariaDB server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureMariaDBSource": {
+      "description": "A copy activity Azure MariaDB source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "MarketoSource": {
+      "description": "A copy activity Marketo server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "PaypalSource": {
+      "description": "A copy activity Paypal Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "PhoenixSource": {
+      "description": "A copy activity Phoenix server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "PrestoSource": {
+      "description": "A copy activity Presto server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "QuickBooksSource": {
+      "description": "A copy activity QuickBooks server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ServiceNowSource": {
+      "description": "A copy activity ServiceNow server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ShopifySource": {
+      "description": "A copy activity Shopify Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SparkSource": {
+      "description": "A copy activity Spark Server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SquareSource": {
+      "description": "A copy activity Square Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "XeroSource": {
+      "description": "A copy activity Xero Service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ZohoSource": {
+      "description": "A copy activity Zoho server source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "NetezzaSource": {
+      "description": "A copy activity Netezza source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        },
+        "partitionOption": {
+          "description": "The partition mechanism that will be used for Netezza read in parallel.",
+          "type": "string",
+          "enum": [
+            "None",
+            "DataSlice",
+            "DynamicRange"
+          ],
+          "x-ms-enum": {
+            "name": "NetezzaPartitionOption",
+            "modelAsString": true
+          }
+        },
+        "partitionSettings": {
+          "description": "The settings that will be leveraged for Netezza source partitioning.",
+          "$ref": "#/definitions/NetezzaPartitionSettings"
+        }
+      }
+    },
+    "NetezzaPartitionSettings": {
+      "description": "The settings that will be leveraged for Netezza source partitioning.",
+      "type": "object",
+      "properties": {
+        "partitionColumnName": {
+          "type": "object",
+          "description": "The name of the column in integer type that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionUpperBound": {
+          "type": "object",
+          "description": "The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        },
+        "partitionLowerBound": {
+          "type": "object",
+          "description": "The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "VerticaSource": {
+      "description": "A copy activity Vertica source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SalesforceMarketingCloudSource": {
+      "description": "A copy activity Salesforce Marketing Cloud source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "ResponsysSource": {
+      "description": "A copy activity Responsys source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "DynamicsAXSource": {
+      "description": "A copy activity Dynamics AX source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data. Default value: 00:05:00. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        }
+      }
+    },
+    "OracleServiceCloudSource": {
+      "description": "A copy activity Oracle Service Cloud source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "GoogleAdWordsSource": {
+      "description": "A copy activity Google AdWords service source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "A query to retrieve data from source. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AmazonRedshiftSource": {
+      "description": "A copy activity source for Amazon Redshift Source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TabularSource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Database query. Type: string (or Expression with resultType string)."
+        },
+        "redshiftUnloadSettings": {
+          "description": "The Amazon S3 settings needed for the interim Amazon S3 when copying from Amazon Redshift with unload. With this, data from Amazon Redshift source will be unloaded into S3 first and then copied into the targeted sink from the interim S3.",
+          "$ref": "#/definitions/RedshiftUnloadSettings"
+        }
+      }
+    },
+    "RedshiftUnloadSettings": {
+      "description": "The Amazon S3 settings needed for the interim Amazon S3 when copying from Amazon Redshift with unload. With this, data from Amazon Redshift source will be unloaded into S3 first and then copied into the targeted sink from the interim S3.",
+      "type": "object",
+      "properties": {
+        "s3LinkedServiceName": {
+          "description": "The name of the Amazon S3 linked service which will be used for the unload operation when copying from the Amazon Redshift source.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "bucketName": {
+          "type": "object",
+          "description": "The bucket of the interim Amazon S3 which will be used to store the unloaded data from Amazon Redshift source. The bucket must be in the same region as the Amazon Redshift source. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "s3LinkedServiceName",
+        "bucketName"
+      ]
+    },
+    "SnowflakeSource": {
+      "description": "A copy activity snowflake source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Snowflake Sql query. Type: string (or Expression with resultType string)."
+        },
+        "exportSettings": {
+          "$ref": "#/definitions/SnowflakeExportCopyCommand",
+          "description": "Snowflake export settings."
+        }
+      },
+      "required": [
+        "exportSettings"
+      ]
+    },
+    "ExportSettings": {
+      "description": "Export command settings.",
+      "discriminator": "type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The export setting type."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "SnowflakeExportCopyCommand": {
+      "description": "Snowflake export command settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExportSettings"
+        }
+      ],
+      "properties": {
+        "additionalCopyOptions": {
+          "type": "object",
+          "description": "Additional copy options directly passed to snowflake Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object). Example: \"additionalCopyOptions\": { \"DATE_FORMAT\": \"MM/DD/YYYY\", \"TIME_FORMAT\": \"'HH24:MI:SS.FF'\" }",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "additionalFormatOptions": {
+          "type": "object",
+          "description": "Additional format options directly passed to snowflake Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object). Example: \"additionalFormatOptions\": { \"OVERWRITE\": \"TRUE\", \"MAX_FILE_SIZE\": \"'FALSE'\" }",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "AzureDatabricksDeltaLakeSource": {
+      "description": "A copy activity Azure Databricks Delta Lake source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Azure Databricks Delta Lake Sql query. Type: string (or Expression with resultType string)."
+        },
+        "exportSettings": {
+          "$ref": "#/definitions/AzureDatabricksDeltaLakeExportCommand",
+          "description": "Azure Databricks Delta Lake export settings."
+        }
+      }
+    },
+    "AzureDatabricksDeltaLakeExportCommand": {
+      "description": "Azure Databricks Delta Lake export command settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExportSettings"
+        }
+      ],
+      "properties": {
+        "dateFormat": {
+          "type": "object",
+          "description": "Specify the date format for the csv in Azure Databricks Delta Lake Copy. Type: string (or Expression with resultType string)."
+        },
+        "timestampFormat": {
+          "type": "object",
+          "description": "Specify the timestamp format for the csv in Azure Databricks Delta Lake Copy. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureDatabricksDeltaLakeSink": {
+      "description": "A copy activity Azure Databricks Delta Lake sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        },
+        "importSettings": {
+          "$ref": "#/definitions/AzureDatabricksDeltaLakeImportCommand",
+          "description": "Azure Databricks Delta Lake import settings."
+        }
+      }
+    },
+    "AzureDatabricksDeltaLakeImportCommand": {
+      "description": "Azure Databricks Delta Lake import command settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ImportSettings"
+        }
+      ],
+      "properties": {
+        "dateFormat": {
+          "type": "object",
+          "description": "Specify the date format for csv in Azure Databricks Delta Lake Copy. Type: string (or Expression with resultType string)."
+        },
+        "timestampFormat": {
+          "type": "object",
+          "description": "Specify the timestamp format for csv in Azure Databricks Delta Lake Copy. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "StoredProcedureParameter": {
+      "description": "SQL stored procedure parameter.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "object",
+          "description": "Stored procedure parameter value. Type: string (or Expression with resultType string)."
+        },
+        "type": {
+          "description": "Stored procedure parameter type.",
+          "$ref": "#/definitions/StoredProcedureParameterType"
+        }
+      }
+    },
+    "StoredProcedureParameterType": {
+      "description": "Stored procedure parameter type.",
+      "type": "string",
+      "enum": [
+        "String",
+        "Int",
+        "Int64",
+        "Decimal",
+        "Guid",
+        "Boolean",
+        "Date"
+      ],
+      "x-ms-enum": {
+        "name": "StoredProcedureParameterType",
+        "modelAsString": true
+      }
+    },
+    "CopySink": {
+      "discriminator": "type",
+      "description": "A copy activity sink.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Copy sink type."
+        },
+        "writeBatchSize": {
+          "type": "object",
+          "description": "Write batch size. Type: integer (or Expression with resultType integer), minimum: 0."
+        },
+        "writeBatchTimeout": {
+          "type": "object",
+          "description": "Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "sinkRetryCount": {
+          "type": "object",
+          "description": "Sink retry count. Type: integer (or Expression with resultType integer)."
+        },
+        "sinkRetryWait": {
+          "type": "object",
+          "description": "Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "maxConcurrentConnections": {
+          "type": "object",
+          "description": "The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "SapCloudForCustomerSink": {
+      "description": "A copy activity SAP Cloud for Customer sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "description": "The write behavior for the operation. Default is 'Insert'.",
+          "type": "string",
+          "enum": [
+            "Insert",
+            "Update"
+          ],
+          "x-ms-enum": {
+            "name": "SapCloudForCustomerSinkWriteBehavior",
+            "modelAsString": true
+          }
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data. Default value: 00:05:00. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        }
+      }
+    },
+    "AzureQueueSink": {
+      "description": "A copy activity Azure Queue sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {}
+    },
+    "CopyBehaviorType": {
+      "description": "All available types of copy behavior.",
+      "type": "string",
+      "enum": [
+        "PreserveHierarchy",
+        "FlattenHierarchy",
+        "MergeFiles"
+      ],
+      "x-ms-enum": {
+        "name": "CopyBehaviorType",
+        "modelAsString": true
+      }
+    },
+    "AzureTableSink": {
+      "description": "A copy activity Azure Table sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "azureTableDefaultPartitionKeyValue": {
+          "type": "object",
+          "description": "Azure Table default partition key value. Type: string (or Expression with resultType string)."
+        },
+        "azureTablePartitionKeyName": {
+          "type": "object",
+          "description": "Azure Table partition key name. Type: string (or Expression with resultType string)."
+        },
+        "azureTableRowKeyName": {
+          "type": "object",
+          "description": "Azure Table row key name. Type: string (or Expression with resultType string)."
+        },
+        "azureTableInsertType": {
+          "type": "object",
+          "description": "Azure Table insert type. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AvroSink": {
+      "description": "A copy activity Avro sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreWriteSettings",
+          "description": "Avro store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/AvroWriteSettings",
+          "description": "Avro format settings."
+        }
+      }
+    },
+    "ParquetSink": {
+      "description": "A copy activity Parquet sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreWriteSettings",
+          "description": "Parquet store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/ParquetWriteSettings",
+          "description": "Parquet format settings."
+        }
+      }
+    },
+    "BinarySink": {
+      "description": "A copy activity Binary sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "storeSettings": {
+          "$ref": "#/definitions/StoreWriteSettings",
+          "description": "Binary store settings."
+        }
+      }
+    },
+    "BlobSink": {
+      "description": "A copy activity Azure Blob sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "blobWriterOverwriteFiles": {
+          "type": "object",
+          "description": "Blob writer overwrite files. Type: boolean (or Expression with resultType boolean)."
+        },
+        "blobWriterDateTimeFormat": {
+          "type": "object",
+          "description": "Blob writer date time format. Type: string (or Expression with resultType string)."
+        },
+        "blobWriterAddHeader": {
+          "type": "object",
+          "description": "Blob writer add header. Type: boolean (or Expression with resultType boolean)."
+        },
+        "copyBehavior": {
+          "description": "The type of copy behavior for copy sink.",
+          "type": "object"
+        }
+      }
+    },
+    "FileSystemSink": {
+      "description": "A copy activity file system sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "copyBehavior": {
+          "description": "The type of copy behavior for copy sink.",
+          "type": "object"
+        }
+      }
+    },
+    "DocumentDbCollectionSink": {
+      "description": "A copy activity Document Database Collection sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "nestingSeparator": {
+          "type": "object",
+          "description": "Nested properties separator. Default is . (dot). Type: string (or Expression with resultType string)."
+        },
+        "writeBehavior": {
+          "type": "object",
+          "description": "Describes how to write data to Azure Cosmos DB. Type: string (or Expression with resultType string). Allowed values: insert and upsert."
+        }
+      }
+    },
+    "CosmosDbSqlApiSink": {
+      "description": "A copy activity Azure CosmosDB (SQL API) Collection sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "type": "object",
+          "description": "Describes how to write data to Azure Cosmos DB. Type: string (or Expression with resultType string). Allowed values: insert and upsert."
+        }
+      }
+    },
+    "SqlSink": {
+      "description": "A copy activity SQL sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "sqlWriterStoredProcedureName": {
+          "type": "object",
+          "description": "SQL writer stored procedure name. Type: string (or Expression with resultType string)."
+        },
+        "sqlWriterTableType": {
+          "type": "object",
+          "description": "SQL writer table type. Type: string (or Expression with resultType string)."
+        },
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "SQL stored procedure parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "storedProcedureTableTypeParameterName": {
+          "type": "object",
+          "description": "The stored procedure parameter name of the table type. Type: string (or Expression with resultType string)."
+        },
+        "tableOption": {
+          "type": "object",
+          "description": "The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SqlServerSink": {
+      "description": "A copy activity SQL server sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "sqlWriterStoredProcedureName": {
+          "type": "object",
+          "description": "SQL writer stored procedure name. Type: string (or Expression with resultType string)."
+        },
+        "sqlWriterTableType": {
+          "type": "object",
+          "description": "SQL writer table type. Type: string (or Expression with resultType string)."
+        },
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "SQL stored procedure parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "storedProcedureTableTypeParameterName": {
+          "type": "object",
+          "description": "The stored procedure parameter name of the table type. Type: string (or Expression with resultType string)."
+        },
+        "tableOption": {
+          "type": "object",
+          "description": "The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureSqlSink": {
+      "description": "A copy activity Azure SQL sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "sqlWriterStoredProcedureName": {
+          "type": "object",
+          "description": "SQL writer stored procedure name. Type: string (or Expression with resultType string)."
+        },
+        "sqlWriterTableType": {
+          "type": "object",
+          "description": "SQL writer table type. Type: string (or Expression with resultType string)."
+        },
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "SQL stored procedure parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "storedProcedureTableTypeParameterName": {
+          "type": "object",
+          "description": "The stored procedure parameter name of the table type. Type: string (or Expression with resultType string)."
+        },
+        "tableOption": {
+          "type": "object",
+          "description": "The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SqlMISink": {
+      "description": "A copy activity Azure SQL Managed Instance sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "sqlWriterStoredProcedureName": {
+          "type": "object",
+          "description": "SQL writer stored procedure name. Type: string (or Expression with resultType string)."
+        },
+        "sqlWriterTableType": {
+          "type": "object",
+          "description": "SQL writer table type. Type: string (or Expression with resultType string)."
+        },
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "SQL stored procedure parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        },
+        "storedProcedureTableTypeParameterName": {
+          "type": "object",
+          "description": "The stored procedure parameter name of the table type. Type: string (or Expression with resultType string)."
+        },
+        "tableOption": {
+          "type": "object",
+          "description": "The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "SqlDWSink": {
+      "description": "A copy activity SQL Data Warehouse sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        },
+        "allowPolyBase": {
+          "type": "object",
+          "description": "Indicates to use PolyBase to copy data into SQL Data Warehouse when applicable. Type: boolean (or Expression with resultType boolean)."
+        },
+        "polyBaseSettings": {
+          "description": "Specifies PolyBase-related settings when allowPolyBase is true.",
+          "$ref": "#/definitions/PolybaseSettings"
+        },
+        "allowCopyCommand": {
+          "type": "object",
+          "description": "Indicates to use Copy Command to copy data into SQL Data Warehouse. Type: boolean (or Expression with resultType boolean)."
+        },
+        "copyCommandSettings": {
+          "description": "Specifies Copy Command related settings when allowCopyCommand is true.",
+          "$ref": "#/definitions/DWCopyCommandSettings"
+        },
+        "tableOption": {
+          "type": "object",
+          "description": "The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "PolybaseSettings": {
+      "description": "PolyBase settings.",
+      "type": "object",
+      "properties": {
+        "rejectType": {
+          "$ref": "#/definitions/PolybaseSettingsRejectType",
+          "description": "Reject type."
+        },
+        "rejectValue": {
+          "type": "object",
+          "description": "Specifies the value or the percentage of rows that can be rejected before the query fails. Type: number (or Expression with resultType number), minimum: 0."
+        },
+        "rejectSampleValue": {
+          "type": "object",
+          "description": "Determines the number of rows to attempt to retrieve before the PolyBase recalculates the percentage of rejected rows. Type: integer (or Expression with resultType integer), minimum: 0."
+        },
+        "useTypeDefault": {
+          "type": "object",
+          "description": "Specifies how to handle missing values in delimited text files when PolyBase retrieves data from the text file. Type: boolean (or Expression with resultType boolean)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      }
+    },
+    "PolybaseSettingsRejectType": {
+      "description": "Indicates whether the RejectValue property is specified as a literal value or a percentage.",
+      "type": "string",
+      "enum": [
+        "value",
+        "percentage"
+      ],
+      "x-ms-enum": {
+        "name": "PolybaseSettingsRejectType",
+        "modelAsString": true
+      }
+    },
+    "DWCopyCommandSettings": {
+      "description": "DW Copy Command settings.",
+      "type": "object",
+      "properties": {
+        "defaultValues": {
+          "type": "array",
+          "description": "Specifies the default values for each target column in SQL DW. The default values in the property overwrite the DEFAULT constraint set in the DB, and identity column cannot have a default value. Type: array of objects (or Expression with resultType array of objects).",
+          "items": {
+            "$ref": "#/definitions/DWCopyCommandDefaultValue"
+          }
+        },
+        "additionalOptions": {
+          "type": "object",
+          "description": "Additional options directly passed to SQL DW in Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object). Example: \"additionalOptions\": { \"MAXERRORS\": \"1000\", \"DATEFORMAT\": \"'ymd'\" }",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DWCopyCommandDefaultValue": {
+      "description": "Default value.",
+      "type": "object",
+      "properties": {
+        "columnName": {
+          "type": "object",
+          "description": "Column name. Type: object (or Expression with resultType string)."
+        },
+        "defaultValue": {
+          "type": "object",
+          "description": "The default value of the column. Type: object (or Expression with resultType string)."
+        }
+      }
+    },
+    "SnowflakeSink": {
+      "description": "A copy activity snowflake sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        },
+        "importSettings": {
+          "$ref": "#/definitions/SnowflakeImportCopyCommand",
+          "description": "Snowflake import settings."
+        }
+      }
+    },
+    "ImportSettings": {
+      "description": "Import command settings.",
+      "discriminator": "type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The import setting type."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "SnowflakeImportCopyCommand": {
+      "description": "Snowflake import command settings.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ImportSettings"
+        }
+      ],
+      "properties": {
+        "additionalCopyOptions": {
+          "type": "object",
+          "description": "Additional copy options directly passed to snowflake Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object). Example: \"additionalCopyOptions\": { \"DATE_FORMAT\": \"MM/DD/YYYY\", \"TIME_FORMAT\": \"'HH24:MI:SS.FF'\" }",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "additionalFormatOptions": {
+          "type": "object",
+          "description": "Additional format options directly passed to snowflake Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object). Example: \"additionalFormatOptions\": { \"FORCE\": \"TRUE\", \"LOAD_UNCERTAIN_FILES\": \"'FALSE'\" }",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "LogStorageSettings": {
+      "description": "(Deprecated. Please use LogSettings) Log storage settings.",
+      "type": "object",
+      "properties": {
+        "linkedServiceName": {
+          "description": "Log storage linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "path": {
+          "type": "object",
+          "description": "The path to storage for storing detailed logs of activity execution. Type: string (or Expression with resultType string)."
+        },
+        "logLevel": {
+          "type": "object",
+          "description": "Gets or sets the log level, support: Info, Warning. Type: string (or Expression with resultType string)."
+        },
+        "enableReliableLogging": {
+          "type": "object",
+          "description": "Specifies whether to enable reliable logging. Type: boolean (or Expression with resultType boolean)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "linkedServiceName"
+      ]
+    },
+    "LogSettings": {
+      "description": "Log settings.",
+      "type": "object",
+      "properties": {
+        "enableCopyActivityLog": {
+          "type": "object",
+          "description": "Specifies whether to enable copy activity log. Type: boolean (or Expression with resultType boolean)."
+        },
+        "copyActivityLogSettings": {
+          "description": "Specifies settings for copy activity log.",
+          "$ref": "#/definitions/CopyActivityLogSettings"
+        },
+        "logLocationSettings": {
+          "description": "Log location settings customer needs to provide when enabling log.",
+          "$ref": "#/definitions/LogLocationSettings"
+        }
+      },
+      "required": [
+        "logLocationSettings"
+      ]
+    },
+    "LogLocationSettings": {
+      "description": "Log location settings.",
+      "type": "object",
+      "properties": {
+        "linkedServiceName": {
+          "description": "Log storage linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "path": {
+          "type": "object",
+          "description": "The path to storage for storing detailed logs of activity execution. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "linkedServiceName"
+      ]
+    },
+    "CopyActivityLogSettings": {
+      "description": "Settings for copy activity log.",
+      "type": "object",
+      "properties": {
+        "logLevel": {
+          "type": "object",
+          "description": "Gets or sets the log level, support: Info, Warning. Type: string (or Expression with resultType string)."
+        },
+        "enableReliableLogging": {
+          "type": "object",
+          "description": "Specifies whether to enable reliable logging. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "StagingSettings": {
+      "description": "Staging settings.",
+      "type": "object",
+      "properties": {
+        "linkedServiceName": {
+          "description": "Staging linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "path": {
+          "type": "object",
+          "description": "The path to storage for storing the interim data. Type: string (or Expression with resultType string)."
+        },
+        "enableCompression": {
+          "type": "object",
+          "description": "Specifies whether to use compression when copying data via an interim staging. Default value is false. Type: boolean (or Expression with resultType boolean)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "linkedServiceName"
+      ]
+    },
+    "RedirectIncompatibleRowSettings": {
+      "description": "Redirect incompatible row settings",
+      "type": "object",
+      "properties": {
+        "linkedServiceName": {
+          "type": "object",
+          "description": "Name of the Azure Storage, Storage SAS, or Azure Data Lake Store linked service used for redirecting incompatible row. Must be specified if redirectIncompatibleRowSettings is specified. Type: string (or Expression with resultType string)."
+        },
+        "path": {
+          "type": "object",
+          "description": "The path for storing the redirect incompatible row data. Type: string (or Expression with resultType string)."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "linkedServiceName"
+      ]
+    },
+    "SkipErrorFile": {
+      "description": "Skip error file.",
+      "type": "object",
+      "properties": {
+        "fileMissing": {
+          "type": "object",
+          "description": "Skip if file is deleted by other client during copy. Default is true. Type: boolean (or Expression with resultType boolean)."
+        },
+        "dataInconsistency": {
+          "type": "object",
+          "description": "Skip if source/sink file changed by other concurrent write. Default is false. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "AdditionalColumns": {
+      "description": "Specify the column name and value of additional columns.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "object",
+          "description": "Additional column name. Type: string (or Expression with resultType string)."
+        },
+        "value": {
+          "type": "object",
+          "description": "Additional column value. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "OracleSink": {
+      "description": "A copy activity Oracle sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "SQL pre-copy script. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "AzureDataLakeStoreSink": {
+      "description": "A copy activity Azure Data Lake Store sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "copyBehavior": {
+          "description": "The type of copy behavior for copy sink.",
+          "type": "object"
+        },
+        "enableAdlsSingleFileParallel": {
+          "description": "Single File Parallel.",
+          "type": "object"
+        }
+      }
+    },
+    "AzureBlobFSSink": {
+      "description": "A copy activity Azure Data Lake Storage Gen2 sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "copyBehavior": {
+          "description": "The type of copy behavior for copy sink.",
+          "type": "object"
+        }
+      }
+    },
+    "AzureSearchIndexSink": {
+      "description": "A copy activity Azure Search Index sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "description": "Specify the write behavior when upserting documents into Azure Search Index.",
+          "type": "string",
+          "enum": [
+            "Merge",
+            "Upload"
+          ],
+          "x-ms-enum": {
+            "name": "AzureSearchIndexWriteBehaviorType",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "OdbcSink": {
+      "description": "A copy activity ODBC sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "A query to execute before starting the copy. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "InformixSink": {
+      "description": "A copy activity Informix sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "A query to execute before starting the copy. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "MicrosoftAccessSink": {
+      "description": "A copy activity Microsoft Access sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "preCopyScript": {
+          "type": "object",
+          "description": "A query to execute before starting the copy. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "DynamicsSinkWriteBehavior": {
+      "description": "Defines values for DynamicsSinkWriteBehavior.",
+      "type": "string",
+      "enum": [
+        "Upsert"
+      ],
+      "x-ms-enum": {
+        "name": "DynamicsSinkWriteBehavior",
+        "modelAsString": true
+      }
+    },
+    "DynamicsSink": {
+      "description": "A copy activity Dynamics sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "description": "The write behavior for the operation.",
+          "$ref": "#/definitions/DynamicsSinkWriteBehavior"
+        },
+        "ignoreNullValues": {
+          "type": "object",
+          "description": "The flag indicating whether ignore null values from input dataset (except key fields) during write operation. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "alternateKeyName": {
+          "type": "object",
+          "description": "The logical name of the alternate key which will be used when upserting records. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "writeBehavior"
+      ]
+    },
+    "DynamicsCrmSink": {
+      "description": "A copy activity Dynamics CRM sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "description": "The write behavior for the operation.",
+          "$ref": "#/definitions/DynamicsSinkWriteBehavior"
+        },
+        "ignoreNullValues": {
+          "type": "object",
+          "description": "The flag indicating whether to ignore null values from input dataset (except key fields) during write operation. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "alternateKeyName": {
+          "type": "object",
+          "description": "The logical name of the alternate key which will be used when upserting records. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "writeBehavior"
+      ]
+    },
+    "CommonDataServiceForAppsSink": {
+      "description": "A copy activity Common Data Service for Apps sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "description": "The write behavior for the operation.",
+          "$ref": "#/definitions/DynamicsSinkWriteBehavior"
+        },
+        "ignoreNullValues": {
+          "type": "object",
+          "description": "The flag indicating whether to ignore null values from input dataset (except key fields) during write operation. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "alternateKeyName": {
+          "type": "object",
+          "description": "The logical name of the alternate key which will be used when upserting records. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "writeBehavior"
+      ]
+    },
+    "AzureDataExplorerSink": {
+      "description": "A copy activity Azure Data Explorer sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "ingestionMappingName": {
+          "type": "object",
+          "description": "A name of a pre-created csv mapping that was defined on the target Kusto table. Type: string."
+        },
+        "ingestionMappingAsJson": {
+          "type": "object",
+          "description": "An explicit column mapping description provided in a json format. Type: string."
+        },
+        "flushImmediately": {
+          "type": "object",
+          "description": "If set to true, any aggregation will be skipped. Default is false. Type: boolean."
+        }
+      }
+    },
+    "SalesforceSink": {
+      "description": "A copy activity Salesforce sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "description": "The write behavior for the operation. Default is Insert.",
+          "type": "string",
+          "enum": [
+            "Insert",
+            "Upsert"
+          ],
+          "x-ms-enum": {
+            "name": "SalesforceSinkWriteBehavior",
+            "modelAsString": true
+          }
+        },
+        "externalIdFieldName": {
+          "type": "object",
+          "description": "The name of the external ID field for upsert operation. Default value is 'Id' column. Type: string (or Expression with resultType string)."
+        },
+        "ignoreNullValues": {
+          "type": "object",
+          "description": "The flag indicating whether or not to ignore null values from input dataset (except key fields) during write operation. Default value is false. If set it to true, it means ADF will leave the data in the destination object unchanged when doing upsert/update operation and insert defined default value when doing insert operation, versus ADF will update the data in the destination object to NULL when doing upsert/update operation and insert NULL value when doing insert operation. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "SalesforceServiceCloudSink": {
+      "description": "A copy activity Salesforce Service Cloud sink.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "description": "The write behavior for the operation. Default is Insert.",
+          "type": "string",
+          "enum": [
+            "Insert",
+            "Upsert"
+          ],
+          "x-ms-enum": {
+            "name": "SalesforceSinkWriteBehavior",
+            "modelAsString": true
+          }
+        },
+        "externalIdFieldName": {
+          "type": "object",
+          "description": "The name of the external ID field for upsert operation. Default value is 'Id' column. Type: string (or Expression with resultType string)."
+        },
+        "ignoreNullValues": {
+          "type": "object",
+          "description": "The flag indicating whether or not to ignore null values from input dataset (except key fields) during write operation. Default value is false. If set it to true, it means ADF will leave the data in the destination object unchanged when doing upsert/update operation and insert defined default value when doing insert operation, versus ADF will update the data in the destination object to NULL when doing upsert/update operation and insert NULL value when doing insert operation. Type: boolean (or Expression with resultType boolean)."
+        }
+      }
+    },
+    "CosmosDbMongoDbApiSink": {
+      "description": "A copy activity sink for a CosmosDB (MongoDB API) database.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySink"
+        }
+      ],
+      "properties": {
+        "writeBehavior": {
+          "type": "object",
+          "description": "Specifies whether the document with same key to be overwritten (upsert) rather than throw exception (insert). The default value is \"insert\". Type: string (or Expression with resultType string). Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "CopyTranslator": {
+      "discriminator": "type",
+      "description": "A copy activity translator.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Copy translator type."
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "TabularTranslator": {
+      "description": "A copy activity tabular translator.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopyTranslator"
+        }
+      ],
+      "properties": {
+        "columnMappings": {
+          "type": "object",
+          "description": "Column mappings. Example: \"UserId: MyUserId, Group: MyGroup, Name: MyName\" Type: string (or Expression with resultType string). This property will be retired. Please use mappings property."
+        },
+        "schemaMapping": {
+          "type": "object",
+          "description": "The schema mapping to map between tabular data and hierarchical data. Example: {\"Column1\": \"$.Column1\", \"Column2\": \"$.Column2.Property1\", \"Column3\": \"$.Column2.Property2\"}. Type: object (or Expression with resultType object). This property will be retired. Please use mappings property."
+        },
+        "collectionReference": {
+          "type": "object",
+          "description": "The JSON Path of the Nested Array that is going to do cross-apply. Type: object (or Expression with resultType object)."
+        },
+        "mapComplexValuesToString": {
+          "type": "object",
+          "description": "Whether to map complex (array and object) values to simple strings in json format. Type: boolean (or Expression with resultType boolean)."
+        },
+        "mappings": {
+          "type": "object",
+          "description": "Column mappings with logical types. Tabular->tabular example: [{\"source\":{\"name\":\"CustomerName\",\"type\":\"String\"},\"sink\":{\"name\":\"ClientName\",\"type\":\"String\"}},{\"source\":{\"name\":\"CustomerAddress\",\"type\":\"String\"},\"sink\":{\"name\":\"ClientAddress\",\"type\":\"String\"}}].  Hierarchical->tabular example: [{\"source\":{\"path\":\"$.CustomerName\",\"type\":\"String\"},\"sink\":{\"name\":\"ClientName\",\"type\":\"String\"}},{\"source\":{\"path\":\"$.CustomerAddress\",\"type\":\"String\"},\"sink\":{\"name\":\"ClientAddress\",\"type\":\"String\"}}]. Type: object (or Expression with resultType object)."
+        },
+        "typeConversion": {
+          "type": "object",
+          "description": "Whether to enable the advanced type conversion feature in the Copy activity. Type: boolean (or Expression with resultType boolean)."
+        },
+        "typeConversionSettings": {
+          "description": "Type conversion settings",
+          "$ref": "#/definitions/TypeConversionSettings"
+        }
+      }
+    },
+    "TypeConversionSettings": {
+      "description": "Type conversion settings",
+      "type": "object",
+      "properties": {
+        "allowDataTruncation": {
+          "type": "object",
+          "description": "Whether to allow data truncation when converting the data. Type: boolean (or Expression with resultType boolean)."
+        },
+        "treatBooleanAsNumber": {
+          "type": "object",
+          "description": "Whether to treat boolean values as numbers. Type: boolean (or Expression with resultType boolean)."
+        },
+        "dateTimeFormat": {
+          "type": "object",
+          "description": "The format for DateTime values. Type: string (or Expression with resultType string)."
+        },
+        "dateTimeOffsetFormat": {
+          "type": "object",
+          "description": "The format for DateTimeOffset values. Type: string (or Expression with resultType string)."
+        },
+        "timeSpanFormat": {
+          "type": "object",
+          "description": "The format for TimeSpan values. Type: string (or Expression with resultType string)."
+        },
+        "culture": {
+          "type": "object",
+          "description": "The culture used to convert data from/to string. Type: string (or Expression with resultType string)."
+        }
+      }
+    },
+    "HDInsightHiveActivity": {
+      "description": "HDInsight Hive activity type.",
+      "type": "object",
+      "x-ms-discriminator-value": "HDInsightHive",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "HDInsight Hive activity properties.",
+          "$ref": "#/definitions/HDInsightHiveActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "HDInsightHiveActivityTypeProperties": {
+      "description": "HDInsight Hive activity properties.",
+      "type": "object",
+      "properties": {
+        "storageLinkedServices": {
+          "description": "Storage linked service references.",
+          "type": "array",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+          }
+        },
+        "arguments": {
+          "description": "User specified arguments to HDInsightActivity.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "getDebugInfo": {
+          "$ref": "#/definitions/HDInsightActivityDebugInfoOption",
+          "description": "Debug info option."
+        },
+        "scriptPath": {
+          "type": "object",
+          "description": "Script path. Type: string (or Expression with resultType string)."
+        },
+        "scriptLinkedService": {
+          "description": "Script linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "defines": {
+          "description": "Allows user to specify defines for Hive job request.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "variables": {
+          "description": "User specified arguments under hivevar namespace.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "queryTimeout": {
+          "type": "integer",
+          "description": "Query timeout value (in minutes).  Effective when the HDInsight cluster is with ESP (Enterprise Security Package)"
+        }
+      }
+    },
+    "HDInsightActivityDebugInfoOption": {
+      "description": "The HDInsightActivityDebugInfoOption settings to use.",
+      "type": "string",
+      "enum": [
+        "None",
+        "Always",
+        "Failure"
+      ],
+      "x-ms-enum": {
+        "name": "HDInsightActivityDebugInfoOption",
+        "modelAsString": true
+      }
+    },
+    "HDInsightPigActivity": {
+      "description": "HDInsight Pig activity type.",
+      "type": "object",
+      "x-ms-discriminator-value": "HDInsightPig",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "HDInsight Pig activity properties.",
+          "$ref": "#/definitions/HDInsightPigActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "HDInsightPigActivityTypeProperties": {
+      "description": "HDInsight Pig activity properties.",
+      "type": "object",
+      "properties": {
+        "storageLinkedServices": {
+          "description": "Storage linked service references.",
+          "type": "array",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+          }
+        },
+        "arguments": {
+          "type": "object",
+          "description": "User specified arguments to HDInsightActivity. Type: array (or Expression with resultType array)."
+        },
+        "getDebugInfo": {
+          "$ref": "#/definitions/HDInsightActivityDebugInfoOption",
+          "description": "Debug info option."
+        },
+        "scriptPath": {
+          "type": "object",
+          "description": "Script path. Type: string (or Expression with resultType string)."
+        },
+        "scriptLinkedService": {
+          "description": "Script linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "defines": {
+          "description": "Allows user to specify defines for Pig job request.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        }
+      }
+    },
+    "HDInsightMapReduceActivity": {
+      "description": "HDInsight MapReduce activity type.",
+      "type": "object",
+      "x-ms-discriminator-value": "HDInsightMapReduce",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "HDInsight MapReduce activity properties.",
+          "$ref": "#/definitions/HDInsightMapReduceActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "HDInsightMapReduceActivityTypeProperties": {
+      "description": "HDInsight MapReduce activity properties.",
+      "type": "object",
+      "properties": {
+        "storageLinkedServices": {
+          "description": "Storage linked service references.",
+          "type": "array",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+          }
+        },
+        "arguments": {
+          "description": "User specified arguments to HDInsightActivity.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "getDebugInfo": {
+          "$ref": "#/definitions/HDInsightActivityDebugInfoOption",
+          "description": "Debug info option."
+        },
+        "className": {
+          "type": "object",
+          "description": "Class name. Type: string (or Expression with resultType string)."
+        },
+        "jarFilePath": {
+          "type": "object",
+          "description": "Jar path. Type: string (or Expression with resultType string)."
+        },
+        "jarLinkedService": {
+          "description": "Jar linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "jarLibs": {
+          "description": "Jar libs.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "defines": {
+          "description": "Allows user to specify defines for the MapReduce job request.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        }
+      },
+      "required": [
+        "className",
+        "jarFilePath"
+      ]
+    },
+    "HDInsightStreamingActivity": {
+      "description": "HDInsight streaming activity type.",
+      "type": "object",
+      "x-ms-discriminator-value": "HDInsightStreaming",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "HDInsight streaming activity properties.",
+          "$ref": "#/definitions/HDInsightStreamingActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "HDInsightStreamingActivityTypeProperties": {
+      "description": "HDInsight streaming activity properties.",
+      "type": "object",
+      "properties": {
+        "storageLinkedServices": {
+          "description": "Storage linked service references.",
+          "type": "array",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+          }
+        },
+        "arguments": {
+          "description": "User specified arguments to HDInsightActivity.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "getDebugInfo": {
+          "$ref": "#/definitions/HDInsightActivityDebugInfoOption",
+          "description": "Debug info option."
+        },
+        "mapper": {
+          "type": "object",
+          "description": "Mapper executable name. Type: string (or Expression with resultType string)."
+        },
+        "reducer": {
+          "type": "object",
+          "description": "Reducer executable name. Type: string (or Expression with resultType string)."
+        },
+        "input": {
+          "type": "object",
+          "description": "Input blob path. Type: string (or Expression with resultType string)."
+        },
+        "output": {
+          "type": "object",
+          "description": "Output blob path. Type: string (or Expression with resultType string)."
+        },
+        "filePaths": {
+          "description": "Paths to streaming job files. Can be directories.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "fileLinkedService": {
+          "description": "Linked service reference where the files are located.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "combiner": {
+          "type": "object",
+          "description": "Combiner executable name. Type: string (or Expression with resultType string)."
+        },
+        "commandEnvironment": {
+          "description": "Command line environment values.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "defines": {
+          "description": "Allows user to specify defines for streaming job request.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        }
+      },
+      "required": [
+        "mapper",
+        "reducer",
+        "input",
+        "output",
+        "filePaths"
+      ]
+    },
+    "HDInsightSparkActivity": {
+      "description": "HDInsight Spark activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "HDInsightSpark",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "HDInsight spark activity properties.",
+          "$ref": "#/definitions/HDInsightSparkActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "HDInsightSparkActivityTypeProperties": {
+      "description": "HDInsight spark activity properties.",
+      "type": "object",
+      "properties": {
+        "rootPath": {
+          "type": "object",
+          "description": "The root path in 'sparkJobLinkedService' for all the job’s files. Type: string (or Expression with resultType string)."
+        },
+        "entryFilePath": {
+          "type": "object",
+          "description": "The relative path to the root folder of the code/package to be executed. Type: string (or Expression with resultType string)."
+        },
+        "arguments": {
+          "description": "The user-specified arguments to HDInsightSparkActivity.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "getDebugInfo": {
+          "$ref": "#/definitions/HDInsightActivityDebugInfoOption",
+          "description": "Debug info option."
+        },
+        "sparkJobLinkedService": {
+          "description": "The storage linked service for uploading the entry file and dependencies, and for receiving logs.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "className": {
+          "description": "The application's Java/Spark main class.",
+          "type": "string"
+        },
+        "proxyUser": {
+          "type": "object",
+          "description": "The user to impersonate that will execute the job. Type: string (or Expression with resultType string)."
+        },
+        "sparkConfig": {
+          "description": "Spark configuration property.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        }
+      },
+      "required": [
+        "rootPath",
+        "entryFilePath"
+      ]
+    },
+    "ExecuteSSISPackageActivity": {
+      "description": "Execute SSIS package activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "ExecuteSSISPackage",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Execute SSIS package activity properties.",
+          "$ref": "#/definitions/ExecuteSSISPackageActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "ExecuteSSISPackageActivityTypeProperties": {
+      "description": "Execute SSIS package activity properties.",
+      "type": "object",
+      "properties": {
+        "packageLocation": {
+          "description": "SSIS package location.",
+          "$ref": "#/definitions/SSISPackageLocation"
+        },
+        "runtime": {
+          "description": "Specifies the runtime to execute SSIS package. The value should be \"x86\" or \"x64\". Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "loggingLevel": {
+          "description": "The logging level of SSIS package execution. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "environmentPath": {
+          "description": "The environment path to execute the SSIS package. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "executionCredential": {
+          "description": "The package execution credential.",
+          "$ref": "#/definitions/SSISExecutionCredential"
+        },
+        "connectVia": {
+          "description": "The integration runtime reference.",
+          "$ref": "../artifacts.json#/definitions/IntegrationRuntimeReference"
+        },
+        "projectParameters": {
+          "description": "The project level parameters to execute the SSIS package.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SSISExecutionParameter"
+          }
+        },
+        "packageParameters": {
+          "description": "The package level parameters to execute the SSIS package.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SSISExecutionParameter"
+          }
+        },
+        "projectConnectionManagers": {
+          "description": "The project level connection managers to execute the SSIS package.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SSISConnectionManager"
+          }
+        },
+        "packageConnectionManagers": {
+          "description": "The package level connection managers to execute the SSIS package.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SSISConnectionManager"
+          }
+        },
+        "propertyOverrides": {
+          "description": "The property overrides to execute the SSIS package.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SSISPropertyOverride"
+          }
+        },
+        "logLocation": {
+          "description": "SSIS package execution log location.",
+          "$ref": "#/definitions/SSISLogLocation"
+        }
+      },
+      "required": [
+        "packageLocation",
+        "connectVia"
+      ]
+    },
+    "SSISPackageLocation": {
+      "description": "SSIS package location.",
+      "type": "object",
+      "properties": {
+        "packagePath": {
+          "description": "The SSIS package path. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "type": {
+          "description": "The type of SSIS package location.",
+          "type": "string",
+          "enum": [
+            "SSISDB",
+            "File",
+            "InlinePackage",
+            "PackageStore"
+          ],
+          "x-ms-enum": {
+            "name": "SsisPackageLocationType",
+            "modelAsString": true
+          }
+        },
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "SSIS package location properties.",
+          "$ref": "#/definitions/SSISPackageLocationTypeProperties"
+        }
+      }
+    },
+    "SSISPackageLocationTypeProperties": {
+      "description": "SSIS package location properties.",
+      "type": "object",
+      "properties": {
+        "packagePassword": {
+          "$ref": "../artifacts.json#/definitions/SecretBase",
+          "description": "Password of the package."
+        },
+        "accessCredential": {
+          "description": "The package access credential.",
+          "$ref": "#/definitions/SSISAccessCredential"
+        },
+        "configurationPath": {
+          "description": "The configuration file of the package execution. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "configurationAccessCredential": {
+          "description": "The configuration file access credential.",
+          "$ref": "#/definitions/SSISAccessCredential"
+        },
+        "packageName": {
+          "description": "The package name.",
+          "type": "string"
+        },
+        "packageContent": {
+          "description": "The embedded package content. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "packageLastModifiedDate": {
+          "description": "The embedded package last modified date.",
+          "type": "string"
+        },
+        "childPackages": {
+          "description": "The embedded child package list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SSISChildPackage"
+          }
+        }
+      }
+    },
+    "SSISConnectionManager": {
+      "description": "SSIS Connection Manager.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/SSISExecutionParameter"
+      }
+    },
+    "SSISExecutionParameter": {
+      "description": "SSIS execution parameter.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "object",
+          "description": "SSIS package execution parameter value. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SSISPropertyOverride": {
+      "description": "SSIS property override.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "object",
+          "description": "SSIS package property override value. Type: string (or Expression with resultType string)."
+        },
+        "isSensitive": {
+          "type": "boolean",
+          "description": "Whether SSIS package property override value is sensitive data. Value will be encrypted in SSISDB if it is true"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SSISExecutionCredential": {
+      "description": "SSIS package execution credential.",
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "object",
+          "description": "Domain for windows authentication."
+        },
+        "userName": {
+          "type": "object",
+          "description": "UseName for windows authentication."
+        },
+        "password": {
+          "$ref": "../artifacts.json#/definitions/SecureString",
+          "description": "Password for windows authentication."
+        }
+      },
+      "required": [
+        "domain",
+        "userName",
+        "password"
+      ]
+    },
+    "SSISAccessCredential": {
+      "description": "SSIS access credential.",
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "object",
+          "description": "Domain for windows authentication."
+        },
+        "userName": {
+          "type": "object",
+          "description": "UseName for windows authentication."
+        },
+        "password": {
+          "$ref": "../artifacts.json#/definitions/SecretBase",
+          "description": "Password for windows authentication."
+        }
+      },
+      "required": [
+        "domain",
+        "userName",
+        "password"
+      ]
+    },
+    "SSISChildPackage": {
+      "description": "SSIS embedded child package.",
+      "type": "object",
+      "properties": {
+        "packagePath": {
+          "type": "object",
+          "description": "Path for embedded child package. Type: string (or Expression with resultType string)."
+        },
+        "packageName": {
+          "type": "string",
+          "description": "Name for embedded child package."
+        },
+        "packageContent": {
+          "type": "object",
+          "description": "Content for embedded child package. Type: string (or Expression with resultType string)."
+        },
+        "packageLastModifiedDate": {
+          "type": "string",
+          "description": "Last modified date for embedded child package."
+        }
+      },
+      "required": [
+        "packagePath",
+        "packageContent"
+      ]
+    },
+    "SSISLogLocation": {
+      "description": "SSIS package execution log location",
+      "type": "object",
+      "properties": {
+        "logPath": {
+          "description": "The SSIS package execution log path. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "type": {
+          "description": "The type of SSIS log location.",
+          "type": "string",
+          "enum": [
+            "File"
+          ],
+          "x-ms-enum": {
+            "name": "SsisLogLocationType",
+            "modelAsString": true
+          }
+        },
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "SSIS package execution log location properties.",
+          "$ref": "#/definitions/SSISLogLocationTypeProperties"
+        }
+      },
+      "required": [
+        "logPath",
+        "type",
+        "typeProperties"
+      ]
+    },
+    "SSISLogLocationTypeProperties": {
+      "description": "SSIS package execution log location properties.",
+      "type": "object",
+      "properties": {
+        "accessCredential": {
+          "description": "The package execution log access credential.",
+          "$ref": "#/definitions/SSISAccessCredential"
+        },
+        "logRefreshInterval": {
+          "type": "object",
+          "description": "Specifies the interval to refresh log. The default interval is 5 minutes. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        }
+      }
+    },
+    "CustomActivity": {
+      "description": "Custom activity type.",
+      "type": "object",
+      "x-ms-discriminator-value": "Custom",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Custom activity properties.",
+          "$ref": "#/definitions/CustomActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "CustomActivityTypeProperties": {
+      "description": "Custom activity properties.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "object",
+          "description": "Command for custom activity Type: string (or Expression with resultType string)."
+        },
+        "resourceLinkedService": {
+          "description": "Resource linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "folderPath": {
+          "type": "object",
+          "description": "Folder path for resource files Type: string (or Expression with resultType string)."
+        },
+        "referenceObjects": {
+          "description": "Reference objects",
+          "$ref": "#/definitions/CustomActivityReferenceObject"
+        },
+        "extendedProperties": {
+          "description": "User defined property bag. There is no restriction on the keys or values that can be used. The user specified custom activity has the full responsibility to consume and interpret the content defined.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "retentionTimeInDays": {
+          "type": "object",
+          "description": "The retention time for the files submitted for custom activity. Type: double (or Expression with resultType double)."
+        },
+        "autoUserSpecification": {
+          "type": "object",
+          "description": "Elevation level and scope for the user, default is nonadmin task. Type: string (or Expression with resultType double)."
+        }
+      },
+      "required": [
+        "command"
+      ]
+    },
+    "CustomActivityReferenceObject": {
+      "description": "Reference objects for custom activity",
+      "type": "object",
+      "properties": {
+        "linkedServices": {
+          "description": "Linked service references.",
+          "type": "array",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+          }
+        },
+        "datasets": {
+          "description": "Dataset references.",
+          "type": "array",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/DatasetReference"
+          }
+        }
+      }
+    },
+    "SqlServerStoredProcedureActivity": {
+      "description": "SQL stored procedure activity type.",
+      "type": "object",
+      "x-ms-discriminator-value": "SqlServerStoredProcedure",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "SQL stored procedure activity properties.",
+          "$ref": "#/definitions/SqlServerStoredProcedureActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties",
+        "linkedServiceName"
+      ]
+    },
+    "SqlServerStoredProcedureActivityTypeProperties": {
+      "description": "SQL stored procedure activity properties.",
+      "type": "object",
+      "properties": {
+        "storedProcedureName": {
+          "type": "object",
+          "description": "Stored procedure name. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object"
+        }
+      },
+      "required": [
+        "storedProcedureName"
+      ]
+    },
+    "ExecutePipelineActivity": {
+      "x-ms-discriminator-value": "ExecutePipeline",
+      "type": "object",
+      "description": "Execute pipeline activity.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Execute pipeline activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ExecutePipelineActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "ExecutePipelineActivityTypeProperties": {
+      "description": "Execute pipeline activity properties.",
+      "type": "object",
+      "properties": {
+        "pipeline": {
+          "description": "Pipeline reference.",
+          "$ref": "../artifacts.json#/definitions/PipelineReference"
+        },
+        "parameters": {
+          "description": "Pipeline parameters.",
+          "$ref": "../artifacts.json#/definitions/ParameterValueSpecification"
+        },
+        "waitOnCompletion": {
+          "description": "Defines whether activity execution will wait for the dependent pipeline execution to finish. Default is false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pipeline"
+      ]
+    },
+    "DeleteActivity": {
+      "x-ms-discriminator-value": "Delete",
+      "description": "Delete activity.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Delete activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/DeleteActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "DeleteActivityTypeProperties": {
+      "description": "Delete activity properties.",
+      "type": "object",
+      "properties": {
+        "recursive": {
+          "type": "object",
+          "description": "If true, files or sub-folders under current folder path will be deleted recursively. Default is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "maxConcurrentConnections": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The max concurrent connections to connect data source at the same time."
+        },
+        "enableLogging": {
+          "type": "object",
+          "description": "Whether to record detailed logs of delete-activity execution. Default value is false. Type: boolean (or Expression with resultType boolean)."
+        },
+        "logStorageSettings": {
+          "description": "Log storage settings customer need to provide when enableLogging is true.",
+          "$ref": "#/definitions/LogStorageSettings"
+        },
+        "dataset": {
+          "description": "Delete activity dataset reference.",
+          "$ref": "../artifacts.json#/definitions/DatasetReference"
+        },
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "Delete activity store settings."
+        }
+      },
+      "required": [
+        "dataset"
+      ]
+    },
+    "AzureDataExplorerCommandActivity": {
+      "x-ms-discriminator-value": "AzureDataExplorerCommand",
+      "description": "Azure Data Explorer command activity.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Azure Data Explorer command activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AzureDataExplorerCommandActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "AzureDataExplorerCommandActivityTypeProperties": {
+      "description": "Azure Data Explorer command activity properties.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "object",
+          "description": "A control command, according to the Azure Data Explorer command syntax. Type: string (or Expression with resultType string)."
+        },
+        "commandTimeout": {
+          "type": "object",
+          "description": "Control command timeout. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))..)"
+        }
+      },
+      "required": [
+        "command"
+      ]
+    },
+    "LookupActivity": {
+      "x-ms-discriminator-value": "Lookup",
+      "description": "Lookup activity.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Lookup activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/LookupActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "LookupActivityTypeProperties": {
+      "description": "Lookup activity properties.",
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Dataset-specific source properties, same as copy activity source.",
+          "$ref": "#/definitions/CopySource"
+        },
+        "dataset": {
+          "description": "Lookup activity dataset reference.",
+          "$ref": "../artifacts.json#/definitions/DatasetReference"
+        },
+        "firstRowOnly": {
+          "type": "object",
+          "description": "Whether to return first row or all rows. Default value is true. Type: boolean (or Expression with resultType boolean)."
+        }
+      },
+      "required": [
+        "source",
+        "dataset"
+      ]
+    },
+    "WebActivityMethod": {
+      "description": "The list of HTTP methods supported by a WebActivity.",
+      "type": "string",
+      "enum": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE"
+      ],
+      "x-ms-enum": {
+        "name": "WebActivityMethod",
+        "modelAsString": true
+      }
+    },
+    "WebActivity": {
+      "x-ms-discriminator-value": "WebActivity",
+      "description": "Web activity.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Web activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/WebActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "WebActivityAuthentication": {
+      "description": "Web activity authentication properties.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Web activity authentication (Basic/ClientCertificate/MSI)",
+          "type": "string"
+        },
+        "pfx": {
+          "description": "Base64-encoded contents of a PFX file.",
+          "$ref": "../artifacts.json#/definitions/SecretBase"
+        },
+        "username": {
+          "description": "Web activity authentication user name for basic authentication.",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password for the PFX file or basic authentication.",
+          "$ref": "../artifacts.json#/definitions/SecretBase"
+        },
+        "resource": {
+          "description": "Resource for which Azure Auth token will be requested when using MSI Authentication. Type: string (or Expression with resultType string).",
+          "type": "object"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "WebActivityTypeProperties": {
+      "description": "Web activity type properties.",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "Rest API method for target endpoint.",
+          "$ref": "#/definitions/WebActivityMethod"
+        },
+        "url": {
+          "type": "object",
+          "description": "Web activity target endpoint and path. Type: string (or Expression with resultType string)."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Represents the headers that will be sent to the request. For example, to set the language and type on a request: \"headers\" : { \"Accept-Language\": \"en-us\", \"Content-Type\": \"application/json\" }. Type: string (or Expression with resultType string)."
+        },
+        "body": {
+          "type": "object",
+          "description": "Represents the payload that will be sent to the endpoint. Required for POST/PUT method, not allowed for GET method Type: string (or Expression with resultType string)."
+        },
+        "authentication": {
+          "description": "Authentication method used for calling the endpoint.",
+          "$ref": "#/definitions/WebActivityAuthentication"
+        },
+        "disableCertValidation": {
+          "type": "boolean",
+          "description": "When set to true, Certificate validation will be disabled."
+        },
+        "datasets": {
+          "type": "array",
+          "description": "List of datasets passed to web endpoint.",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/DatasetReference"
+          }
+        },
+        "linkedServices": {
+          "type": "array",
+          "description": "List of linked services passed to web endpoint.",
+          "items": {
+            "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+          }
+        },
+        "connectVia": {
+          "description": "The integration runtime reference.",
+          "$ref": "../artifacts.json#/definitions/IntegrationRuntimeReference"
+        }
+      },
+      "required": [
+        "method",
+        "url"
+      ]
+    },
+    "GetMetadataActivity": {
+      "x-ms-discriminator-value": "GetMetadata",
+      "description": "Activity to get metadata of dataset",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "GetMetadata activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/GetMetadataActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "GetMetadataActivityTypeProperties": {
+      "description": "GetMetadata activity properties.",
+      "type": "object",
+      "properties": {
+        "dataset": {
+          "description": "GetMetadata activity dataset reference.",
+          "$ref": "../artifacts.json#/definitions/DatasetReference"
+        },
+        "fieldList": {
+          "description": "Fields of metadata to get from dataset.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "storeSettings": {
+          "$ref": "#/definitions/StoreReadSettings",
+          "description": "GetMetadata activity store settings."
+        },
+        "formatSettings": {
+          "$ref": "#/definitions/FormatReadSettings",
+          "description": "GetMetadata activity format settings."
+        }
+      },
+      "required": [
+        "dataset"
+      ]
+    },
+    "IfConditionActivity": {
+      "x-ms-discriminator-value": "IfCondition",
+      "description": "This activity evaluates a boolean expression and executes either the activities under the ifTrueActivities property or the ifFalseActivities property depending on the result of the expression.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "IfCondition activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/IfConditionActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "IfConditionActivityTypeProperties": {
+      "description": "IfCondition activity properties.",
+      "type": "object",
+      "properties": {
+        "expression": {
+          "description": "An expression that would evaluate to Boolean. This is used to determine the block of activities (ifTrueActivities or ifFalseActivities) that will be executed.",
+          "$ref": "../artifacts.json#/definitions/Expression"
+        },
+        "ifTrueActivities": {
+          "type": "array",
+          "description": "List of activities to execute if expression is evaluated to true. This is an optional property and if not provided, the activity will exit without any action.",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        },
+        "ifFalseActivities": {
+          "type": "array",
+          "description": "List of activities to execute if expression is evaluated to false. This is an optional property and if not provided, the activity will exit without any action.",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        }
+      },
+      "required": [
+        "expression"
+      ]
+    },
+    "SwitchActivity": {
+      "x-ms-discriminator-value": "Switch",
+      "description": "This activity evaluates an expression and executes activities under the cases property that correspond to the expression evaluation expected in the equals property.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Switch activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/SwitchActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "SwitchActivityTypeProperties": {
+      "description": "Switch activity properties.",
+      "type": "object",
+      "properties": {
+        "on": {
+          "description": "An expression that would evaluate to a string or integer. This is used to determine the block of activities in cases that will be executed.",
+          "$ref": "../artifacts.json#/definitions/Expression"
+        },
+        "cases": {
+          "type": "array",
+          "description": "List of cases that correspond to expected values of the 'on' property. This is an optional property and if not provided, the activity will execute activities provided in defaultActivities.",
+          "items": {
+            "x-ms-client-flatten": true,
+            "$ref": "#/definitions/SwitchCase"
+          }
+        },
+        "defaultActivities": {
+          "type": "array",
+          "description": "List of activities to execute if no case condition is satisfied. This is an optional property and if not provided, the activity will exit without any action.",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        }
+      },
+      "required": [
+        "on"
+      ]
+    },
+    "SwitchCase": {
+      "description": "Switch cases with have a value and corresponding activities.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Expected value that satisfies the expression result of the 'on' property.",
+          "type": "string"
+        },
+        "activities": {
+          "type": "array",
+          "description": "List of activities to execute for satisfied case condition.",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        }
+      }
+    },
+    "ForEachActivity": {
+      "x-ms-discriminator-value": "ForEach",
+      "description": "This activity is used for iterating over a collection and execute given activities.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "ForEach activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ForEachActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "ForEachActivityTypeProperties": {
+      "description": "ForEach activity properties.",
+      "type": "object",
+      "properties": {
+        "isSequential": {
+          "description": "Should the loop be executed in sequence or in parallel (max 50)",
+          "type": "boolean"
+        },
+        "batchCount": {
+          "description": "Batch count to be used for controlling the number of parallel execution (when isSequential is set to false).",
+          "type": "integer",
+          "maximum": 50
+        },
+        "items": {
+          "description": "Collection to iterate.",
+          "$ref": "../artifacts.json#/definitions/Expression"
+        },
+        "activities": {
+          "type": "array",
+          "description": "List of activities to execute .",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        }
+      },
+      "required": [
+        "items",
+        "activities"
+      ]
+    },
+    "AzureMLBatchExecutionActivity": {
+      "description": "Azure ML Batch Execution activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureMLBatchExecution",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Azure ML Batch Execution activity properties.",
+          "$ref": "#/definitions/AzureMLBatchExecutionActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "AzureMLBatchExecutionActivityTypeProperties": {
+      "description": "Azure ML Batch Execution activity properties.",
+      "type": "object",
+      "properties": {
+        "globalParameters": {
+          "description": "Key,Value pairs to be passed to the Azure ML Batch Execution Service endpoint. Keys must match the names of web service parameters defined in the published Azure ML web service. Values will be passed in the GlobalParameters property of the Azure ML batch execution request.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "webServiceOutputs": {
+          "description": "Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Outputs to AzureMLWebServiceFile objects specifying the output Blob locations. This information will be passed in the WebServiceOutputs property of the Azure ML batch execution request.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AzureMLWebServiceFile"
+          }
+        },
+        "webServiceInputs": {
+          "description": "Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Inputs to AzureMLWebServiceFile objects specifying the input Blob locations.. This information will be passed in the WebServiceInputs property of the Azure ML batch execution request.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AzureMLWebServiceFile"
+          }
+        }
+      }
+    },
+    "AzureMLWebServiceFile": {
+      "description": "Azure ML WebService Input/Output file",
+      "type": "object",
+      "properties": {
+        "filePath": {
+          "type": "object",
+          "description": "The relative file path, including container name, in the Azure Blob Storage specified by the LinkedService. Type: string (or Expression with resultType string)."
+        },
+        "linkedServiceName": {
+          "description": "Reference to an Azure Storage LinkedService, where Azure ML WebService Input/Output file located.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        }
+      },
+      "required": [
+        "linkedServiceName",
+        "filePath"
+      ]
+    },
+    "AzureMLUpdateResourceActivity": {
+      "description": "Azure ML Update Resource management activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureMLUpdateResource",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Azure ML Update Resource management activity properties.",
+          "$ref": "#/definitions/AzureMLUpdateResourceActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "AzureMLUpdateResourceActivityTypeProperties": {
+      "description": "Azure ML Update Resource activity properties.",
+      "type": "object",
+      "properties": {
+        "trainedModelName": {
+          "type": "object",
+          "description": "Name of the Trained Model module in the Web Service experiment to be updated. Type: string (or Expression with resultType string)."
+        },
+        "trainedModelLinkedServiceName": {
+          "description": "Name of Azure Storage linked service holding the .ilearner file that will be uploaded by the update operation.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "trainedModelFilePath": {
+          "type": "object",
+          "description": "The relative file path in trainedModelLinkedService to represent the .ilearner file that will be uploaded by the update operation.  Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "trainedModelName",
+        "trainedModelLinkedServiceName",
+        "trainedModelFilePath"
+      ]
+    },
+    "AzureMLExecutePipelineActivity": {
+      "description": "Azure ML Execute Pipeline activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureMLExecutePipeline",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Azure ML Execute Pipeline activity properties.",
+          "$ref": "#/definitions/AzureMLExecutePipelineActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "AzureMLExecutePipelineActivityTypeProperties": {
+      "description": "Azure ML Execute Pipeline activity properties.",
+      "type": "object",
+      "properties": {
+        "mlPipelineId": {
+          "description": "ID of the published Azure ML pipeline. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "experimentName": {
+          "description": "Run history experiment name of the pipeline run. This information will be passed in the ExperimentName property of the published pipeline execution request. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "mlPipelineParameters": {
+          "description": "Key,Value pairs to be passed to the published Azure ML pipeline endpoint. Keys must match the names of pipeline parameters defined in the published pipeline. Values will be passed in the ParameterAssignments property of the published pipeline execution request. Type: object with key value pairs (or Expression with resultType object).",
+          "type": "object"
+        },
+        "mlParentRunId": {
+          "description": "The parent Azure ML Service pipeline run id. This information will be passed in the ParentRunId property of the published pipeline execution request. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "continueOnStepFailure": {
+          "description": "Whether to continue execution of other steps in the PipelineRun if a step fails. This information will be passed in the continueOnStepFailure property of the published pipeline execution request. Type: boolean (or Expression with resultType boolean).",
+          "type": "object"
+        }
+      },
+      "required": [
+        "mlPipelineId"
+      ]
+    },
+    "AzureMLPipelineParameters": {
+      "description": "Key,Value pairs to be passed to the published Azure ML pipeline endpoint. Keys must match the names of pipeline parameters defined in the published pipeline. Values will be passed in the ParameterAssignments property of the published pipeline execution request.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "description": "Type: string (or Expression with resultType string)."
+      }
+    },
+    "DataLakeAnalyticsUSQLActivity": {
+      "description": "Data Lake Analytics U-SQL activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "DataLakeAnalyticsU-SQL",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Data Lake Analytics U-SQL activity properties.",
+          "$ref": "#/definitions/DataLakeAnalyticsUSQLActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "DataLakeAnalyticsUSQLActivityTypeProperties": {
+      "description": "DataLakeAnalyticsU-SQL activity properties.",
+      "type": "object",
+      "properties": {
+        "scriptPath": {
+          "type": "object",
+          "description": "Case-sensitive path to folder that contains the U-SQL script. Type: string (or Expression with resultType string)."
+        },
+        "scriptLinkedService": {
+          "description": "Script linked service reference.",
+          "$ref": "../artifacts.json#/definitions/LinkedServiceReference"
+        },
+        "degreeOfParallelism": {
+          "type": "object",
+          "description": "The maximum number of nodes simultaneously used to run the job. Default value is 1. Type: integer (or Expression with resultType integer), minimum: 1."
+        },
+        "priority": {
+          "type": "object",
+          "description": "Determines which jobs out of all that are queued should be selected to run first. The lower the number, the higher the priority. Default value is 1000. Type: integer (or Expression with resultType integer), minimum: 1."
+        },
+        "parameters": {
+          "description": "Parameters for U-SQL job request.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "runtimeVersion": {
+          "type": "object",
+          "description": "Runtime version of the U-SQL engine to use. Type: string (or Expression with resultType string)."
+        },
+        "compilationMode": {
+          "type": "object",
+          "description": "Compilation mode of U-SQL. Must be one of these values : Semantic, Full and SingleBox. Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "scriptPath",
+        "scriptLinkedService"
+      ]
+    },
+    "WaitActivity": {
+      "x-ms-discriminator-value": "Wait",
+      "description": "This activity suspends pipeline execution for the specified interval.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Wait activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/WaitActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "WaitActivityTypeProperties": {
+      "description": "Wait activity properties.",
+      "type": "object",
+      "properties": {
+        "waitTimeInSeconds": {
+          "description": "Duration in seconds.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "waitTimeInSeconds"
+      ]
+    },
+    "FailActivity": {
+      "x-ms-discriminator-value": "Fail",
+      "type": "object",
+      "description": "This activity will fail within its own scope and output a custom error message and error code. The error message and code can provided either as a string literal or as an expression that can be evaluated to a string at runtime. The activity scope can be the whole pipeline or a control activity (e.g. foreach, switch, until), if the fail activity is contained in it.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Fail activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/FailActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "FailActivityTypeProperties": {
+      "description": "Fail activity properties.",
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "The error message that surfaced in the Fail activity. It can be dynamic content that's evaluated to a non empty/blank string at runtime. Type: string (or Expression with resultType string).",
+          "type": "object"
+        },
+        "errorCode": {
+          "description": "The error code that categorizes the error type of the Fail activity. It can be dynamic content that's evaluated to a non empty/blank string at runtime. Type: string (or Expression with resultType string).",
+          "type": "object"
+        }
+      },
+      "required": [
+        "message",
+        "errorCode"
+      ]
+    },
+    "UntilActivity": {
+      "x-ms-discriminator-value": "Until",
+      "description": "This activity executes inner activities until the specified boolean expression results to true or timeout is reached, whichever is earlier.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Until activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/UntilActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "UntilActivityTypeProperties": {
+      "description": "Until activity properties.",
+      "type": "object",
+      "properties": {
+        "expression": {
+          "description": "An expression that would evaluate to Boolean. The loop will continue until this expression evaluates to true",
+          "$ref": "../artifacts.json#/definitions/Expression"
+        },
+        "timeout": {
+          "type": "object",
+          "description": "Specifies the timeout for the activity to run. If there is no value specified, it takes the value of TimeSpan.FromDays(7) which is 1 week as default. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9])). Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "activities": {
+          "type": "array",
+          "description": "List of activities to execute.",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        }
+      },
+      "required": [
+        "expression",
+        "activities"
+      ]
+    },
+    "ValidationActivity": {
+      "x-ms-discriminator-value": "Validation",
+      "description": "This activity verifies that an external resource exists.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Validation activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ValidationActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "ValidationActivityTypeProperties": {
+      "description": "Validation activity properties.",
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "type": "object",
+          "description": "Specifies the timeout for the activity to run. If there is no value specified, it takes the value of TimeSpan.FromDays(7) which is 1 week as default. Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "sleep": {
+          "type": "object",
+          "description": "A delay in seconds between validation attempts. If no value is specified, 10 seconds will be used as the default. Type: integer (or Expression with resultType integer)."
+        },
+        "minimumSize": {
+          "type": "object",
+          "description": "Can be used if dataset points to a file. The file must be greater than or equal in size to the value specified. Type: integer (or Expression with resultType integer)."
+        },
+        "childItems": {
+          "type": "object",
+          "description": "Can be used if dataset points to a folder. If set to true, the folder must have at least one file. If set to false, the folder must be empty. Type: boolean (or Expression with resultType boolean)."
+        },
+        "dataset": {
+          "description": "Validation activity dataset reference.",
+          "$ref": "../artifacts.json#/definitions/DatasetReference"
+        }
+      },
+      "required": [
+        "dataset"
+      ]
+    },
+    "FilterActivity": {
+      "x-ms-discriminator-value": "Filter",
+      "description": "Filter and return results from input array based on the conditions.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Filter activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/FilterActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "FilterActivityTypeProperties": {
+      "description": "Filter activity properties.",
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "Input array on which filter should be applied.",
+          "$ref": "../artifacts.json#/definitions/Expression"
+        },
+        "condition": {
+          "description": "Condition to be used for filtering the input.",
+          "$ref": "../artifacts.json#/definitions/Expression"
+        }
+      },
+      "required": [
+        "condition",
+        "items"
+      ]
+    },
+    "DatabricksNotebookActivity": {
+      "description": "DatabricksNotebook activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "DatabricksNotebook",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Databricks Notebook activity properties.",
+          "$ref": "#/definitions/DatabricksNotebookActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "DatabricksNotebookActivityTypeProperties": {
+      "description": "Databricks Notebook activity properties.",
+      "type": "object",
+      "properties": {
+        "notebookPath": {
+          "type": "object",
+          "description": "The absolute path of the notebook to be run in the Databricks Workspace. This path must begin with a slash. Type: string (or Expression with resultType string)."
+        },
+        "baseParameters": {
+          "description": "Base parameters to be used for each run of this job.If the notebook takes a parameter that is not specified, the default value from the notebook will be used.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "libraries": {
+          "description": "A list of libraries to be installed on the cluster that will execute the job.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Databricks library definition.",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "required": [
+        "notebookPath"
+      ]
+    },
+    "DatabricksSparkJarActivity": {
+      "description": "DatabricksSparkJar activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "DatabricksSparkJar",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Databricks SparkJar activity properties.",
+          "$ref": "#/definitions/DatabricksSparkJarActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "DatabricksSparkJarActivityTypeProperties": {
+      "description": "Databricks SparkJar activity properties.",
+      "type": "object",
+      "properties": {
+        "mainClassName": {
+          "type": "object",
+          "description": "The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library. Type: string (or Expression with resultType string)."
+        },
+        "parameters": {
+          "description": "Parameters that will be passed to the main method.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "libraries": {
+          "description": "A list of libraries to be installed on the cluster that will execute the job.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Databricks library definition.",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "required": [
+        "mainClassName"
+      ]
+    },
+    "DatabricksSparkPythonActivity": {
+      "description": "DatabricksSparkPython activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "DatabricksSparkPython",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Databricks SparkPython activity properties.",
+          "$ref": "#/definitions/DatabricksSparkPythonActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "DatabricksSparkPythonActivityTypeProperties": {
+      "description": "Databricks SparkPython activity properties.",
+      "type": "object",
+      "properties": {
+        "pythonFile": {
+          "type": "object",
+          "description": "The URI of the Python file to be executed. DBFS paths are supported. Type: string (or Expression with resultType string)."
+        },
+        "parameters": {
+          "description": "Command line parameters that will be passed to the Python file.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        },
+        "libraries": {
+          "description": "A list of libraries to be installed on the cluster that will execute the job.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Databricks library definition.",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "required": [
+        "pythonFile"
+      ]
+    },
+    "SetVariableActivity": {
+      "x-ms-discriminator-value": "SetVariable",
+      "description": "Set value for a Variable.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Set Variable activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/SetVariableActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "SetVariableActivityTypeProperties": {
+      "description": "SetVariable activity properties.",
+      "type": "object",
+      "properties": {
+        "variableName": {
+          "description": "Name of the variable whose value needs to be set.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value to be set. Could be a static value or Expression",
+          "type": "object"
+        }
+      }
+    },
+    "AppendVariableActivity": {
+      "x-ms-discriminator-value": "AppendVariable",
+      "description": "Append value for a Variable of type Array.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Append Variable activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AppendVariableActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "AppendVariableActivityTypeProperties": {
+      "description": "AppendVariable activity properties.",
+      "type": "object",
+      "properties": {
+        "variableName": {
+          "description": "Name of the variable whose value needs to be appended to.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value to be appended. Could be a static value or Expression",
+          "type": "object"
+        }
+      }
+    },
+    "AzureFunctionActivityMethod": {
+      "description": "The list of HTTP methods supported by a AzureFunctionActivity.",
+      "type": "string",
+      "enum": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "OPTIONS",
+        "HEAD",
+        "TRACE"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFunctionActivityMethod",
+        "modelAsString": true
+      }
+    },
+    "AzureFunctionActivity": {
+      "x-ms-discriminator-value": "AzureFunctionActivity",
+      "description": "Azure Function activity.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "Azure Function activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AzureFunctionActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "AzureFunctionActivityTypeProperties": {
+      "description": "Azure Function activity type properties.",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "Rest API method for target endpoint.",
+          "$ref": "#/definitions/AzureFunctionActivityMethod"
+        },
+        "functionName": {
+          "type": "object",
+          "description": "Name of the Function that the Azure Function Activity will call. Type: string (or Expression with resultType string)"
+        },
+        "headers": {
+          "type": "object",
+          "description": "Represents the headers that will be sent to the request. For example, to set the language and type on a request: \"headers\" : { \"Accept-Language\": \"en-us\", \"Content-Type\": \"application/json\" }. Type: string (or Expression with resultType string)."
+        },
+        "body": {
+          "type": "object",
+          "description": "Represents the payload that will be sent to the endpoint. Required for POST/PUT method, not allowed for GET method Type: string (or Expression with resultType string)."
+        }
+      },
+      "required": [
+        "method",
+        "functionName"
+      ]
+    },
+    "WebHookActivity": {
+      "x-ms-discriminator-value": "WebHook",
+      "description": "WebHook activity.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ControlActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "description": "WebHook activity properties.",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/WebHookActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "WebHookActivityMethod": {
+      "description": "The list of HTTP methods supported by a WebHook activity.",
+      "type": "string",
+      "enum": [
+        "POST"
+      ],
+      "x-ms-enum": {
+        "name": "WebHookActivityMethod",
+        "modelAsString": true
+      }
+    },
+    "WebHookActivityTypeProperties": {
+      "description": "WebHook activity type properties.",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "Rest API method for target endpoint.",
+          "$ref": "#/definitions/WebHookActivityMethod"
+        },
+        "url": {
+          "type": "object",
+          "description": "WebHook activity target endpoint and path. Type: string (or Expression with resultType string)."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "The timeout within which the webhook should be called back. If there is no value specified, it defaults to 10 minutes. Type: string. Pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Represents the headers that will be sent to the request. For example, to set the language and type on a request: \"headers\" : { \"Accept-Language\": \"en-us\", \"Content-Type\": \"application/json\" }. Type: string (or Expression with resultType string)."
+        },
+        "body": {
+          "type": "object",
+          "description": "Represents the payload that will be sent to the endpoint. Required for POST/PUT method, not allowed for GET method Type: string (or Expression with resultType string)."
+        },
+        "authentication": {
+          "description": "Authentication method used for calling the endpoint.",
+          "$ref": "#/definitions/WebActivityAuthentication"
+        },
+        "reportStatusOnCallBack": {
+          "type": "object",
+          "description": "When set to true, statusCode, output and error in callback request body will be consumed by activity. The activity can be marked as failed by setting statusCode >= 400 in callback request. Default is false. Type: boolean (or Expression with resultType boolean)."
+        }
+      },
+      "required": [
+        "method",
+        "url"
+      ]
+    },
+    "ExecuteDataFlowActivity": {
+      "description": "Execute data flow activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "ExecuteDataFlow",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Execute data flow activity properties.",
+          "$ref": "#/definitions/ExecuteDataFlowActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "ExecuteDataFlowActivityTypeProperties": {
+      "description": "Execute data flow activity properties.",
+      "type": "object",
+      "properties": {
+        "dataflow": {
+          "description": "Data flow reference.",
+          "$ref": "../artifacts.json#/definitions/DataFlowReference"
+        },
+        "staging": {
+          "description": "Staging info for execute data flow activity.",
+          "$ref": "../artifacts.json#/definitions/DataFlowStagingInfo"
+        },
+        "integrationRuntime": {
+          "description": "The integration runtime reference.",
+          "$ref": "../artifacts.json#/definitions/IntegrationRuntimeReference"
+        },
+        "compute": {
+          "description": "Compute properties for data flow activity.",
+          "type": "object",
+          "properties": {
+            "computeType": {
+              "description": "Compute type of the cluster which will execute data flow job.",
+              "type": "string",
+              "enum": [
+                "General",
+                "MemoryOptimized",
+                "ComputeOptimized"
+              ],
+              "x-ms-enum": {
+                "name": "DataFlowComputeType",
+                "modelAsString": true
+              }
+            },
+            "coreCount": {
+              "description": "Core count of the cluster which will execute data flow job. Supported values are: 8, 16, 32, 48, 80, 144 and 272.",
+              "type": "integer"
+            }
+          }
+        },
+        "traceLevel": {
+          "description": "Trace level setting used for data flow monitoring output. Supported values are: 'coarse', 'fine', and 'none'. Type: string (or Expression with resultType string)",
+          "type": "object"
+        },
+        "continueOnError": {
+          "description": "Continue on error setting used for data flow execution. Enables processing to continue if a sink fails. Type: boolean (or Expression with resultType boolean)",
+          "type": "object"
+        },
+        "runConcurrently": {
+          "description": "Concurrent run setting used for data flow execution. Allows sinks with the same save order to be processed concurrently. Type: boolean (or Expression with resultType boolean)",
+          "type": "object"
+        }
+      },
+      "required": [
+        "dataflow"
+      ]
+    },
+    "ScriptActivity": {
+      "description": "Script activity type.",
+      "x-ms-discriminator-value": "Script",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Script activity properties.",
+          "$ref": "#/definitions/ScriptActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties",
+        "linkedServiceName"
+      ]
+    },
+    "ScriptActivityTypeProperties": {
+      "description": "Script activity properties.",
+      "type": "object",
+      "properties": {
+        "scripts": {
+          "type": "array",
+          "description": "Array of script blocks. Type: array.",
+          "items": {
+            "$ref": "#/definitions/ScriptActivityScriptBlock"
+          }
+        },
+        "logSettings": {
+          "description": "Log settings of script activity.",
+          "type": "object",
+          "properties": {
+            "logDestination": {
+              "x-ms-enum": {
+                "name": "ScriptActivityLogDestination",
+                "modelAsString": true
+              },
+              "enum": [
+                "ActivityOutput",
+                "ExternalStore"
+              ],
+              "type": "string",
+              "description": "The destination of logs. Type: string."
+            },
+            "logLocationSettings": {
+              "description": "Log location settings customer needs to provide when enabling log.",
+              "$ref": "#/definitions/LogLocationSettings"
+            }
+          },
+          "required": [
+            "logDestination"
+          ]
+        }
+      }
+    },
+    "ScriptActivityScriptBlock": {
+      "description": "Script block of scripts.",
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "object",
+          "description": "The query text. Type: string (or Expression with resultType string)."
+        },
+        "type": {
+          "x-ms-enum": {
+            "name": "ScriptType",
+            "modelAsString": true
+          },
+          "enum": [
+            "Query",
+            "NonQuery"
+          ],
+          "type": "string",
+          "description": "The type of the query. Type: string."
+        },
+        "parameters": {
+          "type": "array",
+          "description": "Array of script parameters. Type: array.",
+          "items": {
+            "$ref": "#/definitions/ScriptActivityParameter"
+          }
+        }
+      },
+      "required": [
+        "text",
+        "type"
+      ]
+    },
+    "ScriptActivityParameter": {
+      "description": "Parameters of a script block.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "object",
+          "description": "The name of the parameter. Type: string (or Expression with resultType string)."
+        },
+        "type": {
+          "description": "The type of the parameter.",
+          "type": "string",
+          "enum": [
+            "Boolean",
+            "DateTime",
+            "DateTimeOffset",
+            "Decimal",
+            "Double",
+            "Guid",
+            "Int16",
+            "Int32",
+            "Int64",
+            "Single",
+            "String",
+            "Timespan"
+          ],
+          "x-ms-enum": {
+            "name": "ScriptActivityParameterType",
+            "modelAsString": true
+          }
+        },
+        "value": {
+          "description": "The value of the parameter.",
+          "type": "object"
+        },
+        "direction": {
+          "description": "The direction of the parameter.",
+          "type": "string",
+          "enum": [
+            "Input",
+            "Output",
+            "InputOutput"
+          ],
+          "x-ms-enum": {
+            "name": "ScriptActivityParameterDirection",
+            "modelAsString": true
+          }
+        },
+        "size": {
+          "description": "The size of the output direction parameter.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "SharePointOnlineListSource": {
+      "description": "A copy activity source for sharePoint online list source.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopySource"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "The OData query to filter the data in SharePoint Online list. For example, \"$top=1\". Type: string (or Expression with resultType string)."
+        },
+        "httpRequestTimeout": {
+          "type": "object",
+          "description": "The wait time to get a response from SharePoint Online. Default value is 5 minutes (00:05:00). Type: string (or Expression with resultType string), pattern: ((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))."
+        }
+      }
+    },
+    "SqlPartitionOption": {
+      "description": "The partition mechanism that will be used for Sql read in parallel.",
+      "type": "string",
+      "enum": [
+        "None",
+        "PhysicalPartitionsOfTable",
+        "DynamicRange"
+      ],
+      "x-ms-enum": {
+        "name": "SqlPartitionOption",
+        "modelAsString": true
+      }
+    },
+    "SapHanaPartitionOption": {
+      "description": "The partition mechanism that will be used for SAP HANA read in parallel.",
+      "type": "string",
+      "enum": [
+        "None",
+        "PhysicalPartitionsOfTable",
+        "SapHanaDynamicRange"
+      ],
+      "x-ms-enum": {
+        "name": "SapHanaPartitionOption",
+        "modelAsString": true
+      }
+    },
+    "SapTablePartitionOption": {
+      "description": "The partition mechanism that will be used for SAP table read in parallel.",
+      "type": "string",
+      "enum": [
+        "None",
+        "PartitionOnInt",
+        "PartitionOnCalendarYear",
+        "PartitionOnCalendarMonth",
+        "PartitionOnCalendarDate",
+        "PartitionOnTime"
+      ],
+      "x-ms-enum": {
+        "name": "SapTablePartitionOption",
+        "modelAsString": true
+      }
+    },
+    "OraclePartitionOption": {
+      "description": "The partition mechanism that will be used for Oracle read in parallel.",
+      "type": "string",
+      "enum": [
+        "None",
+        "PhysicalPartitionsOfTable",
+        "DynamicRange"
+      ],
+      "x-ms-enum": {
+        "name": "OraclePartitionOption",
+        "modelAsString": true
+      }
+    },
+    "TeradataPartitionOption": {
+      "description": "The partition mechanism that will be used for teradata read in parallel.",
+      "type": "string",
+      "enum": [
+        "None",
+        "Hash",
+        "DynamicRange"
+      ],
+      "x-ms-enum": {
+        "name": "TeradataPartitionOption",
+        "modelAsString": true
+      }
+    },
+    "NetezzaPartitionOption": {
+      "description": "The partition mechanism that will be used for Netezza read in parallel.",
+      "type": "string",
+      "enum": [
+        "None",
+        "DataSlice",
+        "DynamicRange"
+      ],
+      "x-ms-enum": {
+        "name": "NetezzaPartitionOption",
+        "modelAsString": true
+      }
+    },
+    "SynapseNotebookActivity": {
+      "description": "Execute Synapse notebook activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "SynapseNotebook",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Execute Synapse notebook activity properties.",
+          "$ref": "#/definitions/SynapseNotebookActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "SynapseNotebookActivityTypeProperties": {
+      "description": "Execute Synapse notebook activity properties.",
+      "type": "object",
+      "properties": {
+        "notebook": {
+          "description": "Synapse notebook reference.",
+          "$ref": "../artifacts.json#/definitions/SynapseNotebookReference"
+        },
+        "parameters": {
+          "description": "Notebook parameters.",
+          "$ref": "../artifacts.json#/definitions/ParameterValueSpecification"
+        }
+      },
+      "required": [
+        "notebook"
+      ]
+    },
+    "SynapseSparkJobDefinitionActivity": {
+      "description": "Execute spark job activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "SparkJob",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExecutionActivity"
+        }
+      ],
+      "properties": {
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Execute spark job activity properties.",
+          "$ref": "#/definitions/SynapseSparkJobActivityTypeProperties"
+        }
+      },
+      "required": [
+        "typeProperties"
+      ]
+    },
+    "SynapseSparkJobActivityTypeProperties": {
+      "description": "Execute spark job activity properties.",
+      "type": "object",
+      "properties": {
+        "sparkJob": {
+          "description": "Synapse spark job reference.",
+          "$ref": "../artifacts.json#/definitions/SynapseSparkJobReference"
+        },
+        "args": {
+          "x-ms-client-name": "arguments",
+          "description": "User specified arguments to SynapseSparkJobDefinitionActivity.",
+          "type": "array",
+          "items": {
+            "description": "Type: string (or Expression with resultType string)."
+          }
+        }
+      },
+      "required": [
+        "sparkJob"
+      ]
+    },
+    "SqlPoolStoredProcedureActivity": {
+      "description": "Execute SQL pool stored procedure activity.",
+      "type": "object",
+      "x-ms-discriminator-value": "SqlPoolStoredProcedure",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Activity"
+        }
+      ],
+      "properties": {
+        "sqlPool": {
+          "description": "SQL pool stored procedure reference.",
+          "$ref": "../artifacts.json#/definitions/SqlPoolReference"
+        },
+        "typeProperties": {
+          "x-ms-client-flatten": true,
+          "description": "Execute SQL pool stored procedure activity properties.",
+          "$ref": "#/definitions/SqlPoolStoredProcedureActivityTypeProperties"
+        }
+      },
+      "required": [
+        "sqlPool",
+        "typeProperties"
+      ]
+    },
+    "SqlPoolStoredProcedureActivityTypeProperties": {
+      "description": "SQL stored procedure activity properties.",
+      "type": "object",
+      "properties": {
+        "storedProcedureName": {
+          "type": "object",
+          "description": "Stored procedure name. Type: string (or Expression with resultType string)."
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StoredProcedureParameter"
+          }
+        }
+      },
+      "required": [
+        "storedProcedureName"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The ADF half of the guard [#411](https://github.com/calvinchengx/fabric-emulator/pull/411) built for Fabric. Fabric's table is now vendored and checked; ADF's vocabulary — which the emulator accepts as a **compatibility surface** (`RunNotebook`, `AzureFunctionActivity`, `DatabricksSparkJar`, the HDInsight family, …) — was still guarded only by hand-written lists in Go. A hand-written list is the thing nothing checks.

## It found a real one

**`SparkJob` — Synapse's spark-job activity — was handled nowhere and reaching the success stub.** The only ADF discriminator still unhandled, and invisible because no list mentioned it.

It is now **refused by name**, not aliased, and the reason is the oracle rather than convenience. ADF's `SparkJob` takes a required `sparkJob` — a `SparkJobDefinitionReference` into a **Synapse workspace** — plus `args`. Fabric's `SparkJobDefinition` activity, which *is* implemented, takes `sparkJobDefinitionId` + `workspaceId` and resolves a **Fabric item**. Treating them as one would mean resolving a Synapse artifact reference against Fabric items: a mapping nobody wrote, and the same objection that refuses a `dbfs:` path in the Databricks activity.

## Pinned properly this time

Unlike Fabric's article (HTML-only, pinned by content hash — the exception #411 had to argue), this is a file in a public git repo, so it is pinned as `third_party/README.md` asks: commit `e773d510`, MIT, `LICENSE` shipped beside it, sha256 + byte size in `PROVENANCE.md`.

## Abstract bases are excluded by derivation, not exemption

Three of the 41 discriminators are not authorable: `Container` (`ControlActivity`) and `Execution` (`ExecutionActivity`) are **base classes** other definitions inherit from. The checker finds them by walking the schema's own `allOf` graph and asking which definitions are someone else's base.

Writing that as an exemption list would have reintroduced, *inside the fix*, precisely the declared list the fix removes. A test asserts both directions: the two bases are excluded, and `Copy`/`HDInsightHive`/`SparkJob` are still present — so the derivation is not just excluding everything.

## What the checker enforces

Every concrete ADF type must reach a **real outcome** — a dispatch case, an interpreter case, or an entry in `unrunnableActivities` with a cause. It does not care which; it cares that the answer is not the stub. 39 concrete types, all handled.

## Evidence

- 1666 Python tests pass; `ruff` clean; `go vet` clean; `internal/api` + `internal/pipeline` green.
- 6 pytest cases drive the checker, each asserting a **failure** direction: an unhandled type, a tampered schema, a schema it can no longer read (a parse finding three types would "pass" while checking nothing), and that all three handling routes count.
- `test_every_make_check_script_is_also_invoked_by_ci` passes — wired into `make check` **and** the CI repo-invariants job.

## One thing I did not do

`TestUnrunnableRefusalsCoverTheDiff` keeps a hand-written mirror of the refusal map. With both halves of the diff now derived, a name missing from the dispatch already fails a checker without it — so that map is largely redundant. What it still adds is the reverse direction *with a reason attached*, and its comments record why each entry exists and when two of them left.

I added a note there rather than deleting it: removing a passing structural test because another test now covers it is worth a second opinion, not a drive-by.