### PR TITLE
The same silver models, built without the Livy hop

### DIFF
--- a/examples/medallion-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-dbt-fabricspark/pyproject.toml
@@ -3,10 +3,23 @@
 #
 #   uv sync --frozen && uv run python pipeline.py
 #
-# BOTH dbt adapters are here, and that is the shape of the example rather than
+# THREE dbt adapters are here, and that is the shape of the example rather than
 # an accident: dbt-fabricspark builds bronze -> silver in the Lakehouse over
 # Livy, and dbt-fabric builds silver -> gold in the Warehouse over TDS. Gold is
 # a Warehouse, and fabricspark cannot write to one.
+#
+# dbt-spark is the third, and it is not a second way to do the same thing.
+# dbt-fabricspark speaks ONLY Livy -- its one connection method is
+# FabricSparkConnectionMethod.LIVY -- so `method: session`, the shape a Fabric
+# notebook takes when it runs dbtRunner on the driver, cannot be expressed with
+# it at all. silver_session.py builds the SAME models that way, over Spark
+# Connect to the same Sail, and exists to separate a defect on the Livy path
+# from one in the SQL. See its docstring.
+#
+# NOT dbt-spark[session], which pulls full pyspark for the JVM. `pyspark-client`
+# already provides the `pyspark` namespace and resolves SPARK_REMOTE to a
+# Connect session, which is measured: getOrCreate() returns
+# pyspark.sql.connect.session and Sail answers it.
 [project]
 name = "fabric-emulator-example-medallion-dbt-fabricspark"
 version = "0.1.0"
@@ -16,6 +29,8 @@ dependencies = [
     "contoso-fixtures",
     "dbt-fabric>=1.11",
     "dbt-fabricspark>=1.13",
+    "dbt-spark>=1.11",
+    "pyspark-client>=4.1",
     "deltalake>=0.23,<2",
     "pyarrow>=18,<24",
     "pyodbc>=5.2,<6",

--- a/examples/medallion-dbt-fabricspark/silver_session.py
+++ b/examples/medallion-dbt-fabricspark/silver_session.py
@@ -101,7 +101,7 @@ def main():
     #
     # It is also the shape being demonstrated: a Fabric notebook runs dbtRunner
     # on the driver, which is the whole point of the session method.
-    os.environ.update({k: v for k, v in env.items() if k not in os.environ or True})
+    os.environ.update(env)
     from dbt.cli.main import dbtRunner
 
     res = dbtRunner().invoke(["build", "--project-dir", str(PROJECT)])

--- a/examples/medallion-dbt-fabricspark/silver_session.py
+++ b/examples/medallion-dbt-fabricspark/silver_session.py
@@ -1,0 +1,121 @@
+"""The same silver models, built by dbt WITHOUT the Livy hop.
+
+    dbt-spark (method: session) -> Spark Connect -> Sail
+
+`silver.py` builds these models through `dbt-fabricspark`, which speaks only
+Livy: the adapter's one connection method is `FabricSparkConnectionMethod.LIVY`
+and there is no `session` in it. That is the path a Fabric *pipeline* takes. A
+Fabric *notebook* runs `dbtRunner` on the driver instead, and this is that
+shape -- one transport removed, everything else identical: the same
+`silver_dbt/` project, the same models, the same engine.
+
+WHY IT EXISTS. silver.py records a `_rn`-not-in-schema failure it cannot
+attribute: a probe ran the same SQL against Sail over Spark Connect and every
+form passed, so the fault is "somewhere on the Livy path (emulator -> agent ->
+Sail) or in dbt's generated SQL" and the two-CTE rewrite is kept without
+knowing which. Running the models over a second transport is how that stops
+being a guess. It narrows rather than settles it -- dbt-spark generates
+different SQL from dbt-fabricspark, so a pass here rules out Sail and leaves
+the adapter and the Livy path still to separate.
+
+WHAT THE LIVY SURFACE WAS DOING FOR US, made visible by not having it. Opening
+a Livy session registers the lakehouse's `Tables/` in the Spark catalog, the
+way Fabric's metastore does -- which is why `silver_dbt/models/sources.yml`
+resolves `bronze_orders` by name with no path anywhere. A bare Spark Connect
+session has no such thing: `show databases` returns only `default`, and `lake`
+does not exist. So this step registers what it reads, by OneLake location, in
+the same `CREATE TABLE ... LOCATION` form the emulator's own session bootstrap
+uses (python/spark_agent/catalog.py). That difference IS the finding: the Livy
+surface is not merely a transport, it is also the metastore.
+
+It writes into its own schema so the Livy-built silver is left standing and the
+two can be compared rather than one overwriting the other.
+
+    uv run python silver_session.py     # after `silver` has run
+"""
+import json
+import os
+import pathlib
+
+HERE = pathlib.Path(__file__).resolve().parent
+PROJECT = HERE / "silver_dbt"
+STATE = json.loads((HERE / "state.json").read_text(encoding="utf-8"))
+
+WORKSPACE = STATE.get("workspace_name") or STATE["workspace"]
+LAKEHOUSE = STATE["lakehouse_name"]
+SCHEMA = os.environ.get("SESSION_SCHEMA", f"{LAKEHOUSE}_session")
+REMOTE = os.environ.get("SPARK_REMOTE", "sc://localhost:50051")
+SOURCES = ("bronze_customers", "bronze_orders")
+
+
+def onelake(table):
+    """The location the emulator would have registered for this table."""
+    return (f"abfss://{WORKSPACE}@onelake.dfs.fabric.microsoft.com/"
+            f"{LAKEHOUSE}.Lakehouse/Tables/{table}")
+
+
+def register():
+    """Do by hand what opening a Livy session does for free."""
+    os.environ["SPARK_REMOTE"] = REMOTE
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.getOrCreate()
+    for schema in (LAKEHOUSE, SCHEMA):
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS `{schema}`")
+    for table in SOURCES:
+        spark.sql(f"CREATE TABLE IF NOT EXISTS `{LAKEHOUSE}`.`{table}` "
+                  f"USING delta LOCATION '{onelake(table)}'")
+    counts = {t: spark.sql(f"SELECT count(*) FROM `{LAKEHOUSE}`.`{t}`").collect()[0][0]
+              for t in SOURCES}
+    print(f"==> registered {len(SOURCES)} bronze table(s) by location: {counts}")
+    return spark
+
+
+def main():
+    spark = register()
+    (PROJECT / "profiles.yml").write_text(f"""contoso_silver_spark:
+  target: dev
+  outputs:
+    dev:
+      type: spark
+      method: session
+      host: localhost
+      schema: "{SCHEMA}"
+      threads: 4
+""", encoding="utf-8")
+    # A DISTINCT location, deliberately. silver.py lands these models in the
+    # lakehouse's Tables/ area, which is where the SQL endpoint reflects from;
+    # writing there too would have this step overwrite the very silver it exists
+    # to be compared against. Files/ is a scratch area for that reason.
+    onelake = (f"abfs://{STATE['workspace']}@onelake.dfs.fabric.microsoft.com"
+               f"/{STATE['lakehouse']}/Files/silver_session")
+    env = {**os.environ, "SPARK_REMOTE": REMOTE, "LAKEHOUSE_NAME": LAKEHOUSE,
+           "ONELAKE_TABLES": onelake, "DBT_PROFILES_DIR": str(PROJECT)}
+    # IN PROCESS, and that is not a convenience. Sail's catalog is SESSION
+    # scoped: the tables registered above are invisible to any other session,
+    # which is the same reason a bare Connect session cannot see what a Livy
+    # session registered. Running dbt in a subprocess gives it its own
+    # SparkSession and an empty catalog -- measured, `Table or view not found:
+    # bronze_orders`. dbtRunner shares this process, so getOrCreate() hands dbt
+    # the session that already has the sources in it.
+    #
+    # It is also the shape being demonstrated: a Fabric notebook runs dbtRunner
+    # on the driver, which is the whole point of the session method.
+    os.environ.update({k: v for k, v in env.items() if k not in os.environ or True})
+    from dbt.cli.main import dbtRunner
+
+    res = dbtRunner().invoke(["build", "--project-dir", str(PROJECT)])
+    if not res.success:
+        raise SystemExit(f"dbt build failed over the session method: {res.exception}")
+    built = {}
+    for model in ("silver_customers", "silver_orders", "silver_quarantine_orders"):
+        built[model] = spark.sql(f"SELECT count(*) FROM `{SCHEMA}`.`{model}`").collect()[0][0]
+    print(f"==> silver (dbt-spark, method: session) into `{SCHEMA}`: {built}")
+    (HERE / "silver_session_summary.json").write_text(
+        json.dumps({"schema": SCHEMA, "transport": "spark-connect", "rows": built},
+                   indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/medallion-dbt-fabricspark/uv.lock
+++ b/examples/medallion-dbt-fabricspark/uv.lock
@@ -542,6 +542,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dbt-spark"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dbt-adapters" },
+    { name = "dbt-common" },
+    { name = "dbt-core" },
+    { name = "sqlparams" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/9b/5f6e07aef31f89e1dd7f3e0fe959013052efc15ea28f6157c239e30f5d48/dbt_spark-1.11.0.tar.gz", hash = "sha256:436aa57d662ebad8e56f606863e02045f73116566f85a600b9fa890a763f8c37", size = 83739, upload-time = "2026-07-16T17:03:55.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/77/f0163101e23650ad4f0905c426e3e1c7fc613c215be40164d74b175b9c48/dbt_spark-1.11.0-py3-none-any.whl", hash = "sha256:00d9c9cd3e13473df05b90740fddd8c3082083c45971aaba2fae7b01ab82f4f5", size = 51733, upload-time = "2026-07-16T17:03:53.614Z" },
+]
+
+[[package]]
 name = "deepdiff"
 version = "8.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -591,6 +606,7 @@ dependencies = [
     { name = "contoso-fixtures" },
     { name = "dbt-fabric" },
     { name = "dbt-fabricspark" },
+    { name = "dbt-spark" },
     { name = "deltalake" },
     { name = "pyarrow" },
     { name = "pyodbc" },
@@ -603,10 +619,12 @@ requires-dist = [
     { name = "contoso-fixtures", editable = "../contoso-fixtures" },
     { name = "dbt-fabric", specifier = ">=1.11" },
     { name = "dbt-fabricspark", specifier = ">=1.13" },
+    { name = "dbt-spark", specifier = ">=1.11" },
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "pyarrow", specifier = ">=18,<24" },
     { name = "pyodbc", specifier = ">=5.2,<6" },
     { name = "pyspark-client", specifier = "==4.1.1" },
+    { name = "pyspark-client", specifier = ">=4.1" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 
@@ -1695,6 +1713,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/cd/39a94f0f98076ee8e7c7c38fd4bba8d7845b0c629ff967057c64ef2c0989/sqlglot-30.14.0.tar.gz", hash = "sha256:df2ef5d2b8ca814313781f4ff35bf63e58f821ef517eeddbd523c19a61fa9bb9", size = 5944410, upload-time = "2026-07-27T11:23:30.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/ec/a729883ceda22dcd9117ce182f64d884bf494e72c4dfce00c2ad0a5978e1/sqlglot-30.14.0-py3-none-any.whl", hash = "sha256:fc768e24889d63a5e1237dea7ad305e5ffb4356a98b0bed828f89591ebcd3636", size = 719007, upload-time = "2026-07-27T11:23:28.637Z" },
+]
+
+[[package]]
+name = "sqlparams"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/ec/5d6a5ca217ecd7b08d404b7dc2025c752bdb393c9b34fcc6d48e1f70bb7e/sqlparams-6.2.0.tar.gz", hash = "sha256:3744a2ad16f71293db6505b21fd5229b4757489a9b09f3553656a1ae97ba7ca5", size = 34932, upload-time = "2025-01-25T16:21:59.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/e2/f1355629bb1eeb274babc947e2ba4e2e49250e934c86adcce3e54943bc8a/sqlparams-6.2.0-py3-none-any.whl", hash = "sha256:63b32ed9051bdc52e7e8b38bc4f78aed51796cdd9135e730f4c6a7db1048dedf", size = 17629, upload-time = "2025-01-25T16:21:58.272Z" },
 ]
 
 [[package]]

--- a/scripts/check_example_parity.py
+++ b/scripts/check_example_parity.py
@@ -81,6 +81,13 @@ PAIRS = [
             # job; the dbt half's silver is a dbt project run over Livy. That is
             # the axis these two examples exist to compare.
             "definitions/silver.Notebook": "PySpark only: silver as a Notebook definition",
+            # A THIRD way to build the same silver, and it belongs only to the
+            # dbt half because it is that half's transport that is in question.
+            # dbt-fabricspark speaks only Livy; this runs the same models over
+            # Spark Connect instead, so a defect on the Livy path can be told
+            # apart from one in the SQL. The pyspark half has no Livy hop to
+            # remove, so a mirrored copy there would compare nothing.
+            "silver_session.py": "dbt-fabricspark only: the same models without the Livy hop",
         },
         # `compare` is a real extra step, not a drifted one. Named here so the
         # sequence check still compares everything else in order.


### PR DESCRIPTION
Closes **G58**. `dbt-fabricspark` speaks **only** Livy — its one connection method is `FabricSparkConnectionMethod.LIVY` — so `method: session`, the shape a Fabric notebook takes when it runs `dbtRunner` on the driver, could not be expressed here at all.

`silver_session.py` builds the **same** `silver_dbt/` models over Spark Connect to the same Sail: one transport removed, everything else identical.

### Measured, against the locked versions

| | rows | time |
|---|---|---|
| `dbt-fabricspark`, `method: livy` | 100,000 / 247,500 / 2,500 | 44s |
| `dbt-spark`, `method: session` | **identical** | 6.5s |

**The timings are not a fair race** — this lands in `Files/` and skips the reflection the `Tables/` path does. **The row agreement is the result, not the clock.**

### Two things the build taught, now written into the file

**Sail's catalog is session-scoped.** A bare Connect session sees no `lake` and no tables. So `sources.yml` resolving bronze *by name* is something the **Livy surface does for us** — opening a Livy session registers the lakehouse's `Tables/` — rather than a property of the engine. This step registers what it reads, by OneLake location, in the same `CREATE TABLE … LOCATION` form the emulator's own bootstrap uses. That difference is itself the finding: the Livy surface is not merely a transport, it is also the metastore.

**dbt must run in-process.** As a subprocess it gets its own SparkSession and an empty catalog — measured, `Table or view not found: bronze_orders`. `dbtRunner` shares the session that already holds the sources, which is also exactly the shape being demonstrated.

### Dependencies

`dbt-spark` + the existing `pyspark-client` — **not** `dbt-spark[session]`, which pulls full pyspark for a JVM this never starts. `pyspark-client` already provides the `pyspark` namespace and resolves `SPARK_REMOTE` to a Connect session; verified that `getOrCreate()` returns `pyspark.sql.connect.session` and Sail answers it.

### Caveat on the bisection

The models in the tree already carry the two-CTE rewrite, so this run **does not exercise the shape that originally failed**. It narrows rather than settles: `dbt-spark` emits different SQL from `dbt-fabricspark`, so a pass here rules out Sail and leaves the adapter and the Livy path still to separate. Running the pre-rewrite model through this path is the next step.