### PR TITLE
Bind README's Real count to the witness checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ the [parity map](docs/parity.md).
 
 | | Claims | Meaning |
 |---|---|---|
-| 🟢 **Real** | **113** | Witnessed — `check_witnesses.py --strict` fails CI if a supported claim loses its witness. Genuine work: real signed JWTs, real bytes, a real engine or client computes |
+| 🟢 **Real** | **124** | Witnessed — `check_witnesses.py --strict` fails CI if a supported claim loses its witness. Genuine work: real signed JWTs, real bytes, a real engine or client computes |
 | 🟡 **Emulated** | management / clock | Faithful API contract and persisted state, but no engine — LROs and generic item jobs on purpose |
 | 🟠 **Non-default engine** | JVM overlay or a profile | Real on the JVM Spark overlay, `--profile rti`, or `--profile eventstream` — *not* "bring your own": `docker compose up` already starts Sail and the SQL Server sidecar |
 | 🔴 **Not implemented** | honest 501 | Deliberately out of scope — Dataflow exec, Purview system classifiers, Fabric Eventhouse streaming ingest / queued `Kusto.Ingest`. The parity map argues where the boundary sits and why |

--- a/docs/24-parity-completion.md
+++ b/docs/24-parity-completion.md
@@ -16,7 +16,8 @@ preceded its code).
 
 Graded from `docs/parity.md` at the time of writing: **60 🟢, 7 🟡, 7 🟠, 14 🔴**
 across 8 areas (a row may carry two marks). **Those counts are historical.**
-`check_witnesses.py --strict` now reports **113** supported (🟢) claims.
+`check_witnesses.py --strict` prints the live supported (🟢) count; README's
+glance table is required to match it.
 CI/CD, Data Warehouse, Platform, and OneLake are effectively complete; Data
 Engineering holds the largest cluster of non-green marks, and "item types,
 engine absent" holds the rest.

--- a/docs/37-runtime-fidelity-gaps.md
+++ b/docs/37-runtime-fidelity-gaps.md
@@ -34,13 +34,13 @@ cannot.
 
 ---
 
-## 1. Environment items: the parse exists, the effect does not
+## 1. Environment items: the parse existed, the effect did not — **DONE**
 
 **What Fabric does.** An Environment item's custom libraries, public packages,
 and Spark properties are installed and applied to the runtime before any user
 code runs. It is where a framework package comes from.
 
-**What the emulator does.** It parses the item correctly and then discards the
+**What the emulator did.** It parsed the item correctly and then discarded the
 answer. `compute.ParseEnvironment` (`internal/compute/definition.go`) resolves
 `requirements.txt`, `*.jar`, and the JSON `sparkProperties` / `pythonLibraries`
 keys into `Environment{PythonPackages, JARs, SparkConfig}`.
@@ -48,22 +48,27 @@ keys into `Environment{PythonPackages, JARs, SparkConfig}`.
 on a missing or wrong-typed Environment item, and stores the result on the run as
 `environment`.
 
-**Nothing reads those three fields.** `PythonPackages`, `SparkConfig`, and
-`JARs` have no consumer anywhere in `internal/` outside the parser and its own
-test. The run *reports* an Environment; the session never *receives* one. The
-working substitute is `_install_custom_wheels` in `python/spark_agent/agent.py`,
+**Nothing read those three fields.** `PythonPackages`, `SparkConfig`, and
+`JARs` had no consumer anywhere in `internal/` outside the parser and its own
+test. The run *reported* an Environment; the session never *received* one. The
+working substitute was `_install_custom_wheels` in `python/spark_agent/agent.py`,
 which installs whatever a consumer bind-mounts at `/opt/wheels` — generic on
 purpose, and explicitly documented as the analog.
 
-**The fix, which is plumbing rather than design.** The front half is built; what
-is missing is the wire between it and the agent:
+That gap is closed. The wire, the conflict rule, and the witness are under
+[Delivered](#delivered-the-wire-and-now-the-proof). The problem is kept here
+because the isolation constraint it named is still why a second Environment is
+refused rather than last-bind-wins.
+
+**The fix, which is plumbing rather than design.** The front half was built; what
+was missing was the wire between it and the agent:
 
 1. Carry the resolved `Environment` in the session bind, beside the `/mount`
    call `registerLakehouseTables` already makes (`internal/api/livy_catalog.go`),
    or as a sibling `/environment` endpoint on the same best-effort contract.
 2. Generalise `_install_custom_wheels` to take a package list instead of only
    globbing `/opt/wheels/*.whl`. The installer, the `uv` path, and the
-   loud-but-not-fatal failure handling already exist.
+   loud-but-not-fatal failure handling already existed.
 3. Apply `SparkConfig` at session setup, where the runtime presets are already
    applied.
 4. `/opt/wheels` demotes from *the* mechanism to the fallback it should be: an

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,0 +1,74 @@
+# Unreleased (after v0.35.0)
+
+Draft of what landed on `main` after the `v0.35.0` tag. Rename this file to
+`v0.36.0.md` (or whichever minor) when tagging. Open pull requests are not
+here.
+
+The range starts at `2f95c3f5` (#416), the first commit after the `v0.35.0`
+tag: 38 changes. The headline is a **Databricks JAR task that actually
+submits**, and two review findings that reached main after it.
+
+**Read the first section if any Databricks JAR task used to be refused with
+"nothing here submits a main class".** That refusal was true of the statement
+endpoint and false of the overlay.
+
+**Read the second if a retry of a failed Environment pip install came back
+`applied: true`.** The cache recorded the attempt, not the result.
+
+---
+
+## A JAR task runs on the JVM overlay, refused where it cannot (#438)
+
+The refusal said nothing here submits a main class, on either engine. The first
+half was true of the statement endpoint; the second was a gap — the overlay
+ships `spark-submit`. Both survivors are probed, not assumed. A jar runs from
+the Files mount or not at all: the mount is enumerated and the request only
+selects from it, so traversal and symlinks match nothing rather than being
+caught after the fact.
+
+## A failed Environment pip install was recorded as applied (#453)
+
+A `/environment` call that failed still entered `_environment_applied`. The
+next bind of the same Environment short-circuited as already installed, so a
+retry of a broken `requirements.txt` looked like success. The cache now records
+a completed install.
+
+The same change restores `os.environ` around every `python/tests` case
+(examples' fixtures wrote `NOTEBOOKUTILS_*` at import and the leak crossed a
+package boundary) and refuses a JAR the Files mount cannot see.
+
+## Databricks JAR `parameters` resolve against the pipeline scope (#454)
+
+`parameters` were `fmt.Sprint`'d into argv, so an expression stayed a literal
+and a non-string value became Go's default formatting. They now go through
+`resolve()`, same as every other activity input. Notes in #455.
+
+## The rest
+
+**The MERGE intercept's reason had expired (#437).** pysail 0.7.1 plans the
+shape the rewrite was written for, control included. The intercept still fires
+until the `az://` case is proven; the justification now says what is true.
+
+**A JVM Connect client measured against Sail (#443).** Handshake, SQL,
+DataFrame ops, parquet and exit codes work; typed map, `sparkContext`, Scala
+UDFs and `addArtifact` are asserted to refuse, so a pass fails the run as a
+moved boundary.
+
+**dbt silver without the Livy hop (#429, #431).** The same silver models over
+Spark Connect: row counts agree with the Livy path. Sail's catalog is session
+scoped, so the Connect path registers what it reads.
+
+**fabric-cli is its own project (#426, #416),** so its pyyaml pin stops holding
+the workspace. **The e2e MLflow server stays unpublished (#425)**
+(GHSA-h7x2-h6g9-p789; nothing to upgrade to). Contract 8's expectations get a
+source that is not our own typing (#434); contract 6 witnesses fall-through
+directly (#433); contract 3's floor expires (#435).
+
+**Dependencies.** tornado 6.5.8; examples take the root's pyarrow range;
+great-expectations held at 1.x; Dependabot watches the seven example projects
+and their lockfiles, and the published images. Plus the usual grouped bumps.
+
+## Upgrading
+
+No configuration changes. Consumers pin by digest, so bump
+`FABRIC_EMULATOR_VERSION` and `FABRIC_EMULATOR_DIGEST` together.

--- a/python/tests/test_check_witnesses.py
+++ b/python/tests/test_check_witnesses.py
@@ -211,8 +211,82 @@ def test_the_actual_repo_passes_strict():
     cw.PARITY = REPO / "docs" / "parity.md"
     cw.MANIFEST = REPO / "docs" / "witnesses.json"
     cw.CI = REPO / ".github" / "workflows" / "ci.yml"
+    cw.README = REPO / "README.md"
     sys.argv = ["check_witnesses.py", "--strict"]
     assert cw.main() == 0
+
+
+# --- README glance table ---------------------------------------------------
+#
+# The landing page interpolates the Real count; README typed it, and the typed
+# copy sat at 113 after the checker had moved. --strict now fails that. The
+# tests below drive the mismatch from the failing side: a checker over a
+# README that currently matches passes whether or not it looks at the cell.
+
+
+def test_readme_real_count_matches():
+    text = "| 🟢 **Real** | **7** | Witnessed |\n"
+    assert cw.readme_real_mismatch(7, text) is None
+
+
+def test_readme_real_count_mismatch_is_the_bug_this_binds():
+    """The live case: glance table 113, checker 124."""
+    text = "| 🟢 **Real** | **113** | Witnessed |\n"
+    msg = cw.readme_real_mismatch(124, text)
+    assert msg is not None
+    assert "113" in msg
+    assert "124" in msg
+
+
+def test_readme_real_count_missing_row_is_reported():
+    """Deleting the table must fail, not silently unbind the count."""
+    msg = cw.readme_real_mismatch(124, "# Parity\n\nNo glance table.\n")
+    assert msg is not None
+    assert "no" in msg.lower()
+
+
+def test_readme_real_count_unbolded_number_does_not_match():
+    """`| 🟢 **Real** | 124 |` is a rewrite this regex does not see."""
+    text = "| 🟢 **Real** | 124 | Witnessed |\n"
+    msg = cw.readme_real_mismatch(124, text)
+    assert msg is not None
+
+
+def test_readme_real_count_duplicate_rows_are_reported():
+    text = "| 🟢 **Real** | **1** | a |\n| 🟢 **Real** | **2** | b |\n"
+    msg = cw.readme_real_mismatch(1, text)
+    assert msg is not None
+    assert "2" in msg
+
+
+def test_strict_fails_when_readme_count_is_stale(tmp_path, capsys):
+    """Wiring: a helper that is never called still leaves --strict green."""
+    stale = tmp_path / "README.md"
+    stale.write_text("| 🟢 **Real** | **113** | Witnessed |\n", encoding="utf-8")
+    cw.ROOT = REPO
+    cw.PARITY = REPO / "docs" / "parity.md"
+    cw.MANIFEST = REPO / "docs" / "witnesses.json"
+    cw.CI = REPO / ".github" / "workflows" / "ci.yml"
+    cw.README = stale
+    sys.argv = ["check_witnesses.py", "--strict"]
+    assert cw.main() == 1
+    out = capsys.readouterr().out
+    assert "113" in out
+    assert "README" in out
+    assert "FAIL:" in out
+
+
+def test_non_strict_reports_a_stale_readme_without_failing(tmp_path, capsys):
+    stale = tmp_path / "README.md"
+    stale.write_text("| 🟢 **Real** | **113** | Witnessed |\n", encoding="utf-8")
+    cw.ROOT = REPO
+    cw.PARITY = REPO / "docs" / "parity.md"
+    cw.MANIFEST = REPO / "docs" / "witnesses.json"
+    cw.CI = REPO / ".github" / "workflows" / "ci.yml"
+    cw.README = stale
+    sys.argv = ["check_witnesses.py"]
+    assert cw.main() == 0
+    assert "113" in capsys.readouterr().out
 
 
 # --- the ecosystem-conformance table -----------------------------------------
@@ -234,7 +308,8 @@ def _restore_module_globals():
     only reason it was safe to leave.
     """
     saved = {name: getattr(cw, name)
-             for name in ("PARITY", "MANIFEST", "ROOT", "CI", "JOB_FOR", "UNCREDITED")
+             for name in ("PARITY", "MANIFEST", "ROOT", "CI", "README",
+                          "JOB_FOR", "UNCREDITED")
              if hasattr(cw, name)}
     yield
     for name, value in saved.items():

--- a/python/tests/test_check_witnesses_verdicts.py
+++ b/python/tests/test_check_witnesses_verdicts.py
@@ -40,6 +40,16 @@ def repo(tmp_path, monkeypatch):
         monkeypatch.setattr(w, "PARITY", p)
         monkeypatch.setattr(w, "MANIFEST", m)
         monkeypatch.setattr(w, "CI", c)
+        # The glance table is bound to the claim count. Leaving README on the
+        # real repo made every one-claim fixture fail --strict against 124 —
+        # the live case that opened this, inverted.
+        n_real = sum(1 for _, verdict in rows if "🟢" in verdict)
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            f"| 🟢 **Real** | **{n_real}** | Witnessed |\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(w, "README", readme)
         # Go-test discovery walks the real repo; pin it so a claim's witness is
         # decided by the manifest under test rather than by whatever exists.
         monkeypatch.setattr(w, "go_test_names", lambda: {"TestReal", "TestGated"})
@@ -65,7 +75,26 @@ def test_a_green_claim_with_a_real_witness_passes(repo, capsys):
          {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
                       "witnesses": ["go:TestReal"]}})
     assert run() == 0
-    assert "supported capability claims: 1" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "supported capability claims: 1" in out
+    assert "README Real count" in out and "matches" in out
+
+
+def test_a_readme_count_that_does_not_match_the_map_fails(repo, capsys):
+    """The fixture writes a matching glance table; this is the case it hid.
+
+    A helper that only runs against the real README still leaves these
+    verdicts green, and the live failure was exactly a synthetic map
+    graded against the committed table.
+    """
+    repo([("Widgets", "🟢 Real")],
+         {"widgets": {"section": "Platform / fundamentals", "claim": "Widgets",
+                      "witnesses": ["go:TestReal"]}})
+    w.README.write_text("| 🟢 **Real** | **113** | Witnessed |\n", encoding="utf-8")
+    assert run() == 1
+    out = capsys.readouterr().out
+    assert "113" in out
+    assert "README.md's 🟢 Real count must match" in out
 
 
 def test_a_non_green_row_is_not_required_to_have_a_witness(repo):

--- a/scripts/build_landing_data.py
+++ b/scripts/build_landing_data.py
@@ -3,9 +3,10 @@
 
 The landing page states six totals. Every one of them moves, and a number typed
 into a page has no idea a row was added: this repo's own docs site carried
-"113 supported capability claims" long after the figure was 120, and the README
-still states a green-row count as a literal bound to nothing. The landing page
-is the front door, so it gets the check the prose never had.
+"113 supported capability claims" long after the figure was 120. The landing
+page interpolates; `check_witnesses.py --strict` now fails when README's Real
+cell is not the same count. The landing page is the front door, so it keeps
+the interpolation check of its own.
 
 So the page reads its totals at run time from JSON copied beside it, and this
 script FAILS when the page carries a literal where a placeholder belongs, or
@@ -245,8 +246,9 @@ def check_page(page: pathlib.Path) -> tuple[int, str]:
 
     What Astro does NOT prevent is somebody typing `139` where `{num(p.real)}`
     belongs, and that is the failure this ever existed for -- these docs once
-    said "113 supported capability claims" long after the number was 120. So
-    the check moves to the source and asks the same question of it.
+    said "113 supported capability claims" long after the number was 120.
+    README's glance table is the same class of literal; the witness checker
+    binds that one. This check still asks the question of the landing page.
     """
     if not page.exists():
         return 1, f"FAIL: {page} does not exist."

--- a/scripts/check_witnesses.py
+++ b/scripts/check_witnesses.py
@@ -67,8 +67,9 @@ nothing while still exiting 0.
 
 Usage:
     check_witnesses.py            report the mapping and exit 0
-    check_witnesses.py --strict   also fail on TODO, dangling refs, or an
-                                  undeclared/stale gate
+    check_witnesses.py --strict   also fail on TODO, dangling refs, an
+                                  undeclared/stale gate, or a README Real
+                                  count that is not the number this prints
 """
 import json
 import pathlib
@@ -87,6 +88,20 @@ if hasattr(sys.stdout, "reconfigure"):
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PARITY = ROOT / "docs" / "parity.md"
 MANIFEST = ROOT / "docs" / "witnesses.json"
+README = ROOT / "README.md"
+
+# README's glance table types the same figure this script prints. The landing
+# page interpolates it; the README was the last typed copy, and it sat at 113
+# after the checker had moved to 124. Bound here so a new row cannot leave the
+# front page stating a number nothing checks.
+#
+# The row is MATCHED, not the surrounding sentence: rewriting the Meaning cell
+# must not disable the check, and deleting the table must fail rather than
+# silently unbind the count.
+README_REAL = re.compile(
+    r"^\|\s*🟢\s+\*\*Real\*\*\s+\|\s+\*\*(\d+)\*\*\s+\|",
+    re.M,
+)
 
 # The ecosystem-conformance section is SKIPPED by the claim scanner below, and
 # correctly: its rows are clients, not capabilities. But that left its 🟢 marks
@@ -351,6 +366,34 @@ def ecosystem_suites() -> list[str]:
     return sorted(set(suites))
 
 
+def readme_real_mismatch(claimed: int, text: str) -> str | None:
+    """None when README's 🟢 Real cell equals `claimed`; otherwise why not.
+
+    Driven from the failing side in the tests: a checker over a README that
+    currently matches passes whether or not this function looks at it.
+    """
+    hits = README_REAL.findall(text)
+    if not hits:
+        return (
+            "README.md has no `| 🟢 **Real** | **N** |` row. The glance table "
+            "is a literal bound to the count this checker prints; if the table "
+            "is rewritten, this regex has to move with it."
+        )
+    if len(hits) > 1:
+        return (
+            f"README.md has {len(hits)} `| 🟢 **Real** | **N** |` rows; "
+            "there must be one."
+        )
+    stated = int(hits[0])
+    if stated != claimed:
+        return (
+            f"README.md says 🟢 Real **{stated}**; this checker counted "
+            f"{claimed} supported claims. The landing page interpolates the "
+            "same figure; the README was the last typed copy."
+        )
+    return None
+
+
 def ecosystem_gaps(manifest: dict) -> list[str]:
     """Every real-client suite in the ecosystem table must back a claim.
 
@@ -462,6 +505,16 @@ def main() -> int:
         return 1
 
     print(f"supported capability claims: {len(claims)}")
+    try:
+        readme_text = README.read_text(encoding="utf-8")
+    except OSError as exc:
+        readme_problem = f"README.md could not be read: {exc}"
+    else:
+        readme_problem = readme_real_mismatch(len(claims), readme_text)
+    if readme_problem:
+        print(f"  README Real count                       : {readme_problem}")
+    else:
+        print(f"  README Real count                       : {len(claims)} (matches)")
     print(f"  witnessed by a real external client (ci:) : {kinds.get('ci', 0)}")
     print(f"  witnessed by Microsoft's own clients (sdk:): {kinds.get('sdk', 0)}")
     print(f"  witnessed by our own Go tests (go:)       : {kinds.get('go', 0)}")
@@ -554,6 +607,10 @@ def main() -> int:
         print("\nFAIL: a client named in the ecosystem-conformance table must be the")
         print("witness for something. That table is the only place several real-client")
         print("suites are recorded, and nothing reconciled it against the manifest.")
+        failed = True
+    if strict and readme_problem:
+        print("\nFAIL: README.md's 🟢 Real count must match the number this checker")
+        print("prints. The glance table is a typed copy of a figure that moves.")
         failed = True
     return 1 if failed else 0
 


### PR DESCRIPTION
## Summary
- `--strict` now fails when README's 🟢 Real cell is not the number the checker prints (it sat at 113 after the count had moved to 124).
- `docs/37` §1 is past tense and points at Delivered; the isolation constraint it named is kept because a second Environment is still refused.
- `docs/release-notes/unreleased.md` drafts post-`v0.35.0` notes for the next tag (open PRs not included). Rename when tagging.

## Test plan
- [ ] `uv run --frozen --group test pytest python/tests/test_check_witnesses.py python/tests/test_build_landing_data.py -q`
- [ ] `python3 scripts/check_witnesses.py --strict` prints `README Real count: 124 (matches)`
- [ ] Confirm a README of **113** against the live map fails `--strict` (covered by `test_strict_fails_when_readme_count_is_stale`)