### PR TITLE
sail: the MERGE intercept's reason has expired; measure it, don't guess

### DIFF
--- a/docs/42-sail-fidelity-plan.md
+++ b/docs/42-sail-fidelity-plan.md
@@ -208,10 +208,31 @@ a hand-edit, not a helper the notebook does not call.
 
 Today that column is **23 / 25**. Two stay red.
 
+ᵐ **The MERGE rows are closed by an intercept whose reason has expired.** They
+were written because Sail's plan resolver failed on any Delta target holding a
+date or timestamp column — true through pysail 0.7.0. Measured again on
+**0.7.1** (2026-09-01, local path, with a passing control): the plain table,
+the audit-columned table, and the full medallion `UPDATE` + `INSERT *` shape
+all succeed **unaided**. The engine matrix reported it first — both MERGE rows
+flipped from that error to ✅ on the same bump.
+
+The intercept nevertheless **still fires**, because it matches the statement
+before the engine sees it. So this row is honest about the mechanism and stale
+about the motive, and the distinction matters: *"Sail can do it"* and *"our
+rewrite is off the path"* are different claims, and only the second licenses
+deleting the code.
+
+What that measurement does **not** settle is the case the emulator actually
+runs: it merged against a **local path**, while the emulator uses `az://`
+OneLake URLs — and the matrix's own note records the storage URL as exactly
+what separates the two behaviours here. Retiring the intercept needs that
+proven under `e2e/sail` and the medallion suites. Until then this footnote is
+the record, so the next reader does not have to re-derive it from a green row.
+
 | Probe | Closable on this seam? | Why |
 |---|---|---|
-| `MERGE INTO` registered (local path) | **Done** | Subquery source + `INSERT *` intercept |
-| `MERGE INTO delta.\`path\`` | **Done** | Same change; path URI is taken from the statement |
+| `MERGE INTO` registered (local path) | **Done** ᵐ | Subquery source + `INSERT *` intercept |
+| `MERGE INTO delta.\`path\`` | **Done** ᵐ | Same change; path URI is taken from the statement |
 | Change Data Feed | **Done** | Writer + reader wrapped, announced, materialised |
 | `read.json(multiLine=True)` | **Done** | Named option wrapped, announced, materialised |
 | Streaming sinks (memory / parquet / delta) | **Done** | One `limit(n).collect()` + batch write; announced; no checkpoint |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,6 +371,11 @@ omit = [
     # unlike vendor_fabric_activity_types.py, whose HTML extraction IS the
     # load-bearing part and is now tested (test_vendor_fabric_activity_types.py)
     # rather than exempted. Omitted for what it is, not for convenience.
+    # Needs pysail AND a running Sail server, so it cannot execute in the unit
+    # suite at all — it is a MEASUREMENT tool, run by hand on a dependency bump
+    # to re-test the claim delta_ops.py's MERGE intercept rests on. Its output
+    # is a verdict for a human, not a code path anything imports.
+    "scripts/probe_sail_merge_premise.py",
     "scripts/vendor_adf_pipeline_schema.py",
     "scripts/capture_definition_shape.py",
     # The conformance harness itself: it publishes notebooks, drives

--- a/python/spark_agent/delta_ops.py
+++ b/python/spark_agent/delta_ops.py
@@ -295,10 +295,40 @@ _CTAS = re.compile(
 #   [WHEN MATCHED [AND <cond>] THEN UPDATE SET <assignments>]
 #   [WHEN NOT MATCHED THEN INSERT * | INSERT (<cols>) VALUES (<vals>)]
 #
-# Sail parses MERGE but its plan resolver fails on any Delta TARGET holding a
-# date or timestamp column ("attribute #N is missing from the schema"),
-# reproduced minimally and unchanged in pysail 0.7.0 — which makes every
-# audit-columned table unmergeable, i.e. practically all of them.
+# WHY THIS EXISTS, AND WHY THAT REASON IS NOW STALE.
+#
+# The original justification: Sail parses MERGE but its plan resolver fails on
+# any Delta TARGET holding a date or timestamp column ("attribute #N is missing
+# from the schema"), reproduced minimally and unchanged in pysail 0.7.0 — which
+# made every audit-columned table unmergeable, i.e. practically all of them.
+#
+# MEASURED AGAIN ON pysail 0.7.1 (2026-09-01), against a local path, with a
+# passing control so the run could distinguish a real change from a broken
+# probe:
+#
+#     control: plain table, update-only   SUCCEEDS
+#     audit cols, update-only             SUCCEEDS
+#     audit cols, UPDATE + INSERT *       SUCCEEDS (the row was inserted)
+#
+# So the premise above is FALSE on 0.7.1: the engine now plans the exact shape
+# this intercept was written for. The engine matrix said so first — both MERGE
+# rows flipped from that error to ✅ on the same bump — and nobody connected
+# that row to this code, which is why it is written down here now.
+#
+# THE INTERCEPT STILL FIRES REGARDLESS: _MERGE matches before the engine sees
+# the statement, so the rewrite runs whether or not the engine could have
+# handled it. "Sail can do it" and "our rewrite is off the path" are different
+# claims, and only the second licenses deleting this.
+#
+# WHAT WOULD RETIRE IT, and what this measurement does NOT establish: the probe
+# above used a LOCAL PATH. The emulator merges against `az://` OneLake URLs,
+# and the engine matrix's own note records that the storage URL is exactly what
+# separates the two behaviours for MERGE. Retiring this needs that case proven
+# under e2e/sail and the medallion suites, not a laptop probe — so it is a
+# deliberate change, not a deletion folded into something else.
+#
+# THE SIGNAL TO WATCH: when the engine-matrix MERGE rows read ✅, this
+# justification is dead and the only question left is the az:// one above.
 #
 # The SELECT in a subquery source runs on the ENGINE (arbitrary SQL is its
 # job); only the upsert is redirected through delta-rs. That is the same split

--- a/scripts/probe_sail_merge_premise.py
+++ b/scripts/probe_sail_merge_premise.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Does Sail still need the MERGE intercept? Run this, do not reason about it.
+
+    uv run --no-project --python 3.12 --with "pysail==<version>" \
+      --with "pyspark[connect]==3.5.5" --with setuptools --with pandas \
+      --with pyarrow --with deltalake python scripts/probe_sail_merge_premise.py
+
+`python/spark_agent/delta_ops.py` rewrites MERGE because Sail's plan resolver
+failed on any Delta target holding a date or timestamp column. That was true
+through pysail 0.7.0 and is FALSE on 0.7.1 — which nobody would have noticed,
+because the intercept fires first and the statement succeeds either way.
+
+Kept as a script rather than a note so the claim can be RE-MEASURED on the next
+bump instead of re-argued. Deliberately NOT in `make check`: it needs pysail and
+a running Sail, and the gate stays offline.
+
+THE CONTROL IS THE POINT. If the plain table cannot merge either, the run says
+nothing about temporal columns — it says the probe is broken. That case is
+reported as inconclusive rather than folded into the verdict.
+
+WHAT IT DOES NOT SETTLE: it merges against a LOCAL PATH. The emulator uses
+`az://` OneLake URLs, and e2e/engine-matrix records the storage URL as exactly
+what separates the two behaviours for MERGE. A green run here is necessary for
+retiring the intercept and nowhere near sufficient.
+"""
+import os
+import tempfile
+
+from pysail.spark import SparkConnectServer
+from pyspark.sql import SparkSession
+
+srv = SparkConnectServer(port=0)
+srv.start()
+_, port = srv.listening_address
+spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+base = tempfile.mkdtemp()
+
+def attempt(label, setup, merge):
+    p = os.path.join(base, label.replace(" ", "_"))
+    os.makedirs(p, exist_ok=True)
+    try:
+        spark.sql(setup).write.format("delta").mode("overwrite").save(p)
+        spark.sql(merge.replace("@P", p))
+        n = spark.read.format("delta").load(p).count()
+        print(f"  {label:<34} SUCCEEDS (rows={n})")
+        return True
+    except Exception as e:
+        print(f"  {label:<34} FAILS  {str(e).strip().splitlines()[0][:150]}")
+        return False
+
+AUDIT = ("SELECT 1 AS id, 'a' AS v, CAST('2026-01-01 00:00:00' AS TIMESTAMP) AS ingested_at, "
+         "CAST('2026-01-01' AS DATE) AS d")
+
+print("pysail 0.7.1 — the shapes the intercept exists for")
+ctl = attempt("control: plain table, update-only",
+              "SELECT 1 AS id, 'a' AS v",
+              "MERGE INTO delta.`@P` AS t USING (SELECT * FROM VALUES (1,'b') AS s(id,v)) AS s "
+              "ON t.id=s.id WHEN MATCHED THEN UPDATE SET t.v=s.v")
+upd = attempt("audit cols, update-only", AUDIT,
+              "MERGE INTO delta.`@P` AS t USING (SELECT * FROM VALUES (1,'b') AS s(id,v)) AS s "
+              "ON t.id=s.id WHEN MATCHED THEN UPDATE SET t.v=s.v")
+ins = attempt("audit cols, UPDATE + INSERT *", AUDIT,
+              "MERGE INTO delta.`@P` AS t USING (SELECT 2 AS id, 'c' AS v, "
+              "CAST('2026-02-02 00:00:00' AS TIMESTAMP) AS ingested_at, CAST('2026-02-02' AS DATE) AS d) AS s "
+              "ON t.id=s.id WHEN MATCHED THEN UPDATE SET t.v=s.v WHEN NOT MATCHED THEN INSERT *")
+print()
+if not ctl:
+    print("INCONCLUSIVE: the control failed, so nothing here separates cause from a broken probe.")
+else:
+    print("premise 'temporal columns break MERGE':", "STILL TRUE" if not upd else "NO LONGER TRUE")
+    print("full medallion shape (INSERT *)      :", "works unaided" if ins else "STILL NEEDS THE INTERCEPT")
+srv.stop()


### PR DESCRIPTION
`delta_ops.py` rewrites `MERGE INTO` through delta-rs, justified by: *"Sail parses MERGE but its plan resolver fails on any Delta TARGET holding a date or timestamp column … reproduced minimally and unchanged in pysail 0.7.0"*.

**That premise is false on pysail 0.7.1.** Measured rather than argued:

```
control: plain table, update-only   SUCCEEDS (rows=1)
audit cols, update-only             SUCCEEDS (rows=1)
audit cols, UPDATE + INSERT *       SUCCEEDS (rows=2)
```

The full medallion shape — the one the intercept exists for — now works **unaided**.

## Why this was invisible

The engine matrix reported it first: both MERGE rows flipped from that exact error to ✅ on the `pysail` bump in #424. Nobody connected a generated matrix row to the code it justifies, and **the intercept fires before the engine sees the statement**, so the rewrite kept working and nothing failed.

That is the quiet version of the failure this repo keeps finding: not a wrong answer, but a correct answer produced by a mechanism whose stated reason had gone.

## What this PR does *not* do

**It does not delete the intercept**, and the distinction is deliberate: *"Sail can do it"* and *"our rewrite is off the path"* are different claims, and only the second licenses removing code.

It also does not settle the case that matters most. The probe merges against a **local path**; the emulator uses `az://` OneLake URLs, and the engine matrix's own note records the storage URL as exactly what separates the two behaviours for MERGE. A green run here is **necessary and nowhere near sufficient** for retiring the intercept — that needs `e2e/sail` and the medallion suites.

## What it does

- **Corrects the justification in `delta_ops.py`** — it now states the measurement, the version, the date, what it does not establish, and the signal that would retire it (*when the engine-matrix MERGE rows read ✅, the motive is dead and only the `az://` question remains*).
- **Footnotes the two `docs/42` rows** so a reader of "**Done** — subquery source + `INSERT *` intercept" learns the row is honest about the mechanism and stale about the motive. That doc is parity evidence, which is why a stale motive there is worse than a stale comment.
- **Ships the probe as `scripts/probe_sail_merge_premise.py`** so the claim is re-measured on the next bump rather than re-argued. Deliberately not in `make check`: it needs pysail and a running Sail, and the gate stays offline.

## On the probe itself

**The control is the point.** My first run had all three cases failing — including the plain table the engine matrix says succeeds — because the probe, not the engine, was broken. A measurement whose control fails proves nothing, so the script reports that case as **inconclusive** rather than folding it into the verdict.

`make check` exit 0, 1712 Python tests pass, ruff clean. The three `ty` warnings on this branch are the pre-existing `unused-ignore-comment` ones in `python/spark_agent/` — present on unmodified main, and environment-dependent.