### PR TITLE
Dependabot watches the seven example lockfiles.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,16 +50,37 @@ updates:
       - dependency-name: typescript
         update-types: ['version-update:semver-major']
 
-  # Python: uv-managed. TWO lockfiles, and the second is not optional.
+  # Python: uv-managed. NINE lockfiles, and this listed two.
+  #
   # e2e/fabric-cli is its own project because ms-fabric-cli pins
   # `pyyaml==6.0.2` exactly and that pin, held in a root dependency group, kept
   # the whole workspace from moving pyyaml. Moving it out must not also move it
   # out of Dependabot's view, so the directory is listed here: ms-fabric-cli
   # keeps getting updates, it just no longer constrains anything else.
+  #
+  # THE SEVEN EXAMPLES EACH HAVE THEIR OWN uv.lock AND NONE WERE WATCHED. They
+  # are not workspace members -- `tool.uv.workspace.members` is `python` and
+  # `python/fabric-target` -- so nothing about the root lockfile reaches them,
+  # and their pins had been drifting unobserved. These are the files people
+  # copy out of this repository to start with, which makes them the worst place
+  # for a stale dependency to sit.
+  #
+  # HOW THIS SURFACED, because the symptom pointed the other way. The
+  # `uv in /examples/medallion, /examples/medallion-spark` job has been failing
+  # with `not found`, naming two directories that this file has never listed
+  # and that stopped existing in 48393313, when the examples were reorganised
+  # into the four medallion folders. Dependabot was running against its own
+  # remembered set rather than against this config. So the visible failure was
+  # two directories watched that should not be, and behind it seven that should
+  # be and were not. Re-reading this file settles both.
+  #
+  # A glob, as the docker ecosystem below already uses, so a new example is
+  # covered by existing.
   - package-ecosystem: uv
     directories:
       - /
       - /e2e/fabric-cli
+      - /examples/*
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
`Dependabot Updates` has a failing `uv` job. The visible symptom and the actual defect point in opposite directions.

## The symptom: two directories that do not exist

```
uv in /examples/medallion, /examples/medallion-spark  →  not found
```

Those paths are not in this file and never have been (`git log -S` across every revision of it finds nothing). They stopped existing in `48393313`, when the examples were reorganised into the four medallion folders. Dependabot was running against **its own remembered set of directories**, not against this config.

## The defect: seven lockfiles nobody was watching

The comment above the `uv` block said "TWO lockfiles". There are **nine**:

| | |
| --- | --- |
| watched | `/`, `/e2e/fabric-cli` |
| **not watched** | `/examples/contoso-fixtures`, `/examples/contoso-fixtures-advanced`, `/examples/fab-driven`, `/examples/medallion-pyspark`, `/examples/medallion-dbt-fabricspark`, `/examples/medallion-advanced-pyspark`, `/examples/medallion-advanced-dbt-fabricspark` |

The examples are **not workspace members** — `tool.uv.workspace.members` is `python` and `python/fabric-target` — so nothing about the root lockfile reaches them. Each carries its own `pyproject.toml` and `uv.lock`, and those pins had been drifting unobserved.

**These are the files people copy out of this repository to start with**, which makes them the worst place in the tree for a stale dependency to sit. So the failing job was watching two directories that should not be watched, while seven that should be were not, and the failure drew attention to the wrong half.

A glob, as the `docker` ecosystem below already uses, so a new example is covered by existing rather than by being remembered.

## Checked

- All seven paths the glob resolves to exist on main and each has both a `pyproject.toml` and a `uv.lock`.
- Config parses; `uv` directories are `['/', '/e2e/fabric-cli', '/examples/*']`.

## Worth knowing

`open-pull-requests-limit` for this ecosystem is 5, and seven directories have just become visible. The first run after this may hit that cap, and the `python` group means one PR per directory rather than one per package. If the cap turns out to hide something, raising it is a separate and deliberate change rather than something to fold in here.
