### PR TITLE
docs/24's own figures had drifted the same way README's had

### DIFF
--- a/docs/24-parity-completion.md
+++ b/docs/24-parity-completion.md
@@ -32,8 +32,12 @@ engine absent" holds the rest.
 
 ## The seven own-only rows, split by whether they CAN be converted
 
-`family_parity.py fabric` reports **106 of 113** green claims independently
-evidenced, and the remaining seven read like a backlog. They are not one list.
+`family_parity.py fabric` reports the live count of green claims that are
+independently evidenced; the seven below are the remainder, and they read like a
+backlog. **The pair of numbers is deliberately not typed here** — it moved from
+106/113 to 117/124 while this sentence sat unchanged, which is the same drift
+`check_witnesses.py --strict` now refuses for README's glance table. Nothing
+binds a figure in this file, so run the tool. They are not one list.
 Sorted by what would actually close them — which is the only sort that tells a
 maintainer where to start:
 
@@ -45,10 +49,15 @@ than not existing yet:
 |---|---|
 | Eventstream operators | filter / groupBy / window are bound through Fabric's own portal and the internal authoring API; no released SDK or CLI exposes them |
 | Eventstream Eventhouse destination | same — the binding has no public client. The *ingest* half is separately witnessed against real Kusto (kustainer); what stays own-only is the eventstream-to-eventhouse binding, not the KQL |
+| `notebookutils` notebook management (create / get / getDefinition / update / updateDefinition / delete / list) | the in-notebook `notebookutils` API, not a REST endpoint an SDK wraps, so no packaged client can speak it. The REST it drives is separately witnessed by the items API rows |
 | `notebookutils.notebook.run` exit values OVER REST | real Fabric **404s this path**. It is a shim convenience the service does not offer, so there is nothing for a real client to agree with. The in-notebook contract it shadows is its own row, green on its own evidence |
 
-So the honest denominator is **110, not 113**, and 106/110 is a floor rather than
-a score with three items of debt hiding in it.
+That is **four** rows, not three — the notebook-management row carried a
+`boundary:` witness in the manifest and was missing from this table. Four of the
+seven can never earn a `ci:` witness, so they belong OUT of the denominator
+rather than in a backlog: the honest denominator is the green count minus four,
+and against it the evidenced share is a floor rather than a score with
+impossible items hiding in it. Only the three gated rows below are real debt.
 
 **Gated on the real-Fabric differential leg — three rows.** Reference-run
 lakehouse rule, `runMultiple` failure contract, `runMultiple` retry and timeouts.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -45,6 +45,16 @@ and a non-string value became Go's default formatting. They now go through
 
 ## The rest
 
+**README's 🟢 Real count is bound to the checker.** `check_witnesses.py
+--strict` now FAILS when README's glance table does not state the supported-claim
+count the checker prints, so adding a 🟢 parity row without touching README is a
+red build rather than a silently stale front page. It had sat at 113 while the
+checker counted 124. Deleting or rewriting the `| 🟢 **Real** | **N** |` row
+fails too, rather than quietly unbinding the number — if the table moves, the
+regex in `scripts/check_witnesses.py` moves with it. The landing page keeps its
+own interpolation check; docs/24's figures are prose and are deliberately no
+longer typed.
+
 **The MERGE intercept's reason had expired (#437).** pysail 0.7.1 plans the
 shape the rewrite was written for, control included. The intercept still fires
 until the `az://` case is proven; the justification now says what is true.


### PR DESCRIPTION
Follow-on to #458. Reviewing that change found the defect it fixes still live
two paragraphs below the fix, in the same file the same commit edited — and it
is on `main`, not just on that branch.

## The figures had drifted, twice

`docs/24-parity-completion.md` line 35 states:

> `family_parity.py fabric` reports **106 of 113** green claims independently evidenced

Measured against the current tree, `python3 scripts/family_parity.py fabric`
(azure-emulators) prints:

```
| green claims | ... | independently evidenced |
|          124 | ... |    117/124 (94%)        |
```

So both numbers are wrong, and the honest-denominator sentence below them
("**110, not 113**, and 106/110") is derived from the stale pair.

**Not retyped as 117/124.** That figure has now drifted twice, nothing in the
repo binds it, and #458's whole argument is that a typed count with no binding
goes stale. The sentence defers to the tool and says why — the same argument
#458 makes for README's glance table, applied to the file making it. `--strict`
cannot bind this one: `family_parity.py` lives in `azure-emulators`, and the
fabric guards are stdlib-only and repo-local.

## The impossible table was missing a row, so "three" was four

`notebookutils` notebook management (create / get / getDefinition / update /
updateDefinition / delete / list) carries a `boundary:` witness in the manifest
but was never listed among the rows no client can witness. The live own-only
set is seven:

| # | claim | class |
|---|---|---|
| 1 | `eventstream-eventhouse-destination` | impossible (`boundary:`) |
| 2 | `eventstream-operators` | impossible (`boundary:`) |
| 3 | `notebookutils-notebook-management-...` | impossible (`boundary:`) — **was missing** |
| 4 | `notebookutils-notebook-run-exit-values-over-rest` | impossible (`boundary:`) |
| 5 | `reference-run-lakehouse-rule` | gated on `real-fabric.yml` |
| 6 | `runmultiple-failure-contract` | gated on `real-fabric.yml` |
| 7 | `runmultiple-retry-and-timeouts` | gated on `real-fabric.yml` |

The document accounted for 3 + 3 while its own heading says seven.

This changes the conclusion rather than just a count: **four** of the seven can
never earn a `ci:` witness and belong out of the denominator, which leaves the
three real-Fabric-gated rows as the only actual debt — the three #384 is about.

## The release note #458 shipped without

`--strict` gained a hard failure mode and `unreleased.md` recorded nothing, so a
contributor adding a 🟢 row would hit a README failure they did not touch with
no account of it anywhere. Added under "The rest".

## Verification

- `check_witnesses.py --strict` — exit 0, 124 supported claims, README matches
- `check_docs_links.py` — 57 published pages, every link resolves
- `check_docs_sidebar.py` — all 57 reachable
- `pytest --cov` — **1804 passed**, 1 skipped, coverage **92.10%** (gate 92.0)

Docs only: no code, no guard logic changed.
