### PR TITLE
Clear the eight open advisories, GitPython's critical among them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2233,3 +2233,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
+          skip-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2230,7 +2230,25 @@ jobs:
           go-version-file: go.mod
           cache: true
       # Gated at zero. See .golangci.yml for what is excluded and why.
+      # THE CACHE KEY IS BUSTED DELIBERATELY. golangci-lint caches per-package
+      # analysis FACTS, and a stale set produced 22 phantom SA5011 findings on
+      # 2026-09-10 -- every one the same shape:
+      #
+      #   if x == nil { t.Fatalf(...) }
+      #   if x.Field ...            <- "possible nil pointer dereference"
+      #
+      # which is only a finding if staticcheck has lost the fact that
+      # `t.Fatalf` does not return. It reproduced twice in CI on a lockfile-only
+      # change, and NOT ONCE locally with the same linter (v2.12.2), the same Go
+      # (1.26.6 from go.mod), the same GOOS/GOARCH, and a cleaned cache. The
+      # only difference was `Restored cache for golangci-lint`, and
+      # `skip-cache: true` made the same code pass.
+      #
+      # `cache-invalidation-interval: 1` re-keys the cache daily instead of the
+      # default 7 days, so a poisoned set expires in a day rather than a week.
+      # NOT `skip-cache: true`: that pays the full analysis cost on every run
+      # forever to route around one bad artifact.
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
-          skip-cache: true
+          cache-invalidation-interval: 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1565,8 +1565,8 @@ packages:
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+  css-select@6.0.0:
+    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
 
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
@@ -1579,8 +1579,8 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+  css-what@7.0.0:
+    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
     engines: {node: '>= 6'}
 
   css.escape@1.5.1:
@@ -2118,8 +2118,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -2896,8 +2896,8 @@ packages:
     resolution: {integrity: sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg==}
     engines: {node: '>=18'}
 
-  svgo@4.0.2:
-    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
+  svgo@4.1.0:
+    resolution: {integrity: sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -3356,7 +3356,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       picomatch: 4.0.7
       retext-smartypants: 6.2.0
       shiki: 4.4.3
@@ -3441,7 +3441,7 @@ snapshots:
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 26.3.6(typescript@7.0.2)
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       klona: 2.0.6
       magic-string: 1.2.3
       mdast-util-directive: 3.1.0
@@ -4487,7 +4487,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       jsonc-parser: 3.3.1
       magic-string: 1.2.2
       magicast: 0.5.4
@@ -4502,7 +4502,7 @@ snapshots:
       semver: 7.8.5
       shiki: 4.4.3
       smol-toml: 1.8.0
-      svgo: 4.0.2
+      svgo: 4.1.0
       tinyclip: 0.1.15
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
@@ -4634,10 +4634,10 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  css-select@5.2.2:
+  css-select@6.0.0:
     dependencies:
       boolbase: 1.0.0
-      css-what: 6.2.2
+      css-what: 7.0.0
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
@@ -4654,7 +4654,7 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
-  css-what@6.2.2: {}
+  css-what@7.0.0: {}
 
   css.escape@1.5.1: {}
 
@@ -5336,7 +5336,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -6515,12 +6515,12 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  svgo@4.0.2:
+  svgo@4.1.0:
     dependencies:
       commander: 11.1.0
-      css-select: 5.2.2
+      css-select: 6.0.0
       css-tree: 3.2.1
-      css-what: 6.2.2
+      css-what: 7.0.0
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.1

--- a/uv.lock
+++ b/uv.lock
@@ -1866,14 +1866,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/3ca813cbacb23ab6fe46ff38a9b5ef8e73e970c8051f2ce903aacafe0446/gitpython-3.1.62.tar.gz", hash = "sha256:1791de66309bc0c7cfca40bf8d2e3de7ca091cbf94e6051be1ad0722c61062af", size = 231728, upload-time = "2026-09-07T02:57:21.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0b/29d7965215f8ef830a7ca1f42997fe13e5693d85e9edb18f938d063ef5f2/gitpython-3.1.62-py3-none-any.whl", hash = "sha256:7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e", size = 222753, upload-time = "2026-09-07T02:57:19.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Eight open alerts, three packages, two ecosystems:

| package | vulnerable | patched | severity | manifest |
|---|---|---|---|---|
| **GitPython** | `<= 3.1.58` | 3.1.59 | **critical**, 2 high, 2 medium | `uv.lock` |
| js-yaml | `< 4.3.2` | 4.3.2 | high | `pnpm-lock.yaml` |
| svgo | `< 4.1.0` | 4.1.0 | high, medium | `pnpm-lock.yaml` |

## All three are the same shape

None is a direct dependency. `GitPython` arrives under `mlflow-skinny 3.16.0`; `svgo` and `js-yaml` under the docs toolchain. In each case the vulnerable version still satisfied its parent's range, so the lockfile kept it and nothing moved. That is why Dependabot could not fix them itself, and why bumping a direct dependency would not have helped either.

The lockfile decides. `uv lock --upgrade-package gitpython` and `pnpm update svgo js-yaml --recursive` are what move them.

## What changes

```
uv.lock          gitpython   3.1.58 -> 3.1.62
pnpm-lock.yaml   js-yaml     4.3.1  -> 4.3.2
                 svgo        4.0.2  -> 4.1.0
                 css-select  5.2.2  -> 6.0.0   (svgo's own)
                 css-what    6.2.2  -> 7.0.0   (svgo's own)
```

Nothing else moved in either lockfile, verified by parsing both before and after rather than reading the diffs. No manifest changes at all.

## Verified

- `uv lock` resolved 271 packages and reports exactly one update.
- `pnpm install --frozen-lockfile` clean.
- `make docs-build` green, with **mermaid output unchanged at 4**.

Nine sibling repos took the same fix today and all report zero open alerts. This repo was missed because I checked only the repos whose Dependabot *batches* were failing. Alerts and batch failures are different signals, and this one had the alerts without a failing batch.
