### PR TITLE
G60: contract 3's floor is hand-maintained, so make it expire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,6 +572,7 @@ jobs:
       # right, the cast of services had drifted. Nothing about adding a service
       # reminds anyone to redraw, so the roster is asserted instead.
       - run: uv run --frozen --no-sync python scripts/check_arch_services.py
+      - run: uv run --frozen --no-sync python scripts/check_runtime_floor_freshness.py
       - run: uv run --frozen --no-sync python scripts/check_endpoint_env_names.py
       - run: uv run --frozen --no-sync python scripts/check_mlflow_unpublished.py
       - run: uv run --frozen --no-sync python scripts/check_image_digests.py

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ check: lint ## Repo invariants — the checks that used to exist only in CI
 	@$(PY) scripts/check_example_portability.py
 	@$(PY) scripts/check_conformance.py --strict
 	@$(PY) scripts/check_arch_services.py
+	@$(PY) scripts/check_runtime_floor_freshness.py
 	@$(PY) scripts/check_endpoint_env_names.py
 	@$(PY) scripts/check_mlflow_unpublished.py
 	@$(PY) scripts/check_fabric_activity_types.py

--- a/e2e/conformance/fabric-runtimes.json
+++ b/e2e/conformance/fabric-runtimes.json
@@ -10,7 +10,20 @@
     "needs >= 3.9, so a notebook could not import the surface at all. The",
     "other versions are RECORDED so a drift is visible, and not asserted,",
     "because whether the engine behaves like Spark 3.5 is the engine matrix's",
-    "question and it answers it row by row rather than by a version string."
+    "question and it answers it row by row rather than by a version string.",
+    "",
+    "SINGLE SOURCED, deliberately and not comfortably. Contracts 2 and 8 hold",
+    "their premises against machine-readable Microsoft artefacts vendored under",
+    "third_party/ -- the dummy-notebookutils wheel, the StorageErrorCode enum.",
+    "Fabric publishes its runtime versions as documentation pages and nothing",
+    "else, so this table is a transcription with nobody to check it against.",
+    "",
+    "Contract 3's comparison is MONOTONE -- an upgrade keeps passing -- so a",
+    "raised floor upstream would leave this number stale and the contract green",
+    "forever. scripts/check_runtime_floor_freshness.py bounds that in time",
+    "instead: every entry must cite its page and the date it was read, and the",
+    "reading expires. That check WILL fail on its own one day, which is the",
+    "design and not a defect."
   ],
   "runtimes": {
     "1.3": {

--- a/python/tests/test_check_runtime_floor_freshness.py
+++ b/python/tests/test_check_runtime_floor_freshness.py
@@ -47,9 +47,14 @@ def test_exactly_at_the_limit_still_passes():
 def test_the_failure_names_the_page_and_the_floor_to_re_check():
     """A stale-date failure is useless without saying what to go and read."""
     read = TODAY - dt.timedelta(days=400)
-    msg = c.problems(_rt(read=read.isoformat()), TODAY)[0]
-    assert "learn.microsoft.com" in msg
-    assert "3.11" in msg
+    entry = _rt(read=read.isoformat())
+    msg = c.problems(entry, TODAY)[0]
+    # The WHOLE cited URL, not a substring of its host: `"host" in url` is the
+    # shape CodeQL flags as incomplete URL sanitisation, and it is a weaker
+    # assertion anyway -- what matters is that the exact page recorded in the
+    # entry is the one the failure tells you to re-read.
+    assert entry["1.3"]["source"] in msg
+    assert entry["1.3"]["python"] in msg
 
 
 def test_a_missing_source_fails():

--- a/python/tests/test_check_runtime_floor_freshness.py
+++ b/python/tests/test_check_runtime_floor_freshness.py
@@ -1,0 +1,95 @@
+"""The freshness bound on contract 3's hand-maintained floor.
+
+Contract 3's comparison is monotone: an upgrade keeps passing, so the contract
+will never go red on its own if Microsoft raises the runtime floor. There is no
+machine-readable oracle to vendor the way contracts 2 and 8 have one, so the
+claim is bounded in time instead — and a time bound that is never exercised is
+just a comment with a date in it.
+
+These pin the boundary rather than the happy path: the day it stops being fresh
+must be a failure, and provenance that is missing or malformed must be too.
+"""
+import datetime as dt
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+import check_runtime_floor_freshness as c  # noqa: E402
+
+TODAY = dt.date(2026, 9, 1)
+
+
+def _rt(**over):
+    base = {"python": "3.11", "source": "https://learn.microsoft.com/x",
+            "read": "2026-08-18"}
+    base.update(over)
+    return {"1.3": base}
+
+
+def test_a_recent_reading_passes():
+    assert c.problems(_rt(), TODAY) == []
+
+
+def test_the_day_after_the_limit_fails():
+    """The boundary itself, because an off-by-one here means the bound never
+    fires or fires a day early forever."""
+    read = TODAY - dt.timedelta(days=c.MAX_AGE_DAYS + 1)
+    found = c.problems(_rt(read=read.isoformat()), TODAY)
+    assert found and "last read" in found[0]
+
+
+def test_exactly_at_the_limit_still_passes():
+    read = TODAY - dt.timedelta(days=c.MAX_AGE_DAYS)
+    assert c.problems(_rt(read=read.isoformat()), TODAY) == []
+
+
+def test_the_failure_names_the_page_and_the_floor_to_re_check():
+    """A stale-date failure is useless without saying what to go and read."""
+    read = TODAY - dt.timedelta(days=400)
+    msg = c.problems(_rt(read=read.isoformat()), TODAY)[0]
+    assert "learn.microsoft.com" in msg
+    assert "3.11" in msg
+
+
+def test_a_missing_source_fails():
+    assert any("no `source`" in p for p in c.problems(_rt(source=""), TODAY))
+
+
+def test_a_malformed_date_fails_rather_than_being_treated_as_fresh():
+    """`read: "soon"` must not sail through — the parse would raise, and a
+    check that raises on bad data is not the same as one that reports it."""
+    found = c.problems(_rt(read="soon"), TODAY)
+    assert found and "not an ISO date" in found[0]
+
+
+def test_no_runtimes_at_all_is_a_failure():
+    assert c.problems({}, TODAY)
+
+
+def test_the_repositorys_own_file_parses_and_is_currently_fresh():
+    """Against the real file, not a fixture — this is the one that will start
+    failing when the reading ages out, which is the point."""
+    runtimes = c.entries(c.RUNTIMES.read_text(encoding="utf-8"))
+    assert "1.3" in runtimes
+    assert c.problems(runtimes, dt.date.today()) == []
+
+
+def test_main_reports_and_returns_zero_on_the_real_tree(capsys):
+    assert c.main() == 0
+    assert "citing a page and a reading date" in capsys.readouterr().out
+
+
+def test_main_returns_one_when_a_reading_has_aged_out(monkeypatch, capsys):
+    monkeypatch.setattr(c, "MAX_AGE_DAYS", -1)
+    assert c.main() == 1
+    assert "last read" in capsys.readouterr().err
+
+
+def test_a_missing_runtimes_file_is_reported_not_raised(monkeypatch, tmp_path, capsys):
+    """The file could be renamed or dropped. That must be a stated failure, not
+    a traceback — a check that crashes reads as broken tooling rather than as
+    the finding it is."""
+    monkeypatch.setattr(c, "RUNTIMES", tmp_path / "gone.json")
+    assert c.main() == 1
+    assert "is missing" in capsys.readouterr().err

--- a/scripts/check_runtime_floor_freshness.py
+++ b/scripts/check_runtime_floor_freshness.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Contract 3's runtime floor is hand-maintained. Say so, and make it expire.
+
+WHY THIS EXISTS. Contract 3 asserts the image declares a Fabric Runtime and
+MEETS its floor, comparing numerically -- `3.11.15` satisfies a `3.11` floor.
+The comparison is MONOTONE, which is correct and is also the problem: an
+upgrade keeps passing, so **nothing about this contract will ever go red on
+its own**. If Microsoft raises the floor, `fabric-runtimes.json` keeps the old
+number, the emulator keeps advertising a version that is no longer current,
+and the probe keeps approving.
+
+That is the opposite failure direction from the one that made this family look:
+contract 6 read an engine's capability GAIN as a defect and was noisy within
+hours (G59). A stale floor is silent, and silence is what a conformance suite
+is worst at noticing about itself.
+
+THERE IS NO ORACLE TO VENDOR. Contracts 2 and 8 hold their premises against
+machine-readable Microsoft artefacts -- the `dummy-notebookutils` wheel, the
+`StorageErrorCode` enum -- both pinned under `third_party/`. Fabric's runtime
+versions are published as documentation pages and nothing else, so the
+transcription cannot be corroborated the same way. Pretending otherwise would
+be worse than admitting it.
+
+SO THE CLAIM IS BOUNDED IN TIME INSTEAD. Each runtime entry already carries the
+page it came from and the date somebody read it. This asserts that both are
+present and that the reading is not older than MAX_AGE_DAYS -- the same move as
+`check_cron_workflow_freshness.py`, which asks the cheaper checkable question
+("has anyone run THIS version?") rather than the unanswerable one.
+
+This check WILL eventually fail without anybody changing the code. That is the
+design: re-reading a page twice a year is the work, and a green that never
+expires is exactly what a single-sourced number does not deserve.
+
+Usage:
+    check_runtime_floor_freshness.py     exit non-zero if provenance is missing or stale
+"""
+import datetime as dt
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+RUNTIMES = ROOT / "e2e" / "conformance" / "fabric-runtimes.json"
+
+# Six months. Fabric runtimes move on the order of a year, so this asks for a
+# re-read twice per runtime generation -- often enough that a raised floor is
+# caught within a release cycle, rarely enough that it is not noise.
+MAX_AGE_DAYS = 183
+
+ISO = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def entries(text: str) -> dict:
+    return json.loads(text)["runtimes"]
+
+
+def problems(runtimes: dict, today: dt.date) -> list[str]:
+    out = []
+    if not runtimes:
+        return ["fabric-runtimes.json declares no runtimes, so contract 3 "
+                "grades against nothing"]
+    for name in sorted(runtimes):
+        entry = runtimes[name]
+        source = entry.get("source", "")
+        read = entry.get("read", "")
+        if not source:
+            out.append(f"runtime {name}: no `source` — a hand-maintained number "
+                       "with no citation cannot be re-read by anyone else")
+        if not ISO.match(str(read)):
+            out.append(f"runtime {name}: `read` is {read!r}, not an ISO date — "
+                       "without it there is no way to tell a current "
+                       "transcription from an old one")
+            continue
+        age = (today - dt.date.fromisoformat(read)).days
+        if age > MAX_AGE_DAYS:
+            out.append(
+                f"runtime {name}: last read {read} ({age} days ago, limit "
+                f"{MAX_AGE_DAYS}). Re-read {source}, confirm `python` is still "
+                f"{entry.get('python', '?')}, and update `read`. If the floor "
+                "moved, contract 3 has been passing against a stale one")
+    return out
+
+
+def main() -> int:
+    if not RUNTIMES.is_file():
+        print(f"check_runtime_floor_freshness: {RUNTIMES} is missing",
+              file=sys.stderr)
+        return 1
+    runtimes = entries(RUNTIMES.read_text(encoding="utf-8"))
+    found = problems(runtimes, dt.date.today())
+    if found:
+        print("check_runtime_floor_freshness:\n  " + "\n  ".join(found),
+              file=sys.stderr)
+        return 1
+    for name in sorted(runtimes):
+        e = runtimes[name]
+        print(f"  runtime {name}: python {e.get('python')} floor, read "
+              f"{e.get('read')} — within {MAX_AGE_DAYS} days")
+    print(f"check_runtime_floor_freshness: {len(runtimes)} runtime(s), each "
+          "citing a page and a reading date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes **G60**. Contract 3 compares the runtime's Python version against a floor, and the comparison is **monotone** — an upgrade keeps passing. That is correct, and it is also why **nothing about this contract will ever go red on its own**. If Microsoft raises the floor, `fabric-runtimes.json` keeps the old number, the emulator keeps advertising a version that is no longer current, and the probe keeps approving.

This is the opposite failure direction from G59's, and the more dangerous one. Contract 6 read an engine's capability *gain* as a defect and was noisy within hours. **A stale floor is silent**, and silence is what a conformance suite is worst at noticing about itself.

### There is no oracle to vendor

Contracts 2 and 8 hold their premises against machine-readable Microsoft artefacts pinned under `third_party/` — the `dummy-notebookutils` wheel, the `StorageErrorCode` enum. Fabric publishes its runtime versions as **documentation pages and nothing else**, so this transcription has nothing to be checked against. Pretending otherwise would be worse than admitting it, so `fabric-runtimes.json` now states what kind of number it holds.

### So the claim is bounded in time instead

Every entry must cite its page and the date somebody read it, and **the reading expires after 183 days** — twice per runtime generation, often enough to catch a raised floor within a release cycle, rarely enough not to be noise. The same move as `check_cron_workflow_freshness.py`: ask the cheaper checkable question rather than the unanswerable one.

**This check will fail on its own one day, with nobody changing the code.** That is the design, not a defect — a green that never expires is exactly what a single-sourced number does not deserve. The failure names the page to re-read and the value to confirm:

> Re-read https://learn.microsoft.com/en-us/fabric/data-engineering/runtime-1-3, confirm `python` is still 3.11, and update `read`. If the floor moved, contract 3 has been passing against a stale one

### Tests pin the boundary, not the happy path

The day after the limit fails; the day *of* it does not; a malformed date is reported rather than raising; a missing citation fails; a missing file is a stated failure rather than a traceback.

97.73% on the script, 92.06% total — run with `--cov` before pushing.

### The audit is now closed

| contract | premise | held against |
|---|---|---|
| 2 | documented member list | pinned stub wheel |
| 6 | ~~engine cannot plan X~~ | replaced by a direct echo witness |
| 8 | refusal codes | vendored `StorageErrorCode` + CPython |
| 3 | runtime floor | **nothing — bounded in time instead** |
