### PR TITLE
Contract 8's expectations get a source that is not our own typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,6 +572,7 @@ jobs:
       # right, the cast of services had drifted. Nothing about adding a service
       # reminds anyone to redraw, so the roster is asserted instead.
       - run: uv run --frozen --no-sync python scripts/check_arch_services.py
+      - run: uv run --frozen --group adls-sdk python scripts/check_refusal_expectations.py
       - run: uv run --frozen --no-sync python scripts/check_endpoint_env_names.py
       - run: uv run --frozen --no-sync python scripts/check_mlflow_unpublished.py
       - run: uv run --frozen --no-sync python scripts/check_image_digests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,7 +572,7 @@ jobs:
       # right, the cast of services had drifted. Nothing about adding a service
       # reminds anyone to redraw, so the roster is asserted instead.
       - run: uv run --frozen --no-sync python scripts/check_arch_services.py
-      - run: uv run --frozen --group adls-sdk python scripts/check_refusal_expectations.py
+      - run: uv run --frozen --no-sync python scripts/check_refusal_expectations.py
       - run: uv run --frozen --no-sync python scripts/check_endpoint_env_names.py
       - run: uv run --frozen --no-sync python scripts/check_mlflow_unpublished.py
       - run: uv run --frozen --no-sync python scripts/check_image_digests.py

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_example_portability.py
 	@$(PY) scripts/check_conformance.py --strict
 	@$(PY) scripts/check_arch_services.py
+	@uv run --frozen --group adls-sdk python scripts/check_refusal_expectations.py
 	@$(PY) scripts/check_endpoint_env_names.py
 	@$(PY) scripts/check_mlflow_unpublished.py
 	@$(PY) scripts/check_fabric_activity_types.py

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_example_portability.py
 	@$(PY) scripts/check_conformance.py --strict
 	@$(PY) scripts/check_arch_services.py
-	@uv run --frozen --group adls-sdk python scripts/check_refusal_expectations.py
+	@$(PY) scripts/check_refusal_expectations.py
 	@$(PY) scripts/check_endpoint_env_names.py
 	@$(PY) scripts/check_mlflow_unpublished.py
 	@$(PY) scripts/check_fabric_activity_types.py

--- a/python/tests/test_check_refusal_expectations.py
+++ b/python/tests/test_check_refusal_expectations.py
@@ -1,0 +1,131 @@
+"""The second-source check, exercised — including its own failure modes.
+
+Contract 8's expectations are a transcription of somebody else's contract, and
+this guard holds them against sources outside the repository so a stale one
+cannot pass quietly. A guard against silent staleness that is itself untested
+is the same defect one level up, which is why the coverage gate refused the
+first version of this script: 70 statements, none of them executed.
+
+What matters here is not that it passes on the tree as it stands — that is one
+data point and it would keep saying so after the logic rotted. It is that each
+disagreement it claims to catch actually makes it fail.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+import check_refusal_expectations as c  # noqa: E402
+
+ENUM = '''
+class StorageErrorCode(str, Enum):
+    directory_not_empty = "DirectoryNotEmpty"
+    blob_not_found = "BlobNotFound"
+'''
+
+
+def _live(tmp_path, mapping):
+    p = tmp_path / "live.py"
+    body = ",\n".join(f'    {k!r}: {v!r}' for k, v in mapping.items())
+    p.write_text(f"REFUSAL_EXPECTATIONS = {{\n{body}\n}}\n", encoding="utf-8")
+    return p
+
+
+def _vendored(tmp_path, text=ENUM):
+    p = tmp_path / "models.py"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    """Point the module at fixtures rather than the repository's own files."""
+    def _go(mapping, enum=ENUM):
+        monkeypatch.setattr(c, "LIVE", _live(tmp_path, mapping))
+        monkeypatch.setattr(c, "VENDORED", _vendored(tmp_path, enum))
+    return _go
+
+
+def test_it_passes_when_both_sources_agree(wired, capsys):
+    wired({"dfs-delete-non-empty-directory": "409 DirectoryNotEmpty",
+           "rm-non-empty-without-recurse": c.posix_rmdir_errno()})
+    assert c.main() == 0
+
+
+def test_a_code_microsoft_does_not_define_fails(wired, capsys):
+    """The staleness this exists for: a renamed or retired code."""
+    wired({"dfs-delete-non-empty-directory": "409 DirectoryWasNotEmpty"})
+    assert c.main() == 1
+    assert "not among the" in capsys.readouterr().err
+
+
+def test_an_errno_cpython_does_not_raise_fails(wired, capsys):
+    wired({"rm-non-empty-without-recurse": "OSError/EACCES"})
+    assert c.main() == 1
+    assert "CPython raises" in capsys.readouterr().err
+
+
+def test_a_case_with_no_declared_source_fails(wired, capsys):
+    """A new case must be corroborated or declared, never silently graded."""
+    wired({"something-new": "409 Whatever"})
+    assert c.main() == 1
+    assert "no source declared" in capsys.readouterr().err
+
+
+def test_a_declared_single_source_is_allowed_through(wired):
+    wired({"mv-onto-existing-without-overwrite": "FileExistsError"})
+    assert c.main() == 0
+
+
+def test_a_second_source_that_lost_the_enum_is_not_silently_empty(wired, capsys):
+    """If the vendored file stops carrying StorageErrorCode, the check must say
+    so — an empty code set would otherwise make every expectation unverifiable
+    while still reporting a comparison."""
+    wired({"dfs-delete-non-empty-directory": "409 DirectoryNotEmpty"},
+          enum="class RenamedAway(str, Enum):\n    x = 'y'\n")
+    assert c.main() == 1
+    assert "no codes parsed" in capsys.readouterr().err
+
+
+def test_a_missing_second_source_is_refused_rather_than_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(c, "LIVE", _live(
+        tmp_path, {"dfs-delete-non-empty-directory": "409 DirectoryNotEmpty"}))
+    monkeypatch.setattr(c, "VENDORED", tmp_path / "absent.py")
+    with pytest.raises(SystemExit):
+        c.main()
+
+
+def test_cpython_really_refuses_a_non_empty_directory():
+    """The corroboration itself, asserted: if this ever returns "no error" the
+    POSIX check silently compares against nothing."""
+    got = c.posix_rmdir_errno()
+    assert got.startswith("OSError/"), got
+    assert got != "no error"
+
+
+def test_the_expectations_parse_from_the_real_file():
+    """The ast path against the tree's own live.py, not a fixture."""
+    exp = c.expectations()
+    assert exp, "REFUSAL_EXPECTATIONS parsed empty from the real live.py"
+    assert "dfs-delete-non-empty-directory" in exp
+
+
+def test_a_live_file_without_the_map_is_refused(tmp_path, monkeypatch):
+    """Parsing rather than importing means the name can simply be absent — and
+    that has to be loud, not an empty dict that grades nothing."""
+    p = tmp_path / "live.py"
+    p.write_text("SOMETHING_ELSE = {}\n", encoding="utf-8")
+    monkeypatch.setattr(c, "LIVE", p)
+    with pytest.raises(SystemExit):
+        c.expectations()
+
+
+def test_the_posix_corroboration_is_skipped_not_faked_off_posix(wired, monkeypatch, capsys):
+    """On Windows the errno differs, so the check reports the corroboration as
+    SKIPPED. It must not quietly pass as though CPython had agreed."""
+    wired({"rm-non-empty-without-recurse": "OSError/ENOTEMPTY"})
+    monkeypatch.setattr(c.os, "name", "nt")
+    assert c.main() == 0
+    assert "corroboration skipped" in capsys.readouterr().out

--- a/python/tests/test_check_refusal_expectations.py
+++ b/python/tests/test_check_refusal_expectations.py
@@ -49,7 +49,7 @@ def wired(tmp_path, monkeypatch):
 
 
 def test_it_passes_when_both_sources_agree(wired, monkeypatch, capsys):
-    monkeypatch.setattr(c.os, "name", "posix")
+    monkeypatch.setattr(c, "POSIX", True)
     wired({"dfs-delete-non-empty-directory": "409 DirectoryNotEmpty",
            "rm-non-empty-without-recurse": c.posix_rmdir_errno()})
     assert c.main() == 0
@@ -66,10 +66,14 @@ def test_an_errno_cpython_does_not_raise_fails(wired, monkeypatch, capsys):
     """Forced onto the POSIX path so the comparison is exercised everywhere.
 
     `main()` SKIPS this corroboration off POSIX, which is deliberate — the
-    errno differs on Windows. Without the monkeypatch this test asserted a
-    failure the Windows runner never produced, and it passed on two platforms
-    of three while proving nothing on the third."""
-    monkeypatch.setattr(c.os, "name", "posix")
+    errno differs on Windows. Without forcing it this test asserted a failure
+    the Windows runner never produced, and it passed on two platforms of three
+    while proving nothing on the third.
+
+    Forced through the module's own flag, NOT by patching `os.name`: pathlib
+    reads that to choose PosixPath over WindowsPath, and patching it made every
+    `Path()` on the Windows runner raise NotImplementedError."""
+    monkeypatch.setattr(c, "POSIX", True)
     wired({"rm-non-empty-without-recurse": "OSError/EACCES"})
     assert c.main() == 1
     assert "CPython raises" in capsys.readouterr().err
@@ -134,6 +138,6 @@ def test_the_posix_corroboration_is_skipped_not_faked_off_posix(wired, monkeypat
     """On Windows the errno differs, so the check reports the corroboration as
     SKIPPED. It must not quietly pass as though CPython had agreed."""
     wired({"rm-non-empty-without-recurse": "OSError/ENOTEMPTY"})
-    monkeypatch.setattr(c.os, "name", "nt")
+    monkeypatch.setattr(c, "POSIX", False)
     assert c.main() == 0
     assert "corroboration skipped" in capsys.readouterr().out

--- a/python/tests/test_check_refusal_expectations.py
+++ b/python/tests/test_check_refusal_expectations.py
@@ -48,7 +48,8 @@ def wired(tmp_path, monkeypatch):
     return _go
 
 
-def test_it_passes_when_both_sources_agree(wired, capsys):
+def test_it_passes_when_both_sources_agree(wired, monkeypatch, capsys):
+    monkeypatch.setattr(c.os, "name", "posix")
     wired({"dfs-delete-non-empty-directory": "409 DirectoryNotEmpty",
            "rm-non-empty-without-recurse": c.posix_rmdir_errno()})
     assert c.main() == 0
@@ -61,7 +62,14 @@ def test_a_code_microsoft_does_not_define_fails(wired, capsys):
     assert "not among the" in capsys.readouterr().err
 
 
-def test_an_errno_cpython_does_not_raise_fails(wired, capsys):
+def test_an_errno_cpython_does_not_raise_fails(wired, monkeypatch, capsys):
+    """Forced onto the POSIX path so the comparison is exercised everywhere.
+
+    `main()` SKIPS this corroboration off POSIX, which is deliberate — the
+    errno differs on Windows. Without the monkeypatch this test asserted a
+    failure the Windows runner never produced, and it passed on two platforms
+    of three while proving nothing on the third."""
+    monkeypatch.setattr(c.os, "name", "posix")
     wired({"rm-non-empty-without-recurse": "OSError/EACCES"})
     assert c.main() == 1
     assert "CPython raises" in capsys.readouterr().err

--- a/scripts/check_refusal_expectations.py
+++ b/scripts/check_refusal_expectations.py
@@ -19,8 +19,12 @@ gaps. The same move is available here and costs no new dependency.
 WHAT BACKS EACH CASE, and the honest answer differs per case:
 
   * the ADLS Gen2 wire code is enumerated by Microsoft's own SDK.
-    `azure.storage.blob.StorageErrorCode` carries 165 codes including
-    `DirectoryNotEmpty`, and it is ALREADY a dependency of this repository.
+    `StorageErrorCode` carries 165 codes including `DirectoryNotEmpty`. It is
+    read from `third_party/azure-storage-error-codes/` rather than imported:
+    every guard here runs under $(PY), which is standard library only, and the
+    first CI job without uv on PATH failed on this check rather than on what it
+    checks. Vendoring is also what makes the pin auditable -- PROVENANCE.md
+    carries the version and the hash of the bytes parsed.
     Azurite would have been the better witness -- it is Microsoft's storage
     implementation -- but it serves Blob/Queue/Table and NOT ADLS Gen2, which
     e2e/azurite-shortcut's own compose says in its header. A DFS-specific
@@ -49,6 +53,7 @@ import tempfile
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 LIVE = ROOT / "e2e" / "conformance" / "live.py"
+VENDORED = ROOT / "third_party" / "azure-storage-error-codes" / "models.py"
 
 # Cases whose expectation this check cannot corroborate, WITH THE REASON. An
 # entry here is a decision someone wrote down, not a gap nobody saw.
@@ -77,6 +82,30 @@ def expectations() -> dict[str, str]:
     raise SystemExit(f"REFUSAL_EXPECTATIONS not found in {LIVE}")
 
 
+def storage_error_codes() -> set[str]:
+    """The codes Microsoft enumerates, parsed from the vendored SDK file.
+
+    `ast` rather than `import`: see the module docstring and PROVENANCE.md.
+    The enum is `class StorageErrorCode(str, Enum)` with `NAME = "Value"`
+    members, and it is the VALUES that go on the wire.
+    """
+    if not VENDORED.is_file():
+        raise SystemExit(
+            f"{VENDORED} is missing — contract 8's second source is vendored, "
+            "not installed; see its PROVENANCE.md")
+    tree = ast.parse(VENDORED.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "StorageErrorCode":
+            return {
+                stmt.value.value
+                for stmt in node.body
+                if isinstance(stmt, ast.Assign)
+                and isinstance(stmt.value, ast.Constant)
+                and isinstance(stmt.value.value, str)
+            }
+    return set()
+
+
 def posix_rmdir_errno() -> str:
     """What CPython ACTUALLY raises removing a non-empty directory."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -97,13 +126,13 @@ def main() -> int:
     # 1. The wire code, against Microsoft's enumeration.
     wire = "dfs-delete-non-empty-directory"
     if wire in exp:
-        try:
-            from azure.storage.blob import StorageErrorCode
-        except ImportError as exc:
-            problems.append(f"{wire}: the second source is unavailable ({exc}); "
-                            "the expectation is unchecked rather than confirmed")
+        codes = storage_error_codes()
+        if not codes:
+            problems.append(
+                f"{wire}: no codes parsed from {VENDORED.name} — the second "
+                "source is unreadable, so the expectation is unchecked rather "
+                "than confirmed")
         else:
-            codes = {c.value for c in StorageErrorCode}
             code = exp[wire].split()[-1]
             if code not in codes:
                 problems.append(

--- a/scripts/check_refusal_expectations.py
+++ b/scripts/check_refusal_expectations.py
@@ -55,6 +55,15 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 LIVE = ROOT / "e2e" / "conformance" / "live.py"
 VENDORED = ROOT / "third_party" / "azure-storage-error-codes" / "models.py"
 
+# Whether the CPython corroboration applies, as a module-level flag rather than
+# a bare `os.name` check at the point of use. A test needs to force this branch
+# on every runner -- the comparison is the thing worth exercising -- and
+# patching `os.name` to do it is a trap: pathlib reads `os.name` to decide
+# between PosixPath and WindowsPath, so forcing it made every `Path()` on the
+# Windows runner raise `NotImplementedError: cannot instantiate 'PosixPath'`.
+# One name owned by this module has no such reach.
+POSIX = os.name == "posix"
+
 # Cases whose expectation this check cannot corroborate, WITH THE REASON. An
 # entry here is a decision someone wrote down, not a gap nobody saw.
 SINGLE_SOURCED = {
@@ -146,7 +155,7 @@ def main() -> int:
     # 2. The errno, against CPython.
     rm = "rm-non-empty-without-recurse"
     if rm in exp:
-        if os.name != "posix":
+        if not POSIX:
             notes.append(f"{rm}: POSIX corroboration skipped on {os.name}")
         else:
             got = posix_rmdir_errno()

--- a/scripts/check_refusal_expectations.py
+++ b/scripts/check_refusal_expectations.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Contract 8's expectations, held against a source that is not our own typing.
+
+WHY THIS EXISTS. Contract 8 grades the emulator against `REFUSAL_EXPECTATIONS`
+-- the error a caller must be able to branch on when an operation is refused.
+That map is a hand transcription of somebody else's contract, and it is the
+only copy. A transcription with one source cannot be wrong out loud: if
+Microsoft renames a code or drops a refusal, the map keeps asserting the old
+one and the probe keeps passing. **Its failure direction is a false GREEN**,
+which is the one nobody notices -- and contract 8 exists precisely to catch the
+permissive direction, so a stale expectation blinds the probe built to see.
+
+This is contract 2's shape applied to contract 8. There, `notebookutils`
+members are transcribed from Learn AND checked against the `dummy-notebookutils`
+wheel Microsoft publishes, with the divergence COMPUTED rather than declared;
+holding two sources together turned "we transcribed carefully" into 15 real
+gaps. The same move is available here and costs no new dependency.
+
+WHAT BACKS EACH CASE, and the honest answer differs per case:
+
+  * the ADLS Gen2 wire code is enumerated by Microsoft's own SDK.
+    `azure.storage.blob.StorageErrorCode` carries 165 codes including
+    `DirectoryNotEmpty`, and it is ALREADY a dependency of this repository.
+    Azurite would have been the better witness -- it is Microsoft's storage
+    implementation -- but it serves Blob/Queue/Table and NOT ADLS Gen2, which
+    e2e/azurite-shortcut's own compose says in its header. A DFS-specific
+    refusal is exactly what it cannot answer.
+
+  * the POSIX errno is enumerated by CPython, by running the operation.
+    `fs.rm`'s docstring says the mapping to `os.rmdir`'s errno is the point, so
+    the standard library is the authority for what that errno IS.
+
+  * and one case has NO second source, which is stated rather than papered
+    over. See SINGLE_SOURCED.
+
+A NEW CASE WITH NO DECLARED SOURCE IS A FAILURE, not an omission -- the same
+rule contract 8 applies to its own cases. Otherwise this check silently grades
+whatever happened to be listed when it was written.
+
+Usage:
+    check_refusal_expectations.py     exit non-zero if a case disagrees or is unaccounted for
+"""
+import ast
+import errno
+import os
+import pathlib
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+LIVE = ROOT / "e2e" / "conformance" / "live.py"
+
+# Cases whose expectation this check cannot corroborate, WITH THE REASON. An
+# entry here is a decision someone wrote down, not a gap nobody saw.
+SINGLE_SOURCED = {
+    "mv-onto-existing-without-overwrite":
+        "no independent source. POSIX `os.rename` REPLACES the destination "
+        "silently, so CPython contradicts this expectation rather than "
+        "corroborating it -- refusing here is the shim's own contract, matching "
+        "what notebookutils does rather than what the C library does. "
+        "Microsoft's stub wheel cannot help either: its bodies are empty, so it "
+        "enumerates the surface and never the behaviour.",
+}
+
+
+def expectations() -> dict[str, str]:
+    """REFUSAL_EXPECTATIONS, parsed rather than imported.
+
+    live.py imports pyspark and carries module-level session state; importing
+    it to read one dict would make this check depend on a Spark install.
+    """
+    tree = ast.parse(LIVE.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+                getattr(t, "id", "") == "REFUSAL_EXPECTATIONS" for t in node.targets):
+            return ast.literal_eval(node.value)
+    raise SystemExit(f"REFUSAL_EXPECTATIONS not found in {LIVE}")
+
+
+def posix_rmdir_errno() -> str:
+    """What CPython ACTUALLY raises removing a non-empty directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        d = pathlib.Path(tmp) / "full"
+        d.mkdir()
+        (d / "child").write_text("x", encoding="utf-8")
+        try:
+            os.rmdir(d)
+        except OSError as exc:
+            return f"{type(exc).__name__}/{errno.errorcode.get(exc.errno, exc.errno)}"
+    return "no error"
+
+
+def main() -> int:
+    exp = expectations()
+    problems, notes = [], []
+
+    # 1. The wire code, against Microsoft's enumeration.
+    wire = "dfs-delete-non-empty-directory"
+    if wire in exp:
+        try:
+            from azure.storage.blob import StorageErrorCode
+        except ImportError as exc:
+            problems.append(f"{wire}: the second source is unavailable ({exc}); "
+                            "the expectation is unchecked rather than confirmed")
+        else:
+            codes = {c.value for c in StorageErrorCode}
+            code = exp[wire].split()[-1]
+            if code not in codes:
+                problems.append(
+                    f"{wire}: expects {code!r}, which is not among the "
+                    f"{len(codes)} codes Microsoft's StorageErrorCode enumerates "
+                    "— either the expectation is stale or the code was renamed")
+            else:
+                notes.append(f"{wire}: {code} confirmed against StorageErrorCode "
+                             f"({len(codes)} codes)")
+
+    # 2. The errno, against CPython.
+    rm = "rm-non-empty-without-recurse"
+    if rm in exp:
+        if os.name != "posix":
+            notes.append(f"{rm}: POSIX corroboration skipped on {os.name}")
+        else:
+            got = posix_rmdir_errno()
+            if got != exp[rm]:
+                problems.append(
+                    f"{rm}: expects {exp[rm]!r} but CPython raises {got!r} "
+                    "removing a non-empty directory")
+            else:
+                notes.append(f"{rm}: {got} confirmed against CPython")
+
+    # 3. Nothing may be unaccounted for.
+    checked = {wire, rm} | set(SINGLE_SOURCED)
+    orphans = sorted(set(exp) - checked)
+    if orphans:
+        problems.append(
+            f"no source declared for {orphans} — add a second source, or record "
+            "it in SINGLE_SOURCED with the reason. A case nobody corroborates "
+            "and nobody flags is the shape this check exists to prevent")
+
+    for n in notes:
+        print(f"  {n}")
+    for name, why in sorted(SINGLE_SOURCED.items()):
+        if name in exp:
+            print(f"  {name}: SINGLE SOURCED — {why[:80]}…")
+    if problems:
+        print("check_refusal_expectations: " + "\n  ".join(["", *problems]),
+              file=sys.stderr)
+        return 1
+    print(f"check_refusal_expectations: {len(exp)} expectations, "
+          f"{len(exp) - len([s for s in SINGLE_SOURCED if s in exp])} corroborated "
+          "by a source outside this repository")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/azure-storage-error-codes/LICENSE
+++ b/third_party/azure-storage-error-codes/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/azure-storage-error-codes/PROVENANCE.md
+++ b/third_party/azure-storage-error-codes/PROVENANCE.md
@@ -1,0 +1,54 @@
+# `StorageErrorCode` — Microsoft's own enumeration of storage error codes
+
+Second source for **contract 8** (*refusal fidelity*) in
+[docs/38](../../docs/38-framework-conformance.md): the code a caller branches on
+when an operation is refused. Vendored so the check can read it with the standard
+library alone, the way every other guard in `scripts/` runs.
+
+| Field | Value |
+|---|---|
+| **Upstream** | `azure-storage-blob` on PyPI — https://pypi.org/project/azure-storage-blob/ |
+| **Pinned revision** | `12.30.1` |
+| **Retrieved** | 2026-09-01 |
+| **Path in wheel** | `azure/storage/blob/_shared/models.py` |
+| **License** | MIT — Microsoft Corporation. Text in [`LICENSE`](LICENSE) |
+| **Used by** | `scripts/check_refusal_expectations.py`, which holds `REFUSAL_EXPECTATIONS` against the codes this file enumerates |
+| **Refresh** | re-copy `_shared/models.py` from the pinned wheel and update the hash below |
+
+## Why this file rather than the installed package
+
+The guards in this repository run under `$(PY)`, which is
+`uv run --frozen --no-sync python` or a bare interpreter — **standard library
+only**. Importing `azure.storage.blob` to read one enum would make an offline
+invariant depend on a synced environment, and the first CI job without `uv` on
+PATH would fail on the guard rather than on the thing it guards. That is exactly
+what happened when this check was first written to import the SDK.
+
+So the file is vendored and parsed with `ast`, which is also what makes the
+pin auditable: the hash below says which bytes were read.
+
+## Why an SDK file is the right oracle, and what it is not
+
+`StorageErrorCode` is Microsoft stating, in a machine-readable form, the set of
+codes its storage services return — 165 of them, including `DirectoryNotEmpty`.
+Our expectations are a hand transcription of the same contract, and a
+transcription with one source cannot be wrong out loud.
+
+**It enumerates codes; it does not say which operation returns which.** That
+mapping stays ours, and stays graded by the live probe. This pin answers a
+narrower question — *is this code one Microsoft actually defines* — which is the
+half that goes stale silently when a code is renamed or retired.
+
+**Azurite would have been the better witness** and cannot serve: it implements
+Blob/Queue/Table and **not** ADLS Gen2, as `e2e/azurite-shortcut/docker-compose.yml`
+states in its own header, so a DFS-specific refusal is precisely what it cannot
+answer.
+
+## Integrity
+
+<!-- integrity:begin -->
+| File | sha256 | Bytes |
+|---|---|---|
+| `LICENSE` | `fd532481d828e13a0b13ccb598e02338a3617740675a862ee6bdc1541b68e93d` | 1073 |
+| `models.py` | `98f0266a18ee41cdc58281682e3c357a5d9e61a1ce782662bdc8153c0157a898` | 26101 |
+<!-- integrity:end -->

--- a/third_party/azure-storage-error-codes/models.py
+++ b/third_party/azure-storage-error-codes/models.py
@@ -1,0 +1,599 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+# pylint: disable=too-many-instance-attributes
+from enum import Enum
+from typing import Optional
+
+from azure.core import CaseInsensitiveEnumMeta
+from azure.core.configuration import Configuration
+from azure.core.pipeline.policies import UserAgentPolicy
+
+
+def get_enum_value(value):
+    if value is None or value in ["None", ""]:
+        return None
+    try:
+        return value.value
+    except AttributeError:
+        return value
+
+
+class StorageErrorCode(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """Error codes returned by the service."""
+
+    # Generic storage values
+    ACCOUNT_ALREADY_EXISTS = "AccountAlreadyExists"
+    ACCOUNT_BEING_CREATED = "AccountBeingCreated"
+    ACCOUNT_IS_DISABLED = "AccountIsDisabled"
+    AUTHENTICATION_FAILED = "AuthenticationFailed"
+    AUTHORIZATION_FAILURE = "AuthorizationFailure"
+    NO_AUTHENTICATION_INFORMATION = "NoAuthenticationInformation"
+    CONDITION_HEADERS_NOT_SUPPORTED = "ConditionHeadersNotSupported"
+    CONDITION_NOT_MET = "ConditionNotMet"
+    EMPTY_METADATA_KEY = "EmptyMetadataKey"
+    INSUFFICIENT_ACCOUNT_PERMISSIONS = "InsufficientAccountPermissions"
+    INTERNAL_ERROR = "InternalError"
+    INVALID_AUTHENTICATION_INFO = "InvalidAuthenticationInfo"
+    INVALID_HEADER_VALUE = "InvalidHeaderValue"
+    INVALID_HTTP_VERB = "InvalidHttpVerb"
+    INVALID_INPUT = "InvalidInput"
+    INVALID_MD5 = "InvalidMd5"
+    INVALID_METADATA = "InvalidMetadata"
+    INVALID_QUERY_PARAMETER_VALUE = "InvalidQueryParameterValue"
+    INVALID_RANGE = "InvalidRange"
+    INVALID_RESOURCE_NAME = "InvalidResourceName"
+    INVALID_URI = "InvalidUri"
+    INVALID_XML_DOCUMENT = "InvalidXmlDocument"
+    INVALID_XML_NODE_VALUE = "InvalidXmlNodeValue"
+    MD5_MISMATCH = "Md5Mismatch"
+    METADATA_TOO_LARGE = "MetadataTooLarge"
+    MISSING_CONTENT_LENGTH_HEADER = "MissingContentLengthHeader"
+    MISSING_REQUIRED_QUERY_PARAMETER = "MissingRequiredQueryParameter"
+    MISSING_REQUIRED_HEADER = "MissingRequiredHeader"
+    MISSING_REQUIRED_XML_NODE = "MissingRequiredXmlNode"
+    MULTIPLE_CONDITION_HEADERS_NOT_SUPPORTED = "MultipleConditionHeadersNotSupported"
+    OPERATION_TIMED_OUT = "OperationTimedOut"
+    OUT_OF_RANGE_INPUT = "OutOfRangeInput"
+    OUT_OF_RANGE_QUERY_PARAMETER_VALUE = "OutOfRangeQueryParameterValue"
+    REQUEST_BODY_TOO_LARGE = "RequestBodyTooLarge"
+    RESOURCE_TYPE_MISMATCH = "ResourceTypeMismatch"
+    REQUEST_URL_FAILED_TO_PARSE = "RequestUrlFailedToParse"
+    RESOURCE_ALREADY_EXISTS = "ResourceAlreadyExists"
+    RESOURCE_NOT_FOUND = "ResourceNotFound"
+    SERVER_BUSY = "ServerBusy"
+    UNSUPPORTED_HEADER = "UnsupportedHeader"
+    UNSUPPORTED_XML_NODE = "UnsupportedXmlNode"
+    UNSUPPORTED_QUERY_PARAMETER = "UnsupportedQueryParameter"
+    UNSUPPORTED_HTTP_VERB = "UnsupportedHttpVerb"
+
+    # Blob values
+    APPEND_POSITION_CONDITION_NOT_MET = "AppendPositionConditionNotMet"
+    BLOB_ACCESS_TIER_NOT_SUPPORTED_FOR_ACCOUNT_TYPE = "BlobAccessTierNotSupportedForAccountType"
+    BLOB_ALREADY_EXISTS = "BlobAlreadyExists"
+    BLOB_NOT_FOUND = "BlobNotFound"
+    BLOB_OVERWRITTEN = "BlobOverwritten"
+    BLOB_TIER_INADEQUATE_FOR_CONTENT_LENGTH = "BlobTierInadequateForContentLength"
+    BLOCK_COUNT_EXCEEDS_LIMIT = "BlockCountExceedsLimit"
+    BLOCK_LIST_TOO_LONG = "BlockListTooLong"
+    CANNOT_CHANGE_TO_LOWER_TIER = "CannotChangeToLowerTier"
+    CANNOT_VERIFY_COPY_SOURCE = "CannotVerifyCopySource"
+    CONTAINER_ALREADY_EXISTS = "ContainerAlreadyExists"
+    CONTAINER_BEING_DELETED = "ContainerBeingDeleted"
+    CONTAINER_DISABLED = "ContainerDisabled"
+    CONTAINER_NOT_FOUND = "ContainerNotFound"
+    CONTENT_LENGTH_LARGER_THAN_TIER_LIMIT = "ContentLengthLargerThanTierLimit"
+    COPY_ACROSS_ACCOUNTS_NOT_SUPPORTED = "CopyAcrossAccountsNotSupported"
+    COPY_ID_MISMATCH = "CopyIdMismatch"
+    FEATURE_VERSION_MISMATCH = "FeatureVersionMismatch"
+    INCREMENTAL_COPY_BLOB_MISMATCH = "IncrementalCopyBlobMismatch"
+    INCREMENTAL_COPY_OF_EARLIER_SNAPSHOT_NOT_ALLOWED = "IncrementalCopyOfEarlierSnapshotNotAllowed"
+    #: Deprecated: Please use INCREMENTAL_COPY_OF_EARLIER_SNAPSHOT_NOT_ALLOWED instead.
+    INCREMENTAL_COPY_OF_EARLIER_VERSION_SNAPSHOT_NOT_ALLOWED = "IncrementalCopyOfEarlierVersionSnapshotNotAllowed"
+    #: Deprecated: Please use INCREMENTAL_COPY_OF_EARLIER_VERSION_SNAPSHOT_NOT_ALLOWED instead.
+    INCREMENTAL_COPY_OF_ERALIER_VERSION_SNAPSHOT_NOT_ALLOWED = "IncrementalCopyOfEarlierVersionSnapshotNotAllowed"
+    INCREMENTAL_COPY_SOURCE_MUST_BE_SNAPSHOT = "IncrementalCopySourceMustBeSnapshot"
+    INFINITE_LEASE_DURATION_REQUIRED = "InfiniteLeaseDurationRequired"
+    INVALID_BLOB_OR_BLOCK = "InvalidBlobOrBlock"
+    INVALID_BLOB_TIER = "InvalidBlobTier"
+    INVALID_BLOB_TYPE = "InvalidBlobType"
+    INVALID_BLOCK_ID = "InvalidBlockId"
+    INVALID_BLOCK_LIST = "InvalidBlockList"
+    INVALID_OPERATION = "InvalidOperation"
+    INVALID_PAGE_RANGE = "InvalidPageRange"
+    INVALID_SOURCE_BLOB_TYPE = "InvalidSourceBlobType"
+    INVALID_SOURCE_BLOB_URL = "InvalidSourceBlobUrl"
+    INVALID_VERSION_FOR_PAGE_BLOB_OPERATION = "InvalidVersionForPageBlobOperation"
+    LEASE_ALREADY_PRESENT = "LeaseAlreadyPresent"
+    LEASE_ALREADY_BROKEN = "LeaseAlreadyBroken"
+    LEASE_ID_MISMATCH_WITH_BLOB_OPERATION = "LeaseIdMismatchWithBlobOperation"
+    LEASE_ID_MISMATCH_WITH_CONTAINER_OPERATION = "LeaseIdMismatchWithContainerOperation"
+    LEASE_ID_MISMATCH_WITH_LEASE_OPERATION = "LeaseIdMismatchWithLeaseOperation"
+    LEASE_ID_MISSING = "LeaseIdMissing"
+    LEASE_IS_BREAKING_AND_CANNOT_BE_ACQUIRED = "LeaseIsBreakingAndCannotBeAcquired"
+    LEASE_IS_BREAKING_AND_CANNOT_BE_CHANGED = "LeaseIsBreakingAndCannotBeChanged"
+    LEASE_IS_BROKEN_AND_CANNOT_BE_RENEWED = "LeaseIsBrokenAndCannotBeRenewed"
+    LEASE_LOST = "LeaseLost"
+    LEASE_NOT_PRESENT_WITH_BLOB_OPERATION = "LeaseNotPresentWithBlobOperation"
+    LEASE_NOT_PRESENT_WITH_CONTAINER_OPERATION = "LeaseNotPresentWithContainerOperation"
+    LEASE_NOT_PRESENT_WITH_LEASE_OPERATION = "LeaseNotPresentWithLeaseOperation"
+    MAX_BLOB_SIZE_CONDITION_NOT_MET = "MaxBlobSizeConditionNotMet"
+    NO_PENDING_COPY_OPERATION = "NoPendingCopyOperation"
+    OPERATION_NOT_ALLOWED_ON_INCREMENTAL_COPY_BLOB = "OperationNotAllowedOnIncrementalCopyBlob"
+    PENDING_COPY_OPERATION = "PendingCopyOperation"
+    PREVIOUS_SNAPSHOT_CANNOT_BE_NEWER = "PreviousSnapshotCannotBeNewer"
+    PREVIOUS_SNAPSHOT_NOT_FOUND = "PreviousSnapshotNotFound"
+    PREVIOUS_SNAPSHOT_OPERATION_NOT_SUPPORTED = "PreviousSnapshotOperationNotSupported"
+    SEQUENCE_NUMBER_CONDITION_NOT_MET = "SequenceNumberConditionNotMet"
+    SEQUENCE_NUMBER_INCREMENT_TOO_LARGE = "SequenceNumberIncrementTooLarge"
+    SNAPSHOT_COUNT_EXCEEDED = "SnapshotCountExceeded"
+    SNAPSHOT_OPERATION_RATE_EXCEEDED = "SnapshotOperationRateExceeded"
+    #: Deprecated: Please use SNAPSHOT_OPERATION_RATE_EXCEEDED instead.
+    SNAPHOT_OPERATION_RATE_EXCEEDED = "SnapshotOperationRateExceeded"
+    SNAPSHOTS_PRESENT = "SnapshotsPresent"
+    SOURCE_CONDITION_NOT_MET = "SourceConditionNotMet"
+    SYSTEM_IN_USE = "SystemInUse"
+    TARGET_CONDITION_NOT_MET = "TargetConditionNotMet"
+    UNAUTHORIZED_BLOB_OVERWRITE = "UnauthorizedBlobOverwrite"
+    BLOB_BEING_REHYDRATED = "BlobBeingRehydrated"
+    BLOB_ARCHIVED = "BlobArchived"
+    BLOB_NOT_ARCHIVED = "BlobNotArchived"
+
+    # Queue values
+    INVALID_MARKER = "InvalidMarker"
+    MESSAGE_NOT_FOUND = "MessageNotFound"
+    MESSAGE_TOO_LARGE = "MessageTooLarge"
+    POP_RECEIPT_MISMATCH = "PopReceiptMismatch"
+    QUEUE_ALREADY_EXISTS = "QueueAlreadyExists"
+    QUEUE_BEING_DELETED = "QueueBeingDeleted"
+    QUEUE_DISABLED = "QueueDisabled"
+    QUEUE_NOT_EMPTY = "QueueNotEmpty"
+    QUEUE_NOT_FOUND = "QueueNotFound"
+
+    # File values
+    CANNOT_DELETE_FILE_OR_DIRECTORY = "CannotDeleteFileOrDirectory"
+    CLIENT_CACHE_FLUSH_DELAY = "ClientCacheFlushDelay"
+    CONTAINER_QUOTA_DOWNGRADE_NOT_ALLOWED = "ContainerQuotaDowngradeNotAllowed"
+    DELETE_PENDING = "DeletePending"
+    DIRECTORY_NOT_EMPTY = "DirectoryNotEmpty"
+    FILE_LOCK_CONFLICT = "FileLockConflict"
+    FILE_SHARE_PROVISIONED_BANDWIDTH_DOWNGRADE_NOT_ALLOWED = "FileShareProvisionedBandwidthDowngradeNotAllowed"
+    FILE_SHARE_PROVISIONED_BANDWIDTH_INVALID = "FileShareProvisionedBandwidthInvalid"
+    FILE_SHARE_PROVISIONED_IOPS_DOWNGRADE_NOT_ALLOWED = "FileShareProvisionedIopsDowngradeNotAllowed"
+    FILE_SHARE_PROVISIONED_IOPS_INVALID = "FileShareProvisionedIopsInvalid"
+    FILE_SHARE_PROVISIONED_STORAGE_INVALID = "FileShareProvisionedStorageInvalid"
+    INVALID_FILE_OR_DIRECTORY_PATH_NAME = "InvalidFileOrDirectoryPathName"
+    PARENT_NOT_FOUND = "ParentNotFound"
+    READ_ONLY_ATTRIBUTE = "ReadOnlyAttribute"
+    SHARE_ALREADY_EXISTS = "ShareAlreadyExists"
+    SHARE_BEING_DELETED = "ShareBeingDeleted"
+    SHARE_DISABLED = "ShareDisabled"
+    SHARE_NOT_FOUND = "ShareNotFound"
+    SHARING_VIOLATION = "SharingViolation"
+    SHARE_SNAPSHOT_IN_PROGRESS = "ShareSnapshotInProgress"
+    SHARE_SNAPSHOT_COUNT_EXCEEDED = "ShareSnapshotCountExceeded"
+    SHARE_SNAPSHOT_NOT_FOUND = "ShareSnapshotNotFound"
+    SHARE_SNAPSHOT_OPERATION_NOT_SUPPORTED = "ShareSnapshotOperationNotSupported"
+    SHARE_HAS_SNAPSHOTS = "ShareHasSnapshots"
+    TOTAL_SHARES_PROVISIONED_CAPACITY_EXCEEDS_ACCOUNT_LIMIT = "TotalSharesProvisionedCapacityExceedsAccountLimit"
+    TOTAL_SHARES_PROVISIONED_IOPS_EXCEEDS_ACCOUNT_LIMIT = "TotalSharesProvisionedIopsExceedsAccountLimit"
+    TOTAL_SHARES_PROVISIONED_BANDWIDTH_EXCEEDS_ACCOUNT_LIMIT = "TotalSharesProvisionedBandwidthExceedsAccountLimit"
+    TOTAL_SHARES_COUNT_EXCEEDS_ACCOUNT_LIMIT = "TotalSharesCountExceedsAccountLimit"
+
+    # DataLake values
+    CONTENT_LENGTH_MUST_BE_ZERO = "ContentLengthMustBeZero"
+    PATH_ALREADY_EXISTS = "PathAlreadyExists"
+    INVALID_FLUSH_POSITION = "InvalidFlushPosition"
+    INVALID_PROPERTY_NAME = "InvalidPropertyName"
+    INVALID_SOURCE_URI = "InvalidSourceUri"
+    UNSUPPORTED_REST_VERSION = "UnsupportedRestVersion"
+    FILE_SYSTEM_NOT_FOUND = "FilesystemNotFound"
+    PATH_NOT_FOUND = "PathNotFound"
+    RENAME_DESTINATION_PARENT_PATH_NOT_FOUND = "RenameDestinationParentPathNotFound"
+    SOURCE_PATH_NOT_FOUND = "SourcePathNotFound"
+    DESTINATION_PATH_IS_BEING_DELETED = "DestinationPathIsBeingDeleted"
+    FILE_SYSTEM_ALREADY_EXISTS = "FilesystemAlreadyExists"
+    FILE_SYSTEM_BEING_DELETED = "FilesystemBeingDeleted"
+    INVALID_DESTINATION_PATH = "InvalidDestinationPath"
+    INVALID_RENAME_SOURCE_PATH = "InvalidRenameSourcePath"
+    INVALID_SOURCE_OR_DESTINATION_RESOURCE_TYPE = "InvalidSourceOrDestinationResourceType"
+    LEASE_IS_ALREADY_BROKEN = "LeaseIsAlreadyBroken"
+    LEASE_NAME_MISMATCH = "LeaseNameMismatch"
+    PATH_CONFLICT = "PathConflict"
+    SOURCE_PATH_IS_BEING_DELETED = "SourcePathIsBeingDeleted"
+
+
+class DictMixin(object):
+
+    def __setitem__(self, key, item):
+        self.__dict__[key] = item
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def __repr__(self):
+        return str(self)
+
+    def __len__(self):
+        return len(self.keys())
+
+    def __delitem__(self, key):
+        self.__dict__[key] = None
+
+    # Compare objects by comparing all attributes.
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    # Compare objects by comparing all attributes.
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __str__(self):
+        return str({k: v for k, v in self.__dict__.items() if not k.startswith("_")})
+
+    def __contains__(self, key):
+        return key in self.__dict__
+
+    def has_key(self, k):
+        return k in self.__dict__
+
+    def update(self, *args, **kwargs):
+        return self.__dict__.update(*args, **kwargs)
+
+    def keys(self):
+        return [k for k in self.__dict__ if not k.startswith("_")]
+
+    def values(self):
+        return [v for k, v in self.__dict__.items() if not k.startswith("_")]
+
+    def items(self):
+        return [(k, v) for k, v in self.__dict__.items() if not k.startswith("_")]
+
+    def get(self, key, default=None):
+        if key in self.__dict__:
+            return self.__dict__[key]
+        return default
+
+
+class LocationMode(object):
+    """
+    Specifies the location the request should be sent to. This mode only applies
+    for RA-GRS accounts which allow secondary read access. All other account types
+    must use PRIMARY.
+    """
+
+    PRIMARY = "primary"  #: Requests should be sent to the primary location.
+    SECONDARY = "secondary"  #: Requests should be sent to the secondary location, if possible.
+
+
+class ResourceTypes(object):
+    """
+    Specifies the resource types that are accessible with the account SAS.
+
+    :param bool service:
+        Access to service-level APIs (e.g., Get/Set Service Properties,
+        Get Service Stats, List Containers/Queues/Shares)
+    :param bool container:
+        Access to container-level APIs (e.g., Create/Delete Container,
+        Create/Delete Queue, Create/Delete Share,
+        List Blobs/Files and Directories)
+    :param bool object:
+        Access to object-level APIs for blobs, queue messages, and
+        files(e.g. Put Blob, Query Entity, Get Messages, Create File, etc.)
+    """
+
+    service: bool = False
+    container: bool = False
+    object: bool = False
+    _str: str
+
+    def __init__(
+        self, service: bool = False, container: bool = False, object: bool = False  # pylint: disable=redefined-builtin
+    ) -> None:
+        self.service = service
+        self.container = container
+        self.object = object
+        self._str = ("s" if self.service else "") + ("c" if self.container else "") + ("o" if self.object else "")
+
+    def __str__(self):
+        return self._str
+
+    @classmethod
+    def from_string(cls, string):
+        """Create a ResourceTypes from a string.
+
+        To specify service, container, or object you need only to
+        include the first letter of the word in the string. E.g. service and container,
+        you would provide a string "sc".
+
+        :param str string: Specify service, container, or object in
+            in the string with the first letter of the word.
+        :return: A ResourceTypes object
+        :rtype: ~azure.storage.blob.ResourceTypes
+        """
+        res_service = "s" in string
+        res_container = "c" in string
+        res_object = "o" in string
+
+        parsed = cls(res_service, res_container, res_object)
+        parsed._str = string
+        return parsed
+
+
+class AccountSasPermissions(object):
+    """
+    :class:`~ResourceTypes` class to be used with generate_account_sas
+    function and for the AccessPolicies used with set_*_acl. There are two types of
+    SAS which may be used to grant resource access. One is to grant access to a
+    specific resource (resource-specific). Another is to grant access to the
+    entire service for a specific account and allow certain operations based on
+    perms found here.
+
+    :param bool read:
+        Valid for all signed resources types (Service, Container, and Object).
+        Permits read permissions to the specified resource type.
+    :param bool write:
+        Valid for all signed resources types (Service, Container, and Object).
+        Permits write permissions to the specified resource type.
+    :param bool delete:
+        Valid for Container and Object resource types, except for queue messages.
+    :param bool delete_previous_version:
+        Delete the previous blob version for the versioning enabled storage account.
+    :param bool list:
+        Valid for Service and Container resource types only.
+    :param bool add:
+        Valid for the following Object resource types only: queue messages, and append blobs.
+    :param bool create:
+        Valid for the following Object resource types only: blobs and files.
+        Users can create new blobs or files, but may not overwrite existing
+        blobs or files.
+    :param bool update:
+        Valid for the following Object resource types only: queue messages.
+    :param bool process:
+        Valid for the following Object resource type only: queue messages.
+    :keyword bool tag:
+        To enable set or get tags on the blobs in the container.
+    :keyword bool filter_by_tags:
+        To enable get blobs by tags, this should be used together with list permission.
+    :keyword bool set_immutability_policy:
+        To enable operations related to set/delete immutability policy.
+        To get immutability policy, you just need read permission.
+    :keyword bool permanent_delete:
+        To enable permanent delete on the blob is permitted.
+        Valid for Object resource type of Blob only.
+    """
+
+    read: bool = False
+    write: bool = False
+    delete: bool = False
+    delete_previous_version: bool = False
+    list: bool = False
+    add: bool = False
+    create: bool = False
+    update: bool = False
+    process: bool = False
+    tag: bool = False
+    filter_by_tags: bool = False
+    set_immutability_policy: bool = False
+    permanent_delete: bool = False
+
+    def __init__(
+        self,
+        read: bool = False,
+        write: bool = False,
+        delete: bool = False,
+        list: bool = False,  # pylint: disable=redefined-builtin
+        add: bool = False,
+        create: bool = False,
+        update: bool = False,
+        process: bool = False,
+        delete_previous_version: bool = False,
+        **kwargs
+    ) -> None:
+        self.read = read
+        self.write = write
+        self.delete = delete
+        self.delete_previous_version = delete_previous_version
+        self.permanent_delete = kwargs.pop("permanent_delete", False)
+        self.list = list
+        self.add = add
+        self.create = create
+        self.update = update
+        self.process = process
+        self.tag = kwargs.pop("tag", False)
+        self.filter_by_tags = kwargs.pop("filter_by_tags", False)
+        self.set_immutability_policy = kwargs.pop("set_immutability_policy", False)
+        self._str = (
+            ("r" if self.read else "")
+            + ("w" if self.write else "")
+            + ("d" if self.delete else "")
+            + ("x" if self.delete_previous_version else "")
+            + ("y" if self.permanent_delete else "")
+            + ("l" if self.list else "")
+            + ("a" if self.add else "")
+            + ("c" if self.create else "")
+            + ("u" if self.update else "")
+            + ("p" if self.process else "")
+            + ("f" if self.filter_by_tags else "")
+            + ("t" if self.tag else "")
+            + ("i" if self.set_immutability_policy else "")
+        )
+
+    def __str__(self):
+        return self._str
+
+    @classmethod
+    def from_string(cls, permission):
+        """Create AccountSasPermissions from a string.
+
+        To specify read, write, delete, etc. permissions you need only to
+        include the first letter of the word in the string. E.g. for read and write
+        permissions you would provide a string "rw".
+
+        :param str permission: Specify permissions in
+            the string with the first letter of the word.
+        :return: An AccountSasPermissions object
+        :rtype: ~azure.storage.blob.AccountSasPermissions
+        """
+        p_read = "r" in permission
+        p_write = "w" in permission
+        p_delete = "d" in permission
+        p_delete_previous_version = "x" in permission
+        p_permanent_delete = "y" in permission
+        p_list = "l" in permission
+        p_add = "a" in permission
+        p_create = "c" in permission
+        p_update = "u" in permission
+        p_process = "p" in permission
+        p_tag = "t" in permission
+        p_filter_by_tags = "f" in permission
+        p_set_immutability_policy = "i" in permission
+        parsed = cls(
+            read=p_read,
+            write=p_write,
+            delete=p_delete,
+            delete_previous_version=p_delete_previous_version,
+            list=p_list,
+            add=p_add,
+            create=p_create,
+            update=p_update,
+            process=p_process,
+            tag=p_tag,
+            filter_by_tags=p_filter_by_tags,
+            set_immutability_policy=p_set_immutability_policy,
+            permanent_delete=p_permanent_delete,
+        )
+
+        return parsed
+
+
+class Services(object):
+    """Specifies the services accessible with the account SAS.
+
+    :keyword bool blob:
+        Access for the `~azure.storage.blob.BlobServiceClient`. Default is False.
+    :keyword bool queue:
+        Access for the `~azure.storage.queue.QueueServiceClient`. Default is False.
+    :keyword bool fileshare:
+        Access for the `~azure.storage.fileshare.ShareServiceClient`. Default is False.
+    """
+
+    def __init__(self, *, blob: bool = False, queue: bool = False, fileshare: bool = False) -> None:
+        self.blob = blob
+        self.queue = queue
+        self.fileshare = fileshare
+        self._str = ("b" if self.blob else "") + ("q" if self.queue else "") + ("f" if self.fileshare else "")
+
+    def __str__(self):
+        return self._str
+
+    @classmethod
+    def from_string(cls, string):
+        """Create Services from a string.
+
+        To specify blob, queue, or file you need only to
+        include the first letter of the word in the string. E.g. for blob and queue
+        you would provide a string "bq".
+
+        :param str string: Specify blob, queue, or file in
+            in the string with the first letter of the word.
+        :return: A Services object
+        :rtype: ~azure.storage.blob.Services
+        """
+        res_blob = "b" in string
+        res_queue = "q" in string
+        res_file = "f" in string
+
+        parsed = cls(blob=res_blob, queue=res_queue, fileshare=res_file)
+        parsed._str = string
+        return parsed
+
+
+class UserDelegationKey(object):
+    """
+    Represents a user delegation key, provided to the user by Azure Storage
+    based on their Azure Active Directory access token.
+
+    The fields are saved as simple strings since the user does not have to interact with this object;
+    to generate an identify SAS, the user can simply pass it to the right API.
+    """
+
+    signed_oid: Optional[str] = None
+    """Object ID of this token."""
+    signed_tid: Optional[str] = None
+    """Tenant ID of the tenant that issued this token."""
+    signed_delegated_user_tid: Optional[str] = None
+    """User Tenant ID of this token."""
+    signed_start: Optional[str] = None
+    """The datetime this token becomes valid."""
+    signed_expiry: Optional[str] = None
+    """The datetime this token expires."""
+    signed_service: Optional[str] = None
+    """What service this key is valid for."""
+    signed_version: Optional[str] = None
+    """The version identifier of the REST service that created this token."""
+    value: Optional[str] = None
+    """The user delegation key."""
+
+    def __init__(self):
+        self.signed_oid = None
+        self.signed_tid = None
+        self.signed_delegated_user_tid = None
+        self.signed_start = None
+        self.signed_expiry = None
+        self.signed_service = None
+        self.signed_version = None
+        self.value = None
+
+
+class StorageConfiguration(Configuration):
+    """
+    Specifies the configurable values used in Azure Storage.
+
+    :param int max_single_put_size: If the blob size is less than or equal max_single_put_size, then the blob will be
+        uploaded with only one http PUT request. If the blob size is larger than max_single_put_size,
+        the blob will be uploaded in chunks. Defaults to 64*1024*1024, or 64MB.
+    :param int copy_polling_interval: The interval in seconds for polling copy operations.
+    :param int max_block_size: The maximum chunk size for uploading a block blob in chunks.
+        Defaults to 4*1024*1024, or 4MB.
+    :param int min_large_block_upload_threshold: The minimum chunk size required to use the memory efficient
+        algorithm when uploading a block blob.
+    :param bool use_byte_buffer: Use a byte buffer for block blob uploads. Defaults to False.
+    :param int max_page_size: The maximum chunk size for uploading a page blob. Defaults to 4*1024*1024, or 4MB.
+    :param int min_large_chunk_upload_threshold: The max size for a single put operation.
+    :param int max_single_get_size: The maximum size for a blob to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks (could be parallel). Defaults to 32*1024*1024, or 32MB.
+    :param int max_chunk_get_size: The maximum chunk size used for downloading a blob. Defaults to 4*1024*1024,
+        or 4MB.
+    :param int max_range_size: The max range size for file upload.
+
+    """
+
+    max_single_put_size: int
+    copy_polling_interval: int
+    max_block_size: int
+    min_large_block_upload_threshold: int
+    use_byte_buffer: bool
+    max_page_size: int
+    min_large_chunk_upload_threshold: int
+    max_single_get_size: int
+    max_chunk_get_size: int
+    max_range_size: int
+    user_agent_policy: UserAgentPolicy
+
+    def __init__(self, **kwargs):
+        super(StorageConfiguration, self).__init__(**kwargs)
+        self.max_single_put_size = kwargs.pop("max_single_put_size", 64 * 1024 * 1024)
+        self.copy_polling_interval = 15
+        self.max_block_size = kwargs.pop("max_block_size", 4 * 1024 * 1024)
+        self.min_large_block_upload_threshold = kwargs.get("min_large_block_upload_threshold", 4 * 1024 * 1024 + 1)
+        self.use_byte_buffer = kwargs.pop("use_byte_buffer", False)
+        self.max_page_size = kwargs.pop("max_page_size", 4 * 1024 * 1024)
+        self.min_large_chunk_upload_threshold = kwargs.pop("min_large_chunk_upload_threshold", 100 * 1024 * 1024 + 1)
+        self.max_single_get_size = kwargs.pop("max_single_get_size", 32 * 1024 * 1024)
+        self.max_chunk_get_size = kwargs.pop("max_chunk_get_size", 4 * 1024 * 1024)
+        self.max_range_size = kwargs.pop("max_range_size", 4 * 1024 * 1024)


### PR DESCRIPTION
Auditing the other contracts for **G59**'s expiry risk produced a result that inverted the question.

### The audit

| # | contract | proof rests on | when the external fact moves |
|---|---|---|---|
| 1 | Context chain | context propagates | safe |
| 2 | Signature shape | Microsoft's documented members | false **green** — *already mitigated* |
| 3 | Runtime floor | `got >= floor`, monotone | false **green** |
| 4 | Write landing | artifact witnesses the write | safe |
| 5 | Concurrent isolation | sessions isolated | safe |
| 6 | Rewrite fall-through | **engine cannot plan X** | false **red** — *fixed in #433* |
| 7 | Credential lifetime | token outlives run | safe |
| 8 | Refusal fidelity | Fabric refuses X with code C | false **green** |

**Contract 6 was the only one that can falsely accuse the emulator** — which is why it was noisy enough to be caught within hours. Contracts 3 and 8 fail the other way, and that is quieter: a stale premise reads as a **pass**.

Contract 8's is the sharper case, because its own docstring says the direction it exists for is the permissive one — an emulator that *allows* what Fabric refuses. If a refusal is dropped upstream, our map keeps asserting it, the probe keeps passing, and the divergence is invisible. `check_conformance.py` does not help: it grades the contract/backend/matrix correspondence, not the premises.

### The second source

Contract 2's shape applied here — two sources, divergence **computed**:

| case | second source |
|---|---|
| `dfs-delete-non-empty-directory` | `azure.storage.blob.StorageErrorCode` — 165 codes incl. `DirectoryNotEmpty`, **already a dependency** |
| `rm-non-empty-without-recurse` | **CPython**, by actually removing a non-empty directory and reading what it raises |
| `mv-onto-existing-without-overwrite` | **none — declared** |

**Azurite would have been the better witness** for the wire code, being Microsoft's own storage implementation and already used here. It cannot serve: it implements Blob/Queue/Table and **not** ADLS Gen2 — which `e2e/azurite-shortcut`'s own compose header states — and a DFS-specific refusal is exactly what it cannot answer. That is recorded in the script so it is not rediscovered.

The third case is single-sourced *with its reason*: POSIX `os.rename` replaces the destination silently, so CPython **contradicts** that expectation rather than corroborating it, and Microsoft's stub wheel has empty bodies. **A new case with no declared source fails** — the same rule contract 8 applies to its own cases.

### Verified

Non-vacuous three ways — a renamed wire code, a wrong errno, and an undeclared new case are each caught; the clean tree passes. Wired into both `make check` and `ci.yml`, so it is not laptop-only (G53).

### Not addressed

**Contract 3's floor is still single-sourced.** It is monotone and slow-moving, so the exposure is smaller, but it is the same shape and nothing checks it.
