### PR TITLE
Execute's 134-line notebook arm becomes a method, and its coverage stops lying

### DIFF
--- a/internal/api/pipeline_notebook_activity_test.go
+++ b/internal/api/pipeline_notebook_activity_test.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/calvinchengx/fabric-emulator/internal/pipeline"
 
 	"github.com/calvinchengx/fabric-emulator/internal/store"
 )
@@ -215,5 +219,120 @@ func TestNotebookActivityOutputShape(t *testing.T) {
 	// No engine ran this notebook, so claiming a Spark session would invent one.
 	if _, present := result["sessionId"]; present {
 		t.Errorf("output.result reports a sessionId for a run no engine executed: %+v", result)
+	}
+}
+
+// --- notebookActivity, extracted from Execute --------------------------------
+//
+// Splitting the 134-line notebook arm out of Execute's switch turned one
+// misleading number into two honest ones: Execute went 78.8% -> 100% (the
+// dispatch really is fully exercised) and the notebook logic appeared at 69.5%,
+// which is what the arm had always been. These close the reachable half of that
+// gap. They use a bare executor and a resolver that fails on demand, because
+// every path below is reached BEFORE the store is touched.
+
+// TestNotebookActivityWorkspaceIDResolveFailurePropagates.
+//
+// workspaceId is an expression like any other, and an unresolvable one must
+// fail the activity. Swallowing it would fall back to the pipeline's own
+// workspace and report "no notebook %q in this workspace" -- blaming the id for
+// a property that was supplied, correct, and simply not evaluated. That is the
+// exact misdiagnosis the comment above this code was written to prevent.
+func TestNotebookActivityWorkspaceIDResolveFailurePropagates(t *testing.T) {
+	e := &pipelineExecutor{wid: "ws-1"}
+	resolve := func(raw json.RawMessage) (any, error) {
+		if strings.Contains(string(raw), "nb-1") {
+			return "nb-1", nil
+		}
+		return nil, fmt.Errorf("unresolved")
+	}
+	_, err := e.notebookActivity(
+		pipeline.Activity{Name: "RunNb", Type: "TridentNotebook"},
+		map[string]json.RawMessage{
+			"notebookId":  json.RawMessage(`"nb-1"`),
+			"workspaceId": json.RawMessage(`"@pipeline().parameters.ws"`),
+		}, resolve)
+	if err == nil {
+		t.Fatal("an unresolvable workspaceId was swallowed")
+	}
+	if !strings.Contains(err.Error(), "workspaceId") {
+		t.Errorf("error = %q, want it to name workspaceId so the author knows "+
+			"which property failed", err)
+	}
+}
+
+// TestNotebookActivityRequiresANotebookID pins the guard that runs first.
+// `nil` and empty are distinct failures upstream but the same failure here,
+// and both must refuse rather than look up the empty id.
+func TestNotebookActivityRequiresANotebookID(t *testing.T) {
+	e := &pipelineExecutor{wid: "ws-1"}
+	for name, resolve := range map[string]func(json.RawMessage) (any, error){
+		"nil":     func(json.RawMessage) (any, error) { return nil, nil },
+		"empty":   func(json.RawMessage) (any, error) { return "", nil },
+		"failing": func(json.RawMessage) (any, error) { return nil, fmt.Errorf("boom") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := e.notebookActivity(
+				pipeline.Activity{Name: "RunNb", Type: "TridentNotebook"},
+				map[string]json.RawMessage{"notebookId": json.RawMessage(`""`)}, resolve)
+			if err == nil {
+				t.Fatal("a missing notebookId was accepted")
+			}
+			if !strings.Contains(err.Error(), "notebookId is required") {
+				t.Errorf("error = %q, want it to name notebookId", err)
+			}
+		})
+	}
+}
+
+// TestNotebookActivityReportsWhatTheEngineDid drives the branch that only
+// exists when an engine is attached: `runsNotebooksItself()`, i.e. a Livy agent
+// is configured, so the run is executed rather than parked at Pending.
+//
+// Without an agent the activity returns Pending and the whole block below is
+// skipped -- which is why it stayed uncovered while every other notebook test
+// passed. An agent stub is enough: the branch is about whether the emulator
+// OWNS the execution, not about Spark actually running.
+//
+// The assertion is on the ACTIVITY's verdict, not on the run's. Either outcome
+// exercises the block; what must not happen is an activity reporting success
+// for a run that did not complete, which is the failure this whole file exists
+// to prevent (see the twelve activity types that "succeeded having run
+// nothing").
+func TestNotebookActivityReportsWhatTheEngineDid(t *testing.T) {
+	a, st := newAPI(t)
+	newAgentStub(t, a)
+	if !a.runsNotebooksItself() {
+		t.Fatal("the stub did not attach: this test would silently assert the " +
+			"no-engine path instead of the engine one")
+	}
+	ws := seedWorkspace(t, st)
+	nb := seedNotebookIn(t, st, ws.ID, "child", "print('hi')\n")
+	content := `{"properties":{"activities":[
+        {"name":"RunNb","type":"TridentNotebook","typeProperties":{"notebookId":"` + nb.ID + `"}}
+      ]}}`
+	pl := createPipeline(t, st, ws.ID, content)
+	_, jid := runJob(t, a, ws.ID, pl.ID, "jobType=Pipeline", "")
+	jobStatus := awaitJob(t, a, ws.ID, pl.ID, jid)
+
+	status, runs := activityRuns(t, a, ws.ID, pl.ID, jid)
+	if len(runs) != 1 {
+		t.Fatalf("expected one activity run, got %+v", runs)
+	}
+	// The activity's verdict and the job's must agree. A Succeeded activity
+	// under a Failed job is precisely the false green this code guards against.
+	//
+	// They agree in MEANING, not in spelling: a job reports Completed/Failed and
+	// an activity Succeeded/Failed, so comparing the strings asserts they differ
+	// -- which this test did on its first run, and reported as a disagreement
+	// when there was none.
+	jobOK := jobStatus == "Completed" || jobStatus == "Succeeded"
+	actOK := runs[0]["status"] == "Succeeded"
+	if jobOK != actOK {
+		t.Errorf("job %s but activity %v -- an activity must not disagree with "+
+			"the job it is the only member of", jobStatus, runs[0]["status"])
+	}
+	if status == "" {
+		t.Error("activity runs reported no status at all")
 	}
 }

--- a/internal/api/pipelines.go
+++ b/internal/api/pipelines.go
@@ -74,140 +74,7 @@ func (e *pipelineExecutor) Execute(act pipeline.Activity, resolve func(json.RawM
 
 	switch act.Type {
 	case "TridentNotebook", "SynapseNotebook", "RunNotebook":
-		// Resolve the referenced notebook and submit a real RunNotebook job —
-		// the pipeline → jobs → notebook chain, end to end.
-		idv, err := resolve(tp["notebookId"])
-		if err != nil || idv == nil || fmt.Sprint(idv) == "" {
-			return nil, fmt.Errorf("notebook activity %q: notebookId is required", act.Name)
-		}
-		nbID := fmt.Sprint(idv)
-		// workspaceId says WHICH workspace holds the notebook, and Fabric marks
-		// it required alongside notebookId precisely because the notebook need
-		// not live beside the pipeline. Ignoring it and always reading the
-		// pipeline's own workspace turns a legitimate cross-workspace activity
-		// into "no notebook %q in this workspace", which blames the id for a
-		// property that was in fact supplied and correct. Absent, it defaults to
-		// the pipeline's workspace, which is the single-workspace shape.
-		nbWID := e.wid
-		if raw, ok := tp["workspaceId"]; ok && len(raw) > 0 {
-			wv, werr := resolve(raw)
-			if werr != nil {
-				return nil, fmt.Errorf("notebook activity %q: workspaceId: %v", act.Name, werr)
-			}
-			// The zero GUID is Fabric's own sentinel for "this pipeline's
-			// workspace" (it is what a same-workspace activity carries in Git),
-			// so it must resolve to e.wid rather than be looked up literally.
-			if s := fmt.Sprint(wv); wv != nil && s != "" && s != "00000000-0000-0000-0000-000000000000" {
-				nbWID = s
-			}
-		}
-		nb, err := e.a.Store.GetItem(nbWID, nbID)
-		if err != nil || nb.Type != "Notebook" {
-			if nbWID != e.wid {
-				return nil, fmt.Errorf("notebook activity %q: no notebook %q in workspace %q", act.Name, nbID, nbWID)
-			}
-			return nil, fmt.Errorf("notebook activity %q: no notebook %q in this workspace", act.Name, nbID)
-		}
-		// The activity's parameters become the run's parameter overrides — the
-		// whole point of a pipeline driving a parameterised notebook. Fabric's
-		// shape is {name: {value, type}}; the value may itself be an
-		// expression (@pipeline().parameters.X), so it resolves against the
-		// pipeline scope before it is handed to the notebook.
-		nbParams := map[string]any{}
-		if raw, ok := tp["parameters"]; ok && len(raw) > 0 {
-			var fields map[string]json.RawMessage
-			if err := json.Unmarshal(raw, &fields); err != nil {
-				return nil, fmt.Errorf("notebook activity %q: parameters are not an object", act.Name)
-			}
-			for name, vraw := range fields {
-				target := vraw
-				var pv struct {
-					Value json.RawMessage `json:"value"`
-				}
-				if json.Unmarshal(vraw, &pv) == nil && len(pv.Value) > 0 {
-					target = pv.Value
-				}
-				v, err := resolve(target)
-				if err != nil {
-					return nil, fmt.Errorf("notebook activity %q parameter %q: %v", act.Name, name, err)
-				}
-				// Fabric takes "simple types such as int, float, bool, and
-				// string"; "complex types such as list and dict aren't yet
-				// supported". Rendering one anyway would be the emulator being
-				// MORE permissive than the thing it emulates, which is the one
-				// direction that actively misleads: the pipeline passes here and
-				// fails in Fabric, so the emulator has certified something it
-				// cannot vouch for. Refuse it here, where the activity contract
-				// lives, before the notebook runs.
-				switch v.(type) {
-				case []any, map[string]any:
-					return nil, fmt.Errorf(
-						"notebook activity %q parameter %q: Fabric notebook parameters support only int, float, bool and string; list and dict are not supported",
-						act.Name, name)
-				}
-				nbParams[name] = v
-			}
-		}
-		// Parse for real, exactly as a direct RunNotebook job POST does
-		// (jobs.go): the Go parser splits the notebook into cells and the
-		// compute binding is resolved, so an engine can execute it and report
-		// back. Without this the activity fabricated a completed job with no
-		// run behind it — nothing to execute, and nothing for lineage or the
-		// notebookRunResult callback to attach to.
-		//
-		// The parse comes FIRST because it decides the job's completion time,
-		// for the reason spelled out in jobs.go: a job the clock completes says
-		// "Completed" while every cell is still Pending. Cells outstanding =>
-		// only the engine finishes this job.
-		run, code := e.a.parseNotebookRun(nb)
-		j := &store.JobInstance{ItemID: nb.ID, JobType: "RunNotebook", InvokeType: "Pipeline"}
-		j.CompleteAt = e.a.Store.Now()
-		if code == "" && len(run.Cells) > 0 {
-			j.CompleteAt = math.MaxInt64
-		}
-		if err := e.a.Store.CreateJobInstance(j); err != nil {
-			return nil, fmt.Errorf("notebook activity %q: %v", act.Name, err)
-		}
-		e.a.saveNotebookRun(j.ID, run)
-		if code != "" {
-			_ = e.a.Store.FinalizeJob(nb.ID, j.ID, code)
-			return nil, fmt.Errorf("notebook activity %q: %s", act.Name, code)
-		}
-		// Fabric's notebook activity is SYNCHRONOUS: the pipeline gates on the
-		// notebook's outcome. With a Spark agent configured the emulator is the
-		// pool (same contract as jobs.go), so drive the run here — in this
-		// goroutine, because the activity must not report before the notebook
-		// finishes — and let the activity succeed or fail on the run's actual
-		// terminal state. Without an agent the run stays Pending for an
-		// external engine's callback, which is the original contract and the
-		// only honest answer when nothing can execute the cells.
-		if e.a.runsNotebooksItself() && len(run.Cells) > 0 {
-			// A pipeline-driven notebook IS the root: nothing referenced it.
-			e.a.driveNotebookRun(nbWID, nb.ID, j.ID, run, nbParams, true, referenceRoot{})
-			status, runJSON, err := e.a.Store.GetNotebookRun(j.ID)
-			if err != nil {
-				return nil, fmt.Errorf("notebook activity %q: run detail lost: %v", act.Name, err)
-			}
-			var detail struct {
-				ExitValue string `json:"exitValue"`
-			}
-			_ = json.Unmarshal([]byte(runJSON), &detail)
-			if status != "Completed" {
-				if jb, err := e.a.Store.GetJobInstance(nb.ID, j.ID); err == nil && jb.FailWith != "" {
-					return nil, fmt.Errorf("notebook activity %q: %s", act.Name, jb.FailWith)
-				}
-				return nil, fmt.Errorf("notebook activity %q: notebook run ended %s", act.Name, status)
-			}
-			return notebookActivityOutput(j.ID, nb.ID, status, detail.ExitValue, notebookSessionID(j.ID)), nil
-		}
-		// No engine: the run is Pending until one executes the cells and
-		// reports back; say that rather than claiming a completion that has
-		// not happened.
-		status, _, err := e.a.Store.GetNotebookRun(j.ID)
-		if err != nil || status == "" {
-			status = "Pending"
-		}
-		return notebookActivityOutput(j.ID, nb.ID, status, "", ""), nil
+		return e.notebookActivity(act, tp, resolve)
 
 	case "ExecutePipeline", "InvokePipeline":
 		// Invoke pipeline: resolve the referenced DataPipeline and run it for
@@ -504,6 +371,159 @@ type oneLakeLoc struct {
 // carry a `location` object {workspaceId?, itemId, path} (workspaceId defaults
 // to the pipeline's workspace; ids accept a GUID or a name). A file copies to
 // the sink path; a directory copies its whole subtree under the sink path.
+// notebookActivity submits a real RunNotebook job for the notebook a pipeline
+// activity references: the pipeline -> jobs -> notebook chain, end to end.
+//
+// EXTRACTED FROM Execute, WHERE IT WAS 134 OF THAT SWITCH'S 292 LINES -- one
+// arm larger than the twenty-one after it combined. `copyActivity` had already
+// established the shape in this file; this arm simply never followed it, and
+// Execute grew around it.
+//
+// The distinction matters here more than in most files. This switch gains arms
+// steadily -- "twelve Fabric activity types were reporting success having run
+// nothing", "nine activity types that silently succeeded" -- so what a reader
+// needs from Execute is the LIST of types it dispatches, and a 134-line arm at
+// the top is the thing that hides it.
+//
+// Behaviour is unchanged: the body is the arm verbatim, and act/tp/resolve are
+// exactly what it already closed over.
+func (e *pipelineExecutor) notebookActivity(act pipeline.Activity, tp map[string]json.RawMessage, resolve func(json.RawMessage) (any, error)) (map[string]any, error) {
+	// Resolve the referenced notebook and submit a real RunNotebook job —
+	// the pipeline → jobs → notebook chain, end to end.
+	idv, err := resolve(tp["notebookId"])
+	if err != nil || idv == nil || fmt.Sprint(idv) == "" {
+		return nil, fmt.Errorf("notebook activity %q: notebookId is required", act.Name)
+	}
+	nbID := fmt.Sprint(idv)
+	// workspaceId says WHICH workspace holds the notebook, and Fabric marks
+	// it required alongside notebookId precisely because the notebook need
+	// not live beside the pipeline. Ignoring it and always reading the
+	// pipeline's own workspace turns a legitimate cross-workspace activity
+	// into "no notebook %q in this workspace", which blames the id for a
+	// property that was in fact supplied and correct. Absent, it defaults to
+	// the pipeline's workspace, which is the single-workspace shape.
+	nbWID := e.wid
+	if raw, ok := tp["workspaceId"]; ok && len(raw) > 0 {
+		wv, werr := resolve(raw)
+		if werr != nil {
+			return nil, fmt.Errorf("notebook activity %q: workspaceId: %v", act.Name, werr)
+		}
+		// The zero GUID is Fabric's own sentinel for "this pipeline's
+		// workspace" (it is what a same-workspace activity carries in Git),
+		// so it must resolve to e.wid rather than be looked up literally.
+		if s := fmt.Sprint(wv); wv != nil && s != "" && s != "00000000-0000-0000-0000-000000000000" {
+			nbWID = s
+		}
+	}
+	nb, err := e.a.Store.GetItem(nbWID, nbID)
+	if err != nil || nb.Type != "Notebook" {
+		if nbWID != e.wid {
+			return nil, fmt.Errorf("notebook activity %q: no notebook %q in workspace %q", act.Name, nbID, nbWID)
+		}
+		return nil, fmt.Errorf("notebook activity %q: no notebook %q in this workspace", act.Name, nbID)
+	}
+	// The activity's parameters become the run's parameter overrides — the
+	// whole point of a pipeline driving a parameterised notebook. Fabric's
+	// shape is {name: {value, type}}; the value may itself be an
+	// expression (@pipeline().parameters.X), so it resolves against the
+	// pipeline scope before it is handed to the notebook.
+	nbParams := map[string]any{}
+	if raw, ok := tp["parameters"]; ok && len(raw) > 0 {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			return nil, fmt.Errorf("notebook activity %q: parameters are not an object", act.Name)
+		}
+		for name, vraw := range fields {
+			target := vraw
+			var pv struct {
+				Value json.RawMessage `json:"value"`
+			}
+			if json.Unmarshal(vraw, &pv) == nil && len(pv.Value) > 0 {
+				target = pv.Value
+			}
+			v, err := resolve(target)
+			if err != nil {
+				return nil, fmt.Errorf("notebook activity %q parameter %q: %v", act.Name, name, err)
+			}
+			// Fabric takes "simple types such as int, float, bool, and
+			// string"; "complex types such as list and dict aren't yet
+			// supported". Rendering one anyway would be the emulator being
+			// MORE permissive than the thing it emulates, which is the one
+			// direction that actively misleads: the pipeline passes here and
+			// fails in Fabric, so the emulator has certified something it
+			// cannot vouch for. Refuse it here, where the activity contract
+			// lives, before the notebook runs.
+			switch v.(type) {
+			case []any, map[string]any:
+				return nil, fmt.Errorf(
+					"notebook activity %q parameter %q: Fabric notebook parameters support only int, float, bool and string; list and dict are not supported",
+					act.Name, name)
+			}
+			nbParams[name] = v
+		}
+	}
+	// Parse for real, exactly as a direct RunNotebook job POST does
+	// (jobs.go): the Go parser splits the notebook into cells and the
+	// compute binding is resolved, so an engine can execute it and report
+	// back. Without this the activity fabricated a completed job with no
+	// run behind it — nothing to execute, and nothing for lineage or the
+	// notebookRunResult callback to attach to.
+	//
+	// The parse comes FIRST because it decides the job's completion time,
+	// for the reason spelled out in jobs.go: a job the clock completes says
+	// "Completed" while every cell is still Pending. Cells outstanding =>
+	// only the engine finishes this job.
+	run, code := e.a.parseNotebookRun(nb)
+	j := &store.JobInstance{ItemID: nb.ID, JobType: "RunNotebook", InvokeType: "Pipeline"}
+	j.CompleteAt = e.a.Store.Now()
+	if code == "" && len(run.Cells) > 0 {
+		j.CompleteAt = math.MaxInt64
+	}
+	if err := e.a.Store.CreateJobInstance(j); err != nil {
+		return nil, fmt.Errorf("notebook activity %q: %v", act.Name, err)
+	}
+	e.a.saveNotebookRun(j.ID, run)
+	if code != "" {
+		_ = e.a.Store.FinalizeJob(nb.ID, j.ID, code)
+		return nil, fmt.Errorf("notebook activity %q: %s", act.Name, code)
+	}
+	// Fabric's notebook activity is SYNCHRONOUS: the pipeline gates on the
+	// notebook's outcome. With a Spark agent configured the emulator is the
+	// pool (same contract as jobs.go), so drive the run here — in this
+	// goroutine, because the activity must not report before the notebook
+	// finishes — and let the activity succeed or fail on the run's actual
+	// terminal state. Without an agent the run stays Pending for an
+	// external engine's callback, which is the original contract and the
+	// only honest answer when nothing can execute the cells.
+	if e.a.runsNotebooksItself() && len(run.Cells) > 0 {
+		// A pipeline-driven notebook IS the root: nothing referenced it.
+		e.a.driveNotebookRun(nbWID, nb.ID, j.ID, run, nbParams, true, referenceRoot{})
+		status, runJSON, err := e.a.Store.GetNotebookRun(j.ID)
+		if err != nil {
+			return nil, fmt.Errorf("notebook activity %q: run detail lost: %v", act.Name, err)
+		}
+		var detail struct {
+			ExitValue string `json:"exitValue"`
+		}
+		_ = json.Unmarshal([]byte(runJSON), &detail)
+		if status != "Completed" {
+			if jb, err := e.a.Store.GetJobInstance(nb.ID, j.ID); err == nil && jb.FailWith != "" {
+				return nil, fmt.Errorf("notebook activity %q: %s", act.Name, jb.FailWith)
+			}
+			return nil, fmt.Errorf("notebook activity %q: notebook run ended %s", act.Name, status)
+		}
+		return notebookActivityOutput(j.ID, nb.ID, status, detail.ExitValue, notebookSessionID(j.ID)), nil
+	}
+	// No engine: the run is Pending until one executes the cells and
+	// reports back; say that rather than claiming a completion that has
+	// not happened.
+	status, _, err := e.a.Store.GetNotebookRun(j.ID)
+	if err != nil || status == "" {
+		status = "Pending"
+	}
+	return notebookActivityOutput(j.ID, nb.ID, status, "", ""), nil
+}
+
 func (e *pipelineExecutor) copyActivity(act pipeline.Activity, tp map[string]json.RawMessage, resolve func(json.RawMessage) (any, error)) (map[string]any, error) {
 	// A REST source is not a OneLake location, so it dispatches BEFORE
 	// resolveLoc — which exists to resolve one. See restconnector.go.


### PR DESCRIPTION
Candidate 3 of 3. `internal/api/pipelines.go` was the second-worst maintenance
hotspot, and its churn is **structural**, not incidental: 32 commits in a year,
driven by adding activity types — *"twelve Fabric activity types were reporting
success having run nothing"*, *"nine activity types that silently succeeded"*.
The file grows one switch arm at a time and will keep doing so.

## The extraction

`Execute` was 292 lines, of which **one arm was 134** — larger than the
twenty-one arms after it combined. `copyActivity` had already established the
shape in this file; the notebook arm simply never followed it.

Extracted verbatim as `notebookActivity(act, tp, resolve)`, matching
`copyActivity`'s signature exactly. `Execute` is now **159 lines** and reads as
what it is: the list of types it dispatches.

## What this is not

**The file's complexity is unchanged, and the hotspot score is untouched.**
`resolveLoc` is still its worst function at ccx 48 — `Execute` was *long*, not
*complex*, because a flat switch costs little per arm. This buys legibility for
the thing that keeps changing, not a better number.

## What it did buy, and it wasn't the goal

| | `Execute` | `notebookActivity` |
|---|---|---|
| before | **78.8%** (dispatch + 134 lines of notebook logic, one number) | hidden |
| after | **100%** | **69.5%** → **83.1%** |

Package total identical at 84.2% before and after the split. **Nothing was
tested that wasn't tested before** — the extraction only made it legible. The
78.8% could not tell you that the dispatch was fully exercised while the
largest arm was the gap.

Three tests then closed that gap to 83.1%, including the branch that only
exists when a Livy agent is attached (`runsNotebooksItself()`). It had stayed
uncovered because every other notebook test runs with no engine and returns
`Pending` before reaching it — an agent stub is enough, since the branch is
about whether the emulator *owns* the execution, not about Spark running.

That test asserted `job status == activity status` on its first run and
reported a disagreement where there was none: a job reports `Completed` and an
activity `Succeeded`, so comparing the strings asserts they differ. It now
compares success-ness, and the comment says why.

What remains uncovered needs a fault-injecting store (`CreateJobInstance` and
`GetNotebookRun` failures) and is honestly integration-level.

## Verification

`go build`, `go vet`, `gofmt`, and the **whole repo's** tests green; ripwire
still reports the tree acyclic.
