### PR TITLE
Fix leaked test env, failed Environment cache, and unmounted JAR submit

### DIFF
--- a/internal/api/jarsubmit.go
+++ b/internal/api/jarsubmit.go
@@ -248,6 +248,11 @@ func (e *pipelineExecutor) databricksJarActivity(
 	defer func() { _, _ = e.a.agentPost("/close", map[string]any{"session": session}) }()
 	// Mounts the lakehouse's Files/ at /lakehouse/default/Files, which is how
 	// the submitted process reaches the jar and anything it reads.
+	if err := e.a.mountLakehouseFiles(session, e.wid, itemID); err != nil {
+		return nil, fmt.Errorf("%s %q: the lakehouse Files mount for item %q is not available, "+
+			"so submitting %q would risk running a stale or wrong jar: %v",
+			label, act.Name, itemID, mainClass, err)
+	}
 	e.a.registerLakehouseTables(session, e.wid, itemID)
 
 	return e.submitMainClass(label, act, session, mainClass, jarMountPath(base), argv, nil)

--- a/internal/api/jarsubmit_test.go
+++ b/internal/api/jarsubmit_test.go
@@ -14,14 +14,22 @@ type jarAgent struct {
 	agent     *fakeAgent
 	available bool
 	exit      int
+	mountOK   bool
 	seen      map[string]any
 }
 
 func newJarAgent(t *testing.T, a *API, available bool, exit int) *jarAgent {
 	t.Helper()
-	j := &jarAgent{available: available, exit: exit}
+	j := &jarAgent{available: available, exit: exit, mountOK: true}
 	j.agent = newFakeAgent(t, a)
 	j.agent.onPost = func(path string, body map[string]any) (map[string]any, bool) {
+		if path == "/mount" {
+			if !j.mountOK {
+				return map[string]any{"mounted": false,
+					"error": "this agent already has lakehouse old mounted"}, true
+			}
+			return map[string]any{"mounted": true}, true
+		}
 		if path != "/submit" {
 			return nil, false
 		}
@@ -97,6 +105,29 @@ func TestDatabricksJarRunsOnAnEngineThatCanSubmit(t *testing.T) {
 	}
 	if s, _ := out["executedBy"].(string); !strings.Contains(s, "not a Databricks cluster") {
 		t.Fatalf("output does not say which engine answered: %+v", out)
+	}
+}
+
+func TestDatabricksJarRefusesWhenTheFilesMountDidNotBind(t *testing.T) {
+	a, st := newAPI(t)
+	j := newJarAgent(t, a, true, 0)
+	j.mountOK = false
+	ws := seedWorkspace(t, st)
+	_, ref := seedJar(t, st, ws.ID)
+
+	pl := createPipeline(t, st, ws.ID, jarPipeline(
+		`"mainClassName":"com.acme.Etl","libraries":[{"jar":"`+ref+`"}]`))
+	_, jid := runJob(t, a, ws.ID, pl.ID, "jobType=Pipeline", "{}")
+	if s := awaitJob(t, a, ws.ID, pl.ID, jid); s != "Failed" {
+		t.Fatalf("job = %s, want Failed when the Files mount refuses", s)
+	}
+	if j.seen != nil {
+		t.Fatalf("submitted despite a failed Files mount: %+v", j.seen)
+	}
+	_, runs := activityRuns(t, a, ws.ID, pl.ID, jid)
+	e, _ := runs[0]["error"].(string)
+	if !strings.Contains(e, "Files mount") || !strings.Contains(e, "stale or wrong jar") {
+		t.Fatalf("error %q does not name the mount risk", e)
 	}
 }
 

--- a/internal/api/livy_catalog.go
+++ b/internal/api/livy_catalog.go
@@ -94,16 +94,9 @@ func (a *API) registerLakehouseTables(session, wid, lid string) {
 	// deliberately says nothing when there are no tables). Best-effort like the
 	// rest of this function; an agent predating /mount answers 404 and the
 	// notebook keeps whatever was staged by hand.
-	if out, err := a.agentPost("/mount", map[string]any{
-		"session": session, "workspace": wid, "lakehouse": lid}); err != nil {
-		log.Printf("livy: mounting lakehouse %s Files for session %s: %v", lid, session, err)
-	} else if mounted, _ := out["mounted"].(bool); !mounted {
-		// The agent answers 200 with mounted:false when it could not mirror
-		// (its error rides in the body). Treating that as success is how a
-		// missing mount stayed invisible until a notebook hit
-		// FileNotFoundError; the cause belongs in THIS log, at bind time.
+	if err := a.mountLakehouseFiles(session, wid, lid); err != nil {
 		log.Printf("livy: lakehouse %s Files did NOT mount for session %s: %v",
-			lid, session, out["error"])
+			lid, session, err)
 	}
 	dirs, err := a.Store.ListOneLakePaths(lid, "Tables", false)
 	if err != nil {
@@ -179,6 +172,22 @@ func (a *API) registerLakehouseTables(session, wid, lid string) {
 		log.Printf("livy: %d of %d table(s) of lakehouse %s did not register: %v",
 			len(skipped), len(tables), it.DisplayName, skipped)
 	}
+}
+
+func (a *API) mountLakehouseFiles(session, wid, lid string) error {
+	out, err := a.agentPost("/mount", map[string]any{
+		"session": session, "workspace": wid, "lakehouse": lid})
+	if err != nil {
+		return fmt.Errorf("mounting lakehouse Files: %w", err)
+	}
+	if mounted, _ := out["mounted"].(bool); !mounted {
+		// The agent answers 200 with mounted:false when it could not mirror
+		// (its error rides in the body). Treating that as success is how a
+		// missing mount stayed invisible until the code using /lakehouse hit
+		// FileNotFoundError; the cause belongs at bind time.
+		return fmt.Errorf("%v", out["error"])
+	}
+	return nil
 }
 
 // applyEnvironment hands a session's Environment to the agent: the packages to

--- a/python/fabric-target/tests/test_fabric_target.py
+++ b/python/fabric-target/tests/test_fabric_target.py
@@ -22,7 +22,10 @@ def clean_env(monkeypatch):
               "FABRIC_URL", "ENTRA_URL", "AZURE_KEY_VAULT_URL",
               "AZURE_CLIENT_ID"):
         monkeypatch.delenv(k, raising=False)
-    fabric_target._cached = None
+    # setattr so the cache is restored on the way OUT as well as cleared on the
+    # way in. `target(fresh=True)` still writes _cached, so this file leaked a
+    # resolved target into whatever ran after it.
+    monkeypatch.setattr(fabric_target, "_cached", None)
 
 
 def test_emulator_defaults_are_zero_config():

--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -270,7 +270,13 @@ def apply_environment(req):
               f"classpath is fixed at engine start, so they are NOT applied "
               f"(docs/37)", file=sys.stderr, flush=True)
 
-    _environment_applied[env_id] = {"session": session, "packages": packages}
+    # Record only a SUCCESS. Remembering a failed pip is how a retry Completes
+    # with the Environment listed and nothing installed — the first bind
+    # correctly reports applied:false, the second claims "already installed".
+    # It also occupies the one-environment slot, so a later different
+    # Environment is refused as a conflict even though nothing was installed.
+    if ok:
+        _environment_applied[env_id] = {"session": session, "packages": packages}
     return {"applied": ok, "reason": detail, "packages": packages,
             "sparkConfig": applied_config, "jarsSkipped": len(jars)}
 

--- a/python/spark_agent/submit.py
+++ b/python/spark_agent/submit.py
@@ -79,8 +79,17 @@ def _resolve_in_mount(requested):
     for dirpath, _dirnames, filenames in os.walk(root):
         for name in filenames:
             found = os.path.join(dirpath, name)
-            if rel(os.path.relpath(found, root)) == wanted:
-                return found
+            if rel(os.path.relpath(found, root)) != wanted:
+                continue
+            if os.path.islink(found):
+                return None
+            resolved = os.path.realpath(found)
+            try:
+                if os.path.commonpath([root, resolved]) != root:
+                    return None
+            except ValueError:  # pragma: no cover - different drives on Windows
+                return None
+            return resolved
     return None
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,49 @@
+"""Process-global state this suite must not carry between tests.
+
+`examples/contoso-fixtures/common.py` calls `apply_notebook_env(_T)` at MODULE
+IMPORT time — deliberately, because a Fabric notebook step imports it and must
+get the notebook runtime context wired for the resolved target before it calls
+anything. Three tests here import that module, so three tests write real
+NOTEBOOKUTILS_* keys into the real `os.environ`.
+
+`monkeypatch` cannot undo that. Those tests do call `monkeypatch.delenv(k,
+raising=False)` for the NOTEBOOKUTILS_* keys first, but delenv records an undo
+entry only for a key that WAS set; keys the import then creates from nothing are
+invisible to it and survive the test, the module, and the session.
+
+What they broke was not another example test but `fabric-target`'s own
+`test_apply_notebook_env_wires_the_shim_for_this_process`, which passed alone and
+failed in the full run. `apply_notebook_env` does not overwrite an already-set
+value (`if override or not os.environ.get(k)`) — documented, intentional, and the
+whole reason an explicit export or compose file wins. Given a leaked key it
+correctly declines to set the value the later test asserts. The production code
+is right; the leak was the defect.
+
+So the environment is snapshotted and restored around EVERY test in this
+directory. It is not scoped to the three importers on purpose: the leak reached a
+test in a different package, which is exactly the kind of coupling a per-file fix
+leaves in place for the next module-level side effect to rediscover.
+"""
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_os_environ():
+    """Snapshot os.environ, hand the test the real one, then put it back.
+
+    Restored in place rather than by rebinding `os.environ`: os.environ is a
+    live mapping whose __setitem__ also calls putenv, and code under test holds
+    references to it (and to `os.getenv`). Rebinding would leave the real
+    process environment — the one a subprocess inherits — untouched.
+    """
+    snapshot = dict(os.environ)
+    try:
+        yield
+    finally:
+        for key in [k for k in os.environ if k not in snapshot]:
+            del os.environ[key]
+        for key, value in snapshot.items():
+            if os.environ.get(key) != value:
+                os.environ[key] = value

--- a/python/tests/test_agent_environment.py
+++ b/python/tests/test_agent_environment.py
@@ -105,13 +105,43 @@ def test_jars_are_reported_as_skipped_rather_than_silently_dropped(agent):
 
 
 def test_a_failed_install_is_reported_not_raised(agent, monkeypatch):
+    attempts = []
+
     def failing(specs, source):
+        attempts.append(list(specs))
         return False, "no matching distribution"
 
     monkeypatch.setitem(agent.__dict__, "_install_packages", failing)
-    out = agent.apply_environment({
-        "session": "s1", "environment": "env-bad", "packages": ["nope==9.9.9"]})
+    req = {"session": "s1", "environment": "env-bad", "packages": ["nope==9.9.9"]}
+    out = agent.apply_environment(req)
     # A session bind must not die because a package failed; the caller logs it
     # and the notebook meets a clear ModuleNotFoundError later.
     assert out["applied"] is False
     assert "no matching distribution" in out["reason"]
+
+    # Recording the failed attempt is how a retry Completes with the
+    # Environment listed and nothing installed. A second bind of the same id
+    # must try again, not claim "already installed".
+    retry = agent.apply_environment({**req, "session": "s2"})
+    assert retry["applied"] is False
+    assert "already installed" not in retry["reason"]
+    assert "no matching distribution" in retry["reason"]
+    assert len(attempts) == 2
+
+
+def test_a_failed_install_does_not_occupy_the_agent(agent, monkeypatch):
+    def install(specs, source):
+        if specs == ["nope==9.9.9"]:
+            return False, "no matching distribution"
+        return True, f"installed {len(specs)} package(s)"
+
+    monkeypatch.setitem(agent.__dict__, "_install_packages", install)
+    assert agent.apply_environment({
+        "session": "s1", "environment": "env-bad", "packages": ["nope==9.9.9"],
+    })["applied"] is False
+    # Nothing was installed, so a later bind of a different Environment is
+    # still allowed — recording the failure would refuse it as a conflict.
+    out = agent.apply_environment({
+        "session": "s2", "environment": "env-good", "packages": ["anytree"],
+    })
+    assert out["applied"] is True

--- a/python/tests/test_example_env_isolation.py
+++ b/python/tests/test_example_env_isolation.py
@@ -1,0 +1,42 @@
+"""The examples' fixtures module must not leak its import-time env into the suite.
+
+This is a test-isolation regression, so what it pins is an ORDER, not a value:
+the two node ids below pass individually and, before `python/tests/conftest.py`
+restored `os.environ` around each test, failed together. Running them in one
+child process is the whole assertion — an in-process check could not make it,
+because by the time this test body runs the fixture has already cleaned up.
+
+`examples/contoso-fixtures/common.py` calls `apply_notebook_env()` at import,
+which writes NOTEBOOKUTILS_* into the real `os.environ`. `apply_notebook_env`
+then declines to overwrite an already-set key, on purpose, so the leaked value
+survives into `fabric-target`'s own test of that function and it reads back the
+wrong URL. See python/tests/conftest.py.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+LEAKER = "python/tests/test_example_sql_endpoint.py"
+VICTIM = ("python/fabric-target/tests/test_fabric_target.py"
+          "::test_apply_notebook_env_wires_the_shim_for_this_process")
+
+
+def test_importing_the_fixtures_module_does_not_break_a_later_test():
+    """The minimal reproducer, run as its own process."""
+    # The child must start from a clean notebook context or it proves nothing:
+    # an ambient NOTEBOOKUTILS_FABRIC_URL in the developer's shell would fail the
+    # victim test whatever this conftest does, and an ambient FABRIC_TARGET
+    # changes which URL the leak carries.
+    env = {k: v for k, v in os.environ.items()
+           if not k.startswith("NOTEBOOKUTILS_") and k != "FABRIC_TARGET"}
+    run = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", LEAKER, VICTIM],
+        cwd=REPO, env=env, capture_output=True, text=True,
+    )
+    assert run.returncode == 0, (
+        "the fixtures module leaked its import-time environment into a later "
+        f"test:\n{run.stdout}\n{run.stderr}"
+    )

--- a/python/tests/test_example_lro.py
+++ b/python/tests/test_example_lro.py
@@ -90,7 +90,8 @@ def load_common(monkeypatch, tmp_path):
     monkeypatch.setenv("FABRIC_TARGET", "emulator")
     monkeypatch.setenv("PIPELINE_STATE", str(tmp_path / "state.json"))
     monkeypatch.setattr(fabric_target, "_az_logged_in", lambda: True)
-    fabric_target._cached = None
+    # setattr, not a bare assignment — see test_example_sql_endpoint.load_common.
+    monkeypatch.setattr(fabric_target, "_cached", None)
     sys.modules.pop("common", None)
     common = importlib.import_module("common")
     (tmp_path / "state.json").write_text('{"workspace": "ws-1"}')

--- a/python/tests/test_example_sql_endpoint.py
+++ b/python/tests/test_example_sql_endpoint.py
@@ -75,7 +75,11 @@ def load_common(monkeypatch, tmp_path, target_name, **env):
     for k, v in env.items():
         monkeypatch.setenv(k, v)
     monkeypatch.setattr(fabric_target, "_az_logged_in", lambda: True)
-    fabric_target._cached = None
+    # setattr, not a bare assignment: `common` resolves a target AT IMPORT, which
+    # populates fabric_target._cached, and a raw write here has no undo. The
+    # resolved target would outlive the test the same way its NOTEBOOKUTILS_*
+    # keys did (python/tests/conftest.py).
+    monkeypatch.setattr(fabric_target, "_cached", None)
     sys.modules.pop("common", None)
     common = importlib.import_module("common")
     (tmp_path / "state.json").write_text('{"workspace": "ws-1"}')

--- a/python/tests/test_spark_agent_submit.py
+++ b/python/tests/test_spark_agent_submit.py
@@ -137,6 +137,19 @@ def test_an_absolute_path_elsewhere_is_refused(has_submit, monkeypatch):
     assert out["ok"] is False and "no jar matching" in out["error"]
 
 
+def test_a_symlink_out_of_the_mount_is_refused(tmp_path, monkeypatch):
+    root = tmp_path / "Files"
+    (root / "jobs").mkdir(parents=True)
+    outside = tmp_path / "outside.jar"
+    outside.write_text("outside")
+    try:
+        (root / "jobs" / "etl.jar").symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks are unavailable on this runner: {exc}")
+    monkeypatch.setattr(s, "MOUNT_ROOT", str(root))
+    assert s._resolve_in_mount("jobs/etl.jar") is None
+
+
 def test_a_sibling_directory_sharing_the_prefix_is_refused(tmp_path, monkeypatch):
     """`/lakehouse/default/Files-evil` starts with the root AS A STRING while
     being a different directory. The enumeration never produces it, so the


### PR DESCRIPTION
## Summary
- Restore `os.environ` (and `fabric_target._cached`) around every `python/tests` case so example imports cannot leak into later tests.
- Record an Environment on the Spark agent only after a successful install, so a retry cannot Complete with packages never installed.
- Fail a Databricks JAR submit when the Files mount did not bind, and refuse a symlink that escapes the mount.

## Test plan
- [x] `uv run --frozen --group test pytest python/tests/test_agent_environment.py python/tests/test_agent_consumer_contract.py python/tests/test_spark_agent_submit.py`
- [x] `go test ./internal/api/ -run 'Environment|Jar|DatabricksJar|Lakehouse'`
- [ ] CI green on this PR (Linux/macOS/Windows matrix)