### PR TITLE
Dependabot watches the seven example projects.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,21 @@ updates:
     directories:
       - /
       - /e2e/fabric-cli
+      # THE EXAMPLES, all seven, each its own project with its own lockfile and
+      # until now watched by nothing. They are the code readers copy, so a
+      # stale pin here is advice rather than an internal detail.
+      #
+      # Found via a stale SECURITY alert, which is the part worth recording:
+      # alert #67 reports tornado against `examples/medallion/uv.lock`, a path
+      # that has not existed since the medallion examples were split into the
+      # four `medallion-*` directories. Security updates follow the dependency
+      # graph and ignore this file, so Dependabot kept trying to update a
+      # deleted manifest and failed at file fetching every run:
+      #   "Repo must contain a requirements.txt, uv.lock, ..."
+      # Every lockfile that actually carries tornado is already on 6.5.8, the
+      # fixed version, so nothing was ever vulnerable -- the alert outlived the
+      # directory it named. Listing the real directories is what lets the graph
+      # be rebuilt from paths that exist.
       - /examples/*
     schedule:
       interval: weekly


### PR DESCRIPTION
`Dependabot Updates` is red on a security update that cannot succeed and never needed to:

```
uv in /examples/medallion for tornado
ERROR Error during file fetching; aborting:
      Repo must contain a requirements.txt, uv.lock, ...
```

**Nothing is vulnerable.** Alert #67 names `examples/medallion/uv.lock`, a path that has not existed since the medallion examples were split into the four `medallion-*` directories. Every lockfile in the repository that actually carries tornado — `examples/medallion-advanced-dbt-fabricspark`, `examples/medallion-advanced-pyspark`, and the root — is already on **6.5.8**, which is the fixed version. The alert outlived the directory it named, and Dependabot fails at file fetching every run trying to update a deleted manifest.

## The gap it exposed

Security updates follow the dependency graph and ignore `dependabot.yml`, which is why this kept firing at a path no config mentions. **Version** updates do read the config, and it listed only `/` and `/e2e/fabric-cli` — so **seven example projects, each with its own `uv.lock`, were watched by nothing at all.**

That matters more here than for internal code: the examples are what readers copy, so a stale pin in one is advice rather than an implementation detail.

Adding `/examples/*` takes uv coverage from **2 of 9 projects to 9 of 9**, verified by expanding the globs against the actual tree rather than by reading the pattern.

Same shape as [#417](https://github.com/calvinchengx/fabric-emulator/pull/417), where `directory: /` turned out to watch 1 of 12 Dockerfiles and miss both published sidecars.

## Not done here

**Alert #67 itself needs dismissing**, and that is a risk-disposition call rather than a config change, so I have left it. It cannot resolve on its own: it points at a manifest that no longer exists, so no update can ever close it. Listing the real directories lets the graph be rebuilt from paths that exist, but the stale alert will keep this job red until someone dismisses it as "no longer vulnerable".