### PR TITLE
The repo's only import cycle is gone, and run_code finally has tests

### DIFF
--- a/python/spark_agent/agent.py
+++ b/python/spark_agent/agent.py
@@ -13,8 +13,6 @@ Stdlib-only HTTP + pyspark. Endpoints (private, emulator-internal):
   POST /statements {session,code} -> {"status":"ok","data":{"text/plain":...}}
   POST /close      {session}    -> drop a session's namespace
 """
-import ast
-import io
 import json
 
 # SPARK_REMOTE (e.g. sc://sail:50051) makes this a Spark Connect client —
@@ -205,6 +203,7 @@ def _install_custom_wheels():
 _install_custom_wheels()
 
 import catalog  # noqa: E402 — after the engine is up; see catalog.py for why it is split out
+import codeexec  # noqa: E402 — run_code lives here; see codeexec.py for why it moved
 import notebook_display  # noqa: E402 — pure rendering, tested without an engine
 import rddfacade  # noqa: E402 — same split: importable with no session, and unit-tested
 import run_magic  # noqa: E402 — a pure source rewrite, tested without an engine
@@ -509,56 +508,6 @@ def runtime_scope(session, req):
             sunbind(stoken)
 
 
-def run_code(code, g):
-    """Exec the block; if its last statement is an expression, eval that and
-    return its repr as the REPL result (Livy semantics). Capture stdout too."""
-    out = io.StringIO()
-    # `%run` is a LINE magic inside an ordinary Python cell, so the cell parser
-    # correctly leaves it alone — but it is a syntax error to Python, and has
-    # to become a call before ast.parse sees it. See run_magic.py.
-    code = run_magic.expand(code)
-    try:
-        tree = ast.parse(code, mode="exec")
-    except SyntaxError:
-        return {"status": "error", "ename": "SyntaxError",
-                "evalue": "invalid syntax", "traceback": traceback.format_exc().splitlines()}
-    last_expr = None
-    if tree.body and isinstance(tree.body[-1], ast.Expr):
-        last_expr = ast.Expression(tree.body.pop().value)
-    try:
-        # NOT redirect_stdout. That assigns `sys.stdout`, one attribute on one
-        # module per interpreter, and this server runs statements concurrently:
-        # measured (#346), one task's response carried another's output and two
-        # came back empty. `task_scope.capturing` binds the buffer in a
-        # ContextVar instead, so each statement resolves its own and neither
-        # restores over the other.
-        with task_scope.capturing(out):
-            if tree.body:
-                exec(compile(tree, "<statement>", "exec"), g)
-            result = eval(compile(last_expr, "<statement>", "eval"), g) if last_expr is not None else None
-        text = out.getvalue()
-        if result is not None:
-            text += repr(result)
-        return {"status": "ok", "execution_count": 0, "data": {"text/plain": text}}
-    except Exception as exc:
-        # A graceful notebook exit surfaces here as an exception named
-        # _NotebookExit (raised by the driver prelude's patched
-        # notebookutils.notebook.exit). Stash its value in THIS session's
-        # globals, the prelude cannot: each session's prelude re-patches the
-        # one shared notebookutils module, so under concurrent notebook runs
-        # the raising function belongs to whichever session ran its prelude
-        # last, and its `global __nb_exit__` writes into that session's
-        # namespace, not the caller's. Observed both ways: SUCCESS exits
-        # recorded Failed, and the dual, a real failure inheriting another
-        # run's exit value, would read as a false green. Matching by type
-        # NAME, not identity, for the same reason: every session defines its
-        # own _NotebookExit class.
-        if type(exc).__name__ == "_NotebookExit":
-            g["__nb_exit__"] = str(exc)
-        tb = traceback.format_exc().splitlines()
-        return {"status": "error", "ename": "Error", "evalue": tb[-1] if tb else "error", "traceback": tb}
-
-
 # The last /register payload per session, kept so a catalog the ENGINE lost can
 # be rebuilt without asking the control plane again. Sail's credential refresh
 # restarts the engine (docker/sail/launcher.py) and the restart takes the
@@ -851,7 +800,7 @@ class Handler(BaseHTTPRequestHandler):
                             elif (req.get("kind") or "").lower() == "sql":
                                 result = sqlrun.run_sql(req.get("code", ""), ns(session))
                             else:
-                                result = run_code(req.get("code", ""), ns(session))
+                                result = codeexec.run_code(req.get("code", ""), ns(session))
                         # The engine dropping our session is not this statement's
                         # fault and, until #312, was permanent: nothing re-ran
                         # getOrCreate(), so every later statement failed the same

--- a/python/spark_agent/codeexec.py
+++ b/python/spark_agent/codeexec.py
@@ -1,0 +1,78 @@
+"""Execute one Python statement block and shape the REPL result.
+
+SPLIT OUT OF agent.py TO BREAK THE ONE IMPORT CYCLE IN THIS REPOSITORY.
+`agent` imported `usercontext` at module scope while `usercontext._dispatch`
+imported `agent` back, inside the function, for this one call. A deferred
+import hides a cycle at runtime; it does not remove it, and the direction that
+mattered was never agent -> usercontext but this single edge.
+
+The second reason is testability, and it is the larger one. Importing `agent`
+runs `_install_custom_wheels()` and needs pyspark, so NO test imports it -- and
+`run_code`, the function every Python statement in a notebook goes through, had
+no test at all. Here it sits beside `run_magic`, `task_scope` and `sqlrun`,
+which this package already keeps importable-without-an-engine for exactly this
+reason, and which are unit-tested.
+
+IMPORTING run_magic HERE IS SAFE despite agent.py deferring it until after
+`_install_custom_wheels()`. That deferral groups the modules that may want a
+custom wheel; `run_magic` and `task_scope` import only the standard library
+(json, re / os, sys, types, contextlib, contextvars), so nothing they need can
+arrive in a wheel and neither can be affected by the ordering.
+"""
+
+import ast
+import io
+import traceback
+
+import run_magic
+import task_scope
+
+
+def run_code(code, g):
+    """Exec the block; if its last statement is an expression, eval that and
+    return its repr as the REPL result (Livy semantics). Capture stdout too."""
+    out = io.StringIO()
+    # `%run` is a LINE magic inside an ordinary Python cell, so the cell parser
+    # correctly leaves it alone — but it is a syntax error to Python, and has
+    # to become a call before ast.parse sees it. See run_magic.py.
+    code = run_magic.expand(code)
+    try:
+        tree = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return {"status": "error", "ename": "SyntaxError",
+                "evalue": "invalid syntax", "traceback": traceback.format_exc().splitlines()}
+    last_expr = None
+    if tree.body and isinstance(tree.body[-1], ast.Expr):
+        last_expr = ast.Expression(tree.body.pop().value)
+    try:
+        # NOT redirect_stdout. That assigns `sys.stdout`, one attribute on one
+        # module per interpreter, and this server runs statements concurrently:
+        # measured (#346), one task's response carried another's output and two
+        # came back empty. `task_scope.capturing` binds the buffer in a
+        # ContextVar instead, so each statement resolves its own and neither
+        # restores over the other.
+        with task_scope.capturing(out):
+            if tree.body:
+                exec(compile(tree, "<statement>", "exec"), g)
+            result = eval(compile(last_expr, "<statement>", "eval"), g) if last_expr is not None else None
+        text = out.getvalue()
+        if result is not None:
+            text += repr(result)
+        return {"status": "ok", "execution_count": 0, "data": {"text/plain": text}}
+    except Exception as exc:
+        # A graceful notebook exit surfaces here as an exception named
+        # _NotebookExit (raised by the driver prelude's patched
+        # notebookutils.notebook.exit). Stash its value in THIS session's
+        # globals, the prelude cannot: each session's prelude re-patches the
+        # one shared notebookutils module, so under concurrent notebook runs
+        # the raising function belongs to whichever session ran its prelude
+        # last, and its `global __nb_exit__` writes into that session's
+        # namespace, not the caller's. Observed both ways: SUCCESS exits
+        # recorded Failed, and the dual, a real failure inheriting another
+        # run's exit value, would read as a false green. Matching by type
+        # NAME, not identity, for the same reason: every session defines its
+        # own _NotebookExit class.
+        if type(exc).__name__ == "_NotebookExit":
+            g["__nb_exit__"] = str(exc)
+        tb = traceback.format_exc().splitlines()
+        return {"status": "error", "ename": "Error", "evalue": tb[-1] if tb else "error", "traceback": tb}

--- a/python/spark_agent/usercontext.py
+++ b/python/spark_agent/usercontext.py
@@ -62,6 +62,19 @@ import sys
 import urllib.parse
 import urllib.request
 
+# Module scope, not deferred inside _dispatch. This used to be `import agent`
+# inside the function, which is how a cycle hides rather than how one is
+# broken: agent imports this module at ITS module scope, so the pair was
+# mutually dependent and only the call order kept it working. codeexec holds
+# run_code and imports neither of us, so the edge is gone rather than delayed.
+import codeexec
+
+# The child entry point is a SIBLING FILE, not this module. Running this one
+# would import agent from inside a library that agent itself imports, which
+# is the cycle that split was made to remove.
+_CHILD_ENTRY = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "usercontext_child.py")
+
 # Names whose VALUE is a key. Scrubbed from the child's environment: the token
 # is the thing being escalated, and the client secret is worse, because a secret
 # mints fresh tokens for as long as it is valid.
@@ -188,7 +201,7 @@ class UserContext:
         # the image with "No module named 'spark_agent'" — measured. Running the
         # file also puts its own directory on sys.path[0], which is what lets
         # the child `import agent` the same way the parent does.
-        self.argv = argv or [sys.executable, os.path.abspath(__file__)]
+        self.argv = argv or [sys.executable, _CHILD_ENTRY]
         self.env = env
         # Applied AFTER scrubbing, so the child can be given the caller's own
         # token by the same name the scrub removed the service one under.
@@ -362,14 +375,12 @@ def _dispatch(code, g, kind, context=None, identity=None):  # pragma: no cover -
     else, so a notebook reading its own identity got a different answer purely
     because its item had a policy on it.
     """
-    import agent
-
     def _run():
         if (kind or "").lower() == "sql":
             import sqlrun
 
             return sqlrun.run_sql(code, g)
-        return agent.run_code(code, g)
+        return codeexec.run_code(code, g)
 
     nbu = g.get("notebookutils")
     bind = getattr(getattr(nbu, "runtime", None), "bind", None)
@@ -600,18 +611,3 @@ def close_session(session):
     # still connected would take the engine out from under a live statement.
     if _engines is not None:
         _engines.release(session)
-
-
-def main():  # pragma: no cover - exercised as a subprocess, not in-process
-    # Opened BEFORE importing agent, which brings up Spark: the descriptor must
-    # be claimed while we still know it is ours, not after a library has had a
-    # chance to touch the table.
-    responses = protocol_stream()
-    import agent
-
-    with responses:
-        serve(sys.stdin.buffer, responses, _dispatch, lambda: agent.ns("child"))
-
-
-if __name__ == "__main__":  # pragma: no cover
-    main()

--- a/python/spark_agent/usercontext_child.py
+++ b/python/spark_agent/usercontext_child.py
@@ -1,0 +1,38 @@
+"""The child process entry point: `python usercontext_child.py`.
+
+SEPARATED FROM usercontext.py TO REMOVE THE LAST EDGE OF THIS REPOSITORY'S ONLY
+IMPORT CYCLE. `agent` imports `usercontext` at module scope, and `usercontext`
+imported `agent` back -- twice. One of those was per-statement and is gone
+(run_code now lives in codeexec). The other is THIS function, and it cannot go
+away: the child genuinely needs the agent module, because `agent.ns` builds the
+per-session SparkSession it runs user code in.
+
+So the module that needs both moves out of the library. usercontext.py is now
+imported-only and imports agent never; this file, which nothing imports, is
+free to import both. A module that is both a library and a __main__ is what put
+the cycle there.
+
+The image ships it: docker/spark-runtime/Dockerfile copies
+`python/spark_agent/*.py`, so a new sibling arrives without a manifest edit.
+"""
+
+import sys
+
+import usercontext
+
+
+def main():  # pragma: no cover - exercised as a subprocess, not in-process
+    # Opened BEFORE importing agent, which brings up Spark: the descriptor must
+    # be claimed while we still know it is ours, not after a library has had a
+    # chance to touch the table. This ordering is why the import is here and not
+    # at module scope, and it survives the move unchanged.
+    responses = usercontext.protocol_stream()
+    import agent
+
+    with responses:
+        usercontext.serve(sys.stdin.buffer, responses, usercontext._dispatch,
+                          lambda: agent.ns("child"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/python/tests/test_spark_agent_codeexec.py
+++ b/python/tests/test_spark_agent_codeexec.py
@@ -1,0 +1,111 @@
+"""`run_code` executes one statement block and shapes the Livy REPL result.
+
+Every Python statement a notebook sends reaches the engine through this
+function, and until it was split out of agent.py it had NO test: importing
+`agent` runs `_install_custom_wheels()` and needs pyspark, so nothing could
+import it in-process. It now sits beside run_magic and task_scope, which this
+package already keeps importable-without-an-engine for exactly that reason.
+
+The assertions are on the RETURNED DOCUMENT, because that document is the wire
+contract a Livy client reads: `status`, `ename`, `evalue`, `traceback`, and
+`data["text/plain"]`. A test that only checked "it did not raise" would pass
+while the client saw the wrong shape.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "spark_agent"))
+
+import codeexec  # noqa: E402
+
+
+def test_a_trailing_expression_comes_back_as_its_repr():
+    """Livy semantics: the last expression is the cell's value."""
+    got = codeexec.run_code("1 + 1", {})
+    assert got["status"] == "ok"
+    assert got["data"]["text/plain"] == "2"
+
+
+def test_statements_without_a_trailing_expression_return_no_value():
+    g = {}
+    got = codeexec.run_code("x = 41\nx += 1", g)
+    assert got["status"] == "ok"
+    # The block ran in the caller's namespace...
+    assert g["x"] == 42
+    # ...and produced no value, which is not the same as producing "None".
+    assert got["data"]["text/plain"] == ""
+
+
+def test_stdout_is_captured_and_precedes_the_value():
+    got = codeexec.run_code("print('hello')\n7", {})
+    assert got["data"]["text/plain"] == "hello\n7"
+
+
+def test_a_none_valued_last_expression_contributes_nothing():
+    """`None` is the value of a bare call, and repr(None) would be noise."""
+    got = codeexec.run_code("print('x')\nNone", {})
+    assert got["data"]["text/plain"] == "x\n"
+
+
+def test_a_syntax_error_is_reported_rather_than_raised():
+    got = codeexec.run_code("def (", {})
+    assert got["status"] == "error"
+    assert got["ename"] == "SyntaxError"
+    assert got["evalue"] == "invalid syntax"
+    assert got["traceback"], "a syntax error must carry a traceback"
+
+
+def test_a_runtime_error_is_reported_with_its_traceback():
+    got = codeexec.run_code("raise ValueError('boom')", {})
+    assert got["status"] == "error"
+    assert got["ename"] == "Error"
+    assert "boom" in got["evalue"]
+    assert any("ValueError" in line for line in got["traceback"])
+
+
+def test_a_notebook_exit_stashes_its_value_in_THIS_namespace():
+    """The exit value must land in the caller's globals, not a shared module.
+
+    Each session's prelude re-patches the one shared notebookutils, so the
+    raising class belongs to whichever session ran its prelude last. Matching by
+    type NAME rather than identity is what keeps a SUCCESS exit from being
+    recorded against another session -- observed both ways, including a real
+    failure inheriting another run's exit value, which reads as a false green.
+    """
+    g = {}
+    src = (
+        "class _NotebookExit(Exception):\n"
+        "    pass\n"
+        "raise _NotebookExit('done')\n"
+    )
+    got = codeexec.run_code(src, g)
+    assert got["status"] == "error"
+    assert g["__nb_exit__"] == "done"
+
+
+def test_an_exit_class_defined_in_another_module_still_matches_by_name():
+    """Identity would fail here; the name is what the contract rests on."""
+    ns = {}
+    exec("class _NotebookExit(Exception):\n    pass\n", ns)
+    g = {"Foreign": ns["_NotebookExit"]}
+    got = codeexec.run_code("raise Foreign('bye')", g)
+    assert got["status"] == "error"
+    assert g["__nb_exit__"] == "bye"
+
+
+def test_an_unrelated_exception_does_not_stash_an_exit_value():
+    """The dual of the test above: a real failure must not look like an exit."""
+    g = {}
+    codeexec.run_code("raise RuntimeError('nope')", g)
+    assert "__nb_exit__" not in g
+
+
+def test_run_magic_is_expanded_before_python_sees_it():
+    """`%run` is a line magic and a syntax error to Python, so it has to become
+    a call before ast.parse runs -- otherwise every cell using one would come
+    back as SyntaxError."""
+    import run_magic
+
+    g = {run_magic.HELPER: lambda *a, **k: "ran"}
+    got = codeexec.run_code("%run other", g)
+    assert got["status"] == "ok", got

--- a/python/tests/test_user_context.py
+++ b/python/tests/test_user_context.py
@@ -11,6 +11,7 @@ Real subprocesses where the behaviour IS the process (scrubbing, death), and
 injected fakes where it is the protocol. A suite that spawned an interpreter for
 every case would be slow and would still not prove the loop.
 """
+import ast
 import io
 import json
 import os
@@ -718,3 +719,50 @@ def test_a_statement_with_no_context_still_runs():
         assert ctx.run("2 + 2")["data"]["text/plain"] == "4"
     finally:
         ctx.close()
+
+
+# --- the child entry point is a SIBLING FILE ---------------------------------
+#
+# usercontext.py used to be both the library agent imports AND the script the
+# child runs, and being both is what made the module import agent back -- the
+# repository's only import cycle. The entry point moved to
+# usercontext_child.py; these pin the parts that would break silently if it
+# moved again, since a wrong default argv fails only when a real child spawns.
+
+
+def test_the_default_child_argv_points_at_the_child_entry_point():
+    ctx = uc.UserContext()
+    assert ctx.argv[0] == sys.executable
+    assert os.path.basename(ctx.argv[1]) == "usercontext_child.py"
+    assert os.path.isfile(ctx.argv[1]), "the spawned file must exist on disk"
+
+
+def test_the_child_entry_point_sits_beside_the_library():
+    """Running it by PATH puts its own directory on sys.path[0], which is what
+    lets the child `import agent` and `import usercontext` the way the parent
+    does. A child in another directory would import neither."""
+    assert os.path.dirname(os.path.abspath(uc.__file__)) == \
+        os.path.dirname(uc.UserContext().argv[1])
+
+
+def test_the_library_no_longer_imports_agent():
+    """The cycle, asserted rather than described.
+
+    agent imports usercontext at module scope. If usercontext imports agent
+    back -- at module scope OR deferred inside a function -- the pair is
+    mutually dependent again and only call order keeps it working.
+    """
+    tree = ast.parse(Path(uc.__file__).read_text(encoding="utf-8"))
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders += [f"line {node.lineno}: import {a.name}"
+                          for a in node.names if a.name == "agent"]
+        elif isinstance(node, ast.ImportFrom) and node.module == "agent":
+            offenders.append(f"line {node.lineno}: from agent import ...")
+    assert offenders == [], (
+        "usercontext.py imports agent again; the cycle is back:\n  "
+        + "\n  ".join(offenders)
+        + "\nThe child entry point belongs in usercontext_child.py, which "
+          "nothing imports."
+    )


### PR DESCRIPTION
Candidate 2 of 3. `python/spark_agent/usercontext.py ↔ agent.py` was the **only
dependency cycle in 1,217 files**. It had *two* edges, needing different fixes.

## The per-statement edge

`usercontext._dispatch` deferred `import agent` inside the function for one
call, `agent.run_code`. **A deferred import hides a cycle at runtime; it does
not remove it.** `run_code` moves to `codeexec.py` — a leaf importing neither
module — and `_dispatch` imports that at module scope.

## The entry-point edge

This one could not go the same way: the child genuinely needs `agent`, because
`agent.ns` builds the per-session `SparkSession` it runs user code in. So the
module that needs both moved **out of the library**. `usercontext.py` is now
imported-only; `usercontext_child.py`, which nothing imports, is free to import
both.

**A module that was both a library and a `__main__` is what put the cycle
there.** Its FD-before-Spark ordering is preserved and still commented, and the
image copies `python/spark_agent/*.py`, so the new sibling ships without a
manifest edit.

ripwire: **1 cycle → `none (acyclic)`**.

## Why this mattered more than tidiness

Importing `agent` runs `_install_custom_wheels()` and needs pyspark, so **no
test imports it** — and `run_code`, which every Python statement in a notebook
goes through, had **no test at all**.

Demonstrated rather than argued: putting `import agent` back into
`usercontext.py` makes `test_user_context.py` fail to **collect**, with
`PySparkRuntimeError: CONNECT_URL_NOT_SET`. The cycle is what made the module
untestable.

`codeexec.py` is now **100% covered** by 10 tests that assert the returned
**document**, since that document is the wire contract a Livy client reads:
`status`, `ename`, `evalue`, `traceback`, `data["text/plain"]`. Both halves of
the `_NotebookExit` rule are pinned — an exit class from another module still
matches **by name**, and an unrelated exception does **not** stash an exit
value.

## Two things I got wrong, and how they were caught

- **The regression guard was vacuous at first.** It string-matched the import
  line, so `import agent  # a comment` slipped straight through — I found that
  by reintroducing the cycle four different ways and watching it stay green. It
  now parses the AST and catches all four (plain, commented,
  `from agent import ns`, `import agent as a`), each verified red.
- **`ast` and `io` left `agent.py` with `run_code`.** My pre-check said they
  were still used; it had counted the uses *inside the function I was about to
  move*. `make lint` caught what I had not.

## Verification

**1787 passed** (+13), coverage **92.11%** against the 92.0 gate, `make lint`
clean, and ripwire confirms the tree is acyclic.
