### PR TITLE
Assert the e2e MLflow server stays unreachable (GHSA-h7x2-h6g9-p789)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,6 +572,7 @@ jobs:
       # right, the cast of services had drifted. Nothing about adding a service
       # reminds anyone to redraw, so the roster is asserted instead.
       - run: uv run --frozen --no-sync python scripts/check_arch_services.py
+      - run: uv run --frozen --no-sync python scripts/check_mlflow_unpublished.py
       - run: uv run --frozen --no-sync python scripts/check_image_digests.py
       # `fabricActivityTypes` is the oracle the dispatch is checked against, and
       # it was transcribed by hand: a type Fabric adds or renames stayed invisible

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_example_portability.py
 	@$(PY) scripts/check_conformance.py --strict
 	@$(PY) scripts/check_arch_services.py
+	@$(PY) scripts/check_mlflow_unpublished.py
 	@$(PY) scripts/check_fabric_activity_types.py
 	@$(PY) scripts/check_adf_activity_types.py
 	@$(PY) scripts/check_docs_sidebar.py

--- a/scripts/check_mlflow_unpublished.py
+++ b/scripts/check_mlflow_unpublished.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""The e2e MLflow server must not publish a port to the host.
+
+WHY THIS EXISTS. GHSA-h7x2-h6g9-p789 (high): MLflow's AI Gateway stores an
+`auth_config.api_base` verbatim with no validation of scheme, host or IP range,
+and its proxy endpoint then fetches that address plus a caller-supplied path and
+returns the body -- a server-side request forgery. MLflow's own SSRF guard,
+`_validate_webhook_url`, is never reached on that path, and `CreateGatewaySecret`
+has no entry in the permission-validator map, so basic authentication is enough.
+
+THERE IS NO VERSION TO UPGRADE TO. The range is `>= 3.13.0, <= 3.15.2` and 3.15.2
+is the newest release; GitHub records no patched version. Downgrading is not
+available either: this project's floor is deliberately 3.15 because a resolve
+below it removed `--disable-security-middleware`, the flag the e2e passes, and
+the container then would not start (see the `mlflow` group in pyproject.toml).
+
+SO THE MITIGATION IS REACHABILITY, and this asserts it rather than trusting it.
+The server exists only inside an e2e compose network and publishes nothing: no
+`ports:` key anywhere in that file. Nothing in this repository uses the AI
+Gateway at all -- the emulator speaks only the tracking, registry and artifact
+APIs -- but the endpoint still EXISTS on that container, so what keeps it
+harmless is that nothing outside the compose network can reach it.
+
+That is a property somebody could delete in one line while debugging, which is
+exactly the kind of line that never gets reverted. Hence a check.
+
+Usage:
+    check_mlflow_unpublished.py      exit non-zero if the e2e stack publishes a port
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+COMPOSE = ROOT / "e2e" / "data-science-loop" / "docker-compose.yml"
+
+
+def main() -> int:
+    if not COMPOSE.is_file():
+        print(f"check_mlflow_unpublished: {COMPOSE} does not exist", file=sys.stderr)
+        return 1
+    text = COMPOSE.read_text(encoding="utf-8")
+
+    offenders = [
+        f"{n}: {line.strip()}"
+        for n, line in enumerate(text.splitlines(), 1)
+        if re.match(r"\s*ports:\s*$", line) or re.match(r"\s*ports:\s*\[", line)
+    ]
+    if offenders:
+        print(
+            "check_mlflow_unpublished: the data-science-loop stack publishes a "
+            "port to the host:\n  " + "\n  ".join(offenders) + "\n\n"
+            "MLflow's AI Gateway (GHSA-h7x2-h6g9-p789) has no fixed release and "
+            "this stack runs a version inside the vulnerable range. Its only\n"
+            "mitigation is that the server is reachable from the compose network "
+            "and nowhere else. If a published port is genuinely needed, say so\n"
+            "here and re-assess the advisory rather than deleting this check.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("check_mlflow_unpublished: the e2e MLflow server publishes no host port")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Dependabot **#56**, high — MLflow's AI Gateway stores `auth_config.api_base` verbatim with no validation of scheme, host or IP range; its proxy then fetches that address plus a caller-supplied path and returns the body. MLflow's own SSRF guard `_validate_webhook_url` is never reached on that path, and `CreateGatewaySecret` has no entry in the permission-validator map.

### There is nothing to upgrade to

| | |
|---|---|
| vulnerable range | `>= 3.13.0, <= 3.15.2` |
| latest release on PyPI | `3.15.2` — **inside the range** |
| first patched version | **none recorded** |

Downgrading is not open either. The floor here is deliberately `3.15` because resolving below it dropped `--disable-security-middleware`, the flag the e2e passes, and the container then would not start — that trap is already written into the `mlflow` group in `pyproject.toml`.

### So the mitigation is reachability — asserted, not assumed

Nothing in this repository touches the AI Gateway. The emulator speaks only the tracking, registry and artifact APIs (`experiments`, `runs`, `model-versions`, `registered-models`, `mlflow-artifacts`); `gateway_api`, `_create_gateway_secret` and `/gateway` appear nowhere.

But **the endpoint still exists on that container**. What keeps it harmless is that the server runs only inside an e2e compose network and publishes no host port — a property one line could delete while debugging, and that is exactly the line nobody reverts. So it is now a `make check` invariant.

Verified non-vacuous against both compose syntaxes (`ports:` block and inline list), by exit code rather than by output.

### What this does not do

It does not make the advisory untrue. It bounds the exposure and pins the bound. **The alert should be re-assessed the moment a patched MLflow lands** — at which point the fix is a version bump and this check goes back to being ordinary defence in depth.