### PR TITLE
Lock the Files mount while statements and spark-submit share it

### DIFF
--- a/python/spark_agent/files_mount.py
+++ b/python/spark_agent/files_mount.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import os
 import posixpath
+import threading
 from typing import TypedDict
 
 
@@ -38,6 +39,17 @@ class _MountState(TypedDict):
 
 MOUNT_ROOT = "/lakehouse/default/Files"
 _state: _MountState = {"workspace": None, "lakehouse": None, "seen": {}}
+# ThreadingHTTPServer serves /statements and /submit at once. refresh/flush/sync
+# mutate this snapshot, and spark-submit reads the tree for up to 900s. Without
+# a lock a torn `_state["seen"]` skips a flush or a submit reads a half-pulled
+# tree. hold() is the same lock, held across a submit so a statement refresh
+# waits rather than rewriting Files/ under spark-submit.
+_lock = threading.RLock()
+
+
+def hold():
+    """Held while spark-submit reads the mount. Same lock as sync/refresh/flush."""
+    return _lock
 
 
 def _under_mount(rel: str):
@@ -178,13 +190,14 @@ def flush() -> dict:
     No-op when nothing is mounted. Failures are counted, not raised: a single
     bad put must not fail the statement that produced the file.
     """
-    workspace, lakehouse = _state["workspace"], _state["lakehouse"]
-    if not workspace or not lakehouse:
-        return {"flushed": 0, "flush_failed": 0}
-    fs = _import_fs()
-    if fs is None:
-        return {"flushed": 0, "flush_failed": 0, "error": "notebookutils unavailable"}
-    return _flush(fs, workspace, lakehouse)
+    with _lock:
+        workspace, lakehouse = _state["workspace"], _state["lakehouse"]
+        if not workspace or not lakehouse:
+            return {"flushed": 0, "flush_failed": 0}
+        fs = _import_fs()
+        if fs is None:
+            return {"flushed": 0, "flush_failed": 0, "error": "notebookutils unavailable"}
+        return _flush(fs, workspace, lakehouse)
 
 
 def _flush(fs, workspace: str, lakehouse: str) -> dict:
@@ -220,16 +233,17 @@ def refresh() -> dict:
     This is "fresh at every statement", not live FUSE. No-op until /mount has
     bound a lakehouse.
     """
-    workspace, lakehouse = _state["workspace"], _state["lakehouse"]
-    if not workspace or not lakehouse:
-        return {"refreshed": False}
-    fs = _import_fs()
-    if fs is None:
-        return {"refreshed": False, "error": "notebookutils unavailable"}
-    out = _flush(fs, workspace, lakehouse)
-    pulled = _pull(fs, workspace, lakehouse)
-    _state["seen"] = _snapshot()
-    return {"refreshed": True, "lakehouse": lakehouse, **out, **pulled}
+    with _lock:
+        workspace, lakehouse = _state["workspace"], _state["lakehouse"]
+        if not workspace or not lakehouse:
+            return {"refreshed": False}
+        fs = _import_fs()
+        if fs is None:
+            return {"refreshed": False, "error": "notebookutils unavailable"}
+        out = _flush(fs, workspace, lakehouse)
+        pulled = _pull(fs, workspace, lakehouse)
+        _state["seen"] = _snapshot()
+        return {"refreshed": True, "lakehouse": lakehouse, **out, **pulled}
 
 
 def sync(workspace: str, lakehouse: str) -> dict:
@@ -242,28 +256,29 @@ def sync(workspace: str, lakehouse: str) -> dict:
     A second bind of a *different* lakehouse is refused and leaves the first
     mount untouched. Re-binding the same lakehouse flushes then re-pulls.
     """
-    fs = _import_fs()
-    if fs is None:
-        return {"mounted": False, "error": "notebookutils unavailable"}
+    with _lock:
+        fs = _import_fs()
+        if fs is None:
+            return {"mounted": False, "error": "notebookutils unavailable"}
 
-    if _state["lakehouse"] not in (None, lakehouse):
-        refused = _conflict(lakehouse)
-        print(f"files_mount: {refused['error']}", flush=True)
-        return refused
+        if _state["lakehouse"] not in (None, lakehouse):
+            refused = _conflict(lakehouse)
+            print(f"files_mount: {refused['error']}", flush=True)
+            return refused
 
-    if _state["lakehouse"] == lakehouse:
-        # Re-bind of the same lakehouse (every notebook run): flush first so
-        # in-flight local writes are not clobbered by the pull.
-        flushed = _flush(fs, workspace, lakehouse)
-    else:
-        flushed = {"flushed": 0, "flush_failed": 0}
+        if _state["lakehouse"] == lakehouse:
+            # Re-bind of the same lakehouse (every notebook run): flush first so
+            # in-flight local writes are not clobbered by the pull.
+            flushed = _flush(fs, workspace, lakehouse)
+        else:
+            flushed = {"flushed": 0, "flush_failed": 0}
 
-    _state["workspace"] = workspace
-    _state["lakehouse"] = lakehouse
-    pulled = _pull(fs, workspace, lakehouse)
-    _state["seen"] = _snapshot()
-    summary = {"mounted": True, "lakehouse": lakehouse, **pulled, **flushed}
-    print(f"files_mount: {lakehouse} -> {MOUNT_ROOT} "
-          f"(copied={pulled['copied']} kept={pulled['kept']} "
-          f"failed={pulled['failed']})", flush=True)
-    return summary
+        _state["workspace"] = workspace
+        _state["lakehouse"] = lakehouse
+        pulled = _pull(fs, workspace, lakehouse)
+        _state["seen"] = _snapshot()
+        summary = {"mounted": True, "lakehouse": lakehouse, **pulled, **flushed}
+        print(f"files_mount: {lakehouse} -> {MOUNT_ROOT} "
+              f"(copied={pulled['copied']} kept={pulled['kept']} "
+              f"failed={pulled['failed']})", flush=True)
+        return summary

--- a/python/spark_agent/files_mount.py
+++ b/python/spark_agent/files_mount.py
@@ -22,6 +22,11 @@ DIVERGENCES FROM REAL FABRIC, stated rather than hidden:
   - One mount point. Sessions bound to DIFFERENT lakehouses share
     /lakehouse/default; a second bind of a different lakehouse is refused
     (docs/37 §2c) rather than silently replacing the first session's files.
+  - Statement refresh and spark-submit share one lock. The agent is a
+    ThreadingHTTPServer, so /statements and /submit run at once; without the
+    lock a refresh rewrites Files/ under a 900s submit, or `_state["seen"]`
+    tears and a later flush skips a write. A submit can therefore stall a
+    statement for up to that timeout — stated, not hidden.
 """
 from __future__ import annotations
 

--- a/python/spark_agent/submit.py
+++ b/python/spark_agent/submit.py
@@ -115,6 +115,14 @@ def submit(main_class, jar_path, args=None, conf=None, timeout=900):
     if not main_class:
         return {"ok": False, "available": True, "exitCode": None,
                 "error": "mainClass is required"}
+    # Pause statement refresh for the walk and the JVM: ThreadingHTTPServer
+    # will otherwise rewrite Files/ under spark-submit (files_mount.hold).
+    import files_mount
+    with files_mount.hold():
+        return _submit_locked(binary, main_class, jar_path, args, conf, timeout)
+
+
+def _submit_locked(binary, main_class, jar_path, args, conf, timeout):
     contained = _resolve_in_mount(jar_path)
     if contained is None:
         # THE AGENT IS A SERVICE, NOT A LIBRARY. Whatever the emulator checks

--- a/python/tests/test_spark_agent_files_mount_e2e.py
+++ b/python/tests/test_spark_agent_files_mount_e2e.py
@@ -350,6 +350,20 @@ def test_the_agent_refreshes_the_mount_around_statements():
 
 def test_hold_blocks_refresh_until_released(mount, monkeypatch):
     """spark-submit holds this lock; a statement refresh must wait, not tear."""
+    _assert_hold_blocks(mount, monkeypatch, lambda: files_mount.refresh())
+
+
+def test_hold_blocks_flush_until_released(mount, monkeypatch):
+    """/close flushes; that must wait too, or it rewrites Files/ under submit."""
+    _assert_hold_blocks(mount, monkeypatch, lambda: files_mount.flush())
+
+
+def test_hold_blocks_sync_until_released(mount, monkeypatch):
+    """/mount during a submit must wait rather than replace the tree being read."""
+    _assert_hold_blocks(mount, monkeypatch, lambda: files_mount.sync("ws", "lh"))
+
+
+def _assert_hold_blocks(_mount, monkeypatch, op):
     base = "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Files"
     tree = FakeFS()
     tree.blobs[f"{base}/ok.txt"] = b"ok"
@@ -365,18 +379,18 @@ def test_hold_blocks_refresh_until_released(mount, monkeypatch):
             entered.set()
             release.wait(2)
 
-    def refresher():
+    def mutator():
         entered.wait(2)
-        files_mount.refresh()
+        op()
         finished.append(True)
 
     t1 = threading.Thread(target=holder)
-    t2 = threading.Thread(target=refresher)
+    t2 = threading.Thread(target=mutator)
     t1.start()
     t2.start()
     assert entered.wait(1)
-    assert t2.join(0.15) is None and finished == [], (
-        "refresh ran while hold() was held")
+    t2.join(0.15)
+    assert t2.is_alive() and finished == [], "mount mutation ran while hold() was held"
     release.set()
     t1.join(2)
     t2.join(2)

--- a/python/tests/test_spark_agent_files_mount_e2e.py
+++ b/python/tests/test_spark_agent_files_mount_e2e.py
@@ -10,6 +10,7 @@ first session's files left intact (docs/37 §2).
 
 import os
 import sys
+import threading
 import types
 from pathlib import Path
 
@@ -345,3 +346,66 @@ def test_the_agent_refreshes_the_mount_around_statements():
     close = src.split('elif self.path == "/close":', 1)[1]
     close = close.split("else:", 1)[0]
     assert "files_mount.flush()" in close
+
+
+def test_hold_blocks_refresh_until_released(mount, monkeypatch):
+    """spark-submit holds this lock; a statement refresh must wait, not tear."""
+    base = "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Files"
+    tree = FakeFS()
+    tree.blobs[f"{base}/ok.txt"] = b"ok"
+    install_tree(monkeypatch, tree)
+    files_mount.sync("ws", "lh")
+
+    entered = threading.Event()
+    release = threading.Event()
+    finished = []
+
+    def holder():
+        with files_mount.hold():
+            entered.set()
+            release.wait(2)
+
+    def refresher():
+        entered.wait(2)
+        files_mount.refresh()
+        finished.append(True)
+
+    t1 = threading.Thread(target=holder)
+    t2 = threading.Thread(target=refresher)
+    t1.start()
+    t2.start()
+    assert entered.wait(1)
+    assert t2.join(0.15) is None and finished == [], (
+        "refresh ran while hold() was held")
+    release.set()
+    t1.join(2)
+    t2.join(2)
+    assert finished == [True]
+
+
+def test_concurrent_refresh_and_flush_leave_a_coherent_seen(mount, monkeypatch):
+    base = "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Files"
+    tree = FakeFS()
+    tree.blobs[f"{base}/ok.txt"] = b"ok"
+    install_tree(monkeypatch, tree)
+    files_mount.sync("ws", "lh")
+    (mount / "local.txt").write_bytes(b"x")
+
+    errors = []
+
+    def hammer():
+        try:
+            for _ in range(15):
+                files_mount.refresh()
+                files_mount.flush()
+        except Exception as exc:  # noqa: BLE001 - collect, then assert empty
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hammer) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+    with files_mount.hold():
+        assert files_mount._state["seen"] == files_mount._snapshot()

--- a/python/tests/test_spark_agent_submit.py
+++ b/python/tests/test_spark_agent_submit.py
@@ -208,6 +208,9 @@ def test_submit_holds_the_mount_lock_while_the_jvm_runs(has_submit, monkeypatch)
         return FakeProc(0, "ok\n")
 
     monkeypatch.setattr(s.subprocess, "run", run)
-    assert s.submit("com.acme.Job", has_submit)["ok"] is True
-    assert blocked == [True], "refresh ran while spark-submit held the mount"
-    waiter[0].join(2)
+    try:
+        assert s.submit("com.acme.Job", has_submit)["ok"] is True
+        assert blocked == [True], "refresh ran while spark-submit held the mount"
+    finally:
+        if waiter:
+            waiter[0].join(2)

--- a/python/tests/test_spark_agent_submit.py
+++ b/python/tests/test_spark_agent_submit.py
@@ -9,6 +9,7 @@ those with it.
 import pathlib
 import subprocess
 import sys
+import threading
 
 import pytest
 
@@ -190,3 +191,23 @@ def test_a_backslash_request_matches_the_same_jar(tmp_path, monkeypatch):
     monkeypatch.setattr(s, "MOUNT_ROOT", str(root))
     for form in ("jobs/etl.jar", "jobs\\etl.jar", str(jar), str(jar).replace("/", "\\")):
         assert s._resolve_in_mount(form) == str(jar.resolve()), form
+
+
+def test_submit_holds_the_mount_lock_while_the_jvm_runs(has_submit, monkeypatch):
+    """A statement refresh must wait, not rewrite Files/ under spark-submit."""
+    import files_mount
+    blocked = []
+    waiter = []
+
+    def run(*_a, **_k):
+        t = threading.Thread(target=files_mount.refresh)
+        waiter.append(t)
+        t.start()
+        t.join(0.15)
+        blocked.append(t.is_alive())
+        return FakeProc(0, "ok\n")
+
+    monkeypatch.setattr(s.subprocess, "run", run)
+    assert s.submit("com.acme.Job", has_submit)["ok"] is True
+    assert blocked == [True], "refresh ran while spark-submit held the mount"
+    waiter[0].join(2)

--- a/python/tests/test_spark_agent_submit.py
+++ b/python/tests/test_spark_agent_submit.py
@@ -214,3 +214,40 @@ def test_submit_holds_the_mount_lock_while_the_jvm_runs(has_submit, monkeypatch)
     finally:
         if waiter:
             waiter[0].join(2)
+
+
+def test_a_sail_refuse_does_not_take_the_mount_lock(monkeypatch):
+    """available:false is a probe, not a submit. Stalling refresh for it would
+    serialise every statement behind a capability the engine does not have."""
+    import files_mount
+    held = []
+    real = files_mount.hold
+    monkeypatch.setattr(files_mount, "hold", lambda: held.append(True) or real())
+    monkeypatch.setattr(s.os.path, "isfile", lambda _: False)
+    monkeypatch.setattr(s.shutil, "which", lambda _: None)
+    out = s.submit("com.acme.Job", "/lakehouse/default/Files/x.jar")
+    assert out["available"] is False
+    assert held == []
+
+
+def test_a_missing_main_class_does_not_take_the_mount_lock(has_submit, monkeypatch):
+    import files_mount
+    held = []
+    real = files_mount.hold
+    monkeypatch.setattr(files_mount, "hold", lambda: held.append(True) or real())
+    monkeypatch.setattr(s.subprocess, "run", lambda *a, **k: FakeProc(0))
+    out = s.submit("", has_submit)
+    assert out["ok"] is False and "mainClass is required" in out["error"]
+    assert held == []
+
+
+def test_an_empty_jar_path_matches_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(s, "MOUNT_ROOT", str(tmp_path / "Files"))
+    (tmp_path / "Files").mkdir()
+    assert s._resolve_in_mount("") is None
+    assert s._resolve_in_mount(None) is None
+
+
+def test_a_missing_mount_directory_matches_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(s, "MOUNT_ROOT", str(tmp_path / "no-such-Files"))
+    assert s._resolve_in_mount("jobs/etl.jar") is None


### PR DESCRIPTION
## Summary
- `/statements` refresh and `/submit` now share one lock on the lakehouse Files mount. The agent is a `ThreadingHTTPServer`; without the lock a refresh can rewrite the tree under a 900s `spark-submit`, or `_state["seen"]` can tear so a later flush skips a write.
- A submit can stall a statement for that timeout — stated in the module divergences, not hidden.
- Witnesses: refresh waits while `hold()` is held; concurrent refresh/flush leaves a coherent `seen`; submit holds the lock for the JVM walk.

## Test plan
- [x] `uv run --frozen --group test pytest python/tests/test_spark_agent_files_mount_e2e.py python/tests/test_spark_agent_submit.py python/tests/test_spark_agent_files_mount.py -q`
- [ ] CI green on this PR