### PR TITLE
Dependabot watches the published images, not just the root Dockerfile.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,12 +61,30 @@ updates:
       python:
         patterns: ['*']
 
-  # The published image's base layers.
+  # The published imageS' base layers, plural. `directory: /` watched exactly
+  # one file, ./Dockerfile, and this repository has twelve. The two that matter
+  # most were among the eleven unwatched: docker/sail and docker/spark-agent are
+  # PUBLISHED to GHCR by the release workflow and pulled by every platform in
+  # the family, and both build `FROM python:3.12-slim` with nothing tracking it.
+  # The runtimes beside them (spark-runtime on apache/spark:3.5.5,
+  # python-runtime, jupyter) were unwatched for the same reason.
+  #
+  # E2E HARNESS IMAGES ARE DELIBERATELY OUT: e2e/*/Dockerfile and
+  # examples/fab-driven exist only inside CI runs, are never published and never
+  # reachable, so a base bump there is noise against the same PR budget the
+  # shipped images compete for. Add `/e2e/*` here if that judgement changes.
   - package-ecosystem: docker
-    directory: /
+    directories:
+      - /
+      - /docker/*
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    groups:
+      # One PR for the four runtimes that share `python:3.12-slim`, rather than
+      # four identical ones.
+      docker:
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
**Why this exists:** #416 fixed the `uv` resolution failure that had been red since 25 August, but nothing has re-run it. A `pyproject.toml` change does not retrigger Dependabot; only a `.github/dependabot.yml` change does, and `gh run rerun` refuses these runs outright (`This workflow run cannot be retried`). So the fix is merged and unproven.

Rather than touch the file pointlessly to force a run, I looked for something real in it, and found this.

## The gap

```yaml
- package-ecosystem: docker
  directory: /
```

`directory: /` watches exactly one file, `./Dockerfile`. This repository has **twelve**, and the two that matter most were among the eleven unwatched:

| Dockerfile | base | published? | watched before |
| --- | --- | --- | --- |
| `./Dockerfile` | `golang:1.26`, `distroless/static-debian12` | yes | ✅ |
| `docker/sail/` | `python:3.12-slim` | **yes, to GHCR** | ❌ |
| `docker/spark-agent/` | `python:3.12-slim` | **yes, to GHCR** | ❌ |
| `docker/spark-runtime/` | `apache/spark:3.5.5-…` | no | ❌ |
| `docker/python-runtime/`, `docker/jupyter/` | `python:3.12-slim` | no | ❌ |

`docker/sail` and `docker/spark-agent` are built and pushed by the release workflow and pulled by every platform in the family. Their base layer was tracked by nothing.

## The change

`directories: [/, /docker/*]`, plus a group so the four runtimes sharing `python:3.12-slim` arrive as one PR rather than four identical ones. Verified by expanding the globs against the actual tree: six Dockerfile directories now covered, and the nine still outside are exactly the e2e harnesses and `examples/fab-driven`.

Those are **deliberately** out and the config says so: they exist only inside CI runs, are never published and never reachable, so a base bump there is noise competing for the same PR budget as the shipped images. The comment records how to add them if that judgement changes.

## What this confirms on merge

The fresh Dependabot batch it triggers is the check on #416, whose `uv` job should now be green. I will report the result either way rather than assuming it.