### PR TITLE
resolveLoc did four jobs in one body; split them and every part reaches 100%

### DIFF
--- a/internal/api/pipeline_loc_test.go
+++ b/internal/api/pipeline_loc_test.go
@@ -1,0 +1,236 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// resolveLoc was the worst function in this file at cognitive complexity 48:
+// flattening Fabric's nested shapes, reading keys out of them, refusing
+// unsupported options and building the address were one 141-line body, and the
+// first three were closures nothing outside could reach.
+//
+// Splitting them out is what makes these tests possible at all. locScopes is
+// now a PURE function and locFields is constructible directly, so the error
+// paths below no longer need a pipeline, a store or a job to reach — they were
+// the uncovered remainder precisely because reaching them used to require one.
+
+func TestLocScopesPrefersTheInnermostValue(t *testing.T) {
+	obj := map[string]json.RawMessage{
+		"workspaceId": json.RawMessage(`"outer"`),
+		"datasetSettings": json.RawMessage(`{
+			"typeProperties": {"location": {"workspaceId": "inner"}}
+		}`),
+	}
+	f := locFields{scopes: locScopes(obj), resolve: keepRaw}
+	got, err := f.field("workspaceId")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An explicit nested value must win: the outer one is the fallback a side
+	// carries when the dataset does not name its own workspace.
+	if got != "inner" {
+		t.Errorf("workspaceId = %q, want the innermost scope's %q", got, "inner")
+	}
+}
+
+func TestLocScopesIgnoresANestedKeyThatIsNotAnObject(t *testing.T) {
+	// `datasetSettings` is a scalar here, which is malformed rather than
+	// absent. descend must decline it instead of failing the whole side: a
+	// Copy carrying one junk sub-object still addresses correctly through the
+	// shapes that ARE well formed.
+	obj := map[string]json.RawMessage{
+		"itemId":          json.RawMessage(`"lh-1"`),
+		"datasetSettings": json.RawMessage(`5`),
+	}
+	scopes := locScopes(obj)
+	if len(scopes) != 1 {
+		t.Fatalf("a non-object datasetSettings produced %d scopes, want only the "+
+			"top level", len(scopes))
+	}
+	f := locFields{scopes: scopes, resolve: keepRaw}
+	if got, _ := f.field("itemId"); got != "lh-1" {
+		t.Errorf("itemId = %q; the well-formed part of the side must still read", got)
+	}
+}
+
+func TestLocFieldsReportsACompositeAsAbsent(t *testing.T) {
+	// `schema` is a COLUMN LIST in Fabric's dataset model, not a namespace.
+	// fmt.Sprint would render it "[]", which is how a Copy once landed bytes at
+	// `Tables/[]/bronze_customers` and reported Succeeded.
+	obj := map[string]json.RawMessage{"schema": json.RawMessage(`["a","b"]`)}
+	f := locFields{scopes: locScopes(obj), resolve: func(raw json.RawMessage) (any, error) {
+		var v any
+		_ = json.Unmarshal(raw, &v)
+		return v, nil
+	}}
+	got, err := f.field("schema")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("a composite resolved to %q; it must read as absent so the "+
+			"caller does not address a path with it", got)
+	}
+}
+
+func TestLocFieldsPropagatesAResolveFailure(t *testing.T) {
+	obj := map[string]json.RawMessage{"workspaceId": json.RawMessage(`"@pipeline().x"`)}
+	f := locFields{scopes: locScopes(obj), resolve: boomResolver}
+	if _, err := f.field("workspaceId"); err == nil {
+		t.Error("an unresolvable field was swallowed; the Copy would then address " +
+			"the pipeline's own workspace as though none had been supplied")
+	}
+}
+
+func TestRefuseUnsupportedCopyNamesWhatItRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name, sideType string
+		obj            string
+		want           string
+	}{
+		{"unknown side type", "SqlServerSource", `{}`, "is not supported"},
+		{"unimplemented option", "", `{"keyColumns":["id"]}`, "keyColumns"},
+		{"value outside what we honour", "", `{"tableActionOption":"Upsert"}`, "tableActionOption"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tc.obj), &obj); err != nil {
+				t.Fatal(err)
+			}
+			f := locFields{scopes: locScopes(obj), resolve: keepRaw}
+			err := refuseUnsupportedCopy("source", tc.sideType, f)
+			if err == nil {
+				t.Fatalf("accepted a side it cannot honour; a Copy would report "+
+					"Succeeded having ignored %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to name %q so the author can fix the "+
+					"pipeline without bisecting it", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRefuseUnsupportedCopyPropagatesAResolveFailure(t *testing.T) {
+	// The allowed-values gate resolves each value before comparing it. An
+	// unresolvable one must fail rather than compare as empty and be skipped,
+	// which would wave through the very option the gate exists to check.
+	obj := map[string]json.RawMessage{"tableActionOption": json.RawMessage(`"@pipeline().x"`)}
+	f := locFields{scopes: locScopes(obj), resolve: boomResolver}
+	if err := refuseUnsupportedCopy("sink", "", f); err == nil {
+		t.Error("an unresolvable tableActionOption was skipped rather than refused")
+	}
+}
+
+func TestResolveLocPropagatesFieldFailures(t *testing.T) {
+	e := &pipelineExecutor{}
+	for _, key := range []string{"workspaceId", "artifactId"} {
+		t.Run(key, func(t *testing.T) {
+			raw := json.RawMessage(fmt.Sprintf(`{"%s":"@pipeline().x"}`, key))
+			resolve := func(r json.RawMessage) (any, error) {
+				if strings.Contains(string(r), "@pipeline().x") {
+					return nil, fmt.Errorf("unresolved")
+				}
+				var v any
+				_ = json.Unmarshal(r, &v)
+				return v, nil
+			}
+			if _, err := e.resolveLoc("source", raw, resolve); err == nil {
+				t.Errorf("an unresolvable %s was swallowed", key)
+			}
+		})
+	}
+}
+
+func TestResolveLocRefusesAnEmptySide(t *testing.T) {
+	e := &pipelineExecutor{}
+	for name, raw := range map[string]json.RawMessage{
+		"absent":    nil,
+		"malformed": json.RawMessage(`not json`),
+	} {
+		if _, err := e.resolveLoc("sink", raw, keepRaw); err == nil {
+			t.Errorf("%s side was accepted", name)
+		}
+	}
+}
+
+func keepRaw(raw json.RawMessage) (any, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw), nil
+	}
+	return v, nil
+}
+
+func boomResolver(json.RawMessage) (any, error) { return nil, fmt.Errorf("unresolved") }
+
+func TestResolveLocPropagatesASideTypeFailure(t *testing.T) {
+	// The discriminator is an expression like any other. An unresolvable one
+	// must fail rather than fall through as "", which is a VALID side type
+	// (the emulator's own simplified shape) — so swallowing it would turn an
+	// unreadable side into an accepted one.
+	e := &pipelineExecutor{}
+	raw := json.RawMessage(`{"type":"@pipeline().x","itemId":"lh","path":"Files/a"}`)
+	if _, err := e.resolveLoc("source", raw, boomResolver); err == nil {
+		t.Error("an unresolvable side type was treated as the empty type, which " +
+			"this emulator accepts")
+	}
+}
+
+// TestCopyPathPropagatesEveryFieldFailure.
+//
+// copyPath consults six keys and each read can fail. Every one of those
+// `if err != nil` lines was uncovered: reaching them used to need a pipeline
+// whose expression failed at exactly one key, and now needs a two-line stub —
+// which is the whole reason resolveLoc's closures became a named type.
+//
+// A swallowed failure here is not cosmetic: copyPath returning ("", nil) reads
+// as "this side names no path", and resolveLoc then reports a missing location
+// rather than the expression that could not be read.
+func TestCopyPathPropagatesEveryFieldFailure(t *testing.T) {
+	e := &pipelineExecutor{}
+	// Answers enough to reach each later key, then fails on the one under test.
+	stub := func(failOn string, answers map[string]string) func(string) (string, error) {
+		return func(k string) (string, error) {
+			if k == failOn {
+				return "", fmt.Errorf("unresolved %s", k)
+			}
+			return answers[k], nil
+		}
+	}
+	for _, tc := range []struct {
+		key     string
+		answers map[string]string
+	}{
+		{"path", nil},
+		{"rootFolder", nil},
+		{"table", map[string]string{"rootFolder": "Tables"}},
+		{"schema", map[string]string{"rootFolder": "Tables", "table": "t"}},
+		{"folderPath", map[string]string{"rootFolder": "Files"}},
+		{"fileName", map[string]string{"rootFolder": "Files", "folderPath": "d"}},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			if _, err := e.copyPath(stub(tc.key, tc.answers)); err == nil {
+				t.Errorf("a failing %q read was swallowed; the Copy would report a "+
+					"missing location instead of the expression it could not read", tc.key)
+			}
+		})
+	}
+}
+
+func TestCopyPathAddressesNothingWhenNoKeyNamesAFile(t *testing.T) {
+	// Neither folderPath nor fileName: the side addresses no path at all. That
+	// is not an error here — resolveLoc turns it into one, with a message that
+	// names both halves it needs.
+	e := &pipelineExecutor{}
+	got, err := e.copyPath(func(string) (string, error) { return "", nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("copyPath = %q for a side naming no file, want empty", got)
+	}
+}

--- a/internal/api/pipelines.go
+++ b/internal/api/pipelines.go
@@ -690,14 +690,15 @@ var copyAllowedValues = map[string][]string{
 //
 // Every field resolves as an expression first, so @pipeline().parameters work
 // throughout.
-func (e *pipelineExecutor) resolveLoc(side string, raw json.RawMessage, resolve func(json.RawMessage) (any, error)) (oneLakeLoc, error) {
-	var obj map[string]json.RawMessage
-	if len(raw) == 0 || json.Unmarshal(raw, &obj) != nil {
-		return oneLakeLoc{}, fmt.Errorf("missing %s", side)
-	}
-
-	// Flatten the shapes into one lookup, innermost last so an explicit nested
-	// value wins over an outer one.
+// locScopes flattens a Copy side's nested shapes into ONE lookup chain,
+// innermost last so an explicit nested value wins over an outer one.
+//
+// Fabric writes the same address several ways -- top level, `datasetSettings`,
+// its `linkedService.properties.typeProperties`, `typeProperties.location`, or
+// `storeSettings` -- and one side may use any mixture. Collecting them in
+// precedence order is what lets a caller ask for a key without knowing which
+// shape supplied it.
+func locScopes(obj map[string]json.RawMessage) []map[string]json.RawMessage {
 	scopes := []map[string]json.RawMessage{obj}
 	descend := func(m map[string]json.RawMessage, keys ...string) map[string]json.RawMessage {
 		cur := m
@@ -732,39 +733,96 @@ func (e *pipelineExecutor) resolveLoc(side string, raw json.RawMessage, resolve 
 	if st := descend(obj, "storeSettings"); st != nil {
 		scopes = append(scopes, st)
 	}
+	return scopes
+}
 
-	lookup := func(k string) (json.RawMessage, bool) {
-		for i := len(scopes) - 1; i >= 0; i-- {
-			if v, ok := scopes[i][k]; ok {
-				return v, true
-			}
-		}
-		return nil, false
-	}
-	field := func(k string) (string, error) {
-		raw, ok := lookup(k)
-		if !ok {
-			return "", nil
-		}
-		v, err := resolve(raw)
-		if err != nil || v == nil {
-			return "", err
-		}
-		// Only a SCALAR addresses anything. Fabric's dataset model reuses names
-		// this lookup wants for things that are not names: `datasetSettings.schema`
-		// is a COLUMN LIST, not a namespace, and `annotations`/`structure` are
-		// arrays too. Flattening the scopes puts them in reach, and fmt.Sprint
-		// would happily render `[]` — which is how a tenant-shaped Copy landed its
-		// bytes at `Tables/[]/bronze_customers` and still reported Succeeded.
-		// A composite here means "this key does not mean what the caller thinks",
-		// so it reads as absent rather than as the string "[]".
-		switch v.(type) {
-		case []any, map[string]any:
-			return "", nil
-		}
-		return fmt.Sprint(v), nil
-	}
+// locFields reads one key out of a flattened scope chain, resolving whatever
+// expression it finds there.
+//
+// These were two closures inside resolveLoc, which is most of why that function
+// carried the highest cognitive complexity in this file: flattening, reading,
+// refusing and addressing were one 141-line body. Same precedence, same
+// composite rule, same absent-vs-error distinction -- only the scope changed.
+type locFields struct {
+	scopes  []map[string]json.RawMessage
+	resolve func(json.RawMessage) (any, error)
+}
 
+// lookup returns the innermost scope's value for k.
+func (f locFields) lookup(k string) (json.RawMessage, bool) {
+	for i := len(f.scopes) - 1; i >= 0; i-- {
+		if v, ok := f.scopes[i][k]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+// field resolves k to a scalar string. An absent key and a COMPOSITE value are
+// both reported as absent with no error; only a failing resolve is an error.
+func (f locFields) field(k string) (string, error) {
+	raw, ok := f.lookup(k)
+	if !ok {
+		return "", nil
+	}
+	v, err := f.resolve(raw)
+	if err != nil || v == nil {
+		return "", err
+	}
+	// Only a SCALAR addresses anything. Fabric's dataset model reuses names
+	// this lookup wants for things that are not names: `datasetSettings.schema`
+	// is a COLUMN LIST, not a namespace, and `annotations`/`structure` are
+	// arrays too. Flattening the scopes puts them in reach, and fmt.Sprint
+	// would happily render `[]` — which is how a tenant-shaped Copy landed its
+	// bytes at `Tables/[]/bronze_customers` and still reported Succeeded.
+	// A composite here means "this key does not mean what the caller thinks",
+	// so it reads as absent rather than as the string "[]".
+	switch v.(type) {
+	case []any, map[string]any:
+		return "", nil
+	}
+	return fmt.Sprint(v), nil
+}
+
+// refuseUnsupportedCopy rejects a Copy side the emulator cannot honour: an
+// unknown side type, an option it does not implement, or an option value
+// outside what it supports.
+//
+// SEPARATE FROM THE ADDRESSING because these checks must run BEFORE any
+// location is built. Accepting a side and then quietly ignoring an option is
+// how a Copy reports Succeeded having written the wrong thing -- which the
+// tables it consults were each added in response to.
+func refuseUnsupportedCopy(side, sideType string, f locFields) error {
+	if !copySideTypes[sideType] {
+		return fmt.Errorf("%s type %q is not supported by the emulator", side, sideType)
+	}
+	for _, opt := range copyUnsupportedOpts {
+		if _, ok := f.lookup(opt.key); ok {
+			return fmt.Errorf("%s option %q: %s", side, opt.key, opt.why)
+		}
+	}
+	for key, allowed := range copyAllowedValues {
+		got, err := f.field(key)
+		if err != nil {
+			return err
+		}
+		if got == "" {
+			continue
+		}
+		if !slices.ContainsFunc(allowed, func(a string) bool { return strings.EqualFold(a, got) }) {
+			return fmt.Errorf("%s option %s=%q is not supported by the emulator (supported: %s)",
+				side, key, got, strings.Join(allowed, ", "))
+		}
+	}
+	return nil
+}
+
+func (e *pipelineExecutor) resolveLoc(side string, raw json.RawMessage, resolve func(json.RawMessage) (any, error)) (oneLakeLoc, error) {
+	var obj map[string]json.RawMessage
+	if len(raw) == 0 || json.Unmarshal(raw, &obj) != nil {
+		return oneLakeLoc{}, fmt.Errorf("missing %s", side)
+	}
+	f := locFields{scopes: locScopes(obj), resolve: resolve}
 	// The discriminator is the side's own `type`, never an inner one: nested
 	// objects carry their own (`datasetSettings.type` is a *dataset* type like
 	// "LakehouseTable", `location.type` a store type like "LakehouseLocation").
@@ -778,43 +836,25 @@ func (e *pipelineExecutor) resolveLoc(side string, raw json.RawMessage, resolve 
 			sideType = fmt.Sprint(v)
 		}
 	}
-	if !copySideTypes[sideType] {
-		return oneLakeLoc{}, fmt.Errorf("%s type %q is not supported by the emulator", side, sideType)
-	}
-	for _, opt := range copyUnsupportedOpts {
-		if _, ok := lookup(opt.key); ok {
-			return oneLakeLoc{}, fmt.Errorf("%s option %q: %s", side, opt.key, opt.why)
-		}
-	}
-	for key, allowed := range copyAllowedValues {
-		got, err := field(key)
-		if err != nil {
-			return oneLakeLoc{}, err
-		}
-		if got == "" {
-			continue
-		}
-		if !slices.ContainsFunc(allowed, func(a string) bool { return strings.EqualFold(a, got) }) {
-			return oneLakeLoc{}, fmt.Errorf("%s option %s=%q is not supported by the emulator (supported: %s)",
-				side, key, got, strings.Join(allowed, ", "))
-		}
+	if err := refuseUnsupportedCopy(side, sideType, f); err != nil {
+		return oneLakeLoc{}, err
 	}
 
-	wsRef, err := field("workspaceId")
+	wsRef, err := f.field("workspaceId")
 	if err != nil {
 		return oneLakeLoc{}, err
 	}
-	itemRef, err := field("itemId")
+	itemRef, err := f.field("itemId")
 	if err != nil {
 		return oneLakeLoc{}, err
 	}
 	if itemRef == "" {
 		// Fabric's linkedService names the lakehouse "artifactId".
-		if itemRef, err = field("artifactId"); err != nil {
+		if itemRef, err = f.field("artifactId"); err != nil {
 			return oneLakeLoc{}, err
 		}
 	}
-	path, err := e.copyPath(field)
+	path, err := e.copyPath(f.field)
 	if err != nil {
 		return oneLakeLoc{}, err
 	}


### PR DESCRIPTION
The function G67 left standing. `resolveLoc` was the worst in
`internal/api/pipelines.go` at **cognitive complexity 48** — 141 lines doing
four separable things, three of them **closures** nothing outside could reach:

| extracted | was |
|---|---|
| `locScopes(obj)` | the shape flattening — now a **pure function** |
| `locFields{scopes, resolve}` | the `lookup` + `field` closures — now a named type |
| `refuseUnsupportedCopy(side, type, f)` | the three refusal gates |

`resolveLoc` keeps its signature (seven callers) and reads as the sequence it
always was. The file's worst function is now `notebookActivity` at **42**, so
this one is no longer the top.

**Same caveat as the three before it:** the file's total complexity is
unchanged, 229 → 230 (the struct). Splitting distributes complexity; the number
that moved is the worst single function.

## What the split made possible

The uncovered remainder was every error path inside those closures, and
reaching them used to require a pipeline whose expression failed at exactly one
key. With `locScopes` pure and `locFields` constructible, a two-line stub does
it:

| | before | after |
|---|---|---|
| `locScopes` | 96.0% | **100%** |
| `lookup`, `field` | — | **100%** |
| `refuseUnsupportedCopy` | 93.3% | **100%** |
| `resolveLoc` | 93.5% | **100%** |
| `copyPath` | 79.3% | **100%** |

`copyPath` was pre-existing and untouched by the refactor — it became reachable
because it already took the `field` function as a parameter, so the same stub
covers its six read sites.

## The tests assert meaning, not that an error occurred

- a **composite reads as absent**, because `fmt.Sprint` would render a column
  list as `[]` — which once landed bytes at `Tables/[]/bronze_customers` and
  reported Succeeded;
- an **unresolvable side type must not fall through to `""`**, since `""` is a
  *valid* type here (the emulator's own simplified shape), so swallowing it
  turns an unreadable side into an accepted one;
- a **swallowed `copyPath` failure** reports a missing location instead of the
  expression that could not be read.

## Verification

`go build`, `go vet`, `gofmt`, and the **whole repo's** tests green.
