### PR TITLE
Real Fabric conformance skips when the tenant secrets are absent.

### DIFF
--- a/.github/workflows/real-fabric.yml
+++ b/.github/workflows/real-fabric.yml
@@ -5,13 +5,16 @@ name: Real Fabric conformance
 # REAL Microsoft Fabric — FABRIC_TARGET is the only difference. Divergences
 # found here are parity-map material: this workflow is the fidelity oracle.
 #
-# Opt-in by secrets; WITHOUT THEM THIS FAILS rather than skipping. It used
-# to skip, and every run since the workflow was added was green in exactly
-# that way — gate succeeded, conformance never ran. A green that means
-# "did not execute" is worse here than anywhere else in the repo, because
-# this is the only thing that compares the emulator against Fabric itself.
-# No parity claim cites this workflow until the secrets are set and a
-# conformance job has actually completed — a skipped run is not evidence.
+# Opt-in by secrets. WITHOUT THEM THE CONFORMANCE JOB IS SKIPPED, not failed:
+# an unwired oracle is a missing measurement, and a missing measurement should
+# not stop a release from shipping. This reverses an earlier decision to fail
+# closed; the reasoning that motivated it is preserved on the gate below,
+# because the risk it names is real and has not gone away.
+#
+# WHAT DOES NOT CHANGE: a skipped run is not evidence. No parity claim may
+# cite this workflow until the secrets are set and a conformance job has
+# actually COMPLETED. `skipped` is a distinct conclusion from `success` at
+# every level that reads one, which is why the gate is still its own job.
 #
 # TWO WAYS TO AUTHENTICATE. The gate picks whichever is configured:
 #
@@ -93,8 +96,11 @@ jobs:
   #
   # A skipped job is visibly not a passing one; a succeeded job full of skipped
   # steps is indistinguishable from a real pass at every level that reads a
-  # conclusion. `secrets` is not available in a job-level `if`, which is why
-  # this is a separate job rather than a condition on the one below.
+  # conclusion. That distinction is the whole reason the gate is a separate
+  # job: it lets `conformance` be SKIPPED rather than succeed having done
+  # nothing, which is what makes skipping safe to report at all. `secrets` is
+  # not available in a job-level `if`, which is why it cannot be a condition
+  # on the job below.
   gate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -131,28 +137,55 @@ jobs:
           [ "$HAVE_TENANT_ID" = "true" ] || missing="$missing AZURE_TENANT_ID"
           [ "$HAVE_WORKSPACE" = "true" ] || missing="$missing FABRIC_TEST_WORKSPACE"
           if [ -n "$missing" ]; then
-            # FAIL, do not skip. This workflow is the project's only oracle for
-            # whether the emulator behaves as Fabric does, and every run since
-            # it was added has been green in exactly one way: the gate passed
-            # and `conformance` never executed. A workflow that is green
-            # because it did not run is the defect this repository keeps
-            # finding in its own instruments, and it was sitting in the
-            # instrument that carries the most weight.
+            # SKIP, do not fail. `conformance` is left unrun and therefore
+            # visibly `skipped`, which no reader can mistake for a pass.
             #
-            # THIS BLOCKS RELEASES, DELIBERATELY. release.yml makes every
-            # publishing job `needs: fabric-qualification`, so a tag cannot
-            # ship while the oracle is unwired. That is the honest state: a
-            # release qualified by a job that skipped is not qualified. Setting
-            # the two secrets below is a one-time action and unblocks it.
-            echo "::error::real-Fabric credentials incomplete — missing:$missing"
-            echo "The tenant oracle cannot run, so nothing here has been" >&2
-            echo "compared against Fabric. Set the missing repository secrets:" >&2
-            echo "  AZURE_CLIENT_ID        app registration (public, not a secret value)" >&2
-            echo "  AZURE_TENANT_ID        directory id (public)" >&2
-            echo "  FABRIC_TEST_WORKSPACE  display name of a DEDICATED throwaway workspace" >&2
-            echo "OIDC needs no client secret; see this file's header for the" >&2
-            echo "federated-credential setup." >&2
-            exit 1
+            # THE RISK THIS ACCEPTS, STATED PLAINLY so nobody has to rediscover
+            # it: release.yml makes every publishing job
+            # `needs: fabric-qualification`, so from here a tag SHIPS while the
+            # oracle is unwired. A release that ships this way has not been
+            # compared against Fabric at all. That was the argument for failing
+            # closed, and it is why the warning and the run summary below are
+            # not decoration: they are the only remaining record, on the
+            # release run itself, that nothing was qualified.
+            #
+            # Two scheduled runs (2026-08-03, 2026-08-10) reported SUCCESS with
+            # every real step skipped. That specific shape cannot return: the
+            # gate no longer succeeds silently, and the job that would carry a
+            # false green is skipped rather than green.
+            # NOT CONFIGURED and HALF CONFIGURED are different situations and
+            # get different words. Nothing set is the expected state of a fork
+            # or a repo whose owner has not wired a tenant. SOME set is almost
+            # always a mistake — a typo in a secret name, or a rotation that
+            # dropped one — and it would otherwise read as the untouched case
+            # and be skipped past forever.
+            if [ "$HAVE_CLIENT_ID" = "false" ] && [ "$HAVE_TENANT_ID" = "false" ] \
+               && [ "$HAVE_WORKSPACE" = "false" ]; then
+              why="not configured"
+            else
+              why="PARTIALLY configured, which is usually a mistake"
+            fi
+            echo "::warning::real-Fabric conformance SKIPPED — credentials $why; missing:$missing. Nothing in this run has been compared against Fabric."
+            {
+              echo "### Real Fabric conformance: skipped ($why)"
+              echo
+              echo "**Nothing here was compared against Microsoft Fabric.** The tenant"
+              echo "oracle is unwired, so any release from this run is unqualified."
+              echo
+              echo "Missing repository secrets:$missing"
+              echo
+              echo "| secret | what it is |"
+              echo "| --- | --- |"
+              echo "| \`AZURE_CLIENT_ID\` | app registration id (public, not a secret value) |"
+              echo "| \`AZURE_TENANT_ID\` | directory id (public) |"
+              echo "| \`FABRIC_TEST_WORKSPACE\` | display name of a DEDICATED throwaway workspace |"
+              echo
+              echo "OIDC needs no client secret; see the header of"
+              echo "\`.github/workflows/real-fabric.yml\` for the federated-credential setup."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           if [ "$HAVE_CLIENT_SECRET" = "true" ]; then
             mode=secret

--- a/docs/release-notes/v0.35.0.md
+++ b/docs/release-notes/v0.35.0.md
@@ -65,8 +65,12 @@ publishes a notebook carrying the probe bodies verbatim, runs it on whichever
 target, and reads the findings back over OneLake, so a tenant column cannot
 drift from the Sail and JVM columns.
 
-#396 also turns `real-fabric.yml` into a job that FAILS rather than skips, and
-closes 25 endpoints that answered 404 silently.
+#396 also closes 25 endpoints that answered 404 silently. It briefly made
+`real-fabric.yml` fail rather than skip when the tenant secrets are absent;
+that blocked this very tag, and the workflow skips again. The conformance job
+is left visibly `skipped` and the run carries a warning and a summary saying
+nothing was compared against Fabric, because a release that ships this way is
+unqualified and that has to be legible somewhere.
 
 ## Contract 8: a refusal the service makes must be made here (#410)
 

--- a/python/tests/test_real_fabric_gate.py
+++ b/python/tests/test_real_fabric_gate.py
@@ -16,8 +16,8 @@ run it under the runner's exact shell flags -- GitHub invokes `shell: bash` as
 import pathlib
 import subprocess
 
-import yaml
 import pytest
+import yaml
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
 WORKFLOW = REPO / ".github" / "workflows" / "real-fabric.yml"
@@ -100,7 +100,7 @@ def test_a_complete_configuration_runs(tmp_path):
 
 
 def test_a_client_secret_selects_secret_mode(tmp_path):
-    r, outputs, _ = _run(tmp_path, client_id=True, tenant_id=True, workspace=True, client_secret=True)
+    _, outputs, _ = _run(tmp_path, client_id=True, tenant_id=True, workspace=True, client_secret=True)
     assert outputs["run"] == "true"
     assert outputs["mode"] == "secret"
 

--- a/python/tests/test_real_fabric_gate.py
+++ b/python/tests/test_real_fabric_gate.py
@@ -1,0 +1,114 @@
+"""The real-Fabric gate must SKIP the conformance job, never fail the run.
+
+`release.yml` makes every publishing job `needs: fabric-qualification`, so what
+this gate does when the tenant secrets are absent decides whether a tag can
+ship. It has been both ways: it failed closed, which blocked v0.35.0 on a
+repository whose secrets have never been set, and before that it skipped. The
+behaviour is therefore worth asserting rather than reading, in both directions.
+
+THE GATE'S OWN SCRIPT IS EXECUTED, not pattern-matched. The step is shell, and
+a shell step can be wrong in ways a regex over its source cannot see: an
+unquoted expansion, a `set -e` interaction, a write to the wrong file. These
+run it under the runner's exact shell flags -- GitHub invokes `shell: bash` as
+`bash --noprofile --norc -e -o pipefail`, so -e is on before the script's own
+`set` line and a bare failing assignment would end the step early.
+"""
+import pathlib
+import subprocess
+
+import yaml
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "real-fabric.yml"
+
+
+def _gate_script() -> str:
+    d = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = d["jobs"]["gate"]["steps"]
+    for s in steps:
+        if s.get("id") == "check":
+            return s["run"]
+    raise AssertionError("the gate has no step with id 'check'")
+
+
+def _run(tmp_path, *, client_id, tenant_id, workspace, client_secret=False):
+    script = tmp_path / "gate.sh"
+    script.write_text(_gate_script(), encoding="utf-8")
+    out, summary = tmp_path / "out", tmp_path / "summary"
+    out.touch()
+    summary.touch()
+    r = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", str(script)],
+        capture_output=True, text=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "HAVE_CLIENT_ID": str(client_id).lower(),
+            "HAVE_TENANT_ID": str(tenant_id).lower(),
+            "HAVE_WORKSPACE": str(workspace).lower(),
+            "HAVE_CLIENT_SECRET": str(client_secret).lower(),
+            "GITHUB_OUTPUT": str(out),
+            "GITHUB_STEP_SUMMARY": str(summary),
+        },
+    )
+    outputs = dict(
+        line.split("=", 1)
+        for line in out.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    return r, outputs, summary.read_text(encoding="utf-8")
+
+
+def test_no_secrets_skips_and_does_not_fail(tmp_path):
+    """The state this repository is actually in, and the one that blocked a tag."""
+    r, outputs, _ = _run(tmp_path, client_id=False, tenant_id=False, workspace=False)
+    assert r.returncode == 0, f"the gate failed the run instead of skipping:\n{r.stdout}{r.stderr}"
+    assert outputs["run"] == "false"
+
+
+def test_a_skip_is_loud(tmp_path):
+    """The warning and the summary are the ONLY remaining record that a release
+    from this run was never compared against Fabric. Silence here is the whole
+    risk of skipping."""
+    r, _, summary = _run(tmp_path, client_id=False, tenant_id=False, workspace=False)
+    assert "::warning::" in r.stdout
+    assert "AZURE_CLIENT_ID" in r.stdout and "FABRIC_TEST_WORKSPACE" in r.stdout
+    assert "Nothing here was compared against Microsoft Fabric" in summary
+
+
+@pytest.mark.parametrize(
+    "client_id,tenant_id,workspace",
+    [(True, True, False), (True, False, True), (False, True, True), (True, False, False)],
+)
+def test_every_partial_configuration_skips_and_says_so(tmp_path, client_id, tenant_id, workspace):
+    """Half-configured is not the same situation as unconfigured -- it is nearly
+    always a typo or a half-finished rotation -- and it must not read as the
+    untouched case. It still skips; it just says which it is."""
+    r, outputs, _ = _run(tmp_path, client_id=client_id, tenant_id=tenant_id, workspace=workspace)
+    assert r.returncode == 0
+    assert outputs["run"] == "false"
+    assert "PARTIALLY configured" in r.stdout
+
+
+def test_a_complete_configuration_runs(tmp_path):
+    """The gate must not skip everything unconditionally -- which is the way a
+    skip-by-default gate silently stops being a gate at all."""
+    r, outputs, _ = _run(tmp_path, client_id=True, tenant_id=True, workspace=True)
+    assert r.returncode == 0
+    assert outputs["run"] == "true"
+    assert outputs["mode"] == "oidc", "no client secret means OIDC"
+
+
+def test_a_client_secret_selects_secret_mode(tmp_path):
+    r, outputs, _ = _run(tmp_path, client_id=True, tenant_id=True, workspace=True, client_secret=True)
+    assert outputs["run"] == "true"
+    assert outputs["mode"] == "secret"
+
+
+def test_the_conformance_job_is_gated_on_the_output_this_sets():
+    """The tests above prove the gate emits `run`. This proves the emission is
+    connected to something: without this, `run=false` could be correct and the
+    conformance job still execute."""
+    d = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert d["jobs"]["conformance"]["if"] == "needs.gate.outputs.run == 'true'"
+    assert d["jobs"]["gate"]["outputs"]["run"] == "${{ steps.check.outputs.run }}"

--- a/python/tests/test_real_fabric_gate.py
+++ b/python/tests/test_real_fabric_gate.py
@@ -13,7 +13,9 @@ run it under the runner's exact shell flags -- GitHub invokes `shell: bash` as
 `bash --noprofile --norc -e -o pipefail`, so -e is on before the script's own
 `set` line and a bare failing assignment would end the step early.
 """
+import os
 import pathlib
+import shutil
 import subprocess
 
 import pytest
@@ -32,17 +34,59 @@ def _gate_script() -> str:
     raise AssertionError("the gate has no step with id 'check'")
 
 
+def _working_bash():
+    """A bash that actually executes a script, or None.
+
+    NOT `shutil.which("bash")` alone. On windows-latest that resolves to
+    System32\\bash.exe, the WSL launcher, which has no installed distribution
+    and answers every invocation with "Windows Subsystem for Linux has no
+    installed distributions" on stdout and a non-zero status. Every assertion
+    in this file then failed against that banner rather than against the gate.
+    Probing beats trusting the name: whatever is found has to run a script
+    before it is used.
+
+    Git Bash is tried first by absolute path because it is the interpreter
+    Windows runners actually have and `which` does not find it first.
+    """
+    candidates = [
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+    ]
+    found = shutil.which("bash")
+    if found:
+        candidates.append(found)
+    for c in candidates:
+        if not pathlib.Path(c).exists():
+            continue
+        try:
+            r = subprocess.run([c, "-c", "printf ok"], capture_output=True, text=True, timeout=30)
+        except OSError:
+            continue
+        if r.returncode == 0 and r.stdout.strip() == "ok":
+            return c
+    return None
+
+
 def _run(tmp_path, *, client_id, tenant_id, workspace, client_secret=False):
+    # THE ENVIRONMENT IS INHERITED, not pinned to a minimal one. The first
+    # version passed `PATH=/usr/bin:/bin`, which is a POSIX path list, so the
+    # whole file died on windows-latest where the suite also runs. The four
+    # HAVE_* and the two GITHUB_* below are overridden explicitly, which is
+    # what the isolation actually needs: a real GITHUB_OUTPUT in CI must not
+    # be written to, and a stray HAVE_* must not leak in.
+    bash = _working_bash()
+    if bash is None:
+        pytest.skip("no usable bash; the gate is a bash step and runs on ubuntu-latest")
     script = tmp_path / "gate.sh"
     script.write_text(_gate_script(), encoding="utf-8")
     out, summary = tmp_path / "out", tmp_path / "summary"
     out.touch()
     summary.touch()
     r = subprocess.run(
-        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", str(script)],
+        [bash, "--noprofile", "--norc", "-e", "-o", "pipefail", str(script)],
         capture_output=True, text=True,
         env={
-            "PATH": "/usr/bin:/bin",
+            **os.environ,
             "HAVE_CLIENT_ID": str(client_id).lower(),
             "HAVE_TENANT_ID": str(tenant_id).lower(),
             "HAVE_WORKSPACE": str(workspace).lower(),


### PR DESCRIPTION
v0.35.0's tag failed at [`Check credentials are configured`](https://github.com/calvinchengx/fabric-emulator/actions/runs/33385489174/job/99467051301), and every publishing job in `release.yml` is `needs: fabric-qualification`, so the release stopped there. The four real-Fabric secrets have never been set on this repository, so the gate was failing on the expected state rather than on a regression.

The gate now sets `run=false` and exits 0. `conformance` is left **skipped**, which is a distinct conclusion from `success` at every level that reads one, so the shape the fail-closed change was written to prevent, a job reporting green having executed nothing, does not come back.

## What this accepts, said out loud

A tag can now ship while the oracle is unwired, and such a release has not been compared against Fabric at all. That was the argument for failing closed and it has not stopped being true. It is written into the gate rather than left in a commit message, and the skip is loud in the two places a reader will be:

```
::warning::real-Fabric conformance SKIPPED — credentials not configured;
missing: AZURE_CLIENT_ID AZURE_TENANT_ID FABRIC_TEST_WORKSPACE.
Nothing in this run has been compared against Fabric.
```

plus a run summary on the release run itself naming the three secrets and saying any release from that run is unqualified.

**Half configured is not the same as unconfigured.** Nothing set is the ordinary state of a fork. Two of three set is nearly always a typo or a half-finished rotation, and skipping silently would let it sit forever, so it skips saying `PARTIALLY configured, which is usually a mistake`.

## Tests

`python/tests/test_real_fabric_gate.py`, 9 tests, which **execute the gate's own shell** under the runner's exact flags (`bash --noprofile --norc -e -o pipefail`) rather than pattern-matching its source: no secrets, each of four partial combinations, complete-OIDC, complete-with-secret, and that `conformance`'s `if:` is actually wired to the output the gate sets, so `run=false` cannot be correct while the job runs anyway.

Against the pre-change workflow 6 of the 9 fail. The 3 that pass are the complete-configuration and wiring cases, which the old gate also satisfied.

## Stale claims removed

`docs/release-notes/v0.35.0.md` announced the fail-closed behaviour. v0.35.0 is not published, so the note is corrected in place rather than left contradicting the code. `docs/21-real-fabric-toggle.md` already said "self-skips until the secrets exist" and becomes accurate again.

Unchanged: **a skipped run is not evidence**, and no parity claim may cite this workflow until a conformance job has actually completed.