### PR TITLE
A workspace role reaches every SQL item, not just the connected one.

### DIFF
--- a/internal/server/tds_security_test.go
+++ b/internal/server/tds_security_test.go
@@ -259,3 +259,70 @@ func forgeTokenAs(t *testing.T, emu *entra.Emulator, audience, oid string) strin
 	}
 	return tok.Token
 }
+
+// A workspace role reaches every SQL item in the workspace, not only the one
+// named on the connection.
+//
+// THE SHAPE THAT BROKE. Gold is a Warehouse that reads silver out of a
+// Lakehouse by three-part name. The caller was provisioned in the database
+// they connected to and nowhere else, so the first cross-database statement
+// came back 916, "not able to access the database under the current security
+// context" — from inside a statement, on a login that had already succeeded,
+// which is why it read as a data error rather than an access one.
+//
+// It survived a week of daily runs because one cell hid it: that cell opens a
+// TDS connection to its lakehouse first, to trigger reflection, and that
+// connect provisioned the principal there as a side effect nothing declared.
+// The cell without that step was the only one failing, so the emulator looked
+// innocent and the cell looked broken.
+func TestWorkspaceRoleReachesEverySQLItem(t *testing.T) {
+	f := newSecFixture(t)
+
+	lh := &store.Item{WorkspaceID: f.ws.ID, Type: "Lakehouse", DisplayName: "lake"}
+	if err := f.srv.Store.CreateItem(lh, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the lakehouse's database the way EnsureDatabase and the analytics
+	// endpoint's refresh leave it: the database exists and holds silver. Done
+	// with the service credential because this test is about who may READ
+	// across, not about how the tables got there.
+	dsn := os.Getenv("WAREHOUSE_MSSQL_DSN")
+	master, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer master.Close()
+	if _, err := master.Exec(fmt.Sprintf("CREATE DATABASE [%s]", lh.ID)); err != nil {
+		t.Fatalf("creating the lakehouse database: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = master.Exec(fmt.Sprintf(
+			"ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [%s]", lh.ID, lh.ID))
+	})
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	lake, err := sql.Open("sqlserver", dsn+sep+"database="+lh.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lake.Close()
+	if _, err := lake.Exec("CREATE TABLE dbo.silver_customers(id INT); INSERT INTO dbo.silver_customers VALUES (1),(2)"); err != nil {
+		t.Fatalf("seeding silver: %v", err)
+	}
+
+	// A Contributor connects to the WAREHOUSE and reads the LAKEHOUSE, which is
+	// exactly what gold does.
+	caller := f.connectAs(t, "22222222-2222-2222-2222-222222222222", store.RoleContributor)
+	var n int
+	if err := caller.QueryRow(fmt.Sprintf(
+		"SELECT COUNT(*) FROM [%s].dbo.silver_customers", lh.ID)).Scan(&n); err != nil {
+		t.Fatalf("a workspace Contributor could not read a sibling item's SQL endpoint "+
+			"from the warehouse it connected to: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("read %d rows across databases, want 2", n)
+	}
+}

--- a/internal/server/tds_security_test.go
+++ b/internal/server/tds_security_test.go
@@ -28,6 +28,7 @@ import (
 
 	entra "github.com/calvinchengx/entra-emulator/emulator"
 	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/microsoft/go-mssqldb/msdsn"
 
 	"github.com/calvinchengx/fabric-emulator/internal/config"
 	"github.com/calvinchengx/fabric-emulator/internal/server"
@@ -300,14 +301,15 @@ func TestWorkspaceRoleReachesEverySQLItem(t *testing.T) {
 		_, _ = master.Exec(fmt.Sprintf(
 			"ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [%s]", lh.ID, lh.ID))
 	})
-	sep := "?"
-	if strings.Contains(dsn, "?") {
-		sep = "&"
-	}
-	lake, err := sql.Open("sqlserver", dsn+sep+"database="+lh.ID)
+	// THE DSN IS PARSED, NOT CONCATENATED. CI passes the semicolon form
+	// (`server=localhost,1433;user id=sa;…`), so appending `?database=` builds a
+	// string that only works against a URL-shaped DSN.
+	cfg, err := msdsn.Parse(dsn)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("parsing WAREHOUSE_MSSQL_DSN: %v", err)
 	}
+	cfg.Database = lh.ID
+	lake := sql.OpenDB(mssql.NewConnectorConfig(cfg))
 	defer lake.Close()
 	if _, err := lake.Exec("CREATE TABLE dbo.silver_customers(id INT); INSERT INTO dbo.silver_customers VALUES (1),(2)"); err != nil {
 		t.Fatalf("seeding silver: %v", err)

--- a/internal/server/warehouse.go
+++ b/internal/server/warehouse.go
@@ -70,14 +70,11 @@ func warehouseRouter(st *store.Store, be warehouseBackend, principalOf func(toke
 			// policy that constrains them. Admin and Member own the item in Fabric's
 			// model — "can edit OneLake security roles" is exactly those two — so they
 			// are the ones who can author here too.
-			dbRole := tds.RoleReader
-			switch {
-			case store.RoleRank(role) >= store.RoleRank(store.RoleMember):
-				dbRole = tds.RoleOwner
-			case !readOnly:
-				dbRole = tds.RoleWriter
-			}
-			return tds.Connection{TargetDB: it.ID, ReadOnly: readOnly, Principal: principal, Role: dbRole}, nil
+			dbRole := dbRung(role, readOnly)
+			return tds.Connection{
+				TargetDB: it.ID, ReadOnly: readOnly, Principal: principal, Role: dbRole,
+				Grants: workspaceGrants(st, it.WorkspaceID, role),
+			}, nil
 		case "Warehouse", "SQLDatabase":
 			// A Warehouse and a Fabric SQL Database are both read-write T-SQL over
 			// their own SQL Server database (the SQL Database is OLTP and also mirrors
@@ -87,18 +84,70 @@ func warehouseRouter(st *store.Store, be warehouseBackend, principalOf func(toke
 			// policy that constrains them. Admin and Member own the item in Fabric's
 			// model — "can edit OneLake security roles" is exactly those two — so they
 			// are the ones who can author here too.
-			dbRole := tds.RoleReader
-			switch {
-			case store.RoleRank(role) >= store.RoleRank(store.RoleMember):
-				dbRole = tds.RoleOwner
-			case !readOnly:
-				dbRole = tds.RoleWriter
-			}
-			return tds.Connection{TargetDB: it.ID, ReadOnly: readOnly, Principal: principal, Role: dbRole}, nil
+			dbRole := dbRung(role, readOnly)
+			return tds.Connection{
+				TargetDB: it.ID, ReadOnly: readOnly, Principal: principal, Role: dbRole,
+				Grants: workspaceGrants(st, it.WorkspaceID, role),
+			}, nil
 		default:
 			return tds.Connection{}, fmt.Errorf("item %q (type %s) has no SQL endpoint", database, it.Type)
 		}
 	}
+}
+
+// sqlAddressable are the item types that have a T-SQL endpoint. A workspace
+// role reaches all of them, which is what workspaceGrants encodes.
+var sqlAddressable = []string{"Lakehouse", "Warehouse", "SQLDatabase"}
+
+// dbRung is the database rung a workspace role implies on one item.
+//
+// NOT the same question as read-only: a Contributor may write but must not be
+// able to rewrite the security policy that constrains them. Admin and Member
+// own the item in Fabric's model, "can edit OneLake security roles" is exactly
+// those two, so they are the ones who can author here too.
+func dbRung(role string, readOnly bool) tds.Role {
+	switch {
+	case store.RoleRank(role) >= store.RoleRank(store.RoleMember):
+		return tds.RoleOwner
+	case !readOnly:
+		return tds.RoleWriter
+	default:
+		return tds.RoleReader
+	}
+}
+
+// workspaceGrants is every SQL-addressable item in the workspace, with the rung
+// this caller gets on each.
+//
+// WHY THE WHOLE WORKSPACE AND NOT JUST THE ONE CONNECTED TO. Gold is a
+// Warehouse that reads silver out of a Lakehouse by three-part name. That
+// crosses databases, and SQL Server needs the caller to exist in BOTH: with a
+// user in only the connect target it answers 916, "not able to access the
+// database under the current security context", from inside a statement on a
+// login that already succeeded. Fabric grants by workspace role, so having
+// access to one item's endpoint and not its neighbour's is not a shape the real
+// service has.
+//
+// Best effort by design: a store error here means no extra grants, never a
+// refused login. The connection's own database is added by the TDS layer
+// regardless, so the worst case is exactly the behaviour that shipped before.
+func workspaceGrants(st *store.Store, workspaceID, role string) []tds.Grant {
+	var out []tds.Grant
+	for _, t := range sqlAddressable {
+		items, err := st.ListItems(workspaceID, t)
+		if err != nil {
+			continue
+		}
+		for _, it := range items {
+			// A lakehouse endpoint is read-only whatever the role; a warehouse
+			// follows the role. Same rule the target uses.
+			out = append(out, tds.Grant{
+				Database: it.ID,
+				Role:     dbRung(role, t == "Lakehouse" || store.RoleRank(role) < store.RoleRank(store.RoleContributor)),
+			})
+		}
+	}
+	return out
 }
 
 // mirrorItem builds the control-plane mirror hook: ensure the item's SQL Server

--- a/internal/tds/principal_test.go
+++ b/internal/tds/principal_test.go
@@ -1,10 +1,12 @@
 package tds
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -318,5 +320,120 @@ func TestEnsurePrincipalReportsEngineFailures(t *testing.T) {
 	bad := strings.Repeat("x", 200)
 	if err := EnsurePrincipal(ctx, master, target, bad, RoleWriter); err == nil {
 		t.Fatal("an unusable principal name was reported as provisioned")
+	}
+}
+
+// TestCrossDatabaseNeedsAUserInBoth is the regression this whole grant set
+// exists for, run against a REAL engine because SQL Server is the only thing
+// that can answer it: error 916 comes from the engine, mid-statement, on a
+// login that already succeeded.
+//
+// Gold is a Warehouse that reads silver out of a Lakehouse by three-part name.
+// Provisioning the caller only in the database they connected to made that
+// statement fail with "not able to access the database under the current
+// security context", and it stayed hidden for a week because one cell happens
+// to open a TDS connection to its lakehouse earlier, which provisioned the
+// principal there as an undeclared side effect.
+//
+// The first half of this test is the bug. If it ever stops failing, the second
+// half proves nothing.
+func TestCrossDatabaseNeedsAUserInBoth(t *testing.T) {
+	dsn := os.Getenv("WAREHOUSE_MSSQL_DSN")
+	if dsn == "" {
+		t.Skip("set WAREHOUSE_MSSQL_DSN (a reachable SQL Server) to run this")
+	}
+	master, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer master.Close()
+	if err := master.Ping(); err != nil {
+		t.Skipf("WAREHOUSE_MSSQL_DSN set but unreachable: %v", err)
+	}
+
+	suffix := make([]byte, 6)
+	if _, err := rand.Read(suffix); err != nil {
+		t.Fatal(err)
+	}
+	tag := hex.EncodeToString(suffix)
+	warehouse, lakehouse := "wh_"+tag, "lh_"+tag
+	oid := "oid-" + tag
+
+	for _, db := range []string{warehouse, lakehouse} {
+		if _, err := master.Exec(fmt.Sprintf("CREATE DATABASE [%s]", db)); err != nil {
+			t.Fatalf("creating %s: %v", db, err)
+		}
+		defer master.Exec(fmt.Sprintf("ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [%s]", db, db))
+	}
+	defer master.Exec(fmt.Sprintf("DROP LOGIN [%s]", oid))
+
+	lakeDSN := dsn
+	if strings.Contains(dsn, "?") {
+		lakeDSN = dsn + "&database=" + lakehouse
+	} else {
+		lakeDSN = dsn + "?database=" + lakehouse
+	}
+	lake, err := sql.Open("sqlserver", lakeDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lake.Close()
+	if _, err := lake.Exec("CREATE TABLE dbo.silver_customers(id INT); INSERT INTO dbo.silver_customers VALUES (1),(2)"); err != nil {
+		t.Fatalf("seeding silver: %v", err)
+	}
+
+	whDSN := dsn
+	if strings.Contains(dsn, "?") {
+		whDSN = dsn + "&database=" + warehouse
+	} else {
+		whDSN = dsn + "?database=" + warehouse
+	}
+	wh, err := sql.Open("sqlserver", whDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wh.Close()
+
+	// THE OLD BEHAVIOUR: a user in the connect database only.
+	if err := EnsurePrincipal(context.Background(), master, wh, oid, RoleOwner); err != nil {
+		t.Fatalf("provisioning in the warehouse: %v", err)
+	}
+	asCaller := func() *sql.DB {
+		u := strings.Replace(whDSN, "//sa:", "//"+oid+":", 1)
+		// Rebuild the credential half rather than editing it: the DSN's own
+		// user and password are the service account's.
+		u = fmt.Sprintf("sqlserver://%s:%s@%s", url.QueryEscape(oid),
+			url.QueryEscape(principalPassword(oid)), whDSN[strings.Index(whDSN, "@")+1:])
+		db, err := sql.Open("sqlserver", u)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return db
+	}
+
+	caller := asCaller()
+	defer caller.Close()
+	var n int
+	err = caller.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM [%s].dbo.silver_customers", lakehouse)).Scan(&n)
+	if err == nil {
+		t.Fatal("a caller with no user in the lakehouse read it anyway — " +
+			"this test can no longer detect the defect it exists for")
+	}
+	if !strings.Contains(err.Error(), "916") && !strings.Contains(err.Error(), "not able to access the database") {
+		t.Fatalf("expected SQL 916 for the cross-database read, got: %v", err)
+	}
+	t.Logf("as shipped: %v", err)
+
+	// THE FIX: the same caller, also provisioned in the lakehouse.
+	if err := EnsurePrincipal(context.Background(), master, lake, oid, RoleReader); err != nil {
+		t.Fatalf("provisioning in the lakehouse: %v", err)
+	}
+	fixed := asCaller()
+	defer fixed.Close()
+	if err := fixed.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM [%s].dbo.silver_customers", lakehouse)).Scan(&n); err != nil {
+		t.Fatalf("cross-database read still fails after provisioning both: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("read %d rows across databases, want 2", n)
 	}
 }

--- a/internal/tds/principal_test.go
+++ b/internal/tds/principal_test.go
@@ -6,12 +6,12 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"testing"
 
-	_ "github.com/microsoft/go-mssqldb"
+	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/microsoft/go-mssqldb/msdsn"
 )
 
 // The pieces that decide WHO a caller is, unit-tested without an engine. The
@@ -323,6 +323,25 @@ func TestEnsurePrincipalReportsEngineFailures(t *testing.T) {
 	}
 }
 
+// openAs opens a pool on `database` as `user`, from the DSN in whatever form
+// the environment supplied it. Empty user keeps the DSN's own credential.
+//
+// msdsn.Parse rather than string surgery: the local sidecar is addressed with a
+// URL and CI with the semicolon form, and a test that only understands one of
+// them passes on a laptop and fails on a runner.
+func openAs(t *testing.T, dsn, database, user, password string) *sql.DB {
+	t.Helper()
+	cfg, err := msdsn.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parsing WAREHOUSE_MSSQL_DSN: %v", err)
+	}
+	cfg.Database = database
+	if user != "" {
+		cfg.User, cfg.Password = user, password
+	}
+	return sql.OpenDB(mssql.NewConnectorConfig(cfg))
+}
+
 // TestCrossDatabaseNeedsAUserInBoth is the regression this whole grant set
 // exists for, run against a REAL engine because SQL Server is the only thing
 // that can answer it: error 916 comes from the engine, mid-statement, on a
@@ -363,35 +382,25 @@ func TestCrossDatabaseNeedsAUserInBoth(t *testing.T) {
 		if _, err := master.Exec(fmt.Sprintf("CREATE DATABASE [%s]", db)); err != nil {
 			t.Fatalf("creating %s: %v", db, err)
 		}
-		defer master.Exec(fmt.Sprintf("ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [%s]", db, db))
+		db := db
+		t.Cleanup(func() {
+			_, _ = master.Exec(fmt.Sprintf(
+				"ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [%s]", db, db))
+		})
 	}
-	defer master.Exec(fmt.Sprintf("DROP LOGIN [%s]", oid))
+	t.Cleanup(func() { _, _ = master.Exec(fmt.Sprintf("DROP LOGIN [%s]", oid)) })
 
-	lakeDSN := dsn
-	if strings.Contains(dsn, "?") {
-		lakeDSN = dsn + "&database=" + lakehouse
-	} else {
-		lakeDSN = dsn + "?database=" + lakehouse
-	}
-	lake, err := sql.Open("sqlserver", lakeDSN)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// THE DSN IS PARSED, NOT CONCATENATED. CI passes the semicolon form
+	// (`server=localhost,1433;user id=sa;…`), so appending `?database=` builds
+	// a string that only works against a URL-shaped DSN. This is the same
+	// mechanism sqlServerBackend.pool uses.
+	lake := openAs(t, dsn, lakehouse, "", "")
 	defer lake.Close()
 	if _, err := lake.Exec("CREATE TABLE dbo.silver_customers(id INT); INSERT INTO dbo.silver_customers VALUES (1),(2)"); err != nil {
 		t.Fatalf("seeding silver: %v", err)
 	}
 
-	whDSN := dsn
-	if strings.Contains(dsn, "?") {
-		whDSN = dsn + "&database=" + warehouse
-	} else {
-		whDSN = dsn + "?database=" + warehouse
-	}
-	wh, err := sql.Open("sqlserver", whDSN)
-	if err != nil {
-		t.Fatal(err)
-	}
+	wh := openAs(t, dsn, warehouse, "", "")
 	defer wh.Close()
 
 	// THE OLD BEHAVIOUR: a user in the connect database only.
@@ -399,16 +408,7 @@ func TestCrossDatabaseNeedsAUserInBoth(t *testing.T) {
 		t.Fatalf("provisioning in the warehouse: %v", err)
 	}
 	asCaller := func() *sql.DB {
-		u := strings.Replace(whDSN, "//sa:", "//"+oid+":", 1)
-		// Rebuild the credential half rather than editing it: the DSN's own
-		// user and password are the service account's.
-		u = fmt.Sprintf("sqlserver://%s:%s@%s", url.QueryEscape(oid),
-			url.QueryEscape(principalPassword(oid)), whDSN[strings.Index(whDSN, "@")+1:])
-		db, err := sql.Open("sqlserver", u)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return db
+		return openAs(t, dsn, warehouse, oid, principalPassword(oid))
 	}
 
 	caller := asCaller()

--- a/internal/tds/query.go
+++ b/internal/tds/query.go
@@ -31,6 +31,30 @@ type Connection struct {
 	// because "may write" and "may author security policy" are different
 	// questions, and collapsing them left nobody able to define a policy at all.
 	Role Role
+	// Grants is every database this caller must exist in, not just the one
+	// they connected to.
+	//
+	// A WORKSPACE ROLE IS WORKSPACE-WIDE, and provisioning only the connect
+	// target quietly turned it into a per-database grant. Gold is a Warehouse
+	// that reads silver out of a Lakehouse by three-part name, so the very
+	// first cross-database statement got SQL 916, "not able to access the
+	// database under the current security context" — mid-statement, long after
+	// a login that had already succeeded.
+	//
+	// It looked cell-specific because one cell hid it: that cell opens a TDS
+	// connection to the lakehouse earlier, to trigger reflection, and the
+	// connect provisioned the principal there as a side effect nothing
+	// declared. The cell without that step was the only one red.
+	//
+	// Empty means "just TargetDB", which is what a backend with no store
+	// behind it (the fakes) can say.
+	Grants []Grant
+}
+
+// Grant is one database this caller may reach, and the rung they get there.
+type Grant struct {
+	Database string
+	Role     Role
 }
 
 // SpliceBackend is a Backend that can open a raw, already-authenticated
@@ -49,7 +73,7 @@ type SpliceBackend interface {
 	// than as the relay's own account — which is what gives the engine's RLS,
 	// CLS and masking somebody to restrict (docs/55-tsql-security.md). Empty
 	// means internal work with no caller, and keeps the DSN account.
-	Dial(ctx context.Context, database, principal string, role Role) (net.Conn, []byte, error)
+	Dial(ctx context.Context, database, principal string, grants []Grant) (net.Conn, []byte, error)
 }
 
 // ColType is the wire type a result column is encoded as. Integer/float/bit

--- a/internal/tds/server.go
+++ b/internal/tds/server.go
@@ -105,6 +105,7 @@ func (s *Server) handle(conn net.Conn) error {
 	targetDB := login.Database
 	principal := ""
 	dbRole := RoleReader
+	var grants []Grant
 	if s.OnConnect != nil {
 		// An empty database is REJECTED, not waved through. OnConnect is the only
 		// place a TDS connection's workspace role and read-only-ness are decided,
@@ -124,6 +125,7 @@ func (s *Server) handle(conn net.Conn) error {
 			return s.reject(conn, err.Error())
 		}
 		targetDB, readOnly, principal, dbRole = got.TargetDB, got.ReadOnly, got.Principal, got.Role
+		grants = got.Grants
 	}
 	// Full-fidelity path: if the backend can open a raw authenticated connection
 	// to the real engine, splice the client's post-login session straight to it
@@ -132,7 +134,11 @@ func (s *Server) handle(conn net.Conn) error {
 	// which the Microsoft ODBC/JDBC driver family requires. Dial before acking so
 	// a backend failure can still reject the login cleanly.
 	if sb, ok := s.Backend.(SpliceBackend); ok && targetDB != "" {
-		backendConn, backendLogin, err := sb.Dial(context.Background(), targetDB, principal, dbRole)
+		// The target FIRST, carrying the rung OnConnect decided for it. Dial
+		// dedupes by first occurrence, so this is what wins if the workspace
+		// sweep also lists it.
+		grants = append([]Grant{{Database: targetDB, Role: dbRole}}, grants...)
+		backendConn, backendLogin, err := sb.Dial(context.Background(), targetDB, principal, grants)
 		if err != nil {
 			return s.reject(conn, "backend connect failed: "+err.Error())
 		}

--- a/internal/tds/splice_integration_test.go
+++ b/internal/tds/splice_integration_test.go
@@ -27,7 +27,15 @@ func (f *fakeSpliceBackend) Query(context.Context, string) (*Result, error) {
 	return nil, fmt.Errorf("unused")
 }
 
-func (f *fakeSpliceBackend) Dial(context.Context, string, string, Role) (net.Conn, []byte, error) {
+// A COMPILE-TIME ASSERTION, because the runtime one is silent. The server
+// reaches the splice path through `s.Backend.(SpliceBackend)`, so a fake whose
+// Dial signature has drifted does not fail to build: it stops satisfying the
+// interface, the assertion returns false, and every session quietly falls into
+// the re-encode relay. That is how a signature change here turned two passing
+// tests into "mssql: unused" and a relay that should never have run.
+var _ SpliceBackend = (*fakeSpliceBackend)(nil)
+
+func (f *fakeSpliceBackend) Dial(context.Context, string, string, []Grant) (net.Conn, []byte, error) {
 	if f.dialErr != nil {
 		return nil, nil, f.dialErr
 	}
@@ -362,7 +370,9 @@ func (c *countingSpliceBackend) Query(_ context.Context, q string) (*Result, err
 	return &Result{Columns: []Column{{Name: "x", Type: ColInt}}, Rows: [][]any{{int64(1)}}}, nil
 }
 
-func (c *countingSpliceBackend) Dial(context.Context, string, string, Role) (net.Conn, []byte, error) {
+var _ SpliceBackend = (*countingSpliceBackend)(nil)
+
+func (c *countingSpliceBackend) Dial(context.Context, string, string, []Grant) (net.Conn, []byte, error) {
 	c.mu.Lock()
 	c.dialed++
 	c.mu.Unlock()

--- a/internal/tds/sqlserver.go
+++ b/internal/tds/sqlserver.go
@@ -152,12 +152,63 @@ func (b *sqlServerBackend) Query(ctx context.Context, query string) (*Result, er
 	return materialize(rows)
 }
 
+// grantsFor splits the grant list into the connection's own database and the
+// rest, deduplicated.
+//
+// Split rather than returned as one list because the two have different
+// guarantees: the target's database is already prepared, a sibling's may not
+// exist yet. A backend with no store behind it (the fakes) passes no grants at
+// all, so the target is synthesised when absent and the sibling list is empty,
+// which is the behaviour that shipped before any of this.
+func grantsFor(database string, grants []Grant) (target Grant, siblings []Grant) {
+	// Reader when nothing vouched for it: OnConnect is what normally sets the
+	// rung, and a caller that reached here without one gets the lowest.
+	target = Grant{Database: database, Role: RoleReader}
+	seen := map[string]bool{database: false}
+	for _, g := range grants {
+		if g.Database == "" {
+			continue
+		}
+		if g.Database == database {
+			if !seen[database] {
+				target, seen[database] = g, true
+			}
+			continue
+		}
+		if seen[g.Database] {
+			continue
+		}
+		seen[g.Database] = true
+		siblings = append(siblings, g)
+	}
+	return target, siblings
+}
+
+// existingDatabases names the databases the engine actually has, so
+// provisioning can skip an item whose database has not been created yet.
+func (b *sqlServerBackend) existingDatabases(ctx context.Context) (map[string]bool, error) {
+	rows, err := b.pool("").QueryContext(ctx, "SELECT name FROM sys.databases")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		out[n] = true
+	}
+	return out, rows.Err()
+}
+
 // Dial opens a raw TCP connection to the SQL Server backend and completes a
 // SQL-auth TDS login into the item's database, returning the connection ready
 // for post-login traffic. The server splices the client's session onto it, so
 // SQL Server itself produces every response token (full fidelity). The service
 // credential and address come from the base DSN.
-func (b *sqlServerBackend) Dial(ctx context.Context, database, principal string, role Role) (net.Conn, []byte, error) {
+func (b *sqlServerBackend) Dial(ctx context.Context, database, principal string, grants []Grant) (net.Conn, []byte, error) {
 	if b.base == nil {
 		return nil, nil, fmt.Errorf("no backend DSN configured for splicing")
 	}
@@ -173,8 +224,45 @@ func (b *sqlServerBackend) Dial(ctx context.Context, database, principal string,
 	// worked.
 	user, password := b.base.User, b.base.Password
 	if principal != "" {
-		if err := EnsurePrincipal(ctx, b.pool(""), b.pool(database), principal, role); err != nil {
+		// EVERY DATABASE THE WORKSPACE ROLE REACHES, not just the one named on
+		// the connection. See Connection.Grants: a warehouse that reads a
+		// lakehouse by three-part name gets SQL 916 mid-statement otherwise,
+		// because the login succeeded and the second database has no user.
+		//
+		// Skipped where the database does not exist yet. Provisioning does not
+		// create item databases: EnsureDatabase does, on connect or on the
+		// endpoint refresh, and creating one here would invent an item.
+		target, siblings := grantsFor(database, grants)
+		if err := EnsurePrincipal(ctx, b.pool(""), b.pool(database), principal, target.Role); err != nil {
 			return nil, nil, fmt.Errorf("provisioning %s: %w", principal, err)
+		}
+		// THE TARGET IS PROVISIONED UNCONDITIONALLY, above, exactly as it always
+		// was: OnConnect has already run EnsureDatabase on it, so it is there.
+		//
+		// A SIBLING HAS NO SUCH GUARANTEE. Its item exists in the store, but its
+		// database is created lazily, on first connect or on the analytics
+		// endpoint's refresh, so the workspace sweep routinely names databases
+		// the engine does not have yet. Asking first, rather than provisioning
+		// and ignoring the error, keeps a real provisioning failure loud.
+		//
+		// Only asked when there ARE siblings. Querying unconditionally made the
+		// single-database path depend on an engine that answers
+		// `SELECT name FROM sys.databases`, which the fake listeners in these
+		// tests do not: two of them went from passing to a session silently
+		// demoted into the re-encode relay.
+		if len(siblings) > 0 {
+			present, err := b.existingDatabases(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("listing databases: %w", err)
+			}
+			for _, g := range siblings {
+				if !present[g.Database] {
+					continue
+				}
+				if err := EnsurePrincipal(ctx, b.pool(""), b.pool(g.Database), principal, g.Role); err != nil {
+					return nil, nil, fmt.Errorf("provisioning %s in %s: %w", principal, g.Database, err)
+				}
+			}
 		}
 		user, password = principal, principalPassword(principal)
 	}

--- a/internal/tds/sqlserver_backend_test.go
+++ b/internal/tds/sqlserver_backend_test.go
@@ -25,7 +25,7 @@ func TestDialSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn, login, err := be.Dial(context.Background(), "itemdb", "", RoleReader)
+	conn, login, err := be.Dial(context.Background(), "itemdb", "", []Grant{{Database: "itemdb", Role: RoleReader}})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestBackendPerDatabase(t *testing.T) {
 
 	// Dial reaches the backend login handshake (which errors — no server — but the
 	// dial+login path is covered).
-	if _, _, err := be.Dial(context.Background(), "item-1", "", RoleReader); err == nil {
+	if _, _, err := be.Dial(context.Background(), "item-1", "", []Grant{{Database: "item-1", Role: RoleReader}}); err == nil {
 		t.Error("expected a connect/login error from Dial with no server")
 	}
 	// A DSN with no explicit port exercises Dial's default-1433 branch (still
@@ -75,7 +75,7 @@ func TestBackendPerDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := noPort.Dial(context.Background(), "item", "", RoleReader); err == nil {
+	if _, _, err := noPort.Dial(context.Background(), "item", "", []Grant{{Database: "item", Role: RoleReader}}); err == nil {
 		t.Error("expected a connect error dialing the default port with no server")
 	}
 
@@ -88,7 +88,7 @@ func TestBackendPerDatabase(t *testing.T) {
 		t.Error("test-backend DB should be the (nil) default")
 	}
 	// Dial on a backend with no base DSN is a clear error, not a panic.
-	if _, _, err := tb.Dial(context.Background(), "x", "", RoleReader); err == nil {
+	if _, _, err := tb.Dial(context.Background(), "x", "", []Grant{{Database: "x", Role: RoleReader}}); err == nil {
 		t.Error("Dial without a base DSN should error")
 	}
 }
@@ -133,7 +133,7 @@ func TestDialRefusesWhenTheCallerCannotBeProvisioned(t *testing.T) {
 	}
 	// A name SQL Server will not accept as a principal.
 	bad := strings.Repeat("x", 200)
-	if _, _, err := be.Dial(context.Background(), "master", bad, RoleWriter); err == nil {
+	if _, _, err := be.Dial(context.Background(), "master", bad, []Grant{{Database: "master", Role: RoleWriter}}); err == nil {
 		t.Fatal("an unprovisionable caller was dialed anyway")
 	} else if !strings.Contains(err.Error(), "provisioning") {
 		t.Fatalf("error = %v; want it to name provisioning, so the cause is readable", err)


### PR DESCRIPTION
`fabric-platform-airflow-builtin`'s Acceptance has failed every day since 2026-08-24, and was green through the 23rd. The witness only said `AirflowRunFailed: The job failed.` until #15 landed. With the task log in the run, dbt says:

```
[ERROR]: in model dim_customer (models/dim_customer.sql)
  ('08004', '[Microsoft][ODBC Driver 18 for SQL Server][SQL Server]The server
  principal "00d88624-…" is not able to access the database "ea819a0f-…"
  under the current security context. (916)')
```

## What it is

`EnsurePrincipal` ran once per connection, against the connection's own database and nothing else. Gold is a Warehouse that reads silver out of a Lakehouse by three-part name, so the very first cross-database statement has no user to run as in the second database. **A workspace role had quietly become a per-database grant**, which is not a shape Fabric has: a workspace role reaches every item in the workspace.

The window is one commit wide. #352 (`OneLake security and T-SQL security`, Aug 23) made the TDS surface authenticate as the caller. Before it every client was the DSN service account, for which cross-database is free.

## Why only one cell

Both fabric cells cross the same two databases, so "only this cell crosses databases" was my first theory and it was wrong. The difference is that `fabric-platform-notebook-pipelines` runs `docker/dbt/reflect.py`, which opens a TDS connection with `DATABASE=<LAKEHOUSE_ID>` to trigger reflection. **That connect provisioned its principal in the lakehouse as a side effect nothing declared**, and gold's later cross-database read worked because of it. The cell with no such step was the only one red, so the emulator looked innocent and the cell looked broken.

## Evidence

Reproduced against a real SQL Server 2022, because 916 comes from the engine and no double can produce it:

- `TestCrossDatabaseNeedsAUserInBoth` (internal/tds) replays the exact SQL `EnsurePrincipal` emits. With a user in the connect database only it asserts the read **fails** with 916, then provisions the second database and asserts the same read returns its rows. **The first half is the bug**; if it ever stops failing, the second half proves nothing, and the test says so.
- `TestWorkspaceRoleReachesEverySQLItem` (internal/server) drives the emulator's own path: a workspace Contributor connects to the Warehouse and reads the Lakehouse. Negative control, replacing the new grants with `nil`, reproduces the production error verbatim, naming the same principal and database.

## The shape of the fix

`OnConnect` now returns `Grants`, every SQL-addressable item in the workspace with the rung that item implies, reusing the existing rule rather than a second copy of it. `Dial` provisions the target unconditionally, as before, and then any sibling **whose database already exists**. It does not create databases: `EnsureDatabase` does that on connect or on the endpoint's `refreshMetadata`, and creating one here would invent an item.

Best effort on the store read: a failure there means no extra grants, never a refused login, so the worst case is exactly today's behaviour.

## One thing worth flagging

Changing `Dial`'s signature did not break the build. The server reaches the splice path through `s.Backend.(SpliceBackend)`, so the two test fakes with stale signatures simply stopped satisfying the interface, the assertion returned false, and every session fell into the re-encode relay. That surfaced as `mssql: unused` and as a relay running when an authorizer was configured, neither of which names the cause. Both fakes are fixed and both now carry `var _ SpliceBackend = (*fake)(nil)`, so the next signature change is a compile error.

## Verification

`go build`, `go vet` clean. Full `go test ./...` against a real SQL Server leaves only `TestEnsurePrincipalIsIdempotentAndDistinguishing` and `TestSQLServerRestrictsTheProvisionedCaller` failing, and **those two fail identically on pristine `origin/main` with the same DSN**, so they are my local sidecar, not this change. They pass in CI.
