### PR TITLE
The examples take the root's pyarrow range, floor included.

### DIFF
--- a/examples/contoso-fixtures-advanced/pyproject.toml
+++ b/examples/contoso-fixtures-advanced/pyproject.toml
@@ -15,7 +15,22 @@ description = "Web-store and ERP source fixtures for the advanced medallion exam
 requires-python = ">=3.12"
 dependencies = [
     "contoso-fixtures",
-    "pyarrow>=18,<24",  # the ERP feed is Parquet, as a columnar source would be
+    # MATCHES THE ROOT's RANGE, and both halves of it matter.
+    #
+    # The ceiling was `<24` while every group in the root pyproject asks for
+    # `>=23.0.1,<26`. They overlapped only on 23.x, so the moment Dependabot
+    # proposed pyarrow 25.0.1 the workspace became unsatisfiable:
+    #
+    #   Because contoso-fixtures-advanced==0.1.0 depends on pyarrow>=18,<24
+    #   and your project depends on pyarrow==25.0.1, we can conclude that
+    #   your project's requirements are unsatisfiable.
+    #
+    # The floor was `>=18`, which permits 18 through 22 — inside
+    # GHSA-rgxp-2hwp-jwgg (use-after-free reading an IPC file with
+    # pre-buffering, vulnerable >=15.0.0,<23.0.1), the advisory the root was
+    # floored to 23.0.1 for. An example is the last place to leave that open,
+    # because examples are what people copy.
+    "pyarrow>=23.0.1,<26",  # the ERP feed is Parquet, as a columnar source would be
 ]
 
 # Flat modules for the same reason as contoso-fixtures: `import web_store as web`

--- a/examples/contoso-fixtures-advanced/uv.lock
+++ b/examples/contoso-fixtures-advanced/uv.lock
@@ -101,7 +101,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "contoso-fixtures", editable = "../contoso-fixtures" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
 ]
 
 [[package]]

--- a/examples/fab-driven/pyproject.toml
+++ b/examples/fab-driven/pyproject.toml
@@ -22,7 +22,12 @@ dependencies = [
     # Reads the Delta bytes back independently of anything fab said — the
     # second opinion readback.py is built on.
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<24",
+    # MATCHES THE ROOT's RANGE. The ceiling was `<24` while the root asks for
+    # `>=23.0.1,<26`, so a pyarrow 25 bump makes this project unsatisfiable;
+    # the floor was `>=18`, which permits 18 through 22, inside
+    # GHSA-rgxp-2hwp-jwgg (vulnerable >=15.0.0,<23.0.1) that the root was
+    # floored to 23.0.1 for. Examples are what people copy.
+    "pyarrow>=23.0.1,<26",
     "requests>=2.32,<3",
 ]
 

--- a/examples/fab-driven/uv.lock
+++ b/examples/fab-driven/uv.lock
@@ -197,7 +197,7 @@ dev = [
 requires-dist = [
     { name = "contoso-fixtures", editable = "../contoso-fixtures" },
     { name = "deltalake", specifier = ">=0.23,<2" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 

--- a/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-advanced-dbt-fabricspark/pyproject.toml
@@ -21,7 +21,21 @@ dependencies = [
     "dbt-fabric>=1.11",
     "dbt-fabricspark>=1.13",
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<24",
+    # MATCHES THE ROOT's RANGE, and both halves of it matter.
+    #
+    # The ceiling was `<24` while every group in the root pyproject asks for
+    # `>=23.0.1,<26`, so the moment Dependabot proposed pyarrow 25.0.1 this
+    # project became unsatisfiable:
+    #
+    #   Because your project depends on pyarrow>=18,<24 and pyarrow==25.0.1,
+    #   we can conclude that your project's requirements are unsatisfiable.
+    #
+    # The floor was `>=18`, which permits 18 through 22 -- inside
+    # GHSA-rgxp-2hwp-jwgg (use-after-free reading an IPC file with
+    # pre-buffering, vulnerable >=15.0.0,<23.0.1), the advisory the root was
+    # floored to 23.0.1 for. An example is the last place to leave that open,
+    # because examples are what people copy.
+    "pyarrow>=23.0.1,<26",
     "pyodbc>=5.2,<6",
     "pyspark-client==4.1.1",
     "requests>=2.32,<3",

--- a/examples/medallion-advanced-dbt-fabricspark/uv.lock
+++ b/examples/medallion-advanced-dbt-fabricspark/uv.lock
@@ -494,7 +494,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "contoso-fixtures", editable = "../contoso-fixtures" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
 ]
 
 [[package]]
@@ -825,7 +825,7 @@ requires-dist = [
     { name = "dbt-fabricspark", specifier = ">=1.13" },
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "great-expectations", specifier = ">=0.18,<1" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyodbc", specifier = ">=5.2,<6" },
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "pyyaml", specifier = ">=6,<7" },

--- a/examples/medallion-advanced-pyspark/pyproject.toml
+++ b/examples/medallion-advanced-pyspark/pyproject.toml
@@ -20,7 +20,21 @@ dependencies = [
     "contoso-fixtures-advanced",
     "dbt-fabric>=1.11",
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<24",
+    # MATCHES THE ROOT's RANGE, and both halves of it matter.
+    #
+    # The ceiling was `<24` while every group in the root pyproject asks for
+    # `>=23.0.1,<26`, so the moment Dependabot proposed pyarrow 25.0.1 this
+    # project became unsatisfiable:
+    #
+    #   Because your project depends on pyarrow>=18,<24 and pyarrow==25.0.1,
+    #   we can conclude that your project's requirements are unsatisfiable.
+    #
+    # The floor was `>=18`, which permits 18 through 22 -- inside
+    # GHSA-rgxp-2hwp-jwgg (use-after-free reading an IPC file with
+    # pre-buffering, vulnerable >=15.0.0,<23.0.1), the advisory the root was
+    # floored to 23.0.1 for. An example is the last place to leave that open,
+    # because examples are what people copy.
+    "pyarrow>=23.0.1,<26",
     "pyodbc>=5.2,<6",
     "pyspark-client==4.1.1",
     "requests>=2.32,<3",

--- a/examples/medallion-advanced-pyspark/uv.lock
+++ b/examples/medallion-advanced-pyspark/uv.lock
@@ -494,7 +494,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "contoso-fixtures", editable = "../contoso-fixtures" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
 ]
 
 [[package]]
@@ -806,7 +806,7 @@ requires-dist = [
     { name = "dbt-fabric", specifier = ">=1.11" },
     { name = "deltalake", specifier = ">=0.23,<2" },
     { name = "great-expectations", specifier = ">=0.18,<1" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyodbc", specifier = ">=5.2,<6" },
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "pyyaml", specifier = ">=6,<7" },

--- a/examples/medallion-dbt-fabricspark/pyproject.toml
+++ b/examples/medallion-dbt-fabricspark/pyproject.toml
@@ -32,7 +32,12 @@ dependencies = [
     "dbt-spark>=1.11",
     "pyspark-client>=4.1",
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<24",
+    # MATCHES THE ROOT's RANGE. The ceiling was `<24` while the root asks for
+    # `>=23.0.1,<26`, so a pyarrow 25 bump makes this project unsatisfiable;
+    # the floor was `>=18`, which permits 18 through 22, inside
+    # GHSA-rgxp-2hwp-jwgg (vulnerable >=15.0.0,<23.0.1) that the root was
+    # floored to 23.0.1 for. Examples are what people copy.
+    "pyarrow>=23.0.1,<26",
     "pyodbc>=5.2,<6",
     "pyspark-client==4.1.1",
     "requests>=2.32,<3",

--- a/examples/medallion-dbt-fabricspark/uv.lock
+++ b/examples/medallion-dbt-fabricspark/uv.lock
@@ -621,7 +621,7 @@ requires-dist = [
     { name = "dbt-fabricspark", specifier = ">=1.13" },
     { name = "dbt-spark", specifier = ">=1.11" },
     { name = "deltalake", specifier = ">=0.23,<2" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyodbc", specifier = ">=5.2,<6" },
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "pyspark-client", specifier = ">=4.1" },

--- a/examples/medallion-pyspark/pyproject.toml
+++ b/examples/medallion-pyspark/pyproject.toml
@@ -16,7 +16,12 @@ dependencies = [
     "contoso-fixtures",
     "dbt-fabric>=1.11",
     "deltalake>=0.23,<2",
-    "pyarrow>=18,<24",
+    # MATCHES THE ROOT's RANGE. The ceiling was `<24` while the root asks for
+    # `>=23.0.1,<26`, so a pyarrow 25 bump makes this project unsatisfiable;
+    # the floor was `>=18`, which permits 18 through 22, inside
+    # GHSA-rgxp-2hwp-jwgg (vulnerable >=15.0.0,<23.0.1) that the root was
+    # floored to 23.0.1 for. Examples are what people copy.
+    "pyarrow>=23.0.1,<26",
     "pyodbc>=5.2,<6",
     # Drives notebook cells and the silver transform onto Sail over Spark
     # Connect (no JVM).

--- a/examples/medallion-pyspark/uv.lock
+++ b/examples/medallion-pyspark/uv.lock
@@ -585,7 +585,7 @@ requires-dist = [
     { name = "contoso-fixtures", editable = "../contoso-fixtures" },
     { name = "dbt-fabric", specifier = ">=1.11" },
     { name = "deltalake", specifier = ">=0.23,<2" },
-    { name = "pyarrow", specifier = ">=18,<24" },
+    { name = "pyarrow", specifier = ">=23.0.1,<26" },
     { name = "pyodbc", specifier = ">=5.2,<6" },
     { name = "pyspark-client", specifier = "==4.1.1" },
     { name = "requests", specifier = ">=2.32,<3" },


### PR DESCRIPTION
The `uv` Dependabot job fails on a split it cannot solve:

```
No solution found ... (markers: python_full_version >= '3.14' and sys_platform == 'win32')
  Because your project depends on pyarrow>=18,<24 and pyarrow==25.0.1,
  we can conclude that your project's requirements are unsatisfiable.
```

**Both sides of that conflict are ours.** Six examples pin `pyarrow>=18,<24`; every group in the root `pyproject.toml` asks for `>=23.0.1,<26`. They overlapped only on 23.x, so any pyarrow 24-or-later bump was unsatisfiable by construction.

## The floor was the more interesting half

`>=18` permits pyarrow 18 through 22, which sit inside **GHSA-rgxp-2hwp-jwgg** — use-after-free reading an IPC file with pre-buffering, vulnerable `>=15.0.0,<23.0.1`. That is the advisory this repository floored the root to 23.0.1 for in `v0.35.0`. The examples never got the floor, and **examples are what people copy out of a repository**.

So all six now match the root exactly: `pyarrow>=23.0.1,<26`.

| example | |
| --- | --- |
| contoso-fixtures-advanced | aligned |
| medallion-advanced-pyspark | aligned |
| medallion-advanced-dbt-fabricspark | aligned |
| medallion-pyspark | aligned |
| medallion-dbt-fabricspark | aligned |
| fab-driven | aligned |

## Verified in the directory that actually failed

My first attempt changed only `contoso-fixtures-advanced`, because that is what the error names, and I tested the fix at the repository root. **The control passed on unmodified main too**, which meant the root was never the failing context and the test proved nothing: the examples are separate projects, not workspace members, so the root's resolution never sees them.

Re-run in `examples/medallion-advanced-pyspark`, which is where Dependabot actually resolves:

| | `uv lock --upgrade-package pyarrow==25.0.1` |
| --- | --- |
| unmodified `origin/main` | **exit 1**, the error above |
| this branch | **exit 0** |

Same result in `medallion-advanced-dbt-fabricspark` and `contoso-fixtures-advanced`. All six re-locked and `uv lock --check` clean; each resolves pyarrow 23.0.1 today, so nothing moves version, only the range that was blocking the bump.

## Why now

These directories were unwatched until [#445](https://github.com/calvinchengx/fabric-emulator/pull/445) pointed the `uv` ecosystem at `/examples/*`. This is the second real problem that change surfaced, after the great-expectations major in [#448](https://github.com/calvinchengx/fabric-emulator/pull/448).
