### PR TITLE
G57: a dismissal with no fix available is a promise to come back

### DIFF
--- a/.github/dismissed-advisories.json
+++ b/.github/dismissed-advisories.json
@@ -1,0 +1,25 @@
+{
+  "_comment": [
+    "Advisories dismissed on this repository, and what would make each one",
+    "wrong again. A Dependabot dismissal is FINAL: the alert never returns, no",
+    "matter what upstream does. Dismissing 'tolerable risk' with no fix",
+    "available is therefore a promise to come back, and nothing in GitHub keeps",
+    "it -- which is what this file and scripts/check_dismissed_advisories.py",
+    "are for.",
+    "",
+    "An entry is removed when the alert is re-opened and the finding actually",
+    "dealt with, not when somebody decides it no longer matters."
+  ],
+  "dismissed": [
+    {
+      "ghsa": "GHSA-h7x2-h6g9-p789",
+      "alert": 56,
+      "ecosystem": "pip",
+      "package": "mlflow",
+      "reason": "tolerable_risk",
+      "dismissed": "2026-09-01",
+      "why": "No fixed release exists: the range is >= 3.13.0, <= 3.15.2 and 3.15.2 IS the newest. Downgrading is closed off too -- the 3.15 floor exists because resolving below it dropped --disable-security-middleware and the container would not start. Nothing here touches the AI Gateway, and the e2e MLflow server runs only inside a compose network publishing no host port, which scripts/check_mlflow_unpublished.py asserts.",
+      "revisit_when": "first_patched_version stops being null"
+    }
+  ]
+}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,3 +68,28 @@ jobs:
       # Reports only vulnerabilities the code can actually REACH, so a finding
       # here is a call path rather than a dependency-tree coincidence.
       - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  # A DISMISSED ALERT NEVER COMES BACK. Dependabot 56 was dismissed as
+  # tolerable risk because the MLflow advisory had no fixed release -- true
+  # when it was written and only until upstream ships one. Nothing in GitHub
+  # re-raises it then, so the dismissal quietly becomes permanent on the
+  # strength of a temporary fact.
+  #
+  # Here rather than in a cron-only workflow of its own: this file already
+  # runs on push, pull_request, a weekly cron and dispatch, so the question
+  # gets asked on every change as well as on a schedule. Its own header states
+  # the rule -- a scanner nobody runs is a scanner that finds nothing.
+  dismissed-advisories:
+    name: Dismissed advisories are still unfixed upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - run: python3 scripts/check_dismissed_advisories.py
+        env:
+          # The endpoint is public; the token only lifts the 60/hour
+          # unauthenticated rate limit that a busy runner IP can hit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/python/tests/test_check_dismissed_advisories.py
+++ b/python/tests/test_check_dismissed_advisories.py
@@ -1,0 +1,160 @@
+"""The promise a dismissal makes, and the day it comes due.
+
+A Dependabot dismissal is final — the alert never returns, whatever upstream
+does. Dismissing "tolerable risk" with no fix available is therefore a decision
+made once on a fact that was temporary, and nothing in GitHub notices when the
+fact changes.
+
+These exercise the day it changes. The fetcher is injected, so no test reaches
+the network: what is under test is the reading of the answer, not GitHub's
+ability to give one.
+"""
+import json
+import pathlib
+import sys
+import urllib.error
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "scripts"))
+
+import check_dismissed_advisories as c  # noqa: E402
+
+ENTRY = {"ghsa": "GHSA-x", "alert": 56, "ecosystem": "pip", "package": "mlflow",
+         "reason": "tolerable_risk", "dismissed": "2026-09-01"}
+
+
+def _advisory(patched=None, name="mlflow", eco="pip"):
+    return {"vulnerabilities": [{
+        "package": {"ecosystem": eco, "name": name},
+        "vulnerable_version_range": ">= 3.13.0, <= 3.15.2",
+        "first_patched_version": {"identifier": patched} if patched else None,
+    }]}
+
+
+def test_no_fix_upstream_leaves_the_dismissal_standing():
+    assert c.review(ENTRY, _advisory()) == []
+
+
+def test_a_patched_release_expires_the_dismissal():
+    """The whole point: the day a fix lands, the reasoning is void."""
+    found = c.review(ENTRY, _advisory(patched="3.15.3"))
+    assert found and "FIXED UPSTREAM in 3.15.3" in found[0]
+    assert "Re-open it" in found[0]
+
+
+def test_the_failure_names_the_alert_to_re_open():
+    """Useless without it — the alert number is the only way back to the thing
+    that was dismissed."""
+    msg = c.review(ENTRY, _advisory(patched="4.0.0"))[0]
+    assert "56" in msg and "tolerable_risk" in msg
+
+
+def test_an_advisory_that_no_longer_lists_the_package_is_flagged():
+    """Withdrawn, re-scoped or renamed — all mean the statement the dismissal
+    rested on has changed, and none should read as 'still fine'."""
+    found = c.review(ENTRY, _advisory(name="something-else"))
+    assert found and "no longer lists" in found[0]
+
+
+def test_a_different_ecosystem_does_not_count_as_a_match():
+    found = c.review(ENTRY, _advisory(eco="npm"))
+    assert found and "no longer lists" in found[0]
+
+
+def test_a_patched_version_given_as_a_bare_string_is_still_read():
+    """The API returns an object today. Tolerating a bare string costs nothing
+    and stops a shape change reading as 'no fix'."""
+    adv = _advisory()
+    adv["vulnerabilities"][0]["first_patched_version"] = "3.15.3"
+    found = c.review(ENTRY, adv)
+    assert found and "3.15.3" in found[0]
+
+
+def test_a_network_failure_is_reported_not_swallowed(monkeypatch, tmp_path, capsys):
+    """An unreachable API must not read as 'nothing has changed' — that is the
+    silent pass this check exists to prevent."""
+    f = tmp_path / "d.json"
+    f.write_text(json.dumps({"dismissed": [ENTRY]}), encoding="utf-8")
+    monkeypatch.setattr(c, "TRACKED", f)
+
+    def boom(_ghsa):
+        raise urllib.error.URLError("no route to host")
+
+    assert c.main(fetcher=boom) == 1
+    assert "unreviewed rather than confirmed" in capsys.readouterr().err
+
+
+def test_main_passes_when_nothing_has_changed(monkeypatch, tmp_path, capsys):
+    f = tmp_path / "d.json"
+    f.write_text(json.dumps({"dismissed": [ENTRY]}), encoding="utf-8")
+    monkeypatch.setattr(c, "TRACKED", f)
+    assert c.main(fetcher=lambda _g: _advisory()) == 0
+    assert "dismissal of alert 56 holds" in capsys.readouterr().out
+
+
+def test_main_fails_once_a_fix_exists(monkeypatch, tmp_path, capsys):
+    f = tmp_path / "d.json"
+    f.write_text(json.dumps({"dismissed": [ENTRY]}), encoding="utf-8")
+    monkeypatch.setattr(c, "TRACKED", f)
+    assert c.main(fetcher=lambda _g: _advisory(patched="3.15.3")) == 1
+    assert "FIXED UPSTREAM" in capsys.readouterr().err
+
+
+def test_an_empty_list_passes_rather_than_erroring(monkeypatch, tmp_path, capsys):
+    f = tmp_path / "d.json"
+    f.write_text(json.dumps({"dismissed": []}), encoding="utf-8")
+    monkeypatch.setattr(c, "TRACKED", f)
+    assert c.main(fetcher=lambda _g: {}) == 0
+    assert "nothing dismissed" in capsys.readouterr().out
+
+
+def test_the_repositorys_own_file_is_well_formed():
+    """Against the real file: every entry needs the fields the check reads, or
+    it would raise KeyError in CI rather than report."""
+    tracked = json.loads(c.TRACKED.read_text(encoding="utf-8"))["dismissed"]
+    for e in tracked:
+        for field in ("ghsa", "alert", "ecosystem", "package", "reason",
+                      "dismissed", "why", "revisit_when"):
+            assert field in e, f"{e.get('ghsa')} is missing {field}"
+
+
+def _sent(monkeypatch, token):
+    """Capture the Request `fetch` builds without sending it."""
+    seen = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"vulnerabilities": []}'
+
+    def fake_urlopen(req, timeout=None):
+        seen["headers"] = dict(req.header_items())
+        seen["url"] = req.full_url
+        return FakeResponse()
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    if token:
+        monkeypatch.setenv("GITHUB_TOKEN", token)
+    monkeypatch.setattr(c.urllib.request, "urlopen", fake_urlopen)
+    c.fetch("GHSA-x")
+    return seen
+
+
+def test_fetch_asks_the_right_url_and_works_without_a_token(monkeypatch):
+    """The endpoint is public — a laptop with no credentials must still get an
+    answer, or the check is CI-only and nobody can reproduce a failure."""
+    seen = _sent(monkeypatch, token=None)
+    assert seen["url"].endswith("/advisories/GHSA-x")
+    assert not any(k.lower() == "authorization" for k in seen["headers"])
+
+
+def test_fetch_uses_a_token_when_one_is_present(monkeypatch):
+    """Only to lift the 60/hour unauthenticated limit a busy runner IP hits."""
+    seen = _sent(monkeypatch, token="t0ken")
+    auth = [v for k, v in seen["headers"].items() if k.lower() == "authorization"]
+    assert auth == ["Bearer t0ken"]

--- a/scripts/check_dismissed_advisories.py
+++ b/scripts/check_dismissed_advisories.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""A dismissal with no fix available is a promise to come back. Keep it.
+
+WHY THIS EXISTS. Dependabot alert 56 (`GHSA-h7x2-h6g9-p789`, high: MLflow's AI
+Gateway permits SSRF through an unvalidated `api_base`) was dismissed as
+*tolerable risk* because there was nothing to upgrade to -- the vulnerable
+range is `>= 3.13.0, <= 3.15.2` and 3.15.2 is the newest release. The exposure
+is bounded by reachability, not removed.
+
+**A DISMISSED ALERT NEVER COMES BACK.** GitHub will not re-raise it when
+upstream ships a fix, and the justification written at dismissal time stays
+true only until it isn't. So the dismissal quietly becomes a permanent
+decision, made once on the strength of a fact that was temporary.
+
+This asks the one question that would change the answer: has a patched version
+appeared? GitHub's advisory API answers it, and the check FAILS when the answer
+is yes -- because at that point the honest state is an open alert and a version
+bump, not a dismissal.
+
+WHERE IT RUNS, and why not in `make check`. It needs the network, and the
+guards in `scripts/` are offline invariants run under `$(PY)`. It lives in
+`security.yml` instead, which already runs on push, pull_request, a weekly
+cron AND dispatch -- so it is exercised on every change as well as on a
+schedule, and never becomes a cron-only workflow nobody has run. That file's
+own header states the rule it is joining: *a scanner nobody runs is a scanner
+that finds nothing.*
+
+Usage:
+    check_dismissed_advisories.py     exit non-zero if a dismissal has expired
+"""
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+TRACKED = ROOT / ".github" / "dismissed-advisories.json"
+API = "https://api.github.com/advisories/"
+
+
+def fetch(ghsa: str) -> dict:
+    """The advisory as GitHub currently states it.
+
+    A token is used when one is present -- CI has `GITHUB_TOKEN` and the
+    unauthenticated limit is 60/hour per IP -- but the endpoint is public, so
+    this works on a laptop with no credentials.
+    """
+    req = urllib.request.Request(
+        API + ghsa,
+        headers={"Accept": "application/vnd.github+json",
+                 "User-Agent": "fabric-emulator-dismissed-advisories"})
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def review(entry: dict, advisory: dict) -> list[str]:
+    """What, if anything, has changed since this was dismissed."""
+    out = []
+    name, eco = entry["package"], entry["ecosystem"]
+    matches = [
+        v for v in advisory.get("vulnerabilities") or []
+        if (v.get("package") or {}).get("name") == name
+        and (v.get("package") or {}).get("ecosystem") == eco
+    ]
+    if not matches:
+        out.append(
+            f"{entry['ghsa']}: no longer lists {eco} {name}. The advisory was "
+            "withdrawn, re-scoped, or the package renamed — either way the "
+            "dismissal rests on a statement that has changed")
+        return out
+    for v in matches:
+        patched = (v.get("first_patched_version") or {})
+        ident = patched.get("identifier") if isinstance(patched, dict) else patched
+        if ident:
+            out.append(
+                f"{entry['ghsa']} ({eco} {name}): FIXED UPSTREAM in {ident}. "
+                f"Alert {entry['alert']} was dismissed as {entry['reason']} "
+                f"on {entry['dismissed']} because there was nothing to upgrade "
+                f"to. There is now. Re-open it and take the fix — the "
+                "dismissal's reasoning has expired")
+    return out
+
+
+def main(fetcher=fetch) -> int:
+    tracked = json.loads(TRACKED.read_text(encoding="utf-8"))["dismissed"]
+    if not tracked:
+        print("check_dismissed_advisories: nothing dismissed")
+        return 0
+    problems, checked = [], 0
+    for entry in tracked:
+        try:
+            advisory = fetcher(entry["ghsa"])
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            problems.append(
+                f"{entry['ghsa']}: could not be read ({exc}). The dismissal is "
+                "unreviewed rather than confirmed still-valid")
+            continue
+        checked += 1
+        problems.extend(review(entry, advisory))
+    if problems:
+        print("check_dismissed_advisories:\n  " + "\n  ".join(problems),
+              file=sys.stderr)
+        return 1
+    for entry in tracked:
+        print(f"  {entry['ghsa']} ({entry['package']}): still no fix upstream — "
+              f"dismissal of alert {entry['alert']} holds")
+    print(f"check_dismissed_advisories: {checked} dismissal(s) re-checked "
+          "against the advisory API")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes **G57**'s open half. Alert **56** (`GHSA-h7x2-h6g9-p789`, high — MLflow's AI Gateway permits SSRF through an unvalidated `api_base`) was dismissed as *tolerable risk* because there was nothing to upgrade to: the range is `>= 3.13.0, <= 3.15.2` and **3.15.2 is the newest release**. The exposure was bounded by reachability, not removed.

**A dismissed alert never comes back.** GitHub will not re-raise it when upstream ships a fix, so the justification written that day quietly becomes a permanent decision resting on a temporary fact. Nothing kept the promise.

### What this adds

- `.github/dismissed-advisories.json` — what was dismissed, why, and **what would make it wrong again**
- `scripts/check_dismissed_advisories.py` — asks the advisory API the one question that changes the answer, and **fails when a patched version appears**, naming the alert to re-open

### Where it runs

In `security.yml`, not a cron-only workflow of its own. That file already runs on `push`, `pull_request`, a weekly cron **and** dispatch — so the question is asked on every change as well as on a schedule, and it doesn't become another workflow whose freshness needs guarding. Its own header states the rule it's joining: *a scanner nobody runs is a scanner that finds nothing.*

Not in `make check`: it needs the network, and the guards there are offline invariants under `$(PY)`.

### Verified both ways

| | |
|---|---|
| against the live API | still no fix — dismissal holds, exit 0 |
| against a simulated fix | **exit 1**, naming alert 56 and the version |

Thirteen tests with the fetcher injected, so none reaches the network. They cover the cases that would otherwise pass silently: an advisory that **no longer lists the package** (withdrawn, re-scoped, renamed) is flagged rather than read as fine; a different ecosystem is not a match; a bare-string version is still read if the API shape changes; and a **network failure reports "unreviewed" rather than passing** — the silent pass this exists to prevent. `fetch()` itself is covered for the public-endpoint and token paths.

98.08% on the script, 92.16% total, run with `--cov` before pushing.

### What it does not do

It does not re-open the alert or take the fix — it makes the day arrive loudly. The entry is removed when the finding is actually dealt with, not when somebody decides it no longer matters.
