### PR TITLE
Release notes for v0.36.0

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,82 +1,10 @@
-# Unreleased (after v0.35.0)
+# Unreleased (after v0.36.0)
 
-Draft of what landed on `main` after the `v0.35.0` tag. Rename this file to
-`v0.36.0.md` (or whichever minor) when tagging. Open pull requests are not
+Draft of what landed on `main` after the `v0.36.0` tag. Rename this file to
+`v0.37.0.md` (or whichever minor) when tagging. Open pull requests are not
 here.
 
-The range starts at `2f95c3f5` (#416), the first commit after the `v0.35.0`
-tag: 38 changes. The headline is a **Databricks JAR task that actually
-submits**, and two review findings that reached main after it.
-
-**Read the first section if any Databricks JAR task used to be refused with
-"nothing here submits a main class".** That refusal was true of the statement
-endpoint and false of the overlay.
-
-**Read the second if a retry of a failed Environment pip install came back
-`applied: true`.** The cache recorded the attempt, not the result.
-
----
-
-## A JAR task runs on the JVM overlay, refused where it cannot (#438)
-
-The refusal said nothing here submits a main class, on either engine. The first
-half was true of the statement endpoint; the second was a gap — the overlay
-ships `spark-submit`. Both survivors are probed, not assumed. A jar runs from
-the Files mount or not at all: the mount is enumerated and the request only
-selects from it, so traversal and symlinks match nothing rather than being
-caught after the fact.
-
-## A failed Environment pip install was recorded as applied (#453)
-
-A `/environment` call that failed still entered `_environment_applied`. The
-next bind of the same Environment short-circuited as already installed, so a
-retry of a broken `requirements.txt` looked like success. The cache now records
-a completed install.
-
-The same change restores `os.environ` around every `python/tests` case
-(examples' fixtures wrote `NOTEBOOKUTILS_*` at import and the leak crossed a
-package boundary) and refuses a JAR the Files mount cannot see.
-
-## Databricks JAR `parameters` resolve against the pipeline scope (#454)
-
-`parameters` were `fmt.Sprint`'d into argv, so an expression stayed a literal
-and a non-string value became Go's default formatting. They now go through
-`resolve()`, same as every other activity input. Notes in #455.
-
-## The rest
-
-**README's 🟢 Real count is bound to the checker.** `check_witnesses.py
---strict` now FAILS when README's glance table does not state the supported-claim
-count the checker prints, so adding a 🟢 parity row without touching README is a
-red build rather than a silently stale front page. It had sat at 113 while the
-checker counted 124. Deleting or rewriting the `| 🟢 **Real** | **N** |` row
-fails too, rather than quietly unbinding the number — if the table moves, the
-regex in `scripts/check_witnesses.py` moves with it. The landing page keeps its
-own interpolation check; docs/24's figures are prose and are deliberately no
-longer typed.
-
-**The MERGE intercept's reason had expired (#437).** pysail 0.7.1 plans the
-shape the rewrite was written for, control included. The intercept still fires
-until the `az://` case is proven; the justification now says what is true.
-
-**A JVM Connect client measured against Sail (#443).** Handshake, SQL,
-DataFrame ops, parquet and exit codes work; typed map, `sparkContext`, Scala
-UDFs and `addArtifact` are asserted to refuse, so a pass fails the run as a
-moved boundary.
-
-**dbt silver without the Livy hop (#429, #431).** The same silver models over
-Spark Connect: row counts agree with the Livy path. Sail's catalog is session
-scoped, so the Connect path registers what it reads.
-
-**fabric-cli is its own project (#426, #416),** so its pyyaml pin stops holding
-the workspace. **The e2e MLflow server stays unpublished (#425)**
-(GHSA-h7x2-h6g9-p789; nothing to upgrade to). Contract 8's expectations get a
-source that is not our own typing (#434); contract 6 witnesses fall-through
-directly (#433); contract 3's floor expires (#435).
-
-**Dependencies.** tornado 6.5.8; examples take the root's pyarrow range;
-great-expectations held at 1.x; Dependabot watches the seven example projects
-and their lockfiles, and the published images. Plus the usual grouped bumps.
+Nothing yet.
 
 ## Upgrading
 

--- a/docs/release-notes/v0.36.0.md
+++ b/docs/release-notes/v0.36.0.md
@@ -1,0 +1,142 @@
+# v0.36.0
+
+The range starts at `2f95c3f5` (#416), the first commit after the `v0.35.0`
+tag, and ends at `156edf85` (#473): 49 changes. The headline is a **security
+clearance** — eight open advisories, one of them critical — and the substance
+behind it is a **Databricks JAR task that actually submits**, plus three
+correctness fixes the review after it turned up.
+
+**Upgrade if you are on `v0.35.0`.** That tag ships a transitively vulnerable
+`GitPython` (critical) and two high-severity docs-toolchain packages. Nothing
+in the emulator's own code was at fault, which is exactly why the lockfiles
+held the old versions and nothing moved on its own.
+
+**Read the JAR section if a Databricks JAR task was refused with "nothing here
+submits a main class".** That refusal was true of the statement endpoint and
+false of the overlay.
+
+**Read the Environment section if a retry of a failed pip install came back
+`applied: true`.** The cache recorded the attempt, not the result.
+
+---
+
+## Eight advisories cleared, GitPython's critical among them (#473, #472)
+
+Three packages, two ecosystems, and all three the same shape:
+
+| package | vulnerable | patched | severity |
+|---|---|---|---|
+| **GitPython** | `<= 3.1.58` | 3.1.62 | **critical**, 2 high, 2 medium |
+| js-yaml | `< 4.3.2` | 4.3.2 | high |
+| svgo | `< 4.1.0` | 4.1.0 | high, medium |
+
+**None is a direct dependency.** `GitPython` arrives under `mlflow-skinny`;
+`svgo` and `js-yaml` under the docs toolchain. In each case the vulnerable
+version still satisfied its parent's range, so the lockfile kept it and nothing
+moved — which is why Dependabot could not fix them itself, and why bumping a
+direct dependency would not have helped either. The lockfile is what decides,
+so the lockfile is what was moved.
+
+## A JAR task runs on the JVM overlay, refused where it cannot (#438)
+
+The refusal said nothing here submits a main class, on either engine. The first
+half was true of the statement endpoint; the second was a gap — the overlay
+ships `spark-submit`. Both survivors are probed, not assumed. A jar runs from
+the Files mount or not at all: the mount is enumerated and the request only
+selects from it, so traversal and symlinks match nothing rather than being
+caught after the fact.
+
+`AzureHDInsight` with a `className` follows the same path (#456) instead of
+being refused for a cause that stopped being true when the overlay landed. Sail
+is still refused by probing `available:false`; `proxyUser` and
+`sparkJobLinkedService` stay refused by name. The ledger no longer claims
+MapReduce is refused because a main class cannot be submitted — that is a
+Hadoop mapper/reducer runtime, not a missing `spark-submit`.
+
+## A failed Environment pip install was recorded as applied (#453)
+
+A `/environment` call that failed still entered `_environment_applied`. The
+next bind of the same Environment short-circuited as already installed, so a
+retry of a broken `requirements.txt` looked like success. The cache now records
+a completed install.
+
+The same change restores `os.environ` around every `python/tests` case
+(examples' fixtures wrote `NOTEBOOKUTILS_*` at import and the leak crossed a
+package boundary) and refuses a JAR the Files mount cannot see.
+
+## The Files mount is locked while statements and spark-submit share it (#457)
+
+The agent is a `ThreadingHTTPServer`, and `/statements` refresh and `/submit`
+both touch the lakehouse Files mount. Without a shared lock a refresh can
+rewrite the tree under a 900-second `spark-submit`, or `_state["seen"]` can
+tear so a later flush skips a write.
+
+A submit can therefore stall a statement for that timeout. That is stated in
+the module's divergences rather than hidden: the cost is real and belongs
+where someone will find it.
+
+## Databricks JAR `parameters` resolve against the pipeline scope (#454, #455)
+
+`parameters` were `fmt.Sprint`'d into argv, so an expression stayed a literal
+and a non-string value became Go's default formatting. They now go through
+`resolve()`, same as every other activity input.
+
+## The rest
+
+**README's 🟢 Real count is bound to the checker (#458, #459).**
+`check_witnesses.py --strict` now FAILS when README's glance table does not
+state the supported-claim count the checker prints, so adding a 🟢 parity row
+without touching README is a red build rather than a silently stale front page.
+It had sat at 113 while the checker counted 124. Deleting or rewriting the
+`| 🟢 **Real** | **N** |` row fails too, rather than quietly unbinding the
+number. Reviewing that change found the same defect still live two paragraphs
+below it in `docs/24`, which is now de-literalised rather than retyped.
+
+**Four functions split, and their coverage stopped averaging (#461–#464).**
+`evalFunc` was 873 lines and 49 switch arms at cognitive complexity 227, the
+highest in the repository; it is now five families and 108. `internal/server`'s
+only import cycle is gone, and `run_code` — which every Python statement in a
+notebook passes through — has tests for the first time, because the cycle was
+what made its module unimportable in a test process. `Execute`'s 134-line
+notebook arm and `resolveLoc`'s four jobs became named functions.
+
+The measurable part is not the complexity: each split left its file's TOTAL
+complexity flat or higher. What moved is that one coverage number over a long
+function is a mean — `evalFunc` read 81.4% while hiding 107 untested refusals,
+and `Execute` read 78.8% while its dispatch was fully exercised and its largest
+arm was not. Package coverage in `internal/semanticmodel` went 89.3% → 96.4%.
+
+**The MERGE intercept's reason had expired (#437).** pysail 0.7.1 plans the
+shape the rewrite was written for, control included. The intercept still fires
+until the `az://` case is proven; the justification now says what is true.
+
+**A JVM Connect client measured against Sail (#443).** Handshake, SQL,
+DataFrame ops, parquet and exit codes work; typed map, `sparkContext`, Scala
+UDFs and `addArtifact` are asserted to refuse, so a pass fails the run as a
+moved boundary.
+
+**dbt silver without the Livy hop (#429, #431).** The same silver models over
+Spark Connect: row counts agree with the Livy path. Sail's catalog is session
+scoped, so the Connect path registers what it reads.
+
+**fabric-cli is its own project (#426, #416),** so its pyyaml pin stops holding
+the workspace. **The e2e MLflow server stays unpublished (#425)**
+(GHSA-h7x2-h6g9-p789; nothing to upgrade to). Contract 8's expectations get a
+source that is not our own typing (#434); contract 6 witnesses fall-through
+directly (#433); contract 3's floor expires (#435).
+
+## Dependencies
+
+`gitpython` 3.1.58 → 3.1.62, `js-yaml` 4.3.1 → 4.3.2, `svgo` 4.0.2 → 4.1.0 and
+`tornado` 6.5.7 → 6.5.8 close the advisories above. `@astrojs/markdown-remark`
+is declared directly, because starlight 0.42.0 drops it (#460).
+
+The examples take the root's pyarrow range, floor included;
+great-expectations is held at 1.x (1.0 replaced the validation API). Dependabot
+now watches the seven example projects, their lockfiles, and the published
+images rather than only the root Dockerfile. Plus the usual grouped bumps.
+
+## Upgrading
+
+No configuration changes. Consumers pin by digest, so bump
+`FABRIC_EMULATOR_VERSION` and `FABRIC_EMULATOR_DIGEST` together.


### PR DESCRIPTION
Prepares `v0.36.0`. **Notes only — this does not tag.**

## Why now

`v0.35.0` was **11 days ago with 49 commits behind it**, against a prior
cadence of a release every 2–6 days (v0.31→v0.35 spanned Aug 19–31).

The decisive part is security: **#473 closed eight advisories, one critical.**
Anyone on the `v0.35.0` tag still gets a transitively vulnerable `GitPython`
plus two high-severity docs-toolchain packages. Open alerts on `main` are 0 —
but a user on the latest tag cannot tell that.

## What changed from the draft

`unreleased.md` had gone stale: it claimed **38 changes ending at #456**, and
eleven more had landed since — including the one that decides whether this
release is urgent.

- **Leads with the security clearance** rather than the JAR task the draft
  headlined. All three packages were transitive, and the vulnerable version
  still satisfied its parent's range, so the lockfile held it and nothing moved
  on its own — which is why Dependabot could not fix them and why bumping a
  direct dependency would not have helped.
- **Folds in what the draft missed**: the Files mount lock (#457), including
  its honest cost — a submit can stall a statement for 900s, stated in the
  module's divergences rather than hidden — and the HDInsight `className` path
  (#456).
- **Describes the four splits (#461–#464) by what actually moved.** Each left
  its file's *total* complexity flat or higher; what changed is that one
  coverage number over a long function is a mean, and both `evalFunc` (81.4%,
  hiding 107 untested refusals) and `Execute` (78.8%, dispatch fully exercised
  and its largest arm not) were averaging one.

`unreleased.md` is reset for the next cycle.

## Verified rather than asserted

- range is `2f95c3f5..156edf85`, **49 commits** — the figures the notes open with
- `check_witnesses.py --strict` prints **124** and README matches it — the
  figure the notes quote
- `check_docs_links.py` and `check_docs_sidebar.py` both clean at 57 pages

## After this merges

Pushing the `v0.36.0` tag triggers the Release workflow, which gates on
`make-targets` across three platforms and calls `real-fabric` qualification,
then publishes: GHCR images, GoReleaser binaries, a Homebrew cask, and
optionally a winget PR. The published release body is **not** generated from
this file — it is applied by hand afterwards, so the last step is
`gh release edit v0.36.0 --notes-file docs/release-notes/v0.36.0.md`.
