### PR TITLE
Release notes for v0.35.0, and backfill v0.34.0.

### DIFF
--- a/docs/release-notes/v0.34.0.md
+++ b/docs/release-notes/v0.34.0.md
@@ -1,0 +1,89 @@
+# v0.34.0
+
+The `notebookutils` release. The shim a Fabric notebook imports went from
+partial and partly-wrong to the whole documented surface — 44 members across 8
+namespaces, each exercised end to end — and closing it turned up ten defects
+that unit tests could not see.
+
+## ⚠️ Upgrade first for this
+
+**`notebookutils.fs.rm(path)` on a directory deleted the entire subtree.**
+OneLake's DELETE ignored `?recursive=` completely, so a bare `rm` took the tree
+with it. ADLS Gen2 answers `409 DirectoryNotEmpty`; the emulator was more
+destructive than the thing it emulates, on the one filesystem operation with no
+undo. Fixed: a non-empty directory is now refused unless `recurse=True`.
+
+## Breaking changes
+
+All are corrections toward Fabric's documented contract — a framework
+introspects these signatures and refuses to start when a parameter name differs
+— but code written against v0.33.0 may need edits.
+
+| v0.33.0 | v0.34.0 | Note |
+|---|---|---|
+| `fs.put(path, content, overwrite=True)` | `put(file, content, overwrite=False)` | **default changed**; an overwrite must now be asked for |
+| `fs.append(path, content)` | `append(file, content, createFileIfNotExists=False)` | |
+| `fs.head(path, maxBytes=)` | `head(file, max_bytes=)` | |
+| `fs.cp(src, dst)` / `mv` | `cp(src, dest)` / `mv` | |
+| `fs.rm(dir)` removed subtrees | `rm(path, recurse=False)` refuses a non-empty directory | see above |
+| `lakehouse.get(lakehouseId)` | `get(name)` | addressed by NAME, as documented; an id still resolves |
+
+Positional callers are mostly unaffected; callers passing these by keyword are
+not.
+
+## Fixed
+
+- **`fs.rm` destroyed directory trees** (above).
+- **`session.stop()` and `session.restartPython()` never worked inside a
+  session.** Both read environment variables that nothing in the tree ever set,
+  so they raised *"this is running outside a notebook session"* — inside one.
+  They are now bound per statement, because one agent serves many concurrent
+  sessions and a process variable would let `stop()` in one notebook end
+  another's.
+- **`restartPython()` left the session without `display`, `displayHTML` and
+  `%run`.** Those are kernel builtins on Fabric; a Python restart cannot remove
+  them.
+- **A referenced notebook resolved `builtin/` to its own folder.** `nbResPath`
+  means the ROOT notebook's resources, and nothing ever sent a root — so a
+  notebook read different files depending on how it was started.
+- **A cell's language was classified and then ignored.** The run loop sent
+  everything that was not `sql` to the Python executor, so correct Scala failed
+  with a Python `SyntaxError` pointing at the user's own code, and a
+  `%%configure` block of JSON failed the same way.
+- **The long-running-operation `Location` header always said `https://`**, so a
+  client following it — the documented route to a result — could not reach an
+  emulator started with `-disable-tls`.
+- **`display()` and `displayHTML()` were absent entirely**, raising `NameError`
+  on one of the most common lines in any Fabric notebook.
+
+## Added
+
+- **The whole documented `notebookutils` surface**: 44 members over `fs`,
+  `notebook`, `credentials`, `lakehouse`, `runtime`, `session`, `udf` and
+  `variableLibrary`, with the documented parameter names in the documented
+  order. Every member is exercised end to end, not merely present.
+- **`help()` on every module**, plus `getHelpString` — the discovery mechanism
+  Fabric's own `fs` page opens by documenting. Derived by introspection, so it
+  cannot drift from the code.
+- **Notebook item management** (`create`, `get`, `list`, `update`, `delete`,
+  `getDefinition`, `updateDefinition`), `lakehouse` definition round-trips,
+  `udf.run`, `runtime.getCurrentWorkspaceId`, `fs.refreshMounts`.
+- **`display()` publishes rich output under a kernel** — `text/html` with a
+  `text/plain` alternative — and prints without one. The shipped JupyterLab
+  binds Fabric's `display`, not IPython's.
+- **Microsoft's own stubs are vendored** (`third_party/notebookutils-stubs/`)
+  and held beside the documentation, so where the two Microsoft sources
+  disagree the divergence is computed rather than assumed.
+
+## Honest limits
+
+`display()` renders a correct HTML table, **not** Fabric's interactive widget
+with its chart views and inspect panel; no local front end can prove
+equivalence with that. The Files mount is a point-in-time copy, not blobfuse.
+`%%configure` is accepted and ignored, out loud. Scala, R and C# cells are
+refused by name rather than mis-executed.
+
+And the standing one: everything here is verified against Microsoft's published
+contract, not against a tenant. It means **conforms to the documentation** — never
+*matches Fabric*.
+

--- a/docs/release-notes/v0.35.0.md
+++ b/docs/release-notes/v0.35.0.md
@@ -1,0 +1,113 @@
+# v0.35.0
+
+The range starts at `e9b85eed` (#396), the first commit after the `v0.34.0`
+tag, and ends at this file: 9 changes. The headline is a **warehouse access
+fix**, and the theme behind most of the rest is **oracles**: three separate
+places where a check was grading against something this repository wrote down
+itself.
+
+**Read the first section if any pipeline builds gold in a Warehouse from
+silver in a Lakehouse.** That has been broken since `v0.33.0` and this is the
+fix.
+
+---
+
+## A workspace role reaches every SQL item, not just the connected one (#413)
+
+**Gold could not read silver.** A Warehouse connection that referenced a
+Lakehouse by three-part name failed with SQL error 916, "the server principal
+is not able to access the database under the current security context",
+raised from inside the statement on a login that had already succeeded.
+
+`v0.33.0` made the T-SQL surface authenticate as the caller rather than as the
+emulator's own service account, which is what gives row-level security,
+column-level security and masking somebody to restrict. The caller was
+provisioned in the database named on the connection and nowhere else, so the
+first cross-database reference had no user to run as. **A workspace role had
+quietly become a per-database grant.** Fabric grants by workspace role: access
+to one item's SQL endpoint and not its neighbour's is not a shape the service
+has.
+
+Now `OnConnect` reports every SQL-addressable item in the workspace with the
+rung the caller gets on each, and the connection provisions all of them whose
+database already exists. It does not create databases; `EnsureDatabase` does
+that on connect and on the analytics endpoint's `refreshMetadata`, and creating
+one here would invent an item.
+
+**Why it took a week to find.** Only one of the two affected cells was red.
+The other opens a TDS connection to its lakehouse first, to trigger reflection,
+and that connect provisioned its principal there as a side effect nothing
+declared. The green cell was not proving the path worked; it was hiding that it
+did not.
+
+The regression test asserts the failure before it asserts the fix: with a user
+in the connect database only, it requires the read to come back 916. If that
+half ever stops failing, the second half proves nothing.
+
+## Three checks that graded against our own transcription
+
+**The activity-type list (#411).** `fabricActivityTypes` was typed in by hand,
+so the structural test built on it derived its answer from a list nothing
+checked. Fabric's activity-type table is now vendored and the list is checked
+against it, pinned by content hash because the article has no commit to pin.
+
+**The ADF compat names (#412).** The same guard for the Data Factory half,
+against a vendored `Pipeline.json`. It immediately found `SparkJob`, Synapse's
+spark-job activity, handled nowhere and reaching the success stub. Refused by
+name now. Abstract bases are excluded by walking `allOf` rather than by an
+exemption list, so a new base does not need remembering.
+
+**The engine matrix (#396, #397).** `docs/engine-matrix.md` compared Sail
+against upstream Apache Spark, and Fabric ships a Microsoft distribution, so no
+column had ever been measured against the thing being emulated. #396 makes the
+matrix say so. #397 is the mechanism that can close it: `e2e/engine-matrix`
+publishes a notebook carrying the probe bodies verbatim, runs it on whichever
+target, and reads the findings back over OneLake, so a tenant column cannot
+drift from the Sail and JVM columns.
+
+#396 also turns `real-fabric.yml` into a job that FAILS rather than skips, and
+closes 25 endpoints that answered 404 silently.
+
+## Contract 8: a refusal the service makes must be made here (#410)
+
+`docs/38` already said it, about signature parameters: being more permissive
+than the thing being emulated is the one direction that actively misleads.
+Nothing applied it to behaviour, and `notebookutils.fs.rm` deleted whole
+directory trees for a release because of it.
+
+Contract 8 makes over-permissiveness a measured class. **It is the only one of
+the eight whose failure mode is a green.** Every other contract catches a wrong
+answer, which is at least visible. This one catches the emulator letting you do
+something the service would have stopped, which is invisible locally by
+construction, because the local run is the one that passes.
+
+## A cron freshness check that could not be satisfied (#398)
+
+`check_cron_workflow_freshness` asked whether a run had happened since the
+workflow file's last-changed timestamp, and told you to dispatch on the branch
+that changed it. Following that advice could not work: **merging re-dates the
+file**, so the squash commit is always newer than the pre-merge run and main
+went red the moment the fix landed. Whoever did exactly what the message asked
+was the person who broke main, twice in one week before the shape of it was
+visible.
+
+A run proves a version of a workflow, and a version is its bytes. It now hashes
+the workflow as committed and asks whether a recent run executed the same
+bytes, so a merge that moves a file without changing it counts.
+
+## Dependencies
+
+**pyarrow floored to 23.0.1 (#409)**, off GHSA-rgxp-2hwp-jwgg (high,
+use-after-free reading an IPC file with pre-buffering, vulnerable
+`>= 15.0.0, < 23.0.1`). The lock held two pyarrow entries, 25.0.1 for
+python >= 3.14 and 21.0.0 for everything below, and everything below is what
+this stack actually runs. Reading the lock in a stale working tree showed only
+the safe one and made the alert look spurious.
+
+**Eight Dependabot updates batched (#408)**, plus the failures batching
+exposed.
+
+## Upgrading
+
+No configuration changes. Consumers pin by digest, so bump
+`FABRIC_EMULATOR_VERSION` and `FABRIC_EMULATOR_DIGEST` together.


### PR DESCRIPTION
Notes for the nine commits since `v0.34.0`, to replace the bare GoReleaser commit list the tag will publish.

The headline is #413: a Warehouse could not read a Lakehouse by three-part name, failing with SQL 916 on a login that had already succeeded. That has been broken since `v0.33.0` made the T-SQL surface authenticate as the caller, and it is why `fabric-platform-airflow-builtin`'s Acceptance has been red every day since Aug 24.

The theme behind most of the rest is oracles: #411, #412 and #396 are each a check that had been grading against something this repository transcribed itself.

**`v0.34.0` had no file in `docs/release-notes/` at all**, though it published a real curated body, so the two halves of that convention had already come apart. Backfilled here from the published release so the directory is continuous.

No automation enforces either half. Worth a checker, but not in a release PR.
