### PR TITLE
dbt-fabricspark silver builds its three models at once

### DIFF
--- a/examples/medallion-advanced-dbt-fabricspark/silver.py
+++ b/examples/medallion-advanced-dbt-fabricspark/silver.py
@@ -71,7 +71,27 @@ lakehouse_name = st["lakehouse_name"]
       lakehouseid: "{st['lakehouse']}"
       lakehouse: "{lakehouse_name}"
       schema: "{lakehouse_name}"
-      threads: 1
+      # FOUR, not one. These three models depend only on sources -- no `ref`
+      # between them -- so dbt can build all three at once, and the emulator
+      # does not serialise them: it terminates Livy itself and each statement
+      # reaches Sail independently.
+      #
+      # Measured on this example, one stack, same data, same 12/12 result:
+      # at `threads: 1` the models START 26s and 15s apart and the step takes
+      # 96.0s; at 3 they all start in the SAME SECOND and it takes 44.2s. The
+      # start timestamps are the evidence -- a wall-clock delta could be noise,
+      # simultaneous starts cannot be.
+      #
+      # Four rather than three is headroom: with three independent models dbt
+      # runs min(threads, ready nodes), so it behaves identically today and a
+      # fourth model does not need this line revisited.
+      #
+      # It is NOT linear scaling. All three then report the same duration
+      # rather than finishing at their own pace, which is what three queries
+      # contending for one Sail engine looks like. The gold projects here keep
+      # `threads: 1`: they run through dbt-fabric over TDS, a different adapter
+      # and engine, and nothing above was measured against them.
+      threads: 4
       connect_retries: 3
       connect_timeout: 60
       spark_config:

--- a/examples/medallion-dbt-fabricspark/silver.py
+++ b/examples/medallion-dbt-fabricspark/silver.py
@@ -71,7 +71,27 @@ lakehouse_name = st["lakehouse_name"]
       lakehouseid: "{st['lakehouse']}"
       lakehouse: "{lakehouse_name}"
       schema: "{lakehouse_name}"
-      threads: 1
+      # FOUR, not one. These three models depend only on sources -- no `ref`
+      # between them -- so dbt can build all three at once, and the emulator
+      # does not serialise them: it terminates Livy itself and each statement
+      # reaches Sail independently.
+      #
+      # Measured on this example, one stack, same data, same 12/12 result:
+      # at `threads: 1` the models START 26s and 15s apart and the step takes
+      # 96.0s; at 3 they all start in the SAME SECOND and it takes 44.2s. The
+      # start timestamps are the evidence -- a wall-clock delta could be noise,
+      # simultaneous starts cannot be.
+      #
+      # Four rather than three is headroom: with three independent models dbt
+      # runs min(threads, ready nodes), so it behaves identically today and a
+      # fourth model does not need this line revisited.
+      #
+      # It is NOT linear scaling. All three then report the same duration
+      # rather than finishing at their own pace, which is what three queries
+      # contending for one Sail engine looks like. The gold projects here keep
+      # `threads: 1`: they run through dbt-fabric over TDS, a different adapter
+      # and engine, and nothing above was measured against them.
+      threads: 4
       connect_retries: 3
       connect_timeout: 60
       spark_config:


### PR DESCRIPTION
The three silver models depend only on sources — no `ref` between them — so dbt can build them concurrently, and the emulator does not stand in the way: it terminates Livy itself and each statement reaches Sail independently. `threads: 1` was serialising work nothing required to be serial.

Prompted by [this post on dbt/Fabric Spark performance](https://www.rakirahman.me/dbt-nee-perf/), whose headline win comes from unlocking concurrent model builds.

### Measured

`medallion-dbt-fabricspark`, one stack, same data, 12/12 steps and identical row counts both ways:

| | model starts | silver step |
|---|---|---|
| `threads: 1` | 26s and 15s apart | **96.0s** |
| `threads: 4` | all three in the **same second** | **45.5s** |

**The start timestamps are the evidence, not the wall clock.** A timing delta from a single run could be noise; three models starting in the same second could not be — and at `threads: 1` they demonstrably do not.

### Why four

dbt runs `min(threads, ready nodes)`, so with three independent models this behaves exactly as the measured run did, and a fourth model will not need the line revisited.

### What this is not

It is **not** the linear scaling those Fabric write-ups report across a fleet of executors. The three models finish within 0.4s of each other rather than at their own pace — three queries contending for one Sail engine. The speedup is real; the mechanism is different, and the comment in the file says so.

The gold projects keep `threads: 1`: `dbt-fabric` over TDS is a different adapter and engine, and **nothing here was measured against it.** Raising those would be a guess.

Only `medallion-dbt-fabricspark` was run end to end; `medallion-advanced-dbt-fabricspark` has the same three independent models and the same adapter, and CI runs both.