### PR TITLE
Hold great-expectations' major: 1.0 replaced the validation API.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,6 +127,37 @@ updates:
       #
       # LIFT THIS when dbt-databricks raises its databricks-sdk ceiling.
       - dependency-name: databricks-sdk
+      # great-expectations 1.0 REPLACED the validation API, so this is a
+      # rewrite rather than a bump. `contract_gate.py` in both advanced
+      # medallion examples builds its validator as
+      #
+      #   ctx.sources.add_pandas(...) -> add_dataframe_asset ->
+      #   build_batch_request -> ctx.get_validator(...)
+      #
+      # and 1.x has none of those: `sources` is `data_sources`, batch requests
+      # became batch definitions, and `get_validator` is gone in favour of
+      # ValidationDefinition. Ten call sites across seven expectation types
+      # (`expect_column_values_to_not_be_null`, `..._to_be_unique`,
+      # `..._to_be_in_set`, `expect_compound_columns_to_be_unique`,
+      # `expect_table_row_count_to_equal`, `..._to_be_between`,
+      # `expect_table_column_count_to_equal`) each change shape and each
+      # returns a different result object.
+      #
+      # HELD BECAUSE THESE GATES ARE A WITNESS SURFACE, not because the work is
+      # large. The examples run the ODCS contracts as gates and prove they can
+      # fail, deliberately breaking a rule and requiring the failure. Rewriting
+      # how they assert as a side effect of a dependency bump would change what
+      # that evidence means, quietly. It earns its own change, with the
+      # deliberate-failure case re-proved on the new API.
+      #
+      # The widening arrived as `great-expectations>=0.18,<1` -> `<2` and broke
+      # both advanced medallion e2es with
+      # `AttributeError: 'EphemeralDataContext' object has no attribute 'sources'`.
+      #
+      # LIFT THIS by doing the migration; there is no upstream change to wait
+      # for. Minor and patch updates inside 0.18 keep flowing.
+      - dependency-name: great-expectations
+        update-types: ['version-update:semver-major']
 
   # The published imageS' base layers, plural. `directory: /` watched exactly
   # one file, ./Dockerfile, and this repository has twelve. The two that matter


### PR DESCRIPTION
`#447` widens `great-expectations` from `>=0.18,<1` to `<2`, and both advanced medallion e2es fail:

```
AttributeError: 'EphemeralDataContext' object has no attribute 'sources'
FAILED at contract_gates.py (exit 1)
```

## This is a rewrite, not a bump

`contract_gate.py` in both advanced medallion examples builds its validator as

```python
ctx.sources.add_pandas(...) → add_dataframe_asset(...) → build_batch_request(...)
→ ctx.get_validator(batch_request=..., create_expectation_suite_with_name=...)
```

**1.x has none of that.** `sources` became `data_sources`, batch requests became batch definitions, and `get_validator` is gone in favour of `ValidationDefinition`. Beyond the constructor, ten call sites across seven expectation types each change shape and each returns a different result object: `expect_column_values_to_not_be_null`, `..._to_be_unique`, `..._to_be_in_set`, `expect_compound_columns_to_be_unique`, `expect_table_row_count_to_equal`, `..._to_be_between`, `expect_table_column_count_to_equal`.

## Held because the gates are evidence, not because the work is large

These examples run the ODCS contracts as gates **and prove the gates can fail**, breaking a rule on purpose and requiring the failure, on the principle that a check never seen to fail is one nobody should trust.

Rewriting how they assert as a side effect of a dependency bump would change what that evidence means, silently and in the same PR as a dozen unrelated updates. The migration earns its own change, with the deliberate-failure case re-proved against the new API.

So this holds the major in the shape this file already uses for `cryptography`, `pandas` and `databricks-sdk`: the constraint is named so it can be rechecked, and the comment says what to do rather than merely that it is held. **Unlike those three there is no upstream change to wait for** — lifting it means doing the migration. Minor and patch updates inside 0.18 keep flowing.

## Why this surfaced now

The examples were unwatched until [#445](https://github.com/calvinchengx/fabric-emulator/pull/445) pointed the `uv` ecosystem at `/examples/*`. The first run afterwards produced #447 and found this on its first attempt, which is the coverage that change was for.
