### PR TITLE
Contract 6 witnesses fall-through directly instead of inferring it

### DIFF
--- a/e2e/conformance/live.py
+++ b/e2e/conformance/live.py
@@ -396,12 +396,33 @@ try:
         # is a separate limitation that happens to be cheap to observe from
         # the same cell.
         _name_ok, _name_err = _try(lambda: spark.sql("OPTIMIZE events").collect())
+        # THE ECHO, and it is the witness that does not rot. The two statements
+        # above prove fall-through by CONTRAST: the unrecognised one must fail
+        # here and succeed on the JVM. That reasoning holds only while the
+        # engine stays incapable, and engines do not. pysail 0.7.1 learned to
+        # plan `MERGE ... WHEN MATCHED THEN DELETE` -- measured against a bare
+        # Sail with no emulator and no agent in the path, 0.7.0 refusing it and
+        # 0.7.1 running it -- so the statement succeeded honestly and the probe
+        # read that as "something rewrote it".
+        #
+        # A string literal cannot go stale that way. The payload contains the
+        # exact construct the rewriter DOES recognise; a rewriter that tokenises
+        # the statement text and acts on what it finds changes these bytes, and
+        # one that stays out of the way cannot. The engine returns the proof and
+        # the emulator cannot forge it without reproducing its own input.
+        _echo_sent = f"OPTIMIZE delta.`{_tbl}`"
+        _echo_rows, _echo_err = _try(lambda: spark.sql(
+            "SELECT '" + _echo_sent.replace("'", "''") + "' AS echo").collect())
+        _echo_got = "" if _echo_err else (_echo_rows[0][0] if _echo_rows else "")
         _findings["fall_through"] = {
             "table_error": "",
             "recognised_ok": not _rec_err,
             "recognised_error": _rec_err,
             "unrecognised_ok": not _unrec_err,
             "unrecognised_error": _unrec_err,
+            "echo_sent": _echo_sent,
+            "echo_got": _echo_got,
+            "echo_error": _echo_err,
             "name_form_ok": not _name_err,
             "name_form_error": _name_err,
         }
@@ -1156,6 +1177,9 @@ def session_fall_through() -> FallThroughClaim:
         recognised_error=_fall_seen.get("recognised_error", ""),
         unrecognised_ok=bool(_fall_seen.get("unrecognised_ok")),
         unrecognised_error=_fall_seen.get("unrecognised_error", ""),
+        echo_sent=_fall_seen.get("echo_sent", ""),
+        echo_got=_fall_seen.get("echo_got", ""),
+        echo_error=_fall_seen.get("echo_error", ""),
         name_form_ok=(None if "name_form_ok" not in _fall_seen
                       else bool(_fall_seen.get("name_form_ok"))),
         name_form_error=_fall_seen.get("name_form_error", ""),

--- a/e2e/conformance/probes.py
+++ b/e2e/conformance/probes.py
@@ -504,6 +504,7 @@ class FallThroughClaim:
     unrecognised_error: str = ""
     echo_sent: str = ""
     echo_got: str = ""
+    echo_error: str = ""
     # None means the surface does not offer a name form to grade (the warehouse
     # leg asserts in Go and has no catalog-name analogue of this). True/False
     # are graded; absence is not silently treated as a pass.
@@ -577,7 +578,16 @@ def fall_through(
             f"({claim.recognised_error[:160]}) — with nothing intercepting, "
             "fall-through proves nothing")
     if claim.echo_sent:
-        if claim.echo_got != claim.echo_sent:
+        # THE ECHO IS PRIMARY where it exists, because it does not depend on the
+        # engine staying incapable. See the note beside it in live.py: pysail
+        # 0.7.1 learned to plan the unrecognised statement, and the contrast
+        # below then read an honest success as a rewrite.
+        if claim.echo_error:
+            problems.append(
+                "the echo statement itself failed "
+                f"({claim.echo_error[:160]}), so the witness is absent rather "
+                "than clean and fall-through is unproven either way")
+        elif claim.echo_got != claim.echo_sent:
             problems.append(
                 "the engine echoed back text the session did not send — "
                 f"sent {claim.echo_sent!r}, got {claim.echo_got!r}; something "
@@ -589,9 +599,17 @@ def fall_through(
                 f"({claim.unrecognised_error[:160]}); with nothing to contrast, "
                 "a pass on the default engine cannot be read as fall-through")
     elif claim.unrecognised_ok:
+        # THE PREMISE IS PART OF THE CLAIM. This branch used to assert a
+        # rewrite outright, and that inference is only as good as "this engine
+        # cannot plan it" -- which an engine release can falsify without
+        # touching this repository, and pysail 0.7.1 did. Naming both causes
+        # costs nothing and stops a capability gain being reported as a defect
+        # in the emulator.
         problems.append(
-            "the unrecognised statement SUCCEEDED on the default engine, which "
-            "this engine cannot plan — so something rewrote it")
+            "the unrecognised statement SUCCEEDED on the default engine. "
+            "Either something rewrote it, or this engine can now plan it and "
+            "this probe's premise is stale — the echo witness tells those "
+            "apart and is absent on this surface, so neither can be ruled out")
     else:
         low = claim.unrecognised_error.lower()
         hit = [m for m in _INTERCEPTOR_MARKERS if m in low]

--- a/python/tests/test_conformance_kit.py
+++ b/python/tests/test_conformance_kit.py
@@ -647,6 +647,44 @@ def test_fall_through_fails_when_the_default_engine_ran_what_it_cannot_plan():
         backend="sail", control=False)
     assert r.status == "fail"
     assert "something rewrote it" in r.error
+    # AND it must not assert that as the only cause. pysail 0.7.1 learned to
+    # plan the statement 0.7.0 refused, which turned an honest success into a
+    # reported rewrite; the premise is part of the claim and has to be named.
+    assert "premise is stale" in r.error
+
+
+def test_a_clean_echo_proves_fall_through_without_the_capability_contrast():
+    """The echo does not go stale when the engine gains a capability.
+
+    unrecognised_ok=True here is the pysail 0.7.1 case: the statement the probe
+    assumes cannot be planned now plans. With the echo clean that is a
+    capability gain and NOT a rewrite, and the contract still holds."""
+    sent = "OPTIMIZE delta.`/tmp/t`"
+    r = probes.fall_through(
+        session=lambda: _ft(unrecognised_ok=True, unrecognised_error="",
+                            echo_sent=sent, echo_got=sent),
+        backend="sail", control=False)
+    assert r.status == "pass"
+
+
+def test_a_mangled_echo_is_a_rewrite_whatever_the_engine_can_plan():
+    sent = "OPTIMIZE delta.`/tmp/t`"
+    r = probes.fall_through(
+        session=lambda: _ft(echo_sent=sent, echo_got="OPTIMIZE delta.'/tmp/t'"),
+        backend="sail", control=False)
+    assert r.status == "fail"
+    assert "echoed back text the session did not send" in r.error
+
+
+def test_an_echo_that_did_not_run_is_absent_rather_than_clean():
+    """The dangerous shape: echo_got == echo_sent == "" would compare equal and
+    read as proof. A failed echo has to say so."""
+    r = probes.fall_through(
+        session=lambda: _ft(echo_sent="OPTIMIZE delta.`/tmp/t`", echo_got="",
+                            echo_error="connection reset"),
+        backend="sail", control=False)
+    assert r.status == "fail"
+    assert "witness is absent" in r.error
 
 
 def test_fall_through_control_engine_must_run_the_statement():


### PR DESCRIPTION
Dependabot [#424](https://github.com/calvinchengx/fabric-emulator/pull/424) turned contract 6 red on `sail` — and **the emulator was not at fault.**

The probe proves fall-through by **contrast**: it sends a statement the engine cannot plan and requires it to fail. `pysail` 0.7.1 learned to plan `MERGE … WHEN MATCHED THEN DELETE`, so the statement succeeded honestly and the probe reported *"so something rewrote it"*.

### Measured against a bare Sail — no emulator, no agent

| pysail | `MERGE … WHEN MATCHED THEN DELETE` |
|---|---|
| 0.7.0 | fails — `attribute ObjectName([Identifier("#0")]) is missing from the schema` |
| 0.7.1 | **succeeds** |

Upstream agrees: v0.7.1 ships *"improved semantics for Delta MERGE"* and *"corrected deletion semantics"*. The inference was only ever as good as its premise, and an engine release can falsify that without touching this repository.

### The echo

The docstring already described this witness for the warehouse — and **nothing populated it**: `echo_sent` and `echo_got` were declared and dead, the branch unreachable.

The session now sends a string literal containing the exact construct the rewriter recognises and compares what comes back. A rewriter that tokenises the statement text changes those bytes; one that stays out of the way cannot. **It does not depend on the engine staying incapable, so it does not rot.**

Where the echo exists it is **primary**: a clean echo with a now-plannable statement is a capability gain, not a defect. An echo that *failed* is reported as **absent rather than clean** — `"" == ""` would otherwise compare equal and read as proof.

### The guard

The contrast branch that remains now names **both** causes instead of asserting the rewrite. A stale premise and a real rewrite look identical from a success; only the echo tells them apart, and the message says so when it is missing.

### Verified

- the literal round-trips verbatim on a real Sail
- three new unit tests: clean echo, mangled echo, failed echo
- the existing "ran what it cannot plan" test now also asserts the premise is named — it was passing on a substring of the old message
- 1690 python tests, `make check`, `make lint` all green

Once this lands, #424 should be re-run: the bump itself is fine.
