### PR TITLE
Hold the three packages mlflow and dbt-databricks cap.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,46 @@ updates:
     groups:
       python:
         patterns: ['*']
+    # THREE PACKAGES ARE CAPPED BY TOOLS WE PIN, NOT BY US. Each entry names
+    # the constraint from the capping package's own published metadata, so the
+    # claim can be rechecked rather than taken on trust, and each says what to
+    # watch for before lifting it. Minor and patch updates keep flowing for all
+    # three; only the majors that cannot resolve are held.
+    #
+    # These were the last three failures in this job. Verified by rewriting the
+    # declared constraint the way Dependabot does and re-locking: pandas and
+    # cryptography reproduce with the mlflow line below, and databricks-sdk
+    # fails in Dependabot with the dbt-databricks line.
+    ignore:
+      # mlflow 3.15.1 `requires_dist`: `cryptography<50,>=43.0.0`.
+      # Our own range is `>=42,<51`, so WE permit 50 and mlflow forbids it.
+      # This is the one with a real cost: cryptography is security-relevant and
+      # 49.x carries no open advisory today, but that could change while the
+      # ceiling holds.
+      #
+      # LIFT THIS when mlflow's `requires_dist` admits cryptography 50.
+      - dependency-name: cryptography
+        update-types: ['version-update:semver-major']
+      # mlflow 3.15.1 `requires_dist`: `pandas<3`.
+      # Our main dependencies already say `pandas>=2,<3`; the `<4` in the
+      # great-expectations group and the range in sail-delta are what let uv
+      # consider pandas 3 at all, and neither can be satisfied while mlflow is
+      # in the workspace. Tightening one of them is not enough, measured: the
+      # other still pulls 3 into the resolution.
+      #
+      # LIFT THIS when mlflow admits pandas 3.
+      - dependency-name: pandas
+        update-types: ['version-update:semver-major']
+      # dbt-databricks 1.12.4 `requires_dist`:
+      # `databricks-sdk<0.118.0,>=0.68.0`, while our `databricks-sdk` group
+      # pins `>=0.130,<1`. That is precisely why the two are already declared
+      # conflicting in pyproject.toml; the conflict keeps them resolvable side
+      # by side but does not stop Dependabot proposing a bump that is
+      # unsatisfiable inside the dbt fork. The same package fails the same way
+      # in contoso-data-product-databricks-jobs, held there for the same reason.
+      #
+      # LIFT THIS when dbt-databricks raises its databricks-sdk ceiling.
+      - dependency-name: databricks-sdk
 
   # The published imageS' base layers, plural. `directory: /` watched exactly
   # one file, ./Dockerfile, and this repository has twelve. The two that matter


### PR DESCRIPTION
The last three failures in this repository's Dependabot `uv` job. Each is a dependency **we** would happily take, capped by a tool we pin.

| held | capped by | the capping package's own `requires_dist` |
| --- | --- | --- |
| `cryptography` (major) | mlflow 3.15.1 | `cryptography<50,>=43.0.0` |
| `pandas` (major) | mlflow 3.15.1 | `pandas<3` |
| `databricks-sdk` | dbt-databricks 1.12.4 | `databricks-sdk<0.118.0,>=0.68.0` |

Every constraint is quoted from PyPI metadata rather than inferred from uv's phrasing, so each claim can be rechecked, and each entry records what to watch for before lifting it. Minor and patch updates keep flowing; only the unresolvable majors are held.

## Two things I corrected while doing this

**There were three failures, not four.** My first pass parsed the job log by pairing each `Updating X` line with the next failure marker and reported pandas, cryptography, databricks-sdk **and mlflow**. Counting distinct `No solution found` reasons instead gives three, each appearing twice, and mlflow is not among them: it is the *cause* in two of them, never the casualty. Confirmed independently by simulating its bump, `mlflow 3.15.1 -> 3.15.2` resolves cleanly.

**A declaration fix does not work here, measured.** `pandas 3` is only reachable because the `great-expectations` group says `pandas>=2.2,<4` while our main dependencies say `>=2,<3`. Tightening that group to `<3` still fails, because `sail-delta` pulls pandas 3 into the resolution too. Neither declaration can be satisfied while mlflow is present, so the honest expression is a hold, not a narrower range.

## The finding worth acting on separately

**mlflow is the hub, and it is unfixably vulnerable.** It caps two of these three, and it carries an open **high** advisory (MLflow AI Gateway SSRF) whose vulnerable range is `>= 3.13.0, <= 3.15.2` with **first patched version: none** — 3.15.2 is the newest release on PyPI, so every version that exists is affected.

I checked whether mlflow could be extracted the way `fabric-cli` was in #426, which would have freed cryptography and pandas *and* removed the advisory from the default branch. **It cannot, cleanly:** both mlflow-bearing groups are consumed through the shared `docker/python-runtime/Dockerfile` parameterised by `UV_GROUP`, which about a dozen e2e stacks use against the root lock. Extracting mlflow means restructuring that mechanism, which is a deliberate design decision rather than a dependency fix, so I have not made it here.

Follows #416 (the conflicts pair), #417 (docker coverage) and #426 (fabric-cli extraction), which cleared the pyyaml failure.